### PR TITLE
Feature: BMDA better usage output and help

### DIFF
--- a/contrib/zsh/_blackmagic
+++ b/contrib/zsh/_blackmagic
@@ -1,0 +1,76 @@
+#compdef blackmagic
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Copyright (c) 2022 Rachel Mant
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+_blackmagic_frequency() {
+	_numbers -u 'Hz' 'frequency' 'k:kilohertz' 'M:megahertz'
+}
+
+_blackmagic_size() {
+	_numbers -u 'B' 'size in bytes' 'k:kibibytes' 'M:mebibytes'
+}
+
+local arguments
+
+arguments=(
+	'-h[show version and help then exit]'
+	'-l[list available supported probes]'
+	'-v=[set the output verbosity level]:number'
+	'(-d -P -s -c)-d=[use a serial device at the given path]:path:_files'
+	'(-d -P -s -c)-P=[use the <number>th debug probe found while scanning the system, see the output from list for the order]:number'
+	'(-d -P -s -c)-s=[select the debug probe with the given serial number]:serial'
+	'(-d -P -s -c)-c=[select the FTDI-based debug probe with of the given type]:type'
+	'-n=[select the target device at the given position in the scan chain]:number'
+	'-j[use JTAG instead of SWD]'
+	'-C[connect to target under hardware reset]'
+	'(-t -T)-t[perform a chain scan and display information about the conected devices]'
+	'(-t -T)-T[perform continues read- or write-back of a value to allow measurement of protocol timing. Aborted by ^C]'
+	'-e[assume external resistors for FTDI devices]'
+	'(-E -w -V -r)-E[erase the target device Flash]'
+	'(-E -w -V -r)-w[write the specified binary file to the target device Flash (the default)]'
+	'(-E -w -V -r)-V[verify the target device Flash against the specified binary file]'
+	'(-E -w -V -r)-r[read the target device Flash]'
+	'-p[power the target from the probe (if possible)]'
+	'-R-[reset the device. If followed by "h", this will be done using the hardware reset line instead of over the debug link]:: :(h)'
+	'-H[do not use the high level command API (bmp-remote)]'
+	'*-M[run target-specific monitor commands]:command'
+	'-a=[start address for the given Flash operation (defaults to the start of Flash)]:address:_numbers "address"'
+	'-S=[number of bytes to work on in the Flash operation (default is till the operation fails or is complete)]:_blackmagic_size'
+	':binary file to use in Flash operations:_files "*.bin"'
+)
+
+if ! (( $words[(Ie)-j] )); then
+	arguments+=(
+		'-f=[set an operating frequency for SWD]:frequency:_blackmagic_frequency'
+		'-m=[use the given target ID for selection in SWD multi-drop]:target'
+	)
+fi
+
+_arguments -s : $arguments

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -49,4 +49,12 @@ void bmp_ident(bmp_info_t *info);
 int find_debuggers(BMP_CL_OPTIONS_t *cl_opts,bmp_info_t *info);
 void libusb_exit_function(bmp_info_t *info);
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <wchar.h>
+#define PRINT_INFO(fmt, ...) wprintf(L(fmt), ##__VA_ARGS__)
+#else
+#include <stdio.h>
+#define PRINT_INFO(fmt, ...) printf((fmt), ##__VA_ARGS__)
+#endif
+
 #endif

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -28,8 +28,8 @@
 
 void bmp_ident(bmp_info_t *info)
 {
-	PRINT_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link V2/3, CMSIS_DAP,"
-		" JLINK and LIBFTDI/MPSSE\n", FIRMWARE_VERSION);
+	PRINT_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP,"
+		" JLink and libftdi/MPSSE\n", FIRMWARE_VERSION);
 	if (info && info->vid && info->pid) {
 		PRINT_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,
 			(info->serial[0]) ? info->serial : NO_SERIAL_NUMBER,

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -28,10 +28,10 @@
 
 void bmp_ident(bmp_info_t *info)
 {
-	DEBUG_INFO("BMP hosted %s\n for ST-Link V2/3, CMSIS_DAP, JLINK and "
+	PRINT_INFO("Black Magic Debug App %s\n for ST-Link V2/3, CMSIS_DAP, JLINK and "
 			   "LIBFTDI/MPSSE\n", FIRMWARE_VERSION);
 	if (info && info->vid && info->pid)
-		DEBUG_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,
+		PRINT_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,
 				   (info->serial[0]) ? info->serial : NO_SERIAL_NUMBER,
 				   info->manufacturer,
 				   info->product);

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -28,13 +28,13 @@
 
 void bmp_ident(bmp_info_t *info)
 {
-	PRINT_INFO("Black Magic Debug App %s\n for ST-Link V2/3, CMSIS_DAP, JLINK and "
-			   "LIBFTDI/MPSSE\n", FIRMWARE_VERSION);
-	if (info && info->vid && info->pid)
+	PRINT_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link V2/3, CMSIS_DAP,"
+		" JLINK and LIBFTDI/MPSSE\n", FIRMWARE_VERSION);
+	if (info && info->vid && info->pid) {
 		PRINT_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,
-				   (info->serial[0]) ? info->serial : NO_SERIAL_NUMBER,
-				   info->manufacturer,
-				   info->product);
+			(info->serial[0]) ? info->serial : NO_SERIAL_NUMBER,
+			info->manufacturer, info->product);
+	}
 }
 
 void libusb_exit_function(bmp_info_t *info)

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -29,8 +29,8 @@ void bmp_ident(bmp_info_t *info)
 {
 	if (!info)
 		return;
-	DEBUG_INFO("BMP hosted (BMP Only) %s\n", FIRMWARE_VERSION);
-	DEBUG_INFO("Using:\n %s %s %s\n", info->manufacturer, info->version, info->serial);
+	PRINT_INFO("Black Magic Debug App (for BMP only) %s\n", FIRMWARE_VERSION);
+	PRINT_INFO("Using:\n %s %s %s\n", info->manufacturer, info->version, info->serial);
 }
 
 void libusb_exit_function(bmp_info_t *info) {(void)info;};

