### PR TITLE
Add null byte to ensure flush happens correctly.

### DIFF
--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -128,7 +128,8 @@ void gdb_putpacket(unsigned char *packet, int size)
 		gdb_if_putchar('#', 0);
 		sprintf(xmit_csum, "%02X", csum);
 		gdb_if_putchar(xmit_csum[0], 0);
-		gdb_if_putchar(xmit_csum[1], 1);
+		gdb_if_putchar(xmit_csum[1], 0);
+		gdb_if_putchar(0, 1);
 #ifdef DEBUG_GDBPACKET
 		DEBUG("\n");
 #endif


### PR DESCRIPTION
Otherwise flush can fail for long (> 256 bytes) strings such as a memory map. Tested on the native platform with linux 3.11.0-20. The null terminator does not affect gdb.
