### PR TITLE
Add support for the SYS_WRITEC semihosting operation.

### DIFF
--- a/src/cortexm.c
+++ b/src/cortexm.c
@@ -989,6 +989,9 @@ static int cortexm_hostio_request(target *t)
 		gdb_putpacket_f("Fwrite,%08X,%08X,%08X",
 				params[0] - 1, params[1], params[2]);
 		break;
+	case SYS_WRITEC: /* writec */
+		gdb_putpacket_f("Fwrite,2,%08X,1", arm_regs[1]);
+		break;
 	case SYS_ISTTY:	/* isatty */
 		gdb_putpacket_f("Fisatty,%08X", params[0] - 1);
 		break;


### PR DESCRIPTION
This is implemented in the same manner as QEMU semihosting
support, specifically, a SYS_WRITEC results in a single
character write to STDERR.
