### PR TITLE
Reduce stack usage, Take 2

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -350,7 +350,7 @@ bool exec_command(char *packet, int len, const cmd_executer *exec)
 	return false;
 }
 
-static void exec_qRcmd(const char *packet,int len)
+static void exec_q_rcmd(const char *packet,int len)
 {
 char *data;
 int datalen;
@@ -393,14 +393,14 @@ handle_q_string_reply(const char *str, const char *param)
 	if(output_len>len) output_len=len;
 	gdb_putpacket2("m",1,str+addr,output_len);
 }
-static void exec_qSupported(const char *packet, int len)
+static void exec_q_supported(const char *packet, int len)
 {
 	(void)packet;
 	(void)len;
 	gdb_putpacket_f("PacketSize=%X;qXfer:memory-map:read+;qXfer:features:read+", BUF_SIZE);
 }
 
-static void exec_qMemoryMap(const char *packet,int len)
+static void exec_q_memory_map(const char *packet,int len)
 {
 	(void)packet;
 	(void)len;
@@ -419,7 +419,7 @@ static void exec_qMemoryMap(const char *packet,int len)
 	handle_q_string_reply(buf, packet);
 }
 
-static void exec_qFeatureRead(const char *packet, int len)
+static void exec_q_feature_read(const char *packet, int len)
 {
 	(void)len;
 	/* Read target description */
@@ -434,7 +434,7 @@ static void exec_qFeatureRead(const char *packet, int len)
 	handle_q_string_reply(target_tdesc(cur_target), packet );
 }
 
