### PR TITLE
LPC-Link and MCU-Link support regression fixes

### DIFF
--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -18,7 +18,7 @@ CFLAGS  +=  -DHOSTED_BMP_ONLY=$(HOSTED_BMP_ONLY)
 
 ifneq (, $(findstring linux, $(SYS)))
 SRC += serial_unix.c
-HIDAPILIB = hidapi-hidraw
+HIDAPILIB = hidapi-libusb
 ifeq ($(ASAN), 1)
 CFLAGS += -fsanitize=address  -Wno-format-truncation
 LDFLAGS += -lasan

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -225,17 +225,14 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 		DEBUG_WIRE("%02x.",	buffer[i]);
 	DEBUG_WIRE("\n");
 	if (type == CMSIS_TYPE_HID) {
-		res = hid_write(handle, buffer, 65);
+		res = hid_write(handle, buffer, rsize + 1);
 		if (res < 0) {
 			DEBUG_WARN( "Error: %ls\n", hid_error(handle));
 			exit(-1);
 		}
-		res = hid_read_timeout(handle, buffer, 65, 1000);
+		res = hid_read(handle, buffer, report_size + 1);
 		if (res < 0) {
 			DEBUG_WARN( "debugger read(): %ls\n", hid_error(handle));
-			exit(-1);
-		} else if (res == 0) {
-			DEBUG_WARN( "timeout\n");
 			exit(-1);
 		}
 	} else if (type == CMSIS_TYPE_BULK) {

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -198,7 +198,7 @@ void dap_connect(bool jtag)
 //-----------------------------------------------------------------------------
 void dap_disconnect(void)
 {
-	uint8_t buf[65];
+	uint8_t buf[1];
 
 	buf[0] = ID_DAP_DISCONNECT;
 	dbg_dap_cmd(buf, sizeof(buf), 1);


### PR DESCRIPTION
Revert hotfixes  to support (experimental) Dragonprobe #981. 