### PR TITLE
Native hw6

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -343,7 +343,18 @@ void platform_request_boot(void)
 
 void exti15_10_isr(void)
 {
-	if (gpio_get(USB_VBUS_PORT, USB_VBUS_PIN)) {
+	uint32_t usb_vbus_port;
+	uint16_t usb_vbus_pin;
+
+	if (platform_hwversion() < 5) {
+		usb_vbus_port = USB_VBUS_PORT;
+		usb_vbus_pin = USB_VBUS_PIN;
+	} else {
+		usb_vbus_port = USB_VBUS5_PORT;
+		usb_vbus_pin = USB_VBUS5_PIN;
+	}
+
+	if (gpio_get(usb_vbus_port, usb_vbus_pin)) {
 		/* Drive pull-up high if VBUS connected */
 		gpio_set_mode(USB_PU_PORT, GPIO_MODE_OUTPUT_10_MHZ,
 				GPIO_CNF_OUTPUT_PUSHPULL, USB_PU_PIN);
@@ -353,24 +364,35 @@ void exti15_10_isr(void)
 				GPIO_CNF_INPUT_FLOAT, USB_PU_PIN);
 	}
 
-	exti_reset_request(USB_VBUS_PIN);
+	exti_reset_request(usb_vbus_pin);
 }
 
 static void setup_vbus_irq(void)
 {
+	uint32_t usb_vbus_port;
+	uint16_t usb_vbus_pin;
+
+	if (platform_hwversion() < 5) {
+		usb_vbus_port = USB_VBUS_PORT;
+		usb_vbus_pin = USB_VBUS_PIN;
+	} else {
+		usb_vbus_port = USB_VBUS5_PORT;
+		usb_vbus_pin = USB_VBUS5_PIN;
+	}
+
 	nvic_set_priority(USB_VBUS_IRQ, IRQ_PRI_USB_VBUS);
 	nvic_enable_irq(USB_VBUS_IRQ);
 
-	gpio_set(USB_VBUS_PORT, USB_VBUS_PIN);
+	gpio_set(usb_vbus_port, usb_vbus_pin);
 	gpio_set(USB_PU_PORT, USB_PU_PIN);
 
-	gpio_set_mode(USB_VBUS_PORT, GPIO_MODE_INPUT,
-			GPIO_CNF_INPUT_PULL_UPDOWN, USB_VBUS_PIN);
+	gpio_set_mode(usb_vbus_port, GPIO_MODE_INPUT,
+			GPIO_CNF_INPUT_PULL_UPDOWN, usb_vbus_pin);
 
 	/* Configure EXTI for USB VBUS monitor */
-	exti_select_source(USB_VBUS_PIN, USB_VBUS_PORT);
-	exti_set_trigger(USB_VBUS_PIN, EXTI_TRIGGER_BOTH);
-	exti_enable_request(USB_VBUS_PIN);
+	exti_select_source(usb_vbus_pin, usb_vbus_port);
+	exti_set_trigger(usb_vbus_pin, EXTI_TRIGGER_BOTH);
+	exti_enable_request(usb_vbus_pin);
 
 	exti15_10_isr();
 }

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -62,6 +62,7 @@ static void setup_vbus_irq(void);
  * 011 - 0xFFFF -   3 - Mini V2.1a and later.
  * 011 - 0xFB04 -   4 - Mini V2.1d and later.
  * xxx - 0xFB05 -   5 - Mini V2.2a and later.
+ * xxx - 0xFB06 -   6 - Mini V2.3a and later.
  *
  * This function will return -2 if the version number does not make sense.
  * This can happen when the Data1 byte contains "garbage". For example a

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -35,15 +35,41 @@
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/stm32/adc.h>
+#include <libopencm3/stm32/flash.h>
 
 static void adc_init(void);
 static void setup_vbus_irq(void);
 
