### PR TITLE
Added support for fine-grained bootloader and flash locking in samd.c

### DIFF
--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -715,11 +715,51 @@ static bool samd_set_flashlock(target *t, uint16_t value, const char **argv)
 	return true;
 }
 
+static bool parse_unsigned(const char *s, uint32_t *val) {
+	int l, st;
+	unsigned long num;
+	
+	l=strlen(s);
+	
+	if (l>2 && s[0]=='0' && (s[1]=='x' || s[1]=='X')) {
+		st=sscanf(s+2, "%lx", &num);
+	} else {
+		st=sscanf(s, "%lu", &num);
+	}
+	
+	if (st<1) {
+		return false;
+	}
+	
+	*val=(uint32_t)num;
+	return true;
+}
+
 static bool samd_cmd_lock_flash(target *t, int argc, const char **argv)
 {
+	unsigned long val;
+	
 	(void)argc;
 	(void)argv;
-	return samd_set_flashlock(t, 0x0000, NULL);
+	
+	if (argc>2) {
+		tc_printf(t, "usage: monitor lock_flash [number]\n");
+		return false;
+	} else if (argc==1) {
+		return samd_set_flashlock(t, 0x0000, NULL);
+	} else {
+		if (!parse_unsigned(argv[1], &val)) {
+			tc_printf(t, "number must be either decimal or 0x prefixed hexadecimal\n");
+			return false;
+		}
+		
+		if (val>0xffff) {
+			tc_printf(t, "number must be between 0 and 0xFFFF\n");
+			return false;
+		}
+		
+		return samd_set_flashlock(t, (uint16_t)val, NULL);
+	}
 }
 
 static bool samd_cmd_unlock_flash(target *t, int argc, const char **argv)
@@ -764,9 +804,30 @@ static bool samd_set_bootprot(target *t, uint16_t value, const char **argv)
 
 static bool samd_cmd_lock_bootprot(target *t, int argc, const char **argv)
 {
+	unsigned long val;
+	
 	(void)argc;
 	(void)argv;
-	return samd_set_bootprot(t, 0, NULL);
+	/* locks first 0x7 .. 0, 0x6 .. 512, 0x5 .. 1024, ..., 0x0 .. 32768 bytes of flash*/
+	
+	if (argc>2) {
+		tc_printf(t, "usage: monitor lock_bootprot [number]\n");
+		return false;
+	} else if (argc==1) {
+		return samd_set_bootprot(t, 0, NULL);
+	} else {
+		if (!parse_unsigned(argv[1], &val)) {
+			tc_printf(t, "number must be either decimal or 0x prefixed hexadecimal\n");
+			return false;
+		}
+		
+		if (val>7) {
+			tc_printf(t, "number must be between 0 and 7\n");
+			return false;
+		}
+		
+		return samd_set_bootprot(t, (uint16_t)val, NULL);
+	}
 }
 
 static bool samd_cmd_unlock_bootprot(target *t, int argc, const char **argv)


### PR DESCRIPTION
Up to now only the whole flash can be locked in one piece. Locking by segments is not supported. 
When locking the bootloader only the largest chunk (32kB) can be locked. 
By specifying an optional numerical parameter (can be given in decimal or 0x prefied hexadecimal) to lock_bootprot (0 is for 32k, 6 is for 512 bytes) and lock_flash monitor commands the extended functionality is obtained. If this parameter is not specified the commands behave as previously. 