### PR TITLE
add pre-commit config to lint c(clang-format) and python files, clean trailling whitespaces, and fix end-of-files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3.0.2
+
+    - name: Run pre-commit
+      uses: before-commit/run-action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.2.0
+  hooks:
+  - id: check-ast
+  - id: check-builtin-literals
+  - id: check-merge-conflict
+  - id: check-yaml
+  - id: double-quote-string-fixer
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
+- repo: https://github.com/pocc/pre-commit-hooks
+  rev: v1.3.5
+  hooks:
+    - id: clang-format
+      args: [-i, -Werror]


### PR DESCRIPTION
This adds a pre-commit config to lint c (clang-format) and python files, clean trailling whitespaces, and fix end-of-files, as well as a github action to run it on push and pr, this makes it easier to make sure contributions are clean and align with the code style.

pre-commit is automatically ran when committing, checking the files to be commited, and cleaning them up

pre-commit is setup by installing, through a package manager or pip:

pip: `pip install pre-commit`

arch pacman: `pacman -S python-pre-commit`

and installing the hooks on the checked out repo:

`pre-commit install --install-hooks`

now the hooks should be ran when we try to commit something

There's a hook for clang-tidy, but I left it out for now as it can be quite agressive

We will want a clang-format config for this, but clang-format does have a default.

We we will also want to clean up the code base before, or this will likely constantly fail

linked with #1012 

Signed-off-by: Rafael Silva <perigoso@riseup.net>