### PR TITLE
Copyright and vendor strings update

### DIFF
--- a/driver/blackmagic.inf
+++ b/driver/blackmagic.inf
@@ -13,17 +13,17 @@
 Signature="$Windows NT$"
 Class=Ports
 ClassGuid={4D36E978-E325-11CE-BFC1-08002BE10318}
-Provider=%BLACKSPHERE%
+Provider=%BLACKMAGIC%
 DriverVer=28/12/2011,0.0.1.1
 
 [Manufacturer]
 %VendorName%=DeviceList, NTamd64
 
 [Strings]
-VendorName = "Black Sphere Technologies"
+VendorName = "Black Magic Debug"
 BLACKMAGICGDB = "Black Magic GDB Server"
 BLACKMAGICUART = "Black Magic UART Port"
-BLACKSPHERE_DISPLAY_NAME = "Black Magic Probe Driver"
+BLACKMAGIC_DISPLAY_NAME = "Black Magic Probe Driver"
 
 [DeviceList]
 %BLACKMAGICGDB%=DriverInstall, USB\VID_1d50&PID_6018&Rev_0100&MI_00
@@ -55,7 +55,7 @@ HKR,,EnumPropPages32,,"MsPorts.dll,SerialPortPropPageProvider"
 AddService = usbser,0x0002,DriverService.nt
 
 [DriverService.nt]
-DisplayName = %BLACKSPHERE_DISPLAY_NAME%
+DisplayName = %BLACKMAGIC_DISPLAY_NAME%
 ServiceType = 1                  ; SERVICE_KERNEL_DRIVER
 StartType = 3                    ; SERVICE_DEMAND_START
 ErrorControl = 1                 ; SERVICE_ERROR_NORMAL
@@ -80,7 +80,7 @@ HKR,,EnumPropPages32,,"MsPorts.dll,SerialPortPropPageProvider"
 AddService = usbser,0x0002,DriverService.NTamd64
 
 [DriverService.NTamd64]
-DisplayName = %BLACKSPHERE_DISPLAY_NAME%
+DisplayName = %BLACKMAGIC_DISPLAY_NAME%
 ServiceType = 1                  ; SERVICE_KERNEL_DRIVER
 StartType = 3                    ; SERVICE_DEMAND_START
 ErrorControl = 1                 ; SERVICE_ERROR_NORMAL

--- a/driver/blackmagic_upgrade.inf
+++ b/driver/blackmagic_upgrade.inf
@@ -4,7 +4,7 @@
 DeviceName = "Black Magic Firmware Upgrade"
 DeviceNameDFU = "Black Magic Probe (Upgrade)"
 DeviceNameTPA = "Black Magic Trace Capture"
-VendorName = "Black Sphere Technologies"
+VendorName = "Black Magic Debug"
 SourceName = "Black Magic Firmware Upgrade Install Disk"
 DeviceID   = "VID_1d50&PID_6018&Rev_0100&MI_04"
 DeviceIDDFU= "VID_1d50&PID_6017&Rev_0100"

--- a/src/command.c
+++ b/src/command.c
@@ -141,7 +141,7 @@ bool cmd_version(target *t, int argc, char **argv)
 #else
 	gdb_out(BOARD_IDENT);
 	gdb_outf(", Hardware Version %d\n", platform_hwversion());
-	gdb_out("Copyright (C) 2015  Black Sphere Technologies Ltd.\n");
+	gdb_out("Copyright (C) 2022 Black Magic Debug Project\n");
 	gdb_out("License GPLv3+: GNU GPL version 3 or later "
 		"<http://gnu.org/licenses/gpl.html>\n\n");
 #endif

