### PR TITLE
Do not turn IDLE LED off when port closed and target already detached

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -296,10 +296,11 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 			if(cur_target) {
 				SET_RUN_STATE(1);
 				target_detach(cur_target);
+				last_target = cur_target;
+				cur_target = NULL;
 			}
-			last_target = cur_target;
-			cur_target = NULL;
-			gdb_putpacketz("OK");
+			if (pbuf[0] == 'D')
+				gdb_putpacketz("OK");
 			break;
 
 		case 'k':	/* Kill the target */

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -117,8 +117,11 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 	while (1) {
 		SET_IDLE_STATE(1);
 		size_t size = gdb_getpacket(pbuf, BUF_SIZE);
-		SET_IDLE_STATE(0);
-		switch (pbuf[0]) {
+		// If port closed and target detached, stay idle
+		if ((pbuf[0] != 0x04) || cur_target) {
+			SET_IDLE_STATE(0);
+		}
+		switch(pbuf[0]) {
 		/* Implementation of these is mandatory! */
 		case 'g': { /* 'g': Read general registers */
 			ERROR_IF_NO_TARGET();


### PR DESCRIPTION
Avoids the IDLE LED to be dimmed after detaching the target. 
Should be #941 friendly as it avoids toggling the LED (human visible).

Additionally, I see no requirement in the GDB protocol to always answer "OK" on a D (detach) command when the target is already detached. I clarified a bit. 
This avoids sending "OK" forever in case of 0x04 command (port closed).