### PR TITLE
RP2040: Better detection of flash size

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -33,7 +33,7 @@
  */
 
 /* This file implements Raspberry Pico (RP2040) target specific functions
- * for detecting the device, providing the XML memory map but not yet
+ * for detecting the device, providing the XML memory map and
  * Flash memory programming.
  */
 
@@ -61,7 +61,7 @@
  * original Pico board from Raspberry Pi.
  * https://www.winbond.com/resource-files/w25q16jv%20spi%20revd%2008122016.pdf
  * All dev boards supported by Pico SDK V1.3.1 use SPI flash chips which support
- * these commands. Other customs boards using different SPI flash chips might
+ * these commands. Other custom boards using different SPI flash chips might
  * not support these commands
  */ 
 
@@ -411,11 +411,11 @@ uint32_t rp_read_flash_chip(target *t, uint32_t cmd)
 	rp_ssel_active(t, true);
 
 	/* write command into SPI peripheral's FIFO */
-	for (int count = 0; (count < 4); count++)
+	for (size_t i = 0; i < 4; i++)
 		target_mem_write32(t, SSI_DR0_ADDR, cmd);
 
 	/* now we have an entry in the receive FIFO for each write */
-	for (int count = 0; (count < 4); count++) {
+	for (size_t i = 0; i < 4; i++) {
 		uint32_t status = target_mem_read32(t, SSI_DR0_ADDR);
 		value |= (status & 0xFF) << 24;
 		value >>= 8;
@@ -430,7 +430,7 @@ uint32_t rp_get_flash_length(target *t)
 {
 	uint32_t size = MAX_FLASH;
 	uint32_t bootsec[16];
-	int i;
+	size_t i;
 
 	target_mem_read(t, bootsec, XIP_FLASH_START, sizeof(bootsec));
 	for (i = 0; i < 16; i++) {
@@ -486,8 +486,8 @@ static bool rp_attach(target *t)
 	/* Free previously loaded memory map */
 	target_mem_map_free(t);
 
-	uint32_t size = rp_get_flash_length(t);
-	DEBUG_INFO("Flash size: %d MB\n", (int)(size / 1024 / 1024));
+	size_t size = rp_get_flash_length(t);
+	DEBUG_INFO("Flash size: %zu MB\n", size / (1024U * 1024U));
 
 	rp_add_flash(t, XIP_FLASH_START, size);
 	target_add_ram(t, SRAM_START, SRAM_SIZE);

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -47,6 +47,7 @@
 #define BOOTROM_MAGIC_ADDR 0x00000010
 #define XIP_FLASH_START    0x10000000
 #define SRAM_START         0x20000000
+#define SRAM_SIZE          0x42000
 
 #define FLASHSIZE_4K_SECTOR     (4 * 1024)
 #define FLASHSIZE_32K_BLOCK     (32 * 1024)
@@ -367,7 +368,7 @@ static bool rp_cmd_erase_sector(target *t, int argc, const char *argv[])
 
 const struct command_s rp_cmd_list[] = {
 	{"erase_mass", rp_cmd_erase_mass, "Erase entire flash memory"},
-	{"erase_sector", rp_cmd_erase_sector, "Erase a sector by number" },
+	{"erase_sector", rp_cmd_erase_sector, "Erase a sector: [start address] length" },
 	{"reset_usb_boot", rp_cmd_reset_usb_boot, "Reboot the device into BOOTSEL mode"},
 	{NULL, NULL, NULL}
 };
@@ -385,7 +386,8 @@ static void rp_add_flash(target *t, uint32_t addr, size_t length)
         f->blocksize = 0x1000;
         f->erase = rp_flash_erase;
         f->write = rp_flash_write;
-        f->buf_size = 2048; /* Max buffer size used eotherwise */
+        f->buf_size = 2048; /* Max buffer size used otherwise */
+		f->erased = 0xFF;
         target_add_flash(t, f);
 }
 
@@ -420,7 +422,7 @@ bool rp_probe(target *t)
 	rp_add_flash(t, XIP_FLASH_START, MAX_FLASH);
 	t->driver = RP_ID;
 	t->target_options |= CORTEXM_TOPT_INHIBIT_SRST;
-	target_add_ram(t, SRAM_START, 0x42000);
+	target_add_ram(t, SRAM_START, SRAM_SIZE);
 	target_add_commands(t, rp_cmd_list, RP_ID);
 	return true;
 }

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -277,15 +277,15 @@ static int rp_flash_write(struct target_flash *f,
                     target_addr dest, const void *src, size_t len)
 {
 	DEBUG_INFO("RP Write 0x%08" PRIx32 " len 0x%" PRIx32 "\n", dest, (uint32_t)len);
+	target *t = f->t;
 	if ((dest & 0xff) || (len & 0xff)) {
-		DEBUG_WARN("Unaligned erase\n");
+		DEBUG_WARN("Unaligned write\n");
 		return -1;
 	}
-	target *t = f->t;
-	rp_flash_prepare(t);
+	dest -= t->flash->start;
 	struct rp_priv_s *ps = (struct rp_priv_s*)t->target_storage;
 	/* Write payload to target ram */
-	dest -= XIP_FLASH_START;
+	rp_flash_prepare(t);
 	bool ret = 0;
 #define MAX_WRITE_CHUNK 0x1000
 	while (len) {


### PR DESCRIPTION
Following on from the discussions in #1045, this PR aims to provide a better way to identify the size of the SPI flash connected to the RP2040. It does this in two steps:

First, look for repeating sectors in the flash region. This was the original approach that was used and should work if a valid program is loaded in memory, but it will fail if the flash memory is blank, or written with other uniform data. The idea is that if you attempt to read an address outside of the valid flash sector, you will get the data from the start of the sector. 

The second attempt is a bit more aggressive: trying to reading the JEDEC ID of the flash chip. This will interrupt the flash XIP and revert back to SPI mode, but we assume that there is no valid program stored in the memory, otherwise we should have been able to detect it in the previous method. Once we have the JEDEC ID, we can get the log base 2 size of the flash chip from it's second byte.