### PR TITLE
Add support for halfword memory accesses.

### DIFF
--- a/src/arm7tdmi.c
+++ b/src/arm7tdmi.c
@@ -129,6 +129,8 @@ void arm7tdmi_jtag_handler(jtag_dev_t *dev)
 	t->check_error = (void *)do_nothing;
 	t->mem_read_words = (void *)do_nothing;
 	t->mem_write_words = (void *)do_nothing;
+	t->mem_read_halfwords = (void *)do_nothing;
+	t->mem_write_halfwords = (void *)do_nothing;
 	t->mem_read_bytes = (void *)do_nothing;
 	t->mem_write_bytes = (void *)do_nothing;
 	t->regs_size = 16 * sizeof(uint32_t);

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -101,6 +101,8 @@ gdb_main(void)
 			uint8_t mem[len];
 			if(((addr & 3) == 0) && ((len & 3) == 0))
 				target_mem_read_words(cur_target, (void*)mem, addr, len);
+			else if(((addr & 1) == 0) && ((len & 1) == 0))
+				target_mem_read_halfwords(cur_target, (void*)mem, addr, len);
 			else
 				target_mem_read_bytes(cur_target, (void*)mem, addr, len);
 			if(target_check_error(cur_target))
@@ -127,6 +129,8 @@ gdb_main(void)
 			unhexify(mem, pbuf + hex, len);
 			if(((addr & 3) == 0) && ((len & 3) == 0))
 				target_mem_write_words(cur_target, addr, (void*)mem, len);
+			else if(((addr & 1) == 0) && ((len & 1) == 0))
+				target_mem_write_halfwords(cur_target, addr, (void*)mem, len);
 			else
 				target_mem_write_bytes(cur_target, addr, (void*)mem, len);
 			if(target_check_error(cur_target))

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -56,6 +56,12 @@ target *target_attach(target *t, target_destroy_callback destroy_cb);
 #define target_mem_write_words(target, dest, src, len)	\
 	(target)->mem_write_words((target), (dest), (src), (len))
 
+#define target_mem_read_halfwords(target, dest, src, len)	\
+	(target)->mem_read_halfwords((target), (dest), (src), (len))
+
+#define target_mem_write_halfwords(target, dest, src, len)	\
+	(target)->mem_write_halfwords((target), (dest), (src), (len))
+
 #define target_mem_read_bytes(target, dest, src, len)	\
 	(target)->mem_read_bytes((target), (dest), (src), (len))
 
@@ -135,6 +141,11 @@ struct target_s {
 				int len);
 	int (*mem_write_words)(struct target_s *target, uint32_t dest,
 				const uint32_t *src, int len);
+
+	int (*mem_read_halfwords)(struct target_s *target, uint16_t *dest, uint32_t src,
+				int len);
+	int (*mem_write_halfwords)(struct target_s *target, uint32_t dest,
+				const uint16_t *src, int len);
 
 	int (*mem_read_bytes)(struct target_s *target, uint8_t *dest, uint32_t src,
 				int len);


### PR DESCRIPTION
I'm working with an FPGA hooked to the STM32 FSMC in 16-bit mode, and I want to be able to poke registers in the FPGA from GDB.

Since both reads and writes may have side effects, it's not safe to decompose 16-bit accesses into two 8-bit accesses or promote it to a 32-bit access (which would get decomposed by the FSMC into two 16-bit accesses) since either will generate an extra access.
