### PR TITLE
Fix: Connect-under-reset handling reliability

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -69,8 +69,6 @@
 #include <fcntl.h>
 #endif
 
-static const char cortexm_driver_str[] = "ARM Cortex-M";
-
 static bool cortexm_vector_catch(target_s *t, int argc, const char **argv);
 #if PC_HOSTED == 0
 static bool cortexm_redirect_stdout(target_s *t, int argc, const char **argv);
@@ -592,7 +590,7 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 	t->mem_read = cortexm_mem_read;
 	t->mem_write = cortexm_mem_write;
 
-	t->driver = cortexm_driver_str;
+	t->driver = "ARM Cortex-M";
 
 	cortexm_read_cpuid(t, ap);
 
@@ -622,7 +620,7 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 	t->breakwatch_set = cortexm_breakwatch_set;
 	t->breakwatch_clear = cortexm_breakwatch_clear;
 
-	target_add_commands(t, cortexm_cmd_list, cortexm_driver_str);
+	target_add_commands(t, cortexm_cmd_list, t->driver);
 
 	if (is_cortexmf) {
 		t->target_options |= TOPT_FLAVOUR_V7MF;


### PR DESCRIPTION
1) When probing under reset, reset is held for too long.

Some parts, in particular the STM32F0, do not respond to queries
for their MCUID while the hard reset line nRST is being asserted.
When attempting to connect under reset, BMP incorrectly continues
to assert reset while querying MCUID. Therefore, some chips only
identify as "ARM Cortex-M", not the proper chip ID. This prevents
binaries from being loaded.

2) When attaching under reset, reset is released too soon.

When attaching under reset, it's critical that user code not be
allowed to run before the debugger commands the chip to halt.
If bad user code is loaded on the device (e.g. that disables the
clock), any window in between releasing reset and commanding a
halt can prevent the BMP from attaching. The BMP incorrectly
releases reset before commanding a halt (in cortexm_forced_halt),
meaning that a bad ELF file can prevent the BMP from attaching,
effectively bricking the chip.

This change fixes both bugs. After this change, if the BMP is in
connect-under-reset mode, then at the start of the probe sequence,
while reset is still asserted, we set up the interrupt catch
vector, send a halt command, and release reset. Also, if we are
under connect-under-reset, we do not resume the chip after probing
is complete.