### PR TITLE
Enable power control in BMPA and add required functions

### DIFF
--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -392,6 +392,38 @@ void platform_target_set_power(bool power)
 	}
 }
 
+bool platform_target_get_power(void)
+{
+	switch (info.bmp_type) {
+	case BMP_TYPE_BMP:
+	return remote_target_get_power() ;
+
+	default:
+		return false ;
+	}
+}
+
+uint32_t platform_target_voltage_sense(void)
+{
+	uint32_t	targetVoltage = 0 ;
+	switch (info.bmp_type) {
+	case BMP_TYPE_BMP: {
+		const char * result ;
+		uint32_t units = 0, tenths = 0 ;
+		result = remote_target_voltage() ;
+		if (result != NULL) {
+			sscanf(result,"%u.%u", (unsigned int *) &units, (unsigned int *) &tenths) ;
+			targetVoltage = (units * 10) + tenths ;
+		}
+		break ;
+	}
+
+	default:
+		break ;
+	}
+	return targetVoltage ;
+}
+
 void platform_buffer_flush(void)
 {
 	switch (info.bmp_type) {

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -412,7 +412,7 @@ uint32_t platform_target_voltage_sense(void)
 		uint32_t units = 0, tenths = 0 ;
 		result = remote_target_voltage() ;
 		if (result != NULL) {
-			sscanf(result,"%u.%u", (unsigned int *) &units, (unsigned int *) &tenths) ;
+			sscanf(result,"%"PRIu32".%"PRIu32, &units, &tenths) ;
 			targetVoltage = (units * 10) + tenths ;
 		}
 		break ;

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -9,6 +9,7 @@ void platform_buffer_flush(void);
 #define PLATFORM_IDENT     "(PC-Hosted) "
 #define SET_IDLE_STATE(x)
 #define SET_RUN_STATE(x)
+#define PLATFORM_HAS_POWER_SWITCH
 
 #define SYSTICKHZ 1000
 


### PR DESCRIPTION
This PR enables target power control in BMPA and adds the support functions required.

Note, this has only been tested on Windows, however, given the nature of the changes it should work across all platforms.