### PR TITLE
clang-format: add initial format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,45 @@
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+# This is currently broken:
+# https://github.com/llvm/llvm-project/issues/53442
+#AlignArrayOfStructures: Left
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+BreakBeforeBraces: Linux
+BasedOnStyle: LLVM
+ColumnLimit: 120
+Cpp11BracedListStyle: false
+IndentCaseLabels: false
+IndentWidth: 8
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+# Taken from git's rules
+#PenaltyBreakAssignment: 10 # Unknown to clang-format-4.0
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+ReflowComments: false
+SpacesBeforeTrailingComments: 1
+SortIncludes: false
+TabWidth: 8
+UseTab: Always


### PR DESCRIPTION
Add a format file for `clang-format`. This is based on the `.clang-format` file from Linux, adjusted to work with this project.

Notably, it opts for 120 characters, given that some functions are rather wide.

Care was chosen to adopt settings that resulted in a minimum of disruption when run through the formatter, however since no formatter has been used before this necessarily results in code that does not conform to the formatter.

This PR is made more to spur discusson on this, depending on whether or not this is a desirable thing to have.