### PR TITLE
Fixed potential Hardfault in platform_init

### DIFF
--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -92,6 +92,11 @@ int platform_init(void)
 
 	cdcacm_init();
 
+	// Set recovery point
+	if (setjmp(fatal_error_jmpbuf)) {
+		return 0; // Do nothing on failure
+	}
+
 	jtag_scan(NULL);
 
 	return 0;

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -140,6 +140,11 @@ int platform_init(void)
 	cdcacm_init();
 	usbuart_init();
 
+	// Set recovery point
+	if (setjmp(fatal_error_jmpbuf)) {
+		return 0; // Do nothing on failure
+	}
+
 	jtag_scan(NULL);
 
 	return 0;

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -121,6 +121,11 @@ int platform_init(void)
 
 	cdcacm_init();
 
+	// Set recovery point
+	if (setjmp(fatal_error_jmpbuf)) {
+		return 0; // Do nothing on failure
+	}
+
 	jtag_scan(NULL);
 
 	return 0;

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -99,6 +99,11 @@ int platform_init(void)
 
 	cdcacm_init();
 
+	// Set recovery point
+	if (setjmp(fatal_error_jmpbuf)) {
+		return 0; // Do nothing on failure
+	}
+
 	jtag_scan(NULL);
 
 	return 0;


### PR DESCRIPTION
Error handling in the low level jtagdp function uses a setjmp/longjmp mechanism (PLATFORM_FATAL_ERROR). During platform_init longjmp can be called despite setjmp not having been called yet, which will cause a hardfault.
