### PR TITLE
Fix RP2040 memory sizes

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -211,7 +211,7 @@ static int rp_flash_erase(struct target_flash *f, target_addr addr,
 	struct rp_priv_s *ps = (struct rp_priv_s*)t->target_storage;
 	/* Register playground*/
 	/* erase */
-#define MAX_FLASH               (2 * 1024 * 1024)
+#define MAX_FLASH               (16 * 1024 * 1024)
 #define FLASHCMD_SECTOR_ERASE   0x20
 #define FLASHCMD_BLOCK32K_ERASE 0x52
 #define FLASHCMD_BLOCK64K_ERASE 0xd8
@@ -408,7 +408,7 @@ bool rp_probe(target *t)
 	}
 	rp_add_flash(t, XIP_FLASH_START, size << 1);
 	t->driver = RP_ID;
-	target_add_ram(t, SRAM_START, 0x40000);
+	target_add_ram(t, SRAM_START, 0x42000);
 	target_add_ram(t, 0x51000000,  0x1000);
 	target_add_commands(t, rp_cmd_list, RP_ID);
 	return true;


### PR DESCRIPTION
This PR changes two values in `rp.c` to better reflect the hardware:

1. SRAM is actually 0x42000 bytes long in total, not 0x40000. It is recommended to put the stack in the part above 0x40000 so blocking access to this severely limits debugging.
2. The MAX_FLASH macro is changed to 16MB rather than 2MB. I am not sure if this is a good change, though, because other parts of the code probe for the size, which seems like maybe would be a better idea? I don't fully understand this code so I'm not sure.