### PR TITLE
Add option to turn SWIM/RST into UART RX/TX

### DIFF
--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -19,6 +19,10 @@ else
 LDFLAGS += --specs=nosys.specs
 endif
 
+ifeq ($(SWIM_AS_UART), 1)
+CFLAGS += -DSWIM_AS_UART=1
+endif
+
 VPATH += platforms/stm32
 
 SRC += 	cdcacm.c	\
@@ -41,4 +45,3 @@ dfu_upgrade: dfu_upgrade.o dfucore.o dfu_f1.o  stlink_common.o
 
 host_clean:
 	-$(Q)$(RM) blackmagic.bin blackmagic_dfu blackmagic_dfu.bin blackmagic_dfu.hex dfu_upgrade dfu_upgrade.bin dfu_upgrade.hex
-

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -82,6 +82,12 @@ void platform_init(void)
 	if (rev > 1) /* Reconnect USB */
 		gpio_set(GPIOA, GPIO15);
 	cdcacm_init();
+
+#ifdef SWIM_AS_UART
+	gpio_primary_remap(AFIO_MAPR_SWJ_CFG_FULL_SWJ,
+			   AFIO_MAPR_USART1_REMAP);
+#endif
+
 	/* Don't enable UART if we're being debugged. */
 	if (!(SCS_DEMCR & SCS_DEMCR_TRCENA))
 		usbuart_init();

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -105,13 +105,21 @@
 #define IRQ_PRI_USB_VBUS	(14 << 4)
 #define IRQ_PRI_SWO_DMA			(1 << 4)
 
+#ifdef SWIM_AS_UART
+#define USBUSART USART1
+#define USBUSART_CR1 USART1_CR1
+#define USBUSART_IRQ NVIC_USART1_IRQ
+#define USBUSART_CLK RCC_USART1
+#define USBUSART_ISR usart1_isr
+#else
 #define USBUSART USART2
 #define USBUSART_CR1 USART2_CR1
 #define USBUSART_IRQ NVIC_USART2_IRQ
 #define USBUSART_CLK RCC_USART2
+#define USBUSART_ISR usart2_isr
+#endif
 #define USBUSART_PORT GPIOA
 #define USBUSART_TX_PIN GPIO2
-#define USBUSART_ISR usart2_isr
 #define USBUSART_TIM TIM4
 #define USBUSART_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM4)
 #define USBUSART_TIM_IRQ NVIC_TIM4_IRQ
@@ -154,4 +162,3 @@ extern uint32_t detect_rev(void);
 #define snprintf sniprintf
 
 #endif
-


### PR DESCRIPTION
This PR allows building for `stlink` with `SWIM_AS_UART=1`, which enables the use of the
SWIM and RST ports as RX and TX on cheap ST-Link V2 clones.

This is done by using USART1 (on the alternative port) instead of USART2.