### PR TITLE
Fix libftdi ftdi_usb_purge_buffers deprecation

### DIFF
--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -47,7 +47,12 @@ static uint8_t jtagtap_next(uint8_t dTMS, uint8_t dTDI);
 int libftdi_jtagtap_init(jtag_proc_t *jtag_proc)
 {
 	assert(ftdic != NULL);
+	/* select new buffer flush function if libftdi 1.5 */
+#ifdef _Ftdi_Pragma
+	int err = ftdi_tcioflush(ftdic);
+#else
 	int err = ftdi_usb_purge_buffers(ftdic);
+#endif
 	if (err != 0) {
 		DEBUG_WARN("ftdi_usb_purge_buffer: %d: %s\n",
 			err, ftdi_get_error_string(ftdic));

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -46,7 +46,12 @@ int libftdi_swdptap_init(swd_proc_t *swd_proc)
 		DEBUG_WARN("SWD not possible or missing item in cable description.\n");
 		return -1;
 	}
+	/* select new buffer flush function if libftdi 1.5 */
+#ifdef _Ftdi_Pragma
+	int err = ftdi_tcioflush(ftdic);
+#else
 	int err = ftdi_usb_purge_buffers(ftdic);
+#endif
 	if (err != 0) {
 		DEBUG_WARN("ftdi_usb_purge_buffer: %d: %s\n",
 			err, ftdi_get_error_string(ftdic));


### PR DESCRIPTION
Check for libftdi 1.5 using `_Ftdi_Pragma` in order to use `ftdi_tcioflush` instead of the newly deprecated `ftdi_usb_purge_buffers`