### PR TITLE
build: Added all_platforms target to toplevel Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,14 @@ ifndef NO_LIBOPENCM3
 endif
 	$(Q)$(MAKE) $(MFLAGS) -C src
 
+all_platforms:
+	$(Q)$(MAKE) $(MFLAGS) -C src $@
+
+
 clean:
 ifndef NO_LIBOPENCM3
 	$(Q)$(MAKE) $(MFLAGS) -C libopencm3 $@
 endif
 	$(Q)$(MAKE) $(MFLAGS) -C src $@
 
+.PHONY: clean all_platforms

--- a/src/Makefile
+++ b/src/Makefile
@@ -136,6 +136,12 @@ clean:	host_clean
 	-$(Q)$(RM) platforms/*/*.o platforms/*/*.d mapfile include/version.h
 
 all_platforms:
+	$(Q)if [ ! -f ../libopencm3/Makefile ]; then \
+		echo "Initialising git submodules..." ;\
+		git submodule init ;\
+		git submodule update ;\
+	fi
+	$(Q)$(MAKE) $(MFLAGS) -C ../libopencm3 lib/stm32/f1 lib/stm32/f4 lib/lm4f
 	$(Q)set -e ;\
 	mkdir -p artifacts/$(shell git describe --always --dirty --tags) ;\
 	echo "<html><body><ul>" > artifacts/index.html ;\


### PR DESCRIPTION
Now it is possible to run the all_platforms build target from the toplevel directory.

The src level all_platforms target now also checks for locm3 existence
as well as triggers build of the needed locm3 libraries.

This prepares for switching the build tests to using the all_platforms build target instead of just the native one.