### PR TITLE
Fix a "hosted" regression that causes a segfault

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -389,15 +389,14 @@ int send_recv(usb_link_t *link,
 {
 	int res = 0;
 	if (txsize) {
-		int txlen = txsize;
 		libusb_fill_bulk_transfer(link->req_trans,
 								  link->ul_libusb_device_handle,
 								  link->ep_tx | LIBUSB_ENDPOINT_OUT,
-								  txbuf, txlen,
+								  txbuf, txsize,
 								  NULL, NULL, 0);
 		size_t i = 0;
-		DEBUG_WIRE(" Send (%3d): ", txlen);
-		for (; i < txlen; ++i) {
+		DEBUG_WIRE(" Send (%3zu): ", txsize);
+		for (; i < txsize; ++i) {
 			DEBUG_WIRE("%02x", txbuf[i]);
 			if ((i & 7U) == 7U)
 				DEBUG_WIRE(".");
@@ -425,12 +424,12 @@ int send_recv(usb_link_t *link,
 		}
 		res = link->rep_trans->actual_length;
 		if (res > 0) {
-			uint8_t *p = rxbuf;
-			DEBUG_WIRE(" Rec (%zu/%d)", rxsize, res);
-			for (size_t i = 0; i < res && i < 32 ; ++i) {
+			const size_t rxlen = (size_t)res;
+			DEBUG_WIRE(" Rec (%zu/%zu)", rxsize, rxlen);
+			for (size_t i = 0; i < rxlen && i < 32 ; ++i) {
 				if (i && ((i & 7U) == 0U))
 					DEBUG_WIRE(".");
-				DEBUG_WIRE("%02x", p[i]);
+				DEBUG_WIRE("%02x", rxbuf[i]);
 			}
 		}
 	}

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -76,11 +76,10 @@ void platform_init(int argc, char **argv)
 	atexit(exit_function);
 	signal(SIGTERM, sigterm_handler);
 	signal(SIGINT, sigterm_handler);
-	if (cl_opts.opt_device) {
+	if (cl_opts.opt_device)
 		info.bmp_type = BMP_TYPE_BMP;
-	} else if (find_debuggers(&cl_opts, &info)) {
+	else if (find_debuggers(&cl_opts, &info))
 		exit(-1);
-	}
 	bmp_ident(&info);
 	switch (info.bmp_type) {
 	case BMP_TYPE_BMP:
@@ -89,11 +88,11 @@ void platform_init(int argc, char **argv)
 		remote_init();
 		break;
 	case BMP_TYPE_STLINKV2:
-		if (stlink_init( &info))
+		if (stlink_init(&info))
 			exit(-1);
 		break;
 	case BMP_TYPE_CMSIS_DAP:
-		if (dap_init( &info))
+		if (dap_init(&info))
 			exit(-1);
 		break;
 	case BMP_TYPE_LIBFTDI:
@@ -107,14 +106,12 @@ void platform_init(int argc, char **argv)
 	default:
 		exit(-1);
 	}
-	int ret = -1;
-	if (cl_opts.opt_mode != BMP_MODE_DEBUG) {
-		ret = cl_execute(&cl_opts);
-	} else {
+	if (cl_opts.opt_mode != BMP_MODE_DEBUG)
+		exit(cl_execute(&cl_opts));
+	else {
 		gdb_if_init();
 		return;
 	}
-	exit(ret);
 }
 
 int platform_adiv5_swdp_scan(uint32_t targetid)

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -522,9 +522,9 @@ int stlink_init(bmp_info_t *info)
 		}
 		if ((result = libusb_open(dev, &sl->ul_libusb_device_handle)) != LIBUSB_SUCCESS)
 		{
-			DEBUG_WARN("Failed to open STLink device %#06x:%#06x - %s",
+			DEBUG_WARN("Failed to open STLink device %04x:%04x - %s\n",
 				desc.idVendor, desc.idProduct, libusb_strerror(result));
-			DEBUG_WARN("Are you sure the permissions on the device are set correctly?");
+			DEBUG_WARN("Are you sure the permissions on the device are set correctly?\n");
 			continue;
 		}
 		char serial[64];


### PR DESCRIPTION
This fixes a regression introduced since v1.7.1 that, under certain circumstances causes a segfault in the BlackMagic Probe Debug App, aka "hosted".
This also aims to improve the general quality of the code involved by bringing it inline with the codebase overall style, and fixing the glaring USB spec violations and UB C issues.

This closes #998.