### PR TITLE
Fix in checksum calculation condition

### DIFF
--- a/src/lpc11xx.c
+++ b/src/lpc11xx.c
@@ -216,7 +216,7 @@ lpc11xx_flash_write(struct target_s *target, uint32_t dest, const uint8_t *src, 
 			chunk_offset = 0;
 
 			/* if we are programming the vectors, calculate the magic number */
-			if (dest == 0) {
+			if (chunk * IAP_PGM_CHUNKSIZE == 0) {
 				uint32_t *w = (uint32_t *)(&flash_pgm.data[0]);
 				uint32_t sum = 0;
 


### PR DESCRIPTION
The original code treats last chunk as first one and hence calculates the magic vector also in the last chunk.
