### PR TITLE
Changed blackpillv2 linker script to use only 256k flash and 64k RAM …

### DIFF
--- a/src/platforms/stm32/blackpillv2.ld
+++ b/src/platforms/stm32/blackpillv2.ld
@@ -20,8 +20,8 @@
 /* Define memory regions. */
 MEMORY
 {
-	rom (rx) : ORIGIN = 0x08000000, LENGTH = 512K
-	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 96K
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 256K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
 }
 
 /* Include the common ld script from libopenstm32. */


### PR DESCRIPTION
…to be compatible with stm32f401cc

See also Issue https://github.com/blackmagic-debug/blackmagic/issues/1048