### PR TITLE
A couple of misc fixes to BMDA ported from Uwe's RISC-V support branch

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -329,7 +329,7 @@ rescan:
 		} else
 			++found_debuggers;
 	}
-	if (found_debuggers == 0 && ftdi_unknown)
+	if (found_debuggers == 0 && ftdi_unknown && !cl_opts->opt_cable)
 		DEBUG_WARN("Generic FTDI MPSSE VID/PID found. Please specify exact type with \"-c <cable>\" !\n");
 	if (found_debuggers == 1 && !cl_opts->opt_cable && info->bmp_type == BMP_TYPE_LIBFTDI)
 		cl_opts->opt_cable = active_cable;

--- a/src/platforms/pc/serial_unix.c
+++ b/src/platforms/pc/serial_unix.c
@@ -173,7 +173,7 @@ int platform_buffer_write(const uint8_t *data, int size)
 	s = write(fd, data, size);
 	if (s < 0) {
 		DEBUG_WARN("Failed to write\n");
-		return(-2);
+		exit(-2);
     }
 
 	return size;


### PR DESCRIPTION
This fixes a clean exit on error bug, and an issue with how BMDA detects some probes ("cables" in the current terminology used)