### PR TITLE
add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,6 +15,7 @@ mkShell {
     gcc-arm-embedded
     dfu-util
 
+    blackmagic
     pkg-config
     libftdi1
     libusb-compat-0_1

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+{
+  pkgs ? import (fetchGit {
+    name = "nixos-21.11-2022-05-17";
+    url = "https://github.com/nixos/nixpkgs/";
+    ref = "refs/heads/nixos-21.11";
+    # `git ls-remote https://github.com/nixos/nixpkgs nixos-21.11`
+    rev = "8b3398bc7587ebb79f93dfeea1b8c574d3c6dba1";
+  }) {}
+}:
+
+with pkgs;
+mkShell {
+  buildInputs = [
+    gnumake
+    gcc-arm-embedded
+    dfu-util
+
+    pkg-config
+    libftdi1
+    libusb-compat-0_1
+    hidapi
+
+    (python3.withPackages (python-packages: with python-packages; [
+      pyusb
+      pyserial
+    ]))
+  ];
+}


### PR DESCRIPTION
This file contains a Nix function, which spawns a [nix-shell](https://nixos.org/manual/nix/unstable/command-ref/nix-shell.html) providing the tools necessary to build and interact with blackmagic.
It's like a `requirements.txt` for people using Nix or NixOS. The development environment is entered by simply running `nix-shell` in the root of the repository.

The package repository is pinned to a commit to provide reproducibility, but can be overwritten from command line.

The file may need to be updated when moving to a newer version of the underlying libraries (e.g. libus) when they bring breaking changes. Ideally this means only updating the `ref` end `ref` in line 5 and 7 