### PR TITLE
update include/version.h only when content changes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -153,7 +153,13 @@ all_platforms:
 
 command.c: include/version.h
 
+GIT_VERSION := $(shell git describe --always --dirty --tags)
+VERSION_HEADER := \#define FIRMWARE_VERSION "$(GIT_VERSION)"
+
 include/version.h: FORCE
-	$(Q)echo " GIT include/version.h"
-	$(Q)echo "#define FIRMWARE_VERSION \"$(shell git describe --always --dirty --tags)\"" > $@
+ifneq ($(file <include/version.h), $(VERSION_HEADER))
+	@echo " GEN GIT  $@"
+	$(Q)$(file >$@,$(VERSION_HEADER))
+endif
+
 -include *.d


### PR DESCRIPTION
this adds on-demand regeneration for `include/version.h`.

without this patch, parts of the code were always recompiled, even though nothing changed at all.