### PR TITLE
Fix for SWD regression - scan retry failure

### DIFF
--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -85,7 +85,7 @@ uint32_t fw_adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 
 	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, APnDP ? IR_APACC : IR_DPACC);
 
-	platform_timeout_set(&timeout, 20);
+	platform_timeout_set(&timeout, 250);
 	do {
 		jtag_dev_shift_dr(&jtag_proc, dp->dp_jd_index, (uint8_t*)&response,
 						  (uint8_t*)&request, 35);

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -227,7 +227,7 @@ uint32_t firmware_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW,
 
 	if((addr & ADIV5_APnDP) && dp->fault) return 0;
 
-	platform_timeout_set(&timeout, 20);
+	platform_timeout_set(&timeout, 250);
 	do {
 		dp->seq_out(request, 8);
 		ack = dp->seq_in(3);


### PR DESCRIPTION
This fixes #1001 and improves robustness of the SWD scan handling.
Additionally this increases the JTAG scan timeout value to match in the hopes that this still lower but not overly aggressively low  timeout value improves robustness.