### PR TITLE
Remove duplicate definition of USBUSART_DMA_TX_ISR

### DIFF
--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -521,13 +521,6 @@ void USBUSART2_DMA_TX_ISR(void)
 }
 #endif
 
-#if defined(USBUSART_DMA_TX_ISR)
-void USBUSART_DMA_TX_ISR(void)
-{
-	USBUSART_DMA_TX_ISR_TEMPLATE(USBUSART_DMA_TX_CHAN);
-}
-#endif
-
 #define USBUSART_DMA_RX_ISR_TEMPLATE(USART_IRQ, DMA_RX_CHAN) do {		\
 	nvic_disable_irq(USART_IRQ);						\
 										\


### PR DESCRIPTION
Fixing #999.

It looks safe for all platforms because it's literally a duplicate copy of another definition of the same function a few lines above.
