### PR TITLE
Cortexm: With connect under reset, keep the device halted until attach.

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -834,9 +834,15 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 		adiv5_ap_unref(ap);
 	}
 	/* We halted at least CortexM for Romtable scan.
-	 * Release the devices now. Attach() will halt them again.*/
-	for (target *t = target_list; t; t = t->next)
-		target_halt_resume(t, false);
+	 * With connect under reset, keep the devices halted.
+	 * Otherwise, release the devices now.
+	 * Attach() will halt them again.
+	 */
+	for (target *t = target_list; t; t = t->next) {
+		if (!connect_assert_srst) {
+			target_halt_resume(t, false);
+		}
+	}
 	adiv5_dp_unref(dp);
 }
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -471,8 +471,6 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		PROBE(lpc17xx_probe);
 	}
 #undef PROBE
-	/* Restart the CortexM we stopped for Romtable scan. Allow pure debug.*/
-	target_halt_resume(t, 0);
 	return true;
 }
 


### PR DESCRIPTION
#249 shows that the device was running after probe with attach with connect under reset was requested. 