### PR TITLE
Symbolically define the USB endpoint addresses and enable them to be overridden by platform if required

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -415,7 +415,7 @@ static bool cmd_traceswo(target *t, int argc, const char **argv)
 	traceswo_init(swo_channelmask);
 #endif
 	serial_no_read(serial_no, sizeof(serial_no));
-	gdb_outf("%s:%02X:%02X\n", serial_no, 5, 0x85);
+	gdb_outf("%s:%02X:%02X\n", serial_no, 5, USB_TRACESWO_EPT_OUT);
 	return true;
 }
 #endif

--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -74,7 +74,7 @@ static const struct usb_device_descriptor dev = {
 static const struct usb_endpoint_descriptor gdb_comm_endp[] = {{
 	.bLength = USB_DT_ENDPOINT_SIZE,
 	.bDescriptorType = USB_DT_ENDPOINT,
-	.bEndpointAddress = 0x82,
+	.bEndpointAddress = CDCACM_GDB_COMM_EPT_OUT,
 	.bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
 	.wMaxPacketSize = 16,
 	.bInterval = 255,
@@ -83,14 +83,14 @@ static const struct usb_endpoint_descriptor gdb_comm_endp[] = {{
 static const struct usb_endpoint_descriptor gdb_data_endp[] = {{
 	.bLength = USB_DT_ENDPOINT_SIZE,
 	.bDescriptorType = USB_DT_ENDPOINT,
-	.bEndpointAddress = 0x01,
+	.bEndpointAddress = CDCACM_GDB_EPT_IN,
 	.bmAttributes = USB_ENDPOINT_ATTR_BULK,
 	.wMaxPacketSize = CDCACM_PACKET_SIZE,
 	.bInterval = 1,
 }, {
 	.bLength = USB_DT_ENDPOINT_SIZE,
 	.bDescriptorType = USB_DT_ENDPOINT,
-	.bEndpointAddress = 0x81,
+	.bEndpointAddress = CDCACM_GDB_DATA_EPT_OUT,
 	.bmAttributes = USB_ENDPOINT_ATTR_BULK,
 	.wMaxPacketSize = CDCACM_PACKET_SIZE,
 	.bInterval = 1,
@@ -177,7 +177,7 @@ static const struct usb_iface_assoc_descriptor gdb_assoc = {
 static const struct usb_endpoint_descriptor uart_comm_endp[] = {{
 	.bLength = USB_DT_ENDPOINT_SIZE,
 	.bDescriptorType = USB_DT_ENDPOINT,
-	.bEndpointAddress = 0x84,
+	.bEndpointAddress = CDCACM_UART_COMM_EPT_OUT,
 	.bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
 	.wMaxPacketSize = 16,
 	.bInterval = 255,
@@ -186,14 +186,14 @@ static const struct usb_endpoint_descriptor uart_comm_endp[] = {{
 static const struct usb_endpoint_descriptor uart_data_endp[] = {{
 	.bLength = USB_DT_ENDPOINT_SIZE,
 	.bDescriptorType = USB_DT_ENDPOINT,
-	.bEndpointAddress = 0x03,
+	.bEndpointAddress = CDCACM_UART_EPT_IN,
 	.bmAttributes = USB_ENDPOINT_ATTR_BULK,
 	.wMaxPacketSize = CDCACM_PACKET_SIZE / 2,
 	.bInterval = 1,
 }, {
 	.bLength = USB_DT_ENDPOINT_SIZE,
 	.bDescriptorType = USB_DT_ENDPOINT,
-	.bEndpointAddress = 0x83,
+	.bEndpointAddress = CDCACM_UART_DATA_EPT_OUT,
 	.bmAttributes = USB_ENDPOINT_ATTR_BULK,
 	.wMaxPacketSize = CDCACM_PACKET_SIZE,
 	.bInterval = 1,
@@ -315,7 +315,7 @@ static const struct usb_iface_assoc_descriptor dfu_assoc = {
 static const struct usb_endpoint_descriptor trace_endp[] = {{
 	.bLength = USB_DT_ENDPOINT_SIZE,
 	.bDescriptorType = USB_DT_ENDPOINT,
-	.bEndpointAddress = 0x85,
+	.bEndpointAddress = USB_TRACESWO_EPT_OUT,
 	.bmAttributes = USB_ENDPOINT_ATTR_BULK,
 	.wMaxPacketSize = 64,
 	.bInterval = 0,
@@ -496,7 +496,7 @@ static void cdcacm_set_modem_state(usbd_device *dev, int iface, bool dsr, bool d
 	notif->wLength = 2;
 	buf[8] = (dsr ? 2 : 0) | (dcd ? 1 : 0);
 	buf[9] = 0;
-	usbd_ep_write_packet(dev, 0x82 + iface, buf, 10);
+	usbd_ep_write_packet(dev, CDCACM_GDB_COMM_EPT_OUT + iface, buf, 10);
 }
 
 static void cdcacm_set_config(usbd_device *dev, uint16_t wValue)
@@ -505,27 +505,27 @@ static void cdcacm_set_config(usbd_device *dev, uint16_t wValue)
 
 	/* GDB interface */
 #if defined(STM32F4) || defined(LM4F)
-	usbd_ep_setup(dev, 0x01, USB_ENDPOINT_ATTR_BULK,
-	              CDCACM_PACKET_SIZE, gdb_usb_out_cb);
+	usbd_ep_setup(dev, CDCACM_GDB_EPT_IN, USB_ENDPOINT_ATTR_BULK,
+				  CDCACM_PACKET_SIZE, gdb_usb_out_cb);
 #else
-	usbd_ep_setup(dev, 0x01, USB_ENDPOINT_ATTR_BULK,
-	              CDCACM_PACKET_SIZE, NULL);
+	usbd_ep_setup(dev, CDCACM_GDB_EPT_IN, USB_ENDPOINT_ATTR_BULK,
+				  CDCACM_PACKET_SIZE, NULL);
 #endif
-	usbd_ep_setup(dev, 0x81, USB_ENDPOINT_ATTR_BULK,
-	              CDCACM_PACKET_SIZE, NULL);
-	usbd_ep_setup(dev, 0x82, USB_ENDPOINT_ATTR_INTERRUPT, 16, NULL);
+	usbd_ep_setup(dev, CDCACM_GDB_DATA_EPT_OUT, USB_ENDPOINT_ATTR_BULK,
+				  CDCACM_PACKET_SIZE, NULL);
+	usbd_ep_setup(dev, CDCACM_GDB_COMM_EPT_OUT, USB_ENDPOINT_ATTR_INTERRUPT, 16, NULL);
 
 	/* Serial interface */
-	usbd_ep_setup(dev, 0x03, USB_ENDPOINT_ATTR_BULK,
-	              CDCACM_PACKET_SIZE / 2, usbuart_usb_out_cb);
-	usbd_ep_setup(dev, 0x83, USB_ENDPOINT_ATTR_BULK,
-	              CDCACM_PACKET_SIZE, usbuart_usb_in_cb);
-	usbd_ep_setup(dev, 0x84, USB_ENDPOINT_ATTR_INTERRUPT, 16, NULL);
+	usbd_ep_setup(dev, CDCACM_UART_EPT_IN, USB_ENDPOINT_ATTR_BULK,
+				  CDCACM_PACKET_SIZE / 2, usbuart_usb_out_cb);
+	usbd_ep_setup(dev, CDCACM_UART_DATA_EPT_OUT, USB_ENDPOINT_ATTR_BULK,
+				  CDCACM_PACKET_SIZE, usbuart_usb_in_cb);
+	usbd_ep_setup(dev, CDCACM_UART_COMM_EPT_OUT, USB_ENDPOINT_ATTR_INTERRUPT, 16, NULL);
 
 #if defined(PLATFORM_HAS_TRACESWO)
 	/* Trace interface */
-	usbd_ep_setup(dev, 0x85, USB_ENDPOINT_ATTR_BULK,
-					64, trace_buf_drain);
+	usbd_ep_setup(dev, USB_TRACESWO_EPT_OUT, USB_ENDPOINT_ATTR_BULK,
+				  64, trace_buf_drain);
 #endif
 
 	usbd_register_control_callback(dev,

--- a/src/platforms/common/cdcacm.h
+++ b/src/platforms/common/cdcacm.h
@@ -32,8 +32,28 @@
 
 #define CDCACM_PACKET_SIZE 	64
 
-#define CDCACM_GDB_ENDPOINT	1
-#define CDCACM_UART_ENDPOINT	3
+/*
+ *	Define the USB endpoints
+ */
+#ifndef CDCACM_GDB_EPT_IN
+#define CDCACM_GDB_EPT_IN 1
+#endif
+#ifndef CDCACM_UART_EPT_IN
+#define CDCACM_UART_EPT_IN 3
+#endif
+
+#ifndef CDCACM_GDB_DATA_EPT_OUT
+#define CDCACM_GDB_DATA_EPT_OUT 0x81
+#endif
+#ifndef CDCACM_GDB_COMM_EPT_OUT
+#define CDCACM_GDB_COMM_EPT_OUT 0x82
+#endif
+#ifndef CDCACM_UART_DATA_EPT_OUT
+#define CDCACM_UART_DATA_EPT_OUT 0x83
+#endif
+#ifndef CDCACM_UART_COMM_EPT_OUT
+#define CDCACM_UART_COMM_EPT_OUT 0x84
+#endif
 
 extern usbd_device *usbdev;
 

--- a/src/platforms/common/traceswo.h
+++ b/src/platforms/common/traceswo.h
@@ -22,6 +22,10 @@
 
 #include <libopencm3/usb/usbd.h>
 
+#ifndef USB_TRACESWO_EPT_OUT
+#define USB_TRACESWO_EPT_OUT 0x85
+#endif
+
 #if defined TRACESWO_PROTOCOL && TRACESWO_PROTOCOL == 2
 /* Default line rate, used as default for a request without baudrate */
 #define SWO_DEFAULT_BAUD (2250000)

--- a/src/platforms/stm32/gdb_if.c
+++ b/src/platforms/stm32/gdb_if.c
@@ -46,7 +46,7 @@ void gdb_if_putchar(unsigned char c, int flush)
 			count_in = 0;
 			return;
 		}
-		while(usbd_ep_write_packet(usbdev, CDCACM_GDB_ENDPOINT,
+		while(usbd_ep_write_packet(usbdev, CDCACM_GDB_EPT_IN,
 			buffer_in, count_in) <= 0);
 
 		if (flush && (count_in == CDCACM_PACKET_SIZE)) {
@@ -56,7 +56,7 @@ void gdb_if_putchar(unsigned char c, int flush)
 			 * that transfer is complete, so we just send a packet
 			 * containing a null byte for now.
 			 */
-			while (usbd_ep_write_packet(usbdev, CDCACM_GDB_ENDPOINT,
+			while (usbd_ep_write_packet(usbdev, CDCACM_GDB_EPT_IN,
 				"\0", 1) <= 0);
 		}
 
@@ -68,11 +68,11 @@ void gdb_if_putchar(unsigned char c, int flush)
 void gdb_usb_out_cb(usbd_device *dev, uint8_t ep)
 {
 	(void)ep;
-	usbd_ep_nak_set(dev, CDCACM_GDB_ENDPOINT, 1);
-	count_new = usbd_ep_read_packet(dev, CDCACM_GDB_ENDPOINT,
+	usbd_ep_nak_set(dev, CDCACM_GDB_EPT_IN, 1);
+	count_new = usbd_ep_read_packet(dev, CDCACM_GDB_EPT_IN,
 	                                double_buffer_out, CDCACM_PACKET_SIZE);
 	if(!count_new) {
-		usbd_ep_nak_set(dev, CDCACM_GDB_ENDPOINT, 0);
+		usbd_ep_nak_set(dev, CDCACM_GDB_EPT_IN, 0);
 	}
 }
 #endif
@@ -87,11 +87,11 @@ static void gdb_if_update_buf(void)
 		count_out = count_new;
 		count_new = 0;
 		out_ptr = 0;
-		usbd_ep_nak_set(usbdev, CDCACM_GDB_ENDPOINT, 0);
+		usbd_ep_nak_set(usbdev, CDCACM_GDB_EPT_IN, 0);
 	}
 	asm volatile ("cpsie i; isb");
 #else
-	count_out = usbd_ep_read_packet(usbdev, CDCACM_GDB_ENDPOINT,
+	count_out = usbd_ep_read_packet(usbdev, CDCACM_GDB_EPT_IN,
 	                                buffer_out, CDCACM_PACKET_SIZE);
 	out_ptr = 0;
 #endif

--- a/src/platforms/stm32/traceswo.c
+++ b/src/platforms/stm32/traceswo.c
@@ -87,11 +87,12 @@ static uint8_t trace_usb_buf_size;
 void trace_buf_push(uint8_t *buf, int len)
 {
 	if (decoding)
-		traceswo_decode(usbdev, CDCACM_UART_ENDPOINT, buf, len);
-	else if (usbd_ep_write_packet(usbdev, 0x85, buf, len) != len) {
+		traceswo_decode(usbdev, CDCACM_UART_EPT_IN, buf, len);
+	else if (usbd_ep_write_packet(usbdev, USB_TRACESWO_EPT_OUT, buf, len) != len)
+	{
 		if (trace_usb_buf_size + len > 64) {
 			/* Stall if upstream to too slow. */
-			usbd_ep_stall_set(usbdev, 0x85, 1);
+			usbd_ep_stall_set(usbdev, USB_TRACESWO_EPT_OUT, 1);
 			trace_usb_buf_size = 0;
 			return;
 		}
@@ -106,7 +107,7 @@ void trace_buf_drain(usbd_device *dev, uint8_t ep)
 		return;
 
 	if (decoding)
-		traceswo_decode(dev, CDCACM_UART_ENDPOINT, trace_usb_buf, trace_usb_buf_size);
+		traceswo_decode(dev, CDCACM_UART_EPT_IN, trace_usb_buf, trace_usb_buf_size);
 	else
 		usbd_ep_write_packet(dev, ep, trace_usb_buf, trace_usb_buf_size);
 	trace_usb_buf_size = 0;

--- a/src/platforms/stm32/traceswoasync.c
+++ b/src/platforms/stm32/traceswoasync.c
@@ -63,7 +63,7 @@ void trace_buf_drain(usbd_device *dev, uint8_t ep)
 		uint16_t rc;
 		if (decoding)
 			/* write decoded swo packets to the uart port */
-			rc = traceswo_decode(dev, CDCACM_UART_ENDPOINT,
+			rc = traceswo_decode(dev, CDCACM_UART_EPT_IN,
 										  &trace_rx_buf[r * FULL_SWO_PACKET],
 										  FULL_SWO_PACKET);
 		else
@@ -122,7 +122,7 @@ void SWO_DMA_ISR(void)
 			   &pingpong_buf[FULL_SWO_PACKET], FULL_SWO_PACKET);
 	}
 	w = (w + 1) % NUM_TRACE_PACKETS;
-	trace_buf_drain(usbdev, 0x85);
+	trace_buf_drain(usbdev, USB_TRACESWO_EPT_OUT);
 }
 
 void traceswo_init(uint32_t baudrate, uint32_t swo_chan_bitmask)

--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -123,7 +123,7 @@ static void usbuart_run(void)
 
 		/* advance fifo out pointer by amount written */
 		buf_rx_out += usbd_ep_write_packet(usbdev,
-				CDCACM_UART_ENDPOINT, packet_buf, packet_size);
+				CDCACM_UART_EPT_IN, packet_buf, packet_size);
 		buf_rx_out %= FIFO_SIZE;
 	}
 }
@@ -167,7 +167,7 @@ void usbuart_usb_out_cb(usbd_device *dev, uint8_t ep)
 	(void)ep;
 
 	char buf[CDCACM_PACKET_SIZE];
-	int len = usbd_ep_read_packet(dev, CDCACM_UART_ENDPOINT,
+	int len = usbd_ep_read_packet(dev, CDCACM_UART_EPT_IN,
 					buf, CDCACM_PACKET_SIZE);
 
 #if defined(BLACKMAGIC)

--- a/src/platforms/tm4c/gdb_if.c
+++ b/src/platforms/tm4c/gdb_if.c
@@ -44,7 +44,7 @@ void gdb_if_putchar(unsigned char c, int flush)
 			count_in = 0;
 			return;
 		}
-		while(usbd_ep_write_packet(usbdev, CDCACM_GDB_ENDPOINT,
+		while(usbd_ep_write_packet(usbdev, CDCACM_GDB_EPT_IN,
 			(uint8_t *)buffer_in, count_in) <= 0);
 		count_in = 0;
 	}
@@ -55,8 +55,8 @@ void gdb_usb_out_cb(usbd_device *dev, uint8_t ep)
 	(void)ep;
 	static uint8_t buf[CDCACM_PACKET_SIZE];
 
-	usbd_ep_nak_set(dev, CDCACM_GDB_ENDPOINT, 1);
-        uint32_t count = usbd_ep_read_packet(dev, CDCACM_GDB_ENDPOINT,
+	usbd_ep_nak_set(dev, CDCACM_GDB_EPT_IN, 1);
+        uint32_t count = usbd_ep_read_packet(dev, CDCACM_GDB_EPT_IN,
                                         (uint8_t *)buf, CDCACM_PACKET_SIZE);
 
 	
@@ -65,7 +65,7 @@ void gdb_usb_out_cb(usbd_device *dev, uint8_t ep)
 		buffer_out[head_out++ % sizeof(buffer_out)] = buf[idx];
 	}
 
-	usbd_ep_nak_set(dev, CDCACM_GDB_ENDPOINT, 0);
+	usbd_ep_nak_set(dev, CDCACM_GDB_EPT_IN, 0);
 }
 
 unsigned char gdb_if_getchar(void)

--- a/src/platforms/tm4c/traceswo.c
+++ b/src/platforms/tm4c/traceswo.c
@@ -36,6 +36,9 @@
 #include <libopencm3/lm4f/uart.h>
 #include <libopencm3/usb/usbd.h>
 
+#ifndef USB_TRACESWO_EPT_OUT
+#define USB_TRACESWO_EPT_OUT 0x85
+#endif
 void traceswo_init(void)
 {
 	periph_clock_enable(RCC_GPIOD);
@@ -73,7 +76,7 @@ void traceswo_init(void)
 	nvic_enable_irq(TRACEUART_IRQ);
 
 	/* Un-stall USB endpoint */
-	usbd_ep_stall_set(usbdev, 0x85, 0);
+	usbd_ep_stall_set(usbdev, USB_TRACESWO_EPT_OUT, 0);
 
 	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO3);
 }
@@ -109,7 +112,8 @@ void trace_buf_push(void)
 		len = 64;
 	}
 
-	if (usbd_ep_write_packet(usbdev, 0x85, (uint8_t *)&buf_rx[buf_rx_out], len) == len) {
+	if (usbd_ep_write_packet(usbdev, USB_TRACESWO_EPT_OUT, (uint8_t *)&buf_rx[buf_rx_out], len) == len)
+	{
 		buf_rx_out += len;
 		buf_rx_out %= FIFO_SIZE;
 	}

--- a/src/platforms/tm4c/usbuart.c
+++ b/src/platforms/tm4c/usbuart.c
@@ -104,7 +104,7 @@ void usbuart_usb_out_cb(usbd_device *dev, uint8_t ep)
 	(void)ep;
 
 	char buf[CDCACM_PACKET_SIZE];
-	int len = usbd_ep_read_packet(dev, CDCACM_UART_ENDPOINT,
+	int len = usbd_ep_read_packet(dev, CDCACM_UART_EPT_IN,
 					buf, CDCACM_PACKET_SIZE);
 
 	for(int i = 0; i < len; i++)
@@ -175,7 +175,7 @@ void USBUART_ISR(void)
 
 		/* advance fifo out pointer by amount written */
 		buf_rx_out += usbd_ep_write_packet(usbdev,
-				CDCACM_UART_ENDPOINT, packet_buf, packet_size);
+				CDCACM_UART_EPT_IN, packet_buf, packet_size);
 		buf_rx_out %= FIFO_SIZE;
 	}
 }


### PR DESCRIPTION
If a platform requires the use of different USB endpoints they may be defined in platform.h for the platform.