+/* Starting with hardware version 4 we are storing the hardware version in the
+ * flash option user Data1 byte.
+ * The hardware version 4 was the transition version that had it's hardware
+ * pins strapped to 3 but contains version 4 in the Data1 byte.
+ * The hardware 4 is backward compatible with V3 but provides the new jumper
+ * connecting STRACE target pin to the UART1 pin.
+ * Hardware version 5 does not have the physically strapped version encoding
+ * any more and the hardware version has to be read out of the option bytes.
+ * This means that older firmware versions that don't do the detection won't
+ * work on the newer hardware.
+ */
+#define BMP_HWVERSION_BYTE FLASH_OPTION_BYTE_2
+
 /* Pins PB[7:5] are used to detect hardware revision.
- * 000 - Original production build.
- * 001 - Mini production build.
- * 010 - Mini V2.0e and later.
- * 011 - Mini V2.1e and later.
+ * User option byte Data1 is used starting with hardware revision 4.
+ * Pin -  OByte - Rev - Description
+ * 000 - 0xFFFF -   0 - Original production build.
+ * 001 - 0xFFFF -   1 - Mini production build.
+ * 010 - 0xFFFF -   2 - Mini V2.0e and later.
+ * 011 - 0xFFFF -   3 - Mini V2.1a and later.
+ * 011 - 0xFB04 -   4 - Mini V2.1d and later.
+ * xxx - 0xFB05 -   5 - Mini V2.2a and later.
+ *
+ * This function will return -2 if the version number does not make sense.
+ * This can happen when the Data1 byte contains "garbage". For example a
+ * hardware revision that is <4 or the high byte is not the binary inverse of
+ * the lower byte.
+ * Note: The high byte of the Data1 option byte should always be the binary
+ * inverse of the lower byte unless the byte is not set, then all bits in both
+ * high and low byte are 0xFF.
  */
 int platform_hwversion(void)
 {
@@ -51,7 +77,25 @@ int platform_hwversion(void)
 	uint16_t hwversion_pins = GPIO7 | GPIO6 | GPIO5;
 	uint16_t unused_pins = hwversion_pins ^ 0xFFFF;
 
-	/* Only check for version if this is the first time. */
+	/* Check if the hwversion is set in the user option byte. */
+	if (hwversion == -1) {
+		if (BMP_HWVERSION_BYTE != 0xFFFF) {
+			/* Check if the data is valid.
+			 * When valid it should only have values 4 and higher.
+			 */
+			if ((BMP_HWVERSION_BYTE >> 8) !=
+			    (~BMP_HWVERSION_BYTE & 0xFF) ||
+			    ((BMP_HWVERSION_BYTE & 0xFF) < 4)) {
+				return -2;
+			} else {
+				hwversion = BMP_HWVERSION_BYTE & 0xFF;
+			}
+		}
+	}
+
+	/* If the hwversion is not set in option bytes check
+	 * the hw pin strapping.
+	 */
 	if (hwversion == -1) {
 		/* Configure the hardware version pins as input pull-up/down */
 		gpio_set_mode(GPIOB, GPIO_MODE_INPUT,

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -80,12 +80,13 @@ int platform_hwversion(void)
 
 	/* Check if the hwversion is set in the user option byte. */
 	if (hwversion == -1) {
-		if (BMP_HWVERSION_BYTE != 0xFFFF) {
+		if ((BMP_HWVERSION_BYTE != 0xFFFF) &&
+		    (BMP_HWVERSION_BYTE != 0x00FF)) {
 			/* Check if the data is valid.
 			 * When valid it should only have values 4 and higher.
 			 */
-			if ((BMP_HWVERSION_BYTE >> 8) !=
-			    (~BMP_HWVERSION_BYTE & 0xFF) ||
+			if (((BMP_HWVERSION_BYTE >> 8) !=
+			     (~BMP_HWVERSION_BYTE & 0xFF)) ||
 			    ((BMP_HWVERSION_BYTE & 0xFF) < 4)) {
 				return -2;
 			} else {

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -254,12 +254,12 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define USBUSART2 USART2
 #define USBUSART2_IRQ NVIC_USART2_IRQ
 #define USBUSART2_ISR(x) usart2_isr(x)
-#define USBUSART2_DMA_TX_CHAN DMA_CHANNEL6
-#define USBUSART2_DMA_TX_IRQ NVIC_DMA1_CHANNEL6_IRQ
-#define USBUSART2_DMA_TX_ISR(x) dma1_channel6_isr(x)
-#define USBUSART2_DMA_RX_CHAN DMA_CHANNEL7
-#define USBUSART2_DMA_RX_IRQ NVIC_DMA1_CHANNEL7_IRQ
-#define USBUSART2_DMA_RX_ISR(x) dma1_channel7_isr(x)
+#define USBUSART2_DMA_TX_CHAN DMA_CHANNEL7
+#define USBUSART2_DMA_TX_IRQ NVIC_DMA1_CHANNEL7_IRQ
+#define USBUSART2_DMA_TX_ISR(x) dma1_channel7_isr(x)
+#define USBUSART2_DMA_RX_CHAN DMA_CHANNEL6
+#define USBUSART2_DMA_RX_IRQ NVIC_DMA1_CHANNEL6_IRQ
+#define USBUSART2_DMA_RX_ISR(x) dma1_channel6_isr(x)
 
 #define TRACE_TIM TIM3
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -61,6 +61,8 @@ int usbuart_debug_write(const char *buf, size_t len);
  * USB cable pull-up: PA8
  * USB VBUS detect:  PB13 -- New on mini design.
  *                           Enable pull up for compatibility.
+ *                           Hardware 4 and older. (we needed the pin for SPI on 5)
+ * 		     PA15 -- Hardware 5 and newer.
  * Force DFU mode button: PB12
  */
 
@@ -96,9 +98,15 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define USB_PU_PORT	GPIOA
 #define USB_PU_PIN	GPIO8
 
+// For HW Rev 4 and older
 #define USB_VBUS_PORT	GPIOB
 #define USB_VBUS_PIN	GPIO13
+// IRQ stays the same for all hw revisions.
 #define USB_VBUS_IRQ	NVIC_EXTI15_10_IRQ
+
+// For HW Rev 5 and newer
+#define USB_VBUS5_PORT	GPIOA
+#define USB_VBUS5_PIN	GPIO15
 
 #define LED_PORT	GPIOB
 #define LED_PORT_UART	GPIOB

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -43,38 +43,38 @@ int usbuart_debug_write(const char *buf, size_t len);
 
 /* Important pin mappings for STM32 implementation:
  *
- * LED0 = 	PB2	(Yellow LED : Running)
- * LED1 = 	PB10	(Yellow LED : Idle)
- * LED2 = 	PB11	(Red LED    : Error)
+ * LED0     = PB2   (Yellow LED : Running)
+ * LED1     = PB10  (Orange LED : Idle)
+ * LED2     = PB11  (Red LED    : Error)
  *
- * TPWR = 	PB0 (input) -- analogue on mini design ADC1, ch8
- * nTRST = 	PB1 (output) [blackmagic]
- * PWR_BR = 	PB1 (output) [blackmagic_mini] -- supply power to the target, active low
- * TMS_DIR =    PA1 (output) [blackmagic_mini v2.1] -- choose direction of the TCK pin, input low, output high
- * SRST_OUT = 	PA2 (output)
- * TDI = 	PA3 (output)
- * TMS = 	PA4 (input/output for SWDIO)
- * TCK = 	PA5 (output SWCLK)
- * TDO = 	PA6 (input)
- * nSRST = 	PA7 (input)
+ * TPWR     = PB0  (input)  -- analogue on mini design ADC1, CH8
+ * nTRST    = PB1  (output) [blackmagic]
+ * PWR_BR   = PB1  (output) [blackmagic_mini] -- supply power to the target, active low
+ * TMS_DIR  = PA1  (output) [blackmagic_mini v2.1] -- choose direction of the TCK pin, input low, output high
+ * SRST_OUT = PA2  (output)
+ * TDI      = PA3  (output)
+ * TMS      = PA4  (input/output for SWDIO)
+ * TCK      = PA5  (output SWCLK)
+ * TDO      = PA6  (input)
+ * nSRST    = PA7  (input)
  *
- * USB cable pull-up: PA8
- * USB VBUS detect:  PB13 -- New on mini design.
- *                           Enable pull up for compatibility.
- *                           Hardware 4 and older. (we needed the pin for SPI on 5)
- * 		     PA15 -- Hardware 5 and newer.
- * Force DFU mode button: PB12
+ * USB_PU   = PA8  (output)
+ * USB_VBUS = PB13 (input)  -- New on mini design.
+ *                             Enable pull up for compatibility.
+ *                             Hardware 4 and older. (we needed the pin for SPI on 5)
+ * 	          PA15 (input)  -- Hardware 5 and newer.
+ * BTN1     = PB12 (input)  -- Force DFU bootloader when pressed during powerup.
  *
  * AUX Interface:
- * SCLK =       PB13
- * COPI =       PB15
- * CIPO =       PB14
- * FLASH_CS =   PB5
- * DISPLAY_CS = PB6
- * DISPLAY_DC = PB8
- * BTN1 =       PB12
- * BTN2 =       PB9
- * VBAT =       PA0 (ADC CH0)
+ * SCLK       = PB13 (output)
+ * COPI       = PB15 (output)
+ * CIPO       = PB14 (input)
+ * FLASH_CS   = PB5  (output)
+ * DISPLAY_CS = PB6  (output)
+ * DISPLAY_DC = PB8  (output)
+ * BTN1       = PB12 (input)  -- Shared with the DFU bootloader button
+ * BTN2       = PB9  (input)
+ * VBAT       = PA0  (input)  -- Battery voltage sense ADC2, CH0
  */
 
 /* Hardware definitions... */

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -41,6 +41,12 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define PLATFORM_IDENT          " "
 #define UPD_IFACE_STRING        "@Internal Flash   /0x08000000/8*001Kg"
 
+/* Hardware version switcher helper
+ * when the hardware version is smaller than ver
+ * it outputs opt1, otherwise opt2 */
+#define HW_SWITCH(ver, opt1, opt2) \
+	((platform_hwversion() < (ver))?(opt1):(opt2))
+
 /* Important pin mappings for STM32 implementation:
  *
  * LED0     = PB2   (Yellow LED : Running)
@@ -51,26 +57,46 @@ int usbuart_debug_write(const char *buf, size_t len);
  * nTRST    = PB1  (output) [blackmagic]
  * PWR_BR   = PB1  (output) [blackmagic_mini] -- supply power to the target, active low
  * TMS_DIR  = PA1  (output) [blackmagic_mini v2.1] -- choose direction of the TCK pin, input low, output high
- * SRST_OUT = PA2  (output)
- * TDI      = PA3  (output)
+ * SRST_OUT = PA2  (output) -- Hardware 5 and older
+ *          = PA9  (output) -- Hardware 6 and newer
+ * TDI      = PA3  (output) -- Hardware 5 and older
+ *          = PA7  (output) -- Hardware 6 and newer
  * TMS      = PA4  (input/output for SWDIO)
  * TCK      = PA5  (output SWCLK)
  * TDO      = PA6  (input)
- * nSRST    = PA7  (input)
+ * TRACESWO = PB7  (input)  -- To allow trace decoding using USART1
+ *                             Hardware 4 has a normally open jumper between TDO and TRACESWO
+ *                             Hardware 5 has hardwired connection between TDO and TRACESWO
+ *          = PA10 (input)  -- Hardware 6 and newer
+ * nSRST    = PA7  (input)  -- Hardware 5 and older
+ *          = PC13 (input)  -- Hardware 6 and newer
  *
  * USB_PU   = PA8  (output)
  * USB_VBUS = PB13 (input)  -- New on mini design.
  *                             Enable pull up for compatibility.
  *                             Hardware 4 and older. (we needed the pin for SPI on 5)
- * 	          PA15 (input)  -- Hardware 5 and newer.
+ * 	        = PA15 (input)  -- Hardware 5 and newer.
  * BTN1     = PB12 (input)  -- Force DFU bootloader when pressed during powerup.
  *
- * AUX Interface:
+ * UART_TX  = PA9  (output) -- USART1 Hardware 5 and older
+ *          = PA2  (output) -- USART2 Hardware 6 and newer
+ * UART_RX  = PA10 (input)  -- USART1 Hardware 5 and older
+ *          = PA3  (input)  -- USART2 Hardware 6 and newer
+ *
+ * On Board OTG Flash: -- Optional on Hardware 5 and newer, since Hardware 6 can be on the main board
+ * FLASH_CS   = PB5  (output)
  * SCLK       = PB13 (output)
  * COPI       = PB15 (output)
  * CIPO       = PB14 (input)
- * FLASH_CS   = PB5  (output)
- * DISPLAY_CS = PB6  (output)
+ *
+ * AUX Interface: -- Hardware 5 and newer
+ * SCLK       = PB13 (output)
+ * COPI       = PB15 (output)
+ * CIPO       = PB14 (input)
+ * FLASH_CS   = PB5  (output) -- Only Hardware 5
+ * SD_CS      = PB6  (output) -- Hardware 6 and newer
+ * DISPLAY_CS = PB6  (output) -- OnlyHardware 5
+ *            = PB7  (output) -- Hardware 6 and newer
  * DISPLAY_DC = PB8  (output)
  * BTN1       = PB12 (input)  -- Shared with the DFU bootloader button
  * BTN2       = PB9  (input)
@@ -84,7 +110,7 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define TMS_PORT	JTAG_PORT
 #define TCK_PORT	JTAG_PORT
 #define TDO_PORT	JTAG_PORT
-#define TDI_PIN		GPIO3
+#define TDI_PIN		HW_SWITCH(6, GPIO3, GPIO7)
 #define TMS_DIR_PIN	GPIO1
 #define TMS_PIN		GPIO4
 #define TCK_PIN		GPIO5
@@ -102,9 +128,9 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define PWR_BR_PORT	GPIOB
 #define PWR_BR_PIN	GPIO1
 #define SRST_PORT	GPIOA
-#define SRST_PIN	GPIO2
+#define SRST_PIN	HW_SWITCH(6, GPIO2, GPIO9)
 #define SRST_SENSE_PORT	GPIOA
-#define SRST_SENSE_PIN	GPIO7
+#define SRST_SENSE_PIN  HW_SWITCH(6, GPIO7, GPIO13)
 
 #define USB_PU_PORT	GPIOA
 #define USB_PU_PIN	GPIO8
@@ -128,12 +154,20 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define LED_IDLE_RUN	LED_1
 #define LED_ERROR	LED_2
 
-/* AUX Port */
+/* OTG Flash HW Rev 5 and newer */
+#define OTG_PORT       GPIOB
+#define OTG_CS         GPIO5
+#define OTG_SCLK       GPIO13
+#define OTG_COPI       GPIO15
+#define OTG_CIPO       GPIO14
+
+/* AUX Port HW Rev 5 and newer */
 #define AUX_PORT       GPIOB
 #define AUX_SCLK_PORT  AUX_PORT
 #define AUX_COPI_PORT  AUX_PORT
 #define AUX_CIPO_PORT  AUX_PORT
 #define AUX_FCS_PORT   AUX_PORT
+#define AUX_SDCS_PORT  AUX_PORT
 #define AUX_DCS_PORT   AUX_PORT
 #define AUX_DDC_PORT   AUX_PORT
 #define AUX_BTN1_PORT  AUX_PORT
@@ -143,7 +177,9 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define AUX_COPI       GPIO15
 #define AUX_CIPO       GPIO14
 #define AUX_FCS        GPIO5
+#define AUX_SDCS       GPIO6
 #define AUX_DCS        GPIO6
+#define AUX_DCS6       GPIO7
 #define AUX_DDC        GPIO8
 #define AUX_BTN1       GPIO12
 #define AUX_BTN2       GPIO9
@@ -191,23 +227,39 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define IRQ_PRI_USB_VBUS        (14 << 4)
 #define IRQ_PRI_TRACE           (0 << 4)
 
-#define USBUSART USART1
-#define USBUSART_CR1 USART1_CR1
-#define USBUSART_DR USART1_DR
-#define USBUSART_IRQ NVIC_USART1_IRQ
-#define USBUSART_CLK RCC_USART1
+#define USBUSART HW_SWITCH(6, USBUSART1, USBUSART2)
+#define USBUSART_IRQ HW_SWITCH(6, NVIC_USART1_IRQ, NVIC_USART2_IRQ)
+#define USBUSART_CLK HW_SWITCH(6, RCC_USART1, RCC_USART2)
 #define USBUSART_PORT GPIOA
-#define USBUSART_TX_PIN GPIO9
-#define USBUSART_RX_PIN GPIO10
-#define USBUSART_ISR(x) usart1_isr(x)
+#define USBUSART_TX_PIN HW_SWITCH(6, GPIO9, GPIO2)
+#define USBUSART_RX_PIN HW_SWITCH(6, GPIO10, GPIO3)
+
 #define USBUSART_DMA_BUS DMA1
 #define USBUSART_DMA_CLK RCC_DMA1
-#define USBUSART_DMA_TX_CHAN DMA_CHANNEL4
-#define USBUSART_DMA_TX_IRQ NVIC_DMA1_CHANNEL4_IRQ
-#define USBUSART_DMA_TX_ISR(x) dma1_channel4_isr(x)
-#define USBUSART_DMA_RX_CHAN DMA_CHANNEL5
-#define USBUSART_DMA_RX_IRQ NVIC_DMA1_CHANNEL5_IRQ
-#define USBUSART_DMA_RX_ISR(x) dma1_channel5_isr(x)
+#define USBUSART_DMA_TX_CHAN HW_SWITCH(6, USBUSART1_DMA_TX_CHAN, USBUSART2_DMA_TX_CHAN)
+#define USBUSART_DMA_RX_CHAN HW_SWITCH(6, USBUSART1_DMA_RX_CHAN, USBUSART2_DMA_RX_CHAN)
+#define USBUSART_DMA_TX_IRQ HW_SWITCH(6, USBUSART1_DMA_TX_IRQ, USBUSART2_DMA_TX_IRQ)
+#define USBUSART_DMA_RX_IRQ HW_SWITCH(6, USBUSART1_DMA_RX_IRQ, USBUSART2_DMA_RX_IRQ)
+
+#define USBUSART1 USART1
+#define USBUSART1_IRQ NVIC_USART1_IRQ
+#define USBUSART1_ISR(x) usart1_isr(x)
+#define USBUSART1_DMA_TX_CHAN DMA_CHANNEL4
+#define USBUSART1_DMA_TX_IRQ NVIC_DMA1_CHANNEL4_IRQ
+#define USBUSART1_DMA_TX_ISR(x) dma1_channel4_isr(x)
+#define USBUSART1_DMA_RX_CHAN DMA_CHANNEL5
+#define USBUSART1_DMA_RX_IRQ NVIC_DMA1_CHANNEL5_IRQ
+#define USBUSART1_DMA_RX_ISR(x) dma1_channel5_isr(x)
+
+#define USBUSART2 USART2
+#define USBUSART2_IRQ NVIC_USART2_IRQ
+#define USBUSART2_ISR(x) usart2_isr(x)
+#define USBUSART2_DMA_TX_CHAN DMA_CHANNEL6
+#define USBUSART2_DMA_TX_IRQ NVIC_DMA1_CHANNEL6_IRQ
+#define USBUSART2_DMA_TX_ISR(x) dma1_channel6_isr(x)
+#define USBUSART2_DMA_RX_CHAN DMA_CHANNEL7
+#define USBUSART2_DMA_RX_IRQ NVIC_DMA1_CHANNEL7_IRQ
+#define USBUSART2_DMA_RX_ISR(x) dma1_channel7_isr(x)
 
 #define TRACE_TIM TIM3
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -64,6 +64,17 @@ int usbuart_debug_write(const char *buf, size_t len);
  *                           Hardware 4 and older. (we needed the pin for SPI on 5)
  * 		     PA15 -- Hardware 5 and newer.
  * Force DFU mode button: PB12
+ *
+ * AUX Interface:
+ * SCLK =       PB13
+ * COPI =       PB15
+ * CIPO =       PB14
+ * FLASH_CS =   PB5
+ * DISPLAY_CS = PB6
+ * DISPLAY_DC = PB8
+ * BTN1 =       PB12
+ * BTN2 =       PB9
+ * VBAT =       PA0 (ADC CH0)
  */
 
 /* Hardware definitions... */
@@ -98,13 +109,13 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define USB_PU_PORT	GPIOA
 #define USB_PU_PIN	GPIO8
 
-// For HW Rev 4 and older
+/* For HW Rev 4 and older */
 #define USB_VBUS_PORT	GPIOB
 #define USB_VBUS_PIN	GPIO13
-// IRQ stays the same for all hw revisions.
+/* IRQ stays the same for all hw revisions. */
 #define USB_VBUS_IRQ	NVIC_EXTI15_10_IRQ
 
-// For HW Rev 5 and newer
+/* For HW Rev 5 and newer */
 #define USB_VBUS5_PORT	GPIOA
 #define USB_VBUS5_PIN	GPIO15
 
@@ -116,6 +127,27 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define LED_UART	LED_0
 #define LED_IDLE_RUN	LED_1
 #define LED_ERROR	LED_2
+
+/* AUX Port */
+#define AUX_PORT       GPIOB
+#define AUX_SCLK_PORT  AUX_PORT
+#define AUX_COPI_PORT  AUX_PORT
+#define AUX_CIPO_PORT  AUX_PORT
+#define AUX_FCS_PORT   AUX_PORT
+#define AUX_DCS_PORT   AUX_PORT
+#define AUX_DDC_PORT   AUX_PORT
+#define AUX_BTN1_PORT  AUX_PORT
+#define AUX_BTN2_PORT  AUX_PORT
+#define AUX_VBAT_PORT  GPIOA
+#define AUX_SCLK       GPIO13
+#define AUX_COPI       GPIO15
+#define AUX_CIPO       GPIO14
+#define AUX_FCS        GPIO5
+#define AUX_DCS        GPIO6
+#define AUX_DDC        GPIO8
+#define AUX_BTN1       GPIO12
+#define AUX_BTN2       GPIO9
+#define AUX_VBAT       GPIO0
 
 # define SWD_CR   GPIO_CRL(SWDIO_PORT)
 # define SWD_CR_MULT (1 << (4 << 2))

--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -274,7 +274,8 @@ void usbuart_usb_out_cb(usbd_device *dev, uint8_t ep)
 	/* Don't bother if uart is disabled.
 	 * This will be the case on mini while we're being debugged.
 	 */
-	if(!(RCC_APB2ENR & RCC_APB2ENR_USART1EN))
+	if(!(RCC_APB2ENR & RCC_APB2ENR_USART1EN) &&
+	   !(RCC_APB1ENR & RCC_APB1ENR_USART2EN))
 	{
 		usbd_ep_nak_set(dev, CDCACM_UART_ENDPOINT, 0);
 		return;

--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -407,7 +407,7 @@ static void usbuart_run(void)
 }
 
 #if defined(USART_ICR)
-#define USBUSART_ISR_TEMPLATE(USART, DMA_IRQ)				\
+#define USBUSART_ISR_TEMPLATE(USART, DMA_IRQ) do {			\
 	nvic_disable_irq(DMA_IRQ);					\
 									\
 	/* Get IDLE flag and reset interrupt flags */ 			\
@@ -420,9 +420,10 @@ static void usbuart_run(void)
 		usbuart_run();						\
 	}								\
 									\
-	nvic_enable_irq(DMA_IRQ);
+	nvic_enable_irq(DMA_IRQ);					\
+} while(0)
 #else
-#define USBUSART_ISR_TEMPLATE(USART, DMA_IRQ)				\
+#define USBUSART_ISR_TEMPLATE(USART, DMA_IRQ) do {			\
 	nvic_disable_irq(DMA_IRQ);					\
 									\
 	/* Get IDLE flag and reset interrupt flags */ 			\
@@ -437,7 +438,8 @@ static void usbuart_run(void)
 		usbuart_run();						\
 	}								\
 									\
-	nvic_enable_irq(DMA_IRQ)
+	nvic_enable_irq(DMA_IRQ);					\
+} while(0)
 #endif
 
 #if defined(USBUSART_ISR)
@@ -473,7 +475,7 @@ void USBUSART2_ISR(void)
 }
 #endif
 
-#define USBUSART_DMA_TX_ISR_TEMPLATE(DMA_TX_CHAN) \
+#define USBUSART_DMA_TX_ISR_TEMPLATE(DMA_TX_CHAN) do {				\
 	nvic_disable_irq(USB_IRQ);						\
 										\
 	/* Stop DMA */								\
@@ -494,7 +496,8 @@ void USBUSART2_ISR(void)
 		tx_trfr_cplt = true;						\
 	}									\
 										\
-	nvic_enable_irq(USB_IRQ)
+	nvic_enable_irq(USB_IRQ);						\
+} while(0)
 
 #if defined(USBUSART_DMA_TX_ISR)
 void USBUSART_DMA_TX_ISR(void)
@@ -524,7 +527,7 @@ void USBUSART_DMA_TX_ISR(void)
 }
 #endif
 
