### PR TITLE
Added internal pull-up to PWR_BR.

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -104,6 +104,15 @@ int platform_init(void)
 			GPIO_CNF_OUTPUT_PUSHPULL,
 			SRST_PIN);
 
+        /* Enable internal pull-up on PWR_BR so that we don't drive
+           TPWR locally or inadvertently supply power to the target. */
+        if (platform_hwversion () > 0) {
+          gpio_set (PWR_BR_PORT, PWR_BR_PIN);
+          gpio_set_mode(PWR_BR_PORT, GPIO_MODE_INPUT,
+                        GPIO_CNF_INPUT_PULL_UPDOWN,
+                        PWR_BR_PIN);
+        }
+
 	/* Setup heartbeat timer */
 	systick_set_clocksource(STK_CTRL_CLKSOURCE_AHB_DIV8);
 	systick_set_reload(900000);	/* Interrupt us at 10 Hz */

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -51,7 +51,8 @@ extern usbd_device *usbdev;
  * LED2 = 	PB11	(Red LED    : Error)
  *
  * TPWR = 	RB0 (input) -- analogue on mini design ADC1, ch8
- * nTRST = 	PB1
+ * nTRST = 	PB1 [blackmagic]
+ * PWR_BR = 	PB1 [blackmagic_mini] -- supply power to the target, active low
  * SRST_OUT = 	PA2
  * TDI = 	PA3
  * TMS = 	PA4 (input for SWDP)
@@ -83,6 +84,8 @@ extern usbd_device *usbdev;
 
 #define TRST_PORT	GPIOB
 #define TRST_PIN	GPIO1
+#define PWR_BR_PORT	GPIOB
+#define PWR_BR_PIN	GPIO1
 #define SRST_PORT	GPIOA
 #define SRST_PIN	GPIO2
 


### PR DESCRIPTION
o Prevent probe from inadvertently powering target.  If PWR_BR is
  allowed to float, the gate on Q1 (blackmagic_mini) will tend to be
  close enough to zero to turn the transistor on.  We activate the
  internal pull-up on this IO pin to force the transistor off.
