### PR TITLE
Add idcode for GD32F303CG detection

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -133,6 +133,7 @@ bool gd32f1_probe(target *t)
 	uint32_t ramSize=signature >>16 ;
 	switch(t->idcode) {
 	case 0x414:  /* Gigadevice gd32f303 */
+	case 0x430:
 		t->driver = "GD32F3";
 		break;
 	case 0x410:  /* Gigadevice gd32f103, gd32e230 */


### PR DESCRIPTION
Add additional case clause to MCU detection for the GigaDevice GD32F303CG in ```gd32f1_probe```