### PR TITLE
Python scripts shebang

### DIFF
--- a/scripts/bootprog.py
+++ b/scripts/bootprog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # bootprog.py: STM32 SystemMemory Production Programmer -- version 1.1
 # Copyright (C) 2011  Black Sphere Technologies 

--- a/scripts/gdb.py
+++ b/scripts/gdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # gdb.py: Python module for low level GDB protocol implementation
 # Copyright (C) 2009  Black Sphere Technologies

--- a/scripts/hexprog.py
+++ b/scripts/hexprog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # hexprog.py: Python application to flash a target with an Intel hex file
 # Copyright (C) 2011  Black Sphere Technologies

--- a/scripts/stm32_mem.py
+++ b/scripts/stm32_mem.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # stm32_mem.py: STM32 memory access using USB DFU class
 # Copyright (C) 2011  Black Sphere Technologies 


### PR DESCRIPTION
Use the `#!/usr/bin/env python` pattern so that the correct python binary is found from the user's environment.