-static void exec_qCRC(const char *packet, int len)
+static void exec_q_crc(const char *packet, int len)
 {
 	(void)len;
 	uint32_t addr, alen;
@@ -453,11 +453,11 @@ static void exec_qCRC(const char *packet, int len)
 }
 static const cmd_executer q_commands[]=
 {
-	{"qRcmd,",                         exec_qRcmd},
-	{"qSupported",                     exec_qSupported},
-	{"qXfer:memory-map:read::",        exec_qMemoryMap},
-	{"qXfer:features:read:target.xml:",exec_qFeatureRead},
-	{"qCRC:",                          exec_qCRC},
+	{"qRcmd,",                         exec_q_rcmd},
+	{"qSupported",                     exec_q_supported},
+	{"qXfer:memory-map:read::",        exec_q_memory_map},
+	{"qXfer:features:read:target.xml:",exec_q_feature_read},
+	{"qCRC:",                          exec_q_crc},
 
 	{NULL,NULL},
 };

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -160,7 +160,6 @@ void gdb_putpacket2(const char *packet1, int size1,const char *packet2, int size
 {
 	int i;
 	unsigned char csum;
-	unsigned char c;
 	char xmit_csum[3];
 	int tries = 0;
 
@@ -185,7 +184,6 @@ void gdb_putpacket(const char *packet, int size)
 {
 	int i;
 	unsigned char csum;
-	unsigned char c;
 	char xmit_csum[3];
 	int tries = 0;
 
@@ -219,7 +217,6 @@ void gdb_putpacket_f(const char *fmt, ...)
 void gdb_out(const char *buf)
 {
 	char *hexdata;
-	int i;
 
 	int l=strlen(buf);
 	hexdata = alloca(2*l+1);

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -138,6 +138,49 @@ int gdb_getpacket(char *packet, int size)
 	return i;
 }
 
+static void gdb_next_char(char c, unsigned char *csum)
+{
+  #if PC_HOSTED == 1
+    if ((c >= 32) && (c < 127))
+      DEBUG_GDB_WIRE("%c", c);
+    else
+      DEBUG_GDB_WIRE("\\x%02X", c);
+  #endif
+    if((c == '$') || (c == '#') || (c == '}') || (c == '*')) {
+      gdb_if_putchar('}', 0);
+      gdb_if_putchar(c ^ 0x20, 0);
+      *csum += '}' + (c ^ 0x20);
+    } else {
+      gdb_if_putchar(c, 0);
+      *csum += c;
+    }
+}
+
+void gdb_putpacket2(const char *packet1, int size1,const char *packet2, int size2)
+{
+	int i;
+	unsigned char csum;
+	unsigned char c;
+	char xmit_csum[3];
+	int tries = 0;
+
+	do {
+		DEBUG_GDB_WIRE("%s : ", __func__);
+		csum = 0;
+		gdb_if_putchar('$', 0);
+
+		for(i = 0; i < size1; i++)
+			gdb_next_char( packet1[i],&csum);
+		for(i = 0; i < size2; i++)
+			gdb_next_char( packet2[i],&csum);
+
+		gdb_if_putchar('#', 0);
+		snprintf(xmit_csum, sizeof(xmit_csum), "%02X", csum);
+		gdb_if_putchar(xmit_csum[0], 0);
+		gdb_if_putchar(xmit_csum[1], 1);
+		DEBUG_GDB_WIRE("\n");
+	} while((gdb_if_getchar_to(2000) != '+') && (tries++ < 3));
+}
 void gdb_putpacket(const char *packet, int size)
 {
 	int i;
@@ -150,23 +193,8 @@ void gdb_putpacket(const char *packet, int size)
 		DEBUG_GDB_WIRE("%s : ", __func__);
 		csum = 0;
 		gdb_if_putchar('$', 0);
-		for(i = 0; i < size; i++) {
-			c = packet[i];
-#if PC_HOSTED == 1
-			if ((c >= 32) && (c < 127))
-				DEBUG_GDB_WIRE("%c", c);
-			else
-				DEBUG_GDB_WIRE("\\x%02X", c);
-#endif
-			if((c == '$') || (c == '#') || (c == '}') || (c == '*')) {
-				gdb_if_putchar('}', 0);
-				gdb_if_putchar(c ^ 0x20, 0);
-				csum += '}' + (c ^ 0x20);
-			} else {
-				gdb_if_putchar(c, 0);
-				csum += c;
-			}
-		}
+		for(i = 0; i < size; i++)
+			gdb_next_char(packet[i],&csum);
 		gdb_if_putchar('#', 0);
 		snprintf(xmit_csum, sizeof(xmit_csum), "%02X", csum);
 		gdb_if_putchar(xmit_csum[0], 0);
@@ -193,10 +221,10 @@ void gdb_out(const char *buf)
 	char *hexdata;
 	int i;
 
-	hexdata = alloca((i = strlen(buf)*2 + 1) + 1);
-	hexdata[0] = 'O';
-	hexify(hexdata+1, buf, strlen(buf));
-	gdb_putpacket(hexdata, i);
+	int l=strlen(buf);
+	hexdata = alloca(2*l+1);
+	hexify(hexdata, buf, l);
+	gdb_putpacket2("O",1,hexdata, 2*l);
 }
 
 void gdb_voutf(const char *fmt, va_list ap)

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -25,6 +25,7 @@
 
 int gdb_getpacket(char *packet, int size);
 void gdb_putpacket(const char *packet, int size);
+void gdb_putpacket2(const char *packet1, int size1,const char *packet2, int size2);
 #define gdb_putpacketz(packet) gdb_putpacket((packet), strlen(packet))
 void gdb_putpacket_f(const char *packet, ...);
 

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -115,7 +115,7 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define USBUSART_DMA_CLK RCC_DMA1
 #define USBUSART_DMA_TX_CHAN DMA_CHANNEL4
 #define USBUSART_DMA_TX_IRQ NVIC_DMA1_CHANNEL4_IRQ
-#define USBUSART_DMA_TX_ISR(x) dma1_channel4_isr(x)
+//#define USBUSART_DMA_TX_ISR(x) dma1_channel4_isr(x)
 #define USBUSART_DMA_RX_CHAN DMA_CHANNEL5
 #define USBUSART_DMA_RX_IRQ NVIC_DMA1_CHANNEL5_IRQ
 #define USBUSART_DMA_RX_ISR(x) dma1_channel5_isr(x)

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -115,7 +115,7 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define USBUSART_DMA_CLK RCC_DMA1
 #define USBUSART_DMA_TX_CHAN DMA_CHANNEL4
 #define USBUSART_DMA_TX_IRQ NVIC_DMA1_CHANNEL4_IRQ
-//#define USBUSART_DMA_TX_ISR(x) dma1_channel4_isr(x)
+#define USBUSART_DMA_TX_ISR(x) dma1_channel4_isr(x)
 #define USBUSART_DMA_RX_CHAN DMA_CHANNEL5
 #define USBUSART_DMA_RX_IRQ NVIC_DMA1_CHANNEL5_IRQ
 #define USBUSART_DMA_RX_ISR(x) dma1_channel5_isr(x)

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -67,6 +67,7 @@ bool firmware_dp_low_write(ADIv5_DP_t *dp, uint16_t addr, const uint32_t data)
  */
 int adiv5_swdp_scan(uint32_t targetid)
 {
+	volatile struct exception e;
 	target_list_free();
 	ADIv5_DP_t idp = {
 		.dp_low_write = firmware_dp_low_write,
@@ -97,7 +98,7 @@ int adiv5_swdp_scan(uint32_t targetid)
 		/* No targetID given on the command line or probe can not
 		 * handle multi-drop. Try to read ID */
 		dp_line_reset(initial_dp);
-		volatile struct exception e;
+
 		TRY_CATCH (e, EXCEPTION_ALL) {
 			idcode = initial_dp->dp_read(initial_dp, ADIV5_DP_IDCODE);
 		}
@@ -109,11 +110,11 @@ int adiv5_swdp_scan(uint32_t targetid)
 			initial_dp->seq_out(0xE79E, 16); /* 0b0111100111100111 */
 			dp_line_reset(initial_dp);
 			initial_dp->fault = 0;
-			volatile struct exception e2;
-			TRY_CATCH (e2, EXCEPTION_ALL) {
+
+			TRY_CATCH (e, EXCEPTION_ALL) {
 				idcode = initial_dp->dp_read(initial_dp, ADIV5_DP_IDCODE);
 			}
-			if (e2.type || initial_dp->fault) {
+			if (e.type || initial_dp->fault) {
 				DEBUG_WARN("No usable DP found\n");
 				return -1;
 			}
@@ -150,7 +151,6 @@ int adiv5_swdp_scan(uint32_t targetid)
 			dp_targetid = (i << 28) | (target_id & 0x0fffffff);
 			initial_dp->dp_low_write(initial_dp, ADIV5_DP_TARGETSEL,
 									dp_targetid);
-			volatile struct exception e;
 			TRY_CATCH (e, EXCEPTION_ALL) {
 				idcode = initial_dp->dp_read(initial_dp, ADIV5_DP_IDCODE);
 			}


### PR DESCRIPTION
Hi
I tried to incorporate the comments, except one :  i let the qRcmd suffix etc... because they are  the actual name of the command i.e.  "qRcmd" => exec_qRcmd(), "qCRC"' => exec_qCRC etc.... I find that much easier to deal with, just search for the command.

Assuming i didnt break anything (had to backport manually things from my working tree), there are 2 follow ups coming : 

1- Construct the memory map using the heap (+autorealloc) instead of 1k on the heap.  I have to backport it from C++ to C.
2- For arm,  the exception allocation is the default arm one i.e. 23 reg x 4 bytes. But cortex m0(+), m3, m4 etc.. are thumb(2) only, so only 10 registers. 120 bytes => 40 bytes, if/when exceptions stack, that makes a difference.

BTW, Is there a .clang-format available to format things properly before submitting ?
Thanks