-#define USBUSART_DMA_RX_ISR_TEMPLATE(USART_IRQ, DMA_RX_CHAN)			\
+#define USBUSART_DMA_RX_ISR_TEMPLATE(USART_IRQ, DMA_RX_CHAN) do {		\
 	nvic_disable_irq(USART_IRQ);						\
 										\
 	/* Clear flags */							\
@@ -532,7 +535,8 @@ void USBUSART_DMA_TX_ISR(void)
 	/* Transmit a packet */							\
 	usbuart_run();								\
 										\
-	nvic_enable_irq(USART_IRQ)
+	nvic_enable_irq(USART_IRQ);						\
+} while(0)
 
 #if defined(USBUSART_DMA_RX_ISR)
 void USBUSART_DMA_RX_ISR(void)


### PR DESCRIPTION
This patch set adds detection and support of native Hardware V4, 5 and 6.

This version is different than PCB revisions. This is the hardware version that used to be encoded using GPIO strapping. Now these versions are stored in user option bytes of the STM32. This future proves us and is making more GPIO available to add new features.

For the fun of it, here is a picture showing a selection of the different native Black Magic Probes throughout history.
![black-magic-hardware-versions-w-legend](https://user-images.githubusercontent.com/17334/158525988-2f44bb9b-b921-47b6-97c7-4801c6fab53a.jpg)

Before this is merged we need to test this patch on all the past hardware to hopefully avoid regression and issues:
* [x] V0 SWD tested
* [x] V0 JTAG tested
* [ ] V1 SWD tested
* [ ] V1 JTAG tested
* [x] V1 UART tested
* [x] V2 SWD tested
* [x] V2 JTAG tested
* [x] V2 UART tested
* [x] V3 SWD tested
* [x] V3 JTAG tested
* [x] V3 UART tested
* [x] V4 SWD tested
* [x] V4 JTAG tested
* [x] V4 UART tested
* [x] V5 SWD tested
* [x] V5 JTAG tested
* [x] V5 UART tested
* [x] V6 SWD tested
* [x] V6 JTAG tested
* [x] V6 UART tested