### PR TITLE
Reduce stack usage

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -56,7 +56,6 @@ static target *last_target;
 static void handle_q_packet(char *packet, int len);
 static void handle_v_packet(char *packet, int len);
 static void handle_z_packet(char *packet, int len);
-
 static void gdb_target_destroy_callback(struct target_controller *tc, target *t)
 {
 	(void)tc;
@@ -330,101 +329,154 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 	}
 }
 
-static void
-handle_q_string_reply(const char *str, const char *param)
+static void handle_q_string_reply(const char *str, const char *param)
 {
 	unsigned long addr, len;
 
-	if (sscanf(param, "%08lx,%08lx", &addr, &len) != 2) {
+	if (sscanf(param, "%08lx,%08lx", &addr, &len) != 2)
+  {
 		gdb_putpacketz("E01");
 		return;
 	}
-	if (addr < strlen (str)) {
-		char reply[len+2];
-		reply[0] = 'm';
-		strncpy (reply + 1, &str[addr], len);
-		if(len > strlen(&str[addr]))
-			len = strlen(&str[addr]);
-		gdb_putpacket(reply, len + 1);
-	} else if (addr == strlen (str)) {
-		gdb_putpacketz("l");
-	} else
-		gdb_putpacketz("E01");
+  if (addr > strlen (str))
+  {
+    	gdb_putpacketz("E01");
+      return;
+  }
+  if(addr== strlen (str))
+  {
+    	gdb_putpacketz("l");
+      return;
+  }
+  unsigned long int outputLen=strlen(str)-addr;
+  if(outputLen>len) outputLen=len;
+  gdb_putpacket2("m",1,str+addr,outputLen);
 }
 
-static void
-handle_q_packet(char *packet, int len)
+typedef struct
 {
-	uint32_t addr, alen;
+    const char *cmdPrefix;
+    void  (*func)(char *packet,int len);
+}cmdExecuter;
+//---
+static void execqRcmd(char *packet,int len)
+{
+  char *data;
+  int datalen;
 
-	if(!strncmp(packet, "qRcmd,", 6)) {
-		char *data;
-		int datalen;
+  /* calculate size and allocate buffer for command */
+  datalen = len/ 2;
+  data = alloca(datalen+1);
+  /* dehexify command */
+  unhexify(data, packet, datalen);
+  data[datalen] = 0;	/* add terminating null */
 
-		/* calculate size and allocate buffer for command */
-		datalen = (len - 6) / 2;
-		data = alloca(datalen+1);
-		/* dehexify command */
-		unhexify(data, packet+6, datalen);
-		data[datalen] = 0;	/* add terminating null */
-
-		int c = command_process(cur_target, data);
-		if(c < 0)
-			gdb_putpacketz("");
-		else if(c == 0)
-			gdb_putpacketz("OK");
-		else
-			gdb_putpacket(hexify(pbuf, "Failed\n", strlen("Failed\n")),
-						  2 * strlen("Failed\n"));
-
-	} else if (!strncmp (packet, "qSupported", 10)) {
-		/* Query supported protocol features */
-		gdb_putpacket_f("PacketSize=%X;qXfer:memory-map:read+;qXfer:features:read+", BUF_SIZE);
-
-	} else if (strncmp (packet, "qXfer:memory-map:read::", 23) == 0) {
-		/* Read target XML memory map */
-		if((!cur_target) && last_target) {
-			/* Attach to last target if detached. */
-			cur_target = target_attach(last_target,
-						   &gdb_controller);
-		}
-		if (!cur_target) {
-			gdb_putpacketz("E01");
-			return;
-		}
-		char buf[1024];
-		target_mem_map(cur_target, buf, sizeof(buf)); /* Fixme: Check size!*/
-		handle_q_string_reply(buf, packet + 23);
-
-	} else if (strncmp (packet, "qXfer:features:read:target.xml:", 31) == 0) {
-		/* Read target description */
-		if((!cur_target) && last_target) {
-			/* Attach to last target if detached. */
-			cur_target = target_attach(last_target,
-						   &gdb_controller);
-		}
-		if (!cur_target) {
-			gdb_putpacketz("E01");
-			return;
-		}
-		handle_q_string_reply(target_tdesc(cur_target), packet + 31);
-	} else if (sscanf(packet, "qCRC:%" PRIx32 ",%" PRIx32, &addr, &alen) == 2) {
-		if(!cur_target) {
-			gdb_putpacketz("E01");
-			return;
-		}
-		uint32_t crc;
-		int res = generic_crc32(cur_target, &crc, addr, alen);
-		if (res)
-			gdb_putpacketz("E03");
-		else
-			gdb_putpacket_f("C%lx", crc);
-
-	} else {
-		DEBUG_GDB("*** Unsupported packet: %s\n", packet);
-		gdb_putpacket("", 0);
-	}
+  int c = command_process(cur_target, data);
+  if(c < 0)
+    gdb_putpacketz("");
+  else if(c == 0)
+    gdb_putpacketz("OK");
+  else
+    gdb_putpacket(hexify(pbuf, "Failed\n", strlen("Failed\n")),
+            2 * strlen("Failed\n"));
 }
+static void execqSupported(char *packet, int len)
+{
+    (void)(packet);
+    (void)(len);
+  	gdb_putpacket_f("PacketSize=%X;qXfer:memory-map:read+;qXfer:features:read+", BUF_SIZE);
+}
+extern  char *ztarget_mem_map(const target *t);
+static void execqMemoryMap(char *packet,int len)
+{
+    (void)(len);
+    /* Read target XML memory map */
+    if((!cur_target) && last_target) {
+    	/* Attach to last target if detached. */
+    	cur_target = target_attach(last_target,
+    				   &gdb_controller);
+    }
+ 		if (!cur_target) {
+ 			gdb_putpacketz("E01");
+ 			return;
+ 		}
+
+    //ok, grab the full reply
+    char buf[1024];
+    target_mem_map(cur_target, buf, sizeof(buf)); /* Fixme: Check size!*/
+    handle_q_string_reply(buf,packet);
+}
+
+static void execqFeatureRead(char *packet, int len)
+{
+  (void)(len);
+  /* Read target description */
+  if((!cur_target) && last_target) {
+    /* Attach to last target if detached. */
+    cur_target = target_attach(last_target, &gdb_controller);
+  }
+  if (!cur_target) {
+    gdb_putpacketz("E01");
+    return;
+  }
+  handle_q_string_reply(target_tdesc(cur_target), packet );
+}
+
+static void execqCRC(char *packet, int len)
+{
+  uint32_t addr, alen;
+  (void)(len);
+  if (sscanf(packet, "%" PRIx32 ",%" PRIx32, &addr, &alen) == 2) {
+   if(!cur_target) {
+     gdb_putpacketz("E01");
+     return;
+   }
+   uint32_t crc;
+   int res = generic_crc32(cur_target, &crc, addr, alen);
+   if (res)
+     gdb_putpacketz("E03");
+   else
+     gdb_putpacket_f("C%lx", crc);
+  }
+}
+//----
+static const cmdExecuter qCommands[]=
+{
+    {"qRcmd,",                         execqRcmd},
+    {"qSupported",                     execqSupported},
+    {"qXfer:memory-map:read::",        execqMemoryMap},
+    {"qXfer:features:read:target.xml:",execqFeatureRead},
+    {"qCRC:"                          ,execqCRC},
+    {NULL,NULL},
+};
+/**
+
+*/
+bool execCommand(char *packet, int len, const cmdExecuter *exec)
+{
+  while(exec->cmdPrefix)
+  {
+      int l=strlen(exec->cmdPrefix);
+      if(!strncmp(packet,exec->cmdPrefix,l))
+      {
+        exec->func(packet+l,len-l);
+        return true;
+      }
+      exec++;
+  }
+  return false;
+}
+
+static void handle_q_packet(char *packet, int len)
+{
+  if(execCommand(packet,len,qCommands))
+  {
+    return;
+  }
+	DEBUG_GDB("*** Unsupported packet: %s\n", packet);
+	gdb_putpacket("", 0);
+}
+
 
 static void
 handle_v_packet(char *packet, int plen)

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -160,7 +160,6 @@ void gdb_putpacket2(const char *packet1, int size1,const char *packet2, int size
 {
 	int i;
 	unsigned char csum;
-	unsigned char c;
 	char xmit_csum[3];
 	int tries = 0;
 
@@ -185,7 +184,6 @@ void gdb_putpacket(const char *packet, int size)
 {
 	int i;
 	unsigned char csum;
-	unsigned char c;
 	char xmit_csum[3];
 	int tries = 0;
 

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -138,6 +138,49 @@ int gdb_getpacket(char *packet, int size)
 	return i;
 }
 
+static void gdb_next_char(char c, unsigned char *csum)
+{
+  #if PC_HOSTED == 1
+    if ((c >= 32) && (c < 127))
+      DEBUG_GDB_WIRE("%c", c);
+    else
+      DEBUG_GDB_WIRE("\\x%02X", c);
+  #endif
+    if((c == '$') || (c == '#') || (c == '}') || (c == '*')) {
+      gdb_if_putchar('}', 0);
+      gdb_if_putchar(c ^ 0x20, 0);
+      *csum += '}' + (c ^ 0x20);
+    } else {
+      gdb_if_putchar(c, 0);
+      *csum += c;
+    }
+}
+
+void gdb_putpacket2(const char *packet1, int size1,const char *packet2, int size2)
+{
+	int i;
+	unsigned char csum;
+	unsigned char c;
+	char xmit_csum[3];
+	int tries = 0;
+
+	do {
+		DEBUG_GDB_WIRE("%s : ", __func__);
+		csum = 0;
+		gdb_if_putchar('$', 0);
+
+    for(i = 0; i < size1; i++)
+        gdb_next_char( packet1[i],&csum);
+    for(i = 0; i < size2; i++)
+        gdb_next_char( packet2[i],&csum);
+
+		gdb_if_putchar('#', 0);
+		snprintf(xmit_csum, sizeof(xmit_csum), "%02X", csum);
+		gdb_if_putchar(xmit_csum[0], 0);
+		gdb_if_putchar(xmit_csum[1], 1);
+		DEBUG_GDB_WIRE("\n");
+	} while((gdb_if_getchar_to(2000) != '+') && (tries++ < 3));
+}
 void gdb_putpacket(const char *packet, int size)
 {
 	int i;
@@ -150,23 +193,8 @@ void gdb_putpacket(const char *packet, int size)
 		DEBUG_GDB_WIRE("%s : ", __func__);
 		csum = 0;
 		gdb_if_putchar('$', 0);
-		for(i = 0; i < size; i++) {
-			c = packet[i];
-#if PC_HOSTED == 1
-			if ((c >= 32) && (c < 127))
-				DEBUG_GDB_WIRE("%c", c);
-			else
-				DEBUG_GDB_WIRE("\\x%02X", c);
-#endif
-			if((c == '$') || (c == '#') || (c == '}') || (c == '*')) {
-				gdb_if_putchar('}', 0);
-				gdb_if_putchar(c ^ 0x20, 0);
-				csum += '}' + (c ^ 0x20);
-			} else {
-				gdb_if_putchar(c, 0);
-				csum += c;
-			}
-		}
+		for(i = 0; i < size; i++)
+      gdb_next_char(packet[i],&csum);
 		gdb_if_putchar('#', 0);
 		snprintf(xmit_csum, sizeof(xmit_csum), "%02X", csum);
 		gdb_if_putchar(xmit_csum[0], 0);

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -25,6 +25,7 @@
 
 int gdb_getpacket(char *packet, int size);
 void gdb_putpacket(const char *packet, int size);
+void gdb_putpacket2(const char *packet1, int size1,const char *packet2, int size2);
 #define gdb_putpacketz(packet) gdb_putpacket((packet), strlen(packet))
 void gdb_putpacket_f(const char *packet, ...);
 
@@ -33,5 +34,3 @@ void gdb_voutf(const char *fmt, va_list);
 void gdb_outf(const char *fmt, ...);
 
 #endif
-
-

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -67,6 +67,7 @@ bool firmware_dp_low_write(ADIv5_DP_t *dp, uint16_t addr, const uint32_t data)
  */
 int adiv5_swdp_scan(uint32_t targetid)
 {
+  volatile struct exception e;
 	target_list_free();
 	ADIv5_DP_t idp = {
 		.dp_low_write = firmware_dp_low_write,
@@ -97,7 +98,7 @@ int adiv5_swdp_scan(uint32_t targetid)
 		/* No targetID given on the command line or probe can not
 		 * handle multi-drop. Try to read ID */
 		dp_line_reset(initial_dp);
-		volatile struct exception e;
+
 		TRY_CATCH (e, EXCEPTION_ALL) {
 			idcode = initial_dp->dp_read(initial_dp, ADIV5_DP_IDCODE);
 		}
@@ -109,11 +110,11 @@ int adiv5_swdp_scan(uint32_t targetid)
 			initial_dp->seq_out(0xE79E, 16); /* 0b0111100111100111 */
 			dp_line_reset(initial_dp);
 			initial_dp->fault = 0;
-			volatile struct exception e2;
-			TRY_CATCH (e2, EXCEPTION_ALL) {
+
+			TRY_CATCH (e, EXCEPTION_ALL) {
 				idcode = initial_dp->dp_read(initial_dp, ADIV5_DP_IDCODE);
 			}
-			if (e2.type || initial_dp->fault) {
+			if (e.type || initial_dp->fault) {
 				DEBUG_WARN("No usable DP found\n");
 				return -1;
 			}
@@ -150,7 +151,6 @@ int adiv5_swdp_scan(uint32_t targetid)
 			dp_targetid = (i << 28) | (target_id & 0x0fffffff);
 			initial_dp->dp_low_write(initial_dp, ADIV5_DP_TARGETSEL,
 									dp_targetid);
-			volatile struct exception e;
 			TRY_CATCH (e, EXCEPTION_ALL) {
 				idcode = initial_dp->dp_read(initial_dp, ADIV5_DP_IDCODE);
 			}


### PR DESCRIPTION
Hi,
This a request for comments on the following changes to see if it's worth cleaning and submitting  (they are probably not following the coding standard for the moment , i.e. evil tab vs nice space etc...). 
As a result the indentation is all over the place for now, sorry for that.

The main aim is to reduce the stack usage which  is high at the moment 
The patch contains several sub changes :

- reuse the exception when they dont stack, gain of ~ 140 bytes on the stack
- split the commands beginning by q into a command engine to have several smaller functions for simplicity/clarity sake
(the same can be done for 'v' commands)
- Add a gdb_put_packet2(a,b) function that sends a packet made of 2 sub packets
- Use the above to avoid duplicating the data on the stack for the memory map /xml commands, i.e. the above is used to add the 'm' in front of the reply without having to duplicate.

I have another one i need to change before submitting where  the memory map reply is built using auto growing heap allocatio instead of the 1024 bytes allocated on the stack in the main code.

Thank you
Ps: I had to patch locally the conflicting USBUSART_DMA_TX_ISR locally when used for swlink as there seems to be a duplicate define there