--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -414,7 +414,7 @@ static char serial_no[DFU_SERIAL_LENGTH];
 #define BOARD_IDENT "Black Magic Probe " PLATFORM_IDENT FIRMWARE_VERSION
 
 static const char *usb_strings[] = {
-	"Black Sphere Technologies",
+	"Black Magic Debug",
 	BOARD_IDENT,
 	serial_no,
 	"Black Magic GDB Server",

--- a/src/platforms/f4discovery/Readme.md
+++ b/src/platforms/f4discovery/Readme.md
@@ -60,6 +60,6 @@ To exit from dfu mode press a "key" and "reset", release reset. BMP firmware sho
 
 SWJ frequency setting
 ====================================
-https://github.com/blacksphere/blackmagic/pull/783#issue-529197718
+https://github.com/blackmagic-debug/blackmagic/pull/783#issue-529197718
 
 `mon freq 900k` helps at most

--- a/src/platforms/hosted/Readme.md
+++ b/src/platforms/hosted/Readme.md
@@ -171,7 +171,7 @@ cables already listed and propose other cable. A link to the schematics
 is welcome.
 
 ## Feedback
-### Issues and Pull request on https://github.com/blacksphere/blackmagic/
+### Issues and Pull request on https://github.com/blackmagic-debug/blackmagic/
 ### Discussions on Discord.
 You can find the Discord link here: https://1bitsquared.com/pages/chat
 ### Blackmagic mailing list http://sourceforge.net/mail/?group_id=407419

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -159,7 +159,9 @@ print_probes_info:
  * Recent: Black_Sphere_Technologies_Black_Magic_Probe_v1.7.1-212-g212292ab_7BAE7AB8-if00
  * usb-Black_Sphere_Technologies_Black_Magic_Probe__SWLINK__v1.7.1-155-gf55ad67b-dirty_DECB8811-if00
  */
-#define BMP_IDSTRING "usb-Black_Sphere_Technologies_Black_Magic_Probe"
+#define BMP_IDSTRING_BLACKSPHERE "usb-Black_Sphere_Technologies_Black_Magic_Probe"
+#define BMP_IDSTRING_BLACKMAGIC "usb-Black_Magic_Debug_Black_Magic_Probe"
+#define BMP_IDSTRING_1BITSQUARED "usb-1BitSquared_Black_Magic_Probe"
 #define DEVICE_BY_ID "/dev/serial/by-id/"
 
 /*
@@ -170,7 +172,7 @@ print_probes_info:
  */
 static int scan_linux_id(char *name, char *type, char *version, char  *serial)
 {
-	name += strlen(BMP_IDSTRING) + 1;
+	name += strlen(BMP_IDSTRING_BLACKSPHERE) + 1;
 	while (*name == '_')
 		name++;
 	if (!*name) {
@@ -279,7 +281,7 @@ int find_debuggers(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
 				strncpy(info->version, version, sizeof(info->version));
 				break;
 			} else if (found_bmps > 0) {
-				DEBUG_WARN("%2d: %s, Black Sphere Technologies, Black Magic "
+				DEBUG_WARN("%2d: %s, Black Magic Debug, Black Magic "
 						   "Probe (%s), %s\n", i, serial, type, version);
 			}
 		}

--- a/src/platforms/pc/serial_unix.c
+++ b/src/platforms/pc/serial_unix.c
@@ -95,7 +95,9 @@ int serial_open(BMP_CL_OPTIONS_t *cl_opts, char *serial)
     return set_interface_attribs();
 }
 #else
-#define BMP_IDSTRING "usb-Black_Sphere_Technologies_Black_Magic_Probe"
+#define BMP_IDSTRING_BLACKSPHERE "usb-Black_Sphere_Technologies_Black_Magic_Probe"
+#define BMP_IDSTRING_BLACKMAGIC "usb-Black_Magic_Debug_Black_Magic_Probe"
+#define BMP_IDSTRING_1BITSQUARED "usb-1BitSquared_Black_Magic_Probe"
 #define DEVICE_BY_ID "/dev/serial/by-id/"
 int serial_open(BMP_CL_OPTIONS_t *cl_opts, char *serial)
 {
@@ -111,7 +113,9 @@ int serial_open(BMP_CL_OPTIONS_t *cl_opts, char *serial)
 		int num_devices = 0;
 		int num_total = 0;
 		while ((dp = readdir(dir)) != NULL) {
-			if ((strstr(dp->d_name, BMP_IDSTRING)) &&
+			if ((strstr(dp->d_name, BMP_IDSTRING_BLACKSPHERE) ||
+			     strstr(dp->d_name, BMP_IDSTRING_BLACKMAGIC) ||
+			     strstr(dp->d_name, BMP_IDSTRING_1BITSQUARED)) &&
 				(strstr(dp->d_name, "-if00"))) {
 				num_total++;
 				if ((serial) && (!strstr(dp->d_name, serial)))
@@ -130,7 +134,9 @@ int serial_open(BMP_CL_OPTIONS_t *cl_opts, char *serial)
 			dir = opendir(DEVICE_BY_ID);
 			if (dir) {
 				while ((dp = readdir(dir)) != NULL) {
-					if ((strstr(dp->d_name, BMP_IDSTRING)) &&
+					if ((strstr(dp->d_name, BMP_IDSTRING_BLACKSPHERE) ||
+					     strstr(dp->d_name, BMP_IDSTRING_BLACKMAGIC) ||
+					     strstr(dp->d_name, BMP_IDSTRING_1BITSQUARED)) &&
 						(strstr(dp->d_name, "-if00")))
 						DEBUG_WARN("%s\n", dp->d_name);
 				}

--- a/src/platforms/stm32/dfucore.c
+++ b/src/platforms/stm32/dfucore.c
@@ -130,7 +130,7 @@ static char if_string[] = DFU_IFACE_STRING;
 #define BOARD_IDENT_DFU(BOARD_TYPE) "Black Magic Probe DFU " PLATFORM_IDENT  "" FIRMWARE_VERSION
 
 static const char *usb_strings[] = {
-	"Black Sphere Technologies",
+	"Black Magic Debug",
 	BOARD_IDENT_DFU(PLATFORM_IDENT),
 	serial_no,
 	/* This string is used by ST Microelectronics' DfuSe utility */

--- a/upgrade/main.c
+++ b/upgrade/main.c
@@ -38,7 +38,7 @@
 void banner(void)
 {
 	puts("\nBlack Magic Probe -- Firmware Upgrade Utility -- Version " VERSION);
-	puts("Copyright (C) 2011  Black Sphere Technologies Ltd.");
+	puts("Copyright (C) 2022 Black Magic Debug Project");
 	puts("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n");
 }
 
@@ -74,12 +74,16 @@ struct usb_device * find_dev(void)
 
 			if (((dev->descriptor.idProduct == 0x5740) ||
 			     (dev->descriptor.idProduct == 0x6018)) &&
-			   !strcmp(man, "Black Sphere Technologies"))
+			    (!strcmp(man, "Black Sphere Technologies") ||
+			     !strcmp(man, "Black Magic Debug") ||
+			     !strcmp(man, "1BitSquared")))
 				return dev;
 
 			if (((dev->descriptor.idProduct == 0xDF11) ||
 			     (dev->descriptor.idProduct == 0x6017)) &&
-			   !strcmp(man, "Black Sphere Technologies"))
+			    (!strcmp(man, "Black Sphere Technologies") ||
+			     !strcmp(man, "Black Magic Debug") ||
+			     !strcmp(man, "1BitSquared")))
 				return dev;
 		}
 	}


### PR DESCRIPTION
As the GitHub organization was renamed to Black Magic Debug. The copyright and USB vendor strings are not correct any more. This PR fixes this.

We are leaving the codebase Copyright header strings in place as they are correct and the code was written and copyrighted by the Black Sphere Technologies company.

The only issue that remains that the new probes might not be detected correctly by Black Magic App (BMA aka. hosted) in "serial" mode. The code for the device detection in there is so convoluted and hard to read that I decided not to touch it until it is completely rewritten in a proper way.