### PR TITLE
Added support for synwit ARM chips (SWm050)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -59,6 +59,7 @@ SRC =			\
 	stm32l4.c	\
 	stm32g0.c	\
 	target.c	\
+	synwit.c	\
 
 include $(PLATFORM_DIR)/Makefile.inc
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -447,6 +447,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		} else if (ap->ap_partno == 0x471)  { /* Cortex-M0 ROM */
 			PROBE(lpc11xx_probe); /* LPC24C11 */
 			PROBE(lpc43xx_probe);
+			PROBE(synwit_probe);
 		} else if (ap->ap_partno == 0x4c4) { /* Cortex-M4 ROM */
 			/* The LPC546xx and LPC43xx parts present with the same AP ROM Part
 			Number, so we need to probe both. Unfortunately, when probing for

--- a/src/target/synwit.c
+++ b/src/target/synwit.c
@@ -11,7 +11,7 @@
 #define FLASHREG2	0x1F000038
 #define FLASHKEY	0xAAAAAAAA
 #define SYS_CFG_0	0x400F0000
-#define SYS_DBLF	0x400F0008	
+#define SYS_DBLF	0x400F0008
 
 // decalrations
 static void synwit_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize);
@@ -20,7 +20,7 @@ static int synwit_flash_write(struct target_flash *f, target_addr dest, const vo
 bool synwit_probe(target *t);
 
 
-static bool synwit_cmd_erase_mass(target *t);
+static bool synwit_cmd_erase_mass(target *t, int argc, const char **argv);
 
 const struct command_s synwit_cmd_list[] = {
 	{"erase_mass", (cmd_handler)synwit_cmd_erase_mass, "Erase entire flash memory"},
@@ -100,23 +100,27 @@ static int synwit_flash_write(struct target_flash *f, target_addr dest, const vo
 
 bool synwit_probe(target *t)
 {
-	t->idcode = target_mem_read32(t, CPUID);
+	uint32_t idcode = target_mem_read32(t, CPUID);
 
-	switch(t->idcode)
+	switch(idcode)
 	{
-		case 0x410CC200:	t->driver = "Synwit SWM050";
-					target_add_ram(t, 0x20000000, 0x400);
-					synwit_add_flash(t, 0x00000000, 0x2000, 0x200);
-					
-					return true;
-		default:		return false;
+		case 0x410CC200:
+			t->driver = "Synwit SWM050";
+			target_add_ram(t, 0x20000000, 0x400);
+			synwit_add_flash(t, 0x00000000, 0x2000, 0x200);
+			return true;
+		default:
+			return false;
 	}
 
 	return false;
 }
 
-static bool synwit_cmd_erase_mass(target *t)
+static bool synwit_cmd_erase_mass(target *t, int argc, const char **argv)
 {
+	(void)argc;
+	(void)argv;
+
 	// 18Mhz
 	target_mem_write32(t, SYS_CFG_0, 1);
 	target_mem_write32(t, SYS_DBLF, 0);

--- a/src/target/synwit.c
+++ b/src/target/synwit.c
@@ -1,0 +1,144 @@
+
+
+#include "general.h"
+#include "target.h"
+#include "target_internal.h"
+#include "cortexm.h"
+
+//defines
+#define CPUID		0xE000ED00
+#define FLASHREG1	0x1F000000
+#define FLASHREG2	0x1F000038
+#define FLASHKEY	0xAAAAAAAA
+#define SYS_CFG_0	0x400F0000
+#define SYS_DBLF	0x400F0008	
+
+// decalrations
+static void synwit_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize);
+static int synwit_flash_erase(struct target_flash *f, target_addr addr, size_t len);
+static int synwit_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+bool synwit_probe(target *t);
+
+
+static bool synwit_cmd_erase_mass(target *t);
+
+const struct command_s synwit_cmd_list[] = {
+	{"erase_mass", (cmd_handler)synwit_cmd_erase_mass, "Erase entire flash memory"},
+	{NULL, NULL, NULL}
+};
+
+
+static void synwit_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize)
+{
+	struct target_flash *f = calloc(1, sizeof(*f));
+
+	f->start = addr;
+	f->length = length;
+	f->blocksize = erasesize;
+	f->erase = synwit_flash_erase;
+	f->write = synwit_flash_write;
+	f->buf_size = erasesize;
+	f->erased = 0xff;
+	target_add_flash(t, f);
+
+	target_add_commands(t, synwit_cmd_list, "synwit");
+}
+
+static int synwit_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+{
+	target *t = f->t;
+
+	// 18Mhz
+	target_mem_write32(t, SYS_CFG_0, 1);
+	target_mem_write32(t, SYS_DBLF, 0);
+
+	// we want to erase page
+	target_mem_write32(t, FLASHREG1, 4);
+
+	// select right page
+	while(len)
+	{
+		target_mem_write32(t, addr, FLASHKEY);
+		platform_delay(1);
+
+		len-=f->blocksize;
+		addr+=f->blocksize;
+	}
+
+	// close flashinterface
+	target_mem_write32(t, FLASHREG1, 0);
+
+	return 0;
+}
+
+static int synwit_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len)
+{
+	target *t = f->t;
+	uint32_t *source = (uint32_t*) src;
+
+	// 18Mhz
+	target_mem_write32(t, SYS_CFG_0, 1);
+	target_mem_write32(t, SYS_DBLF, 0);
+
+	// we want to write bytes
+	target_mem_write32(t, FLASHREG1, 1);
+
+	while(len)
+	{
+		target_mem_write32(t, dest, *source);
+
+		source++;
+		dest+=4;
+		len-=4;
+	}
+
+	// close flashinterface
+	target_mem_write32(t, FLASHREG1, 0);
+
+	return 0;
+}
+
+bool synwit_probe(target *t)
+{
+	t->idcode = target_mem_read32(t, CPUID);
+
+	switch(t->idcode)
+	{
+		case 0x410CC200:	t->driver = "Synwit SWM050";
+					target_add_ram(t, 0x20000000, 0x400);
+					synwit_add_flash(t, 0x00000000, 0x2000, 0x200);
+					
+					return true;
+		default:		return false;
+	}
+
+	return false;
+}
+
+static bool synwit_cmd_erase_mass(target *t)
+{
+	// 18Mhz
+	target_mem_write32(t, SYS_CFG_0, 1);
+	target_mem_write32(t, SYS_DBLF, 0);
+
+	// erasechipcmd
+	target_mem_write32(t, FLASHREG1, 6);
+	target_mem_write32(t, FLASHREG2, 1);
+	target_mem_write32(t, 0x0, FLASHKEY);
+
+	// delay 2170 on 18Mhz
+	// approx 1ms
+	platform_delay(1);
+
+	// close flashinterface
+	target_mem_write32(t, FLASHREG1, 0);
+
+	// success?
+	tc_printf(t, "Device is erased\n");
+
+	return true;
+}
+
+
+
+

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -197,4 +197,6 @@ bool efm32_probe(target *t);
 bool msp432_probe(target *t);
 bool ke04_probe(target *t);
 bool rp_probe(target *t);
+bool synwit_probe(target *t);
+
 #endif


### PR DESCRIPTION
This is a cleaned up and rebased pull request #401 

After evaluation, this does not seem to be complete? Is it possible to do anything more than erase and write the flash on the part? If you would like this added to BMP codebase the implementation has to be able to also debug the firmware by stepping through the code of the target. We aspire to be more than just a flash programmer. :)

As I don't have access to any of the synwit chips I can not test this. All I could do is clean up this pull request to best of my abilities.

If someone from the original contributors like @sdmprutser or @david-sawatzke can test this pull request, or provide me with a test target I can test this and merge it into master.

I am sorry this patch was sitting for so long but it would be a bummer to not get it merged if it is fully functional and useful. Otherwise I will be forced to close this pull request. :(