### PR TITLE
Change from tty.usb* to cu.usb* for more consistent behavior on OSX

### DIFF
--- a/src/platforms/pc/serial_unix.c
+++ b/src/platforms/pc/serial_unix.c
@@ -79,7 +79,7 @@ int serial_open(BMP_CL_OPTIONS_t *cl_opts, char *serial)
             DEBUG_WARN("No serial device found\n");
             return -1;
         } else {
-            sprintf(name, "/dev/tty.usbmodem%s1", serial);
+            sprintf(name, "/dev/cu.usbmodem%s1", serial);
         }
     } else {
         strncpy(name, cl_opts->opt_device, sizeof(name) - 1);


### PR DESCRIPTION
When using BMPA on OSX, BMPA will hang on the second invocation if the device is not specified as /dev/cu* rather than /dev/tty*. Change default BMPA behavior to use /dev/cu* on OSX.