--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -130,52 +130,65 @@ static void bmp_munmap(struct mmap_data *map)
 static void cl_help(char **argv)
 {
 	bmp_ident(NULL);
-	DEBUG_WARN("Usage: %s [options]\n", argv[0]);
-	DEBUG_WARN("\t-h\t\t: This help.\n");
-	DEBUG_WARN("\t-v[bitmask]\t: Increasing verbosity. Bitmask:\n");
-	DEBUG_WARN("\t\t\t  1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROBE, 16 = WIRE\n");
-	DEBUG_WARN("\t-l\t\t: List available probes\n");
-	DEBUG_WARN("Probe selection arguments:\n");
-	DEBUG_WARN("\t-d \"path\"\t: Use serial BMP device at <path>");
-#if HOSTED_BMP_ONLY == 1 && defined(__APPLE__)
-	DEBUG_WARN("\n");
-#else
-	DEBUG_WARN(". Deprecated!\n");
-#endif
-	DEBUG_WARN("\t-P <pos>\t: Use debugger found at position <pos>\n");
-	DEBUG_WARN("\t-n <num>\t: Use target device found at position <num>\n");
-	DEBUG_WARN("\t-s \"serial\"\t: Use dongle with (partial) "
-		  "serial number \"serial\"\n");
-	DEBUG_WARN("\t-c \"string\"\t: Use ftdi dongle with type \"string\"\n");
-	DEBUG_WARN("\t\t Use \"list\" to list available cables\n");
-	DEBUG_WARN("Run mode related options:\n");
-	DEBUG_WARN("\tDefault mode is to start the debug server at :2000\n");
-	DEBUG_WARN("\t-j\t\t: Use JTAG. SWD is default.\n");
-	DEBUG_WARN("\t-f\t\t: Set minimum high and low times of SWJ waveform.\n");
-	DEBUG_WARN("\t-C\t\t: Connect under hardware reset\n");
-	DEBUG_WARN("\t-t\t\t: Scan SWD or JTAG and display information about \n"
-			   "\t\t\t  connected devices\n");
-	DEBUG_WARN("\t-T\t\t: Continuous read/write-back some value to allow\n"
-			   "\t\t\t  timing insection of SWJ. Abort with ^C\n");
-	DEBUG_WARN("\t-e\t\t: Assume \"resistor SWD connection\" on FTDI: TDI\n"
-               "\t\t\t  connected to TMS, TDO to TDI with eventual resistor\n");
-	DEBUG_WARN("\t-E\t\t: Erase flash until flash end or for given size\n");
-	DEBUG_WARN("\t-w\t\t: Write binary file to target flash (default).\n");
-	DEBUG_WARN("\t-V\t\t: Verify flash against binary file. Can be combined\n"
-	           "\t\t\t  with -w to verify right after programming.\n");
-	DEBUG_WARN("\t-r\t\t: Read flash and write to binary file\n");
-	DEBUG_WARN("\t-p\t\t: Supplies power to the target (where applicable)\n");
-	DEBUG_WARN("\t-R[h]\t\t: Reset device. Default via SWJ or by hardware(h)\n");
-	DEBUG_WARN("\t-H\t\t: Do not use high level commands (BMP-Remote)\n");
-	DEBUG_WARN("\t-m <target>\t: Use (target)id for SWD multi-drop.\n");
-	DEBUG_WARN("\t-M <string>\t: Run target specific monitor commands. Quote multi\n");
-	DEBUG_WARN("\t\t\t  word strings. Run \"-M help\" for help.\n");
-	DEBUG_WARN("Flash operation modifiers options:\n");
-	DEBUG_WARN("\tDefault action with given file is to write to flash\n");
-	DEBUG_WARN("\t-a <addr>\t: Start flash operation at flash address <addr>\n"
-		"\t\t\t  Default start is start of flash in memory map\n");
-	DEBUG_WARN("\t-S <num>\t: Read <num> bytes. Default is until read fails.\n");
-	DEBUG_WARN("\t <file>\t\t: Use (binary) file <file> for flash operation\n");
+	PRINT_INFO("\n");
+	PRINT_INFO("Usage: %s [-h | -l | [-vBITMASK] [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]\n", argv[0]);
+	PRINT_INFO("  [-n NUMBER] [-j] [-C] [-t | -T] [-e] [-p] [-R[h]] [-H] [-M STRING ...]\n");
+	PRINT_INFO("  [-E | -w | -V | -r] [-a ADDR] [-S number] [file]]\n");
+	PRINT_INFO("\n");
+	PRINT_INFO("Single-shot and verbosity options [-h | -l | -vBITMASK]:\n");
+	PRINT_INFO("\t-h              Show the version version and this help, then exit\n");
+	PRINT_INFO("\t-l              List available supported probes\n");
+	PRINT_INFO("\t-v<bitmask>     Set the output verbosity level based on some combination of:\n");
+	PRINT_INFO("\t                  1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROBE, 16 = WIRE\n");
+	PRINT_INFO("\n");
+	PRINT_INFO("Probe selection arguments [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]:\n");
+	PRINT_INFO("\t-d <path>       Use a serial device at the given path (Deprecated!)\n");
+	PRINT_INFO("\t-P <number>     Use the <number>th debug probe found while scanning the\n");
+	PRINT_INFO("\t                  system, see the output from list for the order\n");
+	PRINT_INFO("\t-s <serial>     Select the debug probe with the given serial number\n");
+	PRINT_INFO("\t-c <type>       Select the FTDI-based debug probe with of the given\n");
+	PRINT_INFO("\t                  type (cable)\n");
+	PRINT_INFO("\n");
+	PRINT_INFO("The default is to start a debug server at localhost:2000\n");
+	PRINT_INFO("General configuration options: [-n NUMBER] [-j] [-C] [-t | -T] [-e] [-p] [-R[h]]\n");
+	PRINT_INFO("  [-H] [-M STRING ...]\n");
+	PRINT_INFO("\t-n <number>     Select the target device at the given position in the\n");
+	PRINT_INFO("\t                  scan chain (use the -t option to get a scan chain listing)\n");
+	PRINT_INFO("\t-j              Use JTAG instead of SWD\n");
+	PRINT_INFO("\t-C              Connect to target under hardware reset\n");
+	PRINT_INFO("\t-t              Perform a chain scan and display information about the\n");
+	PRINT_INFO("\t                  conected devices\n");
+	PRINT_INFO("\t-T              Perform continues read- or write-back of a value to allow\n");
+	PRINT_INFO("\t                  measurement of protocol timing. Aborted by ^C\n");
+	PRINT_INFO("\t-e              Assume external resistors for FTDI devices, that is having the\n");
+	PRINT_INFO("\t                  FTDI chip connected through resistors to TMS, TDI and TDO\n");
+	PRINT_INFO("\t-p              Power the target from the probe (if possible)\n");
+	PRINT_INFO("\t-R[h]           Reset the device. If followed by 'h', this will be done using\n");
+	PRINT_INFO("\t                  the hardware reset line instead of over the debug link\n");
+	PRINT_INFO("\t-H              Do not use the high level command API (bmp-remote)\n");
+	PRINT_INFO("\t-M <string>     Run target-specific monitor commands. This option\n");
+	PRINT_INFO("\t                  can be repeated for as many commands you wish to run.\n");
+	PRINT_INFO("\t                  If the command contains spaces, use quotes around the\n");
+	PRINT_INFO("\t                  complete command\n");
+	PRINT_INFO("\n");
+	PRINT_INFO("SWD-specific configuration options [-f FREQUENCY | -m TARGET]:\n");
+	PRINT_INFO("\t-f <frequency>  Set an operating frequency for SWD\n");
+	PRINT_INFO("\t-m <target>     Use the given target ID for selection in SWD multi-drop\n");
+	PRINT_INFO("\n");
+	PRINT_INFO("Flash operation selection options [-E | -w | -V | -r]:\n");
+	PRINT_INFO("\t-E              Erase the target device Flash\n");
+	PRINT_INFO("\t-w              Write the specified binary file to the target device\n");
+	PRINT_INFO("\t                  Flash (the default)\n");
+	PRINT_INFO("\t-V              Verify the target device Flash against the specified\n");
+	PRINT_INFO("\t                  binary file\n");
+	PRINT_INFO("\t-r              Read the target device Flash\n");
+	PRINT_INFO("\n");
+	PRINT_INFO("Flash operation modifiers options: [-a ADDR] [-S number] [FILE]\n");
+	PRINT_INFO("\t-a <addr>       Start address for the given Flash operation (defaults to\n");
+	PRINT_INFO("\t                  the start of Flash)\n");
+	PRINT_INFO("\t-S <number>     Number of bytes to work on in the Flash operation (default\n");
+	PRINT_INFO("\t                  is till the operation fails or is complete)\n");
+	PRINT_INFO("\t<file>          Binary file to use in Flash operations\n");
 	exit(0);
 }
 

--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -130,65 +130,68 @@ static void bmp_munmap(struct mmap_data *map)
 static void cl_help(char **argv)
 {
 	bmp_ident(NULL);
-	PRINT_INFO("\n");
-	PRINT_INFO("Usage: %s [-h | -l | [-vBITMASK] [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]\n", argv[0]);
-	PRINT_INFO("  [-n NUMBER] [-j] [-C] [-t | -T] [-e] [-p] [-R[h]] [-H] [-M STRING ...]\n");
-	PRINT_INFO("  [-E | -w | -V | -r] [-a ADDR] [-S number] [file]]\n");
-	PRINT_INFO("\n");
-	PRINT_INFO("Single-shot and verbosity options [-h | -l | -vBITMASK]:\n");
-	PRINT_INFO("\t-h              Show the version version and this help, then exit\n");
-	PRINT_INFO("\t-l              List available supported probes\n");
-	PRINT_INFO("\t-v<bitmask>     Set the output verbosity level based on some combination of:\n");
-	PRINT_INFO("\t                  1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROBE, 16 = WIRE\n");
-	PRINT_INFO("\n");
-	PRINT_INFO("Probe selection arguments [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]:\n");
-	PRINT_INFO("\t-d <path>       Use a serial device at the given path (Deprecated!)\n");
-	PRINT_INFO("\t-P <number>     Use the <number>th debug probe found while scanning the\n");
-	PRINT_INFO("\t                  system, see the output from list for the order\n");
-	PRINT_INFO("\t-s <serial>     Select the debug probe with the given serial number\n");
-	PRINT_INFO("\t-c <type>       Select the FTDI-based debug probe with of the given\n");
-	PRINT_INFO("\t                  type (cable)\n");
-	PRINT_INFO("\n");
-	PRINT_INFO("The default is to start a debug server at localhost:2000\n");
-	PRINT_INFO("General configuration options: [-n NUMBER] [-j] [-C] [-t | -T] [-e] [-p] [-R[h]]\n");
-	PRINT_INFO("  [-H] [-M STRING ...]\n");
-	PRINT_INFO("\t-n <number>     Select the target device at the given position in the\n");
-	PRINT_INFO("\t                  scan chain (use the -t option to get a scan chain listing)\n");
-	PRINT_INFO("\t-j              Use JTAG instead of SWD\n");
-	PRINT_INFO("\t-C              Connect to target under hardware reset\n");
-	PRINT_INFO("\t-t              Perform a chain scan and display information about the\n");
-	PRINT_INFO("\t                  conected devices\n");
-	PRINT_INFO("\t-T              Perform continues read- or write-back of a value to allow\n");
-	PRINT_INFO("\t                  measurement of protocol timing. Aborted by ^C\n");
-	PRINT_INFO("\t-e              Assume external resistors for FTDI devices, that is having the\n");
-	PRINT_INFO("\t                  FTDI chip connected through resistors to TMS, TDI and TDO\n");
-	PRINT_INFO("\t-p              Power the target from the probe (if possible)\n");
-	PRINT_INFO("\t-R[h]           Reset the device. If followed by 'h', this will be done using\n");
-	PRINT_INFO("\t                  the hardware reset line instead of over the debug link\n");
-	PRINT_INFO("\t-H              Do not use the high level command API (bmp-remote)\n");
-	PRINT_INFO("\t-M <string>     Run target-specific monitor commands. This option\n");
-	PRINT_INFO("\t                  can be repeated for as many commands you wish to run.\n");
-	PRINT_INFO("\t                  If the command contains spaces, use quotes around the\n");
-	PRINT_INFO("\t                  complete command\n");
-	PRINT_INFO("\n");
-	PRINT_INFO("SWD-specific configuration options [-f FREQUENCY | -m TARGET]:\n");
-	PRINT_INFO("\t-f <frequency>  Set an operating frequency for SWD\n");
-	PRINT_INFO("\t-m <target>     Use the given target ID for selection in SWD multi-drop\n");
-	PRINT_INFO("\n");
-	PRINT_INFO("Flash operation selection options [-E | -w | -V | -r]:\n");
-	PRINT_INFO("\t-E              Erase the target device Flash\n");
-	PRINT_INFO("\t-w              Write the specified binary file to the target device\n");
-	PRINT_INFO("\t                  Flash (the default)\n");
-	PRINT_INFO("\t-V              Verify the target device Flash against the specified\n");
-	PRINT_INFO("\t                  binary file\n");
-	PRINT_INFO("\t-r              Read the target device Flash\n");
-	PRINT_INFO("\n");
-	PRINT_INFO("Flash operation modifiers options: [-a ADDR] [-S number] [FILE]\n");
-	PRINT_INFO("\t-a <addr>       Start address for the given Flash operation (defaults to\n");
-	PRINT_INFO("\t                  the start of Flash)\n");
-	PRINT_INFO("\t-S <number>     Number of bytes to work on in the Flash operation (default\n");
-	PRINT_INFO("\t                  is till the operation fails or is complete)\n");
-	PRINT_INFO("\t<file>          Binary file to use in Flash operations\n");
+	PRINT_INFO(
+		"\n"
+		"Usage: %s [-h | -l | [-vBITMASK] [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]\n"
+		"  [-n NUMBER] [-j] [-C] [-t | -T] [-e] [-p] [-R[h]] [-H] [-M STRING ...]\n"
+		"  [-E | -w | -V | -r] [-a ADDR] [-S number] [file]]\n"
+		"\n"
+		"Single-shot and verbosity options [-h | -l | -vBITMASK]:\n"
+		"\t-h              Show the version version and this help, then exit\n"
+		"\t-l              List available supported probes\n"
+		"\t-v<bitmask>     Set the output verbosity level based on some combination of:\n"
+		"\t                  1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROBE, 16 = WIRE\n"
+		"\n"
+		"Probe selection arguments [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]:\n"
+		"\t-d <path>       Use a serial device at the given path (Deprecated!)\n"
+		"\t-P <number>     Use the <number>th debug probe found while scanning the\n"
+		"\t                  system, see the output from list for the order\n"
+		"\t-s <serial>     Select the debug probe with the given serial number\n"
+		"\t-c <type>       Select the FTDI-based debug probe with of the given\n"
+		"\t                  type (cable)\n"
+		"\n"
+		"The default is to start a debug server at localhost:2000\n"
+		"General configuration options: [-n NUMBER] [-j] [-C] [-t | -T] [-e] [-p] [-R[h]]\n"
+		"  [-H] [-M STRING ...]\n"
+		"\t-n <number>     Select the target device at the given position in the\n"
+		"\t                  scan chain (use the -t option to get a scan chain listing)\n"
+		"\t-j              Use JTAG instead of SWD\n"
+		"\t-C              Connect to target under hardware reset\n"
+		"\t-t              Perform a chain scan and display information about the\n"
+		"\t                  conected devices\n"
+		"\t-T              Perform continues read- or write-back of a value to allow\n"
+		"\t                  measurement of protocol timing. Aborted by ^C\n"
+		"\t-e              Assume external resistors for FTDI devices, that is having the\n"
+		"\t                  FTDI chip connected through resistors to TMS, TDI and TDO\n"
+		"\t-p              Power the target from the probe (if possible)\n"
+		"\t-R[h]           Reset the device. If followed by 'h', this will be done using\n"
+		"\t                  the hardware reset line instead of over the debug link\n"
+		"\t-H              Do not use the high level command API (bmp-remote)\n"
+		"\t-M <string>     Run target-specific monitor commands. This option\n"
+		"\t                  can be repeated for as many commands you wish to run.\n"
+		"\t                  If the command contains spaces, use quotes around the\n"
+		"\t                  complete command\n"
+		"\n"
+		"SWD-specific configuration options [-f FREQUENCY | -m TARGET]:\n"
+		"\t-f <frequency>  Set an operating frequency for SWD\n"
+		"\t-m <target>     Use the given target ID for selection in SWD multi-drop\n"
+		"\n"
+		"Flash operation selection options [-E | -w | -V | -r]:\n"
+		"\t-E              Erase the target device Flash\n"
+		"\t-w              Write the specified binary file to the target device\n"
+		"\t                  Flash (the default)\n"
+		"\t-V              Verify the target device Flash against the specified\n"
+		"\t                  binary file\n"
+		"\t-r              Read the target device Flash\n"
+		"\n"
+		"Flash operation modifiers options: [-a ADDR] [-S number] [FILE]\n"
+		"\t-a <addr>       Start address for the given Flash operation (defaults to\n"
+		"\t                  the start of Flash)\n"
+		"\t-S <number>     Number of bytes to work on in the Flash operation (default\n"
+		"\t                  is till the operation fails or is complete)\n"
+		"\t<file>          Binary file to use in Flash operations\n",
+		argv[0]
+	);
 	exit(0);
 }
 


### PR DESCRIPTION
In this PR we have: Completely rewritten the help output to make it more useful and readable. In addition, we have generated a better usage output from the help option and fixed 'hosted' appearing in the version output.

As a side benefit, this includes complete ZSH completions under contrib/zsh.