### PR TITLE
Configure SRST output as open-drain for BMP Mini hardware

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -98,10 +98,15 @@ int platform_init(void)
 	 * to release the device from reset if this floats. */
 	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
 			GPIO_CNF_OUTPUT_PUSHPULL, GPIO7);
-	/* Enable SRST output */
-	gpio_set_val(SRST_PORT, SRST_PIN, platform_hwversion() > 0);
+	/* Enable SRST output. Original uses a NPN to pull down, so setting the
+	 * output HIGH asserts. Mini is directly connected so use open drain output
+	 * and set LOW to assert.
+	 */
+	platform_srst_set_val(false);
 	gpio_set_mode(SRST_PORT, GPIO_MODE_OUTPUT_50_MHZ,
-			GPIO_CNF_OUTPUT_PUSHPULL,
+			(platform_hwversion() == 0
+				? GPIO_CNF_OUTPUT_PUSHPULL
+				: GPIO_CNF_OUTPUT_OPENDRAIN),
 			SRST_PIN);
 
 	/* Setup heartbeat timer */

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -217,3 +217,4 @@ static inline u16 _gpio_get(u32 gpioport, u16 gpios)
 #define disconnect_usb() gpio_set_mode(USB_PU_PORT, GPIO_MODE_INPUT, 0, USB_PU_PIN);
 void assert_boot_pin(void);
 void setup_vbus_irq(void);
+void platform_srst_set_val(bool assert);


### PR DESCRIPTION
Since the Mini connects SRST directly to the target, it should be configured in open-drain mode. Original hardware uses a NPN so it remains push-pull with inverted logic, as before.
