### PR TITLE
build: Corrected the all_platform build target.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -145,13 +145,18 @@ all_platforms:
 	$(Q)set -e ;\
 	mkdir -p artifacts/$(shell git describe --always --dirty --tags) ;\
 	echo "<html><body><ul>" > artifacts/index.html ;\
+	$(MAKE) clean ;\
 	for i in platforms/*/Makefile.inc ; do \
 		export DIRNAME=`dirname $$i` ;\
 		export PROBE_HOST=`basename $$DIRNAME` ;\
 		export CFLAGS=-Werror ;\
 		echo "Building for hardware platform: $$PROBE_HOST" ;\
-		$(MAKE) clean ;\
 		$(MAKE);\
+		if [ -f blackmagic ]; then \
+			mv blackmagic artifacts/blackmagic-$$PROBE_HOST ;\
+			echo "<li><a href='blackmagic-$$PROBE_HOST'>$$PROBE_HOST</a></li>"\
+				>> artifacts/index.html ;\
+		fi ;\
 		if [ -f blackmagic.bin ]; then \
 			mv blackmagic.bin artifacts/blackmagic-$$PROBE_HOST.bin ;\
 			echo "<li><a href='blackmagic-$$PROBE_HOST.bin'>$$PROBE_HOST</a></li>"\
@@ -162,9 +167,10 @@ all_platforms:
 			echo "<li><a href='blackmagic_dfu-$$PROBE_HOST.bin'>$$PROBE_HOST DFU</a></li>"\
 				>> artifacts/index.html ;\
 		fi ;\
+		$(MAKE) clean ;\
 	done ;\
 	echo "</ul></body></html>" >> artifacts/index.html ;\
-	cp artifacts/*.bin artifacts/$(shell git describe --always --dirty --tags)
+	cp artifacts/blackmagic* artifacts/$(shell git describe --always --dirty --tags)
 
 command.c: include/version.h
 

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -83,3 +83,8 @@ else
 SRC += bmp_serial.c
 endif
 PC_HOSTED = 1
+
+all: blackmagic
+
+host_clean:
+	-$(Q)$(RM) blackmagic


### PR DESCRIPTION
The target was building but not including the BMDA binary, as the
build system does not expect a binary that does not end with `.bin`.
Additionally this corrects the BMDA Makefile.inc that was missing the
`all` and `host_clean` targets.