### PR TITLE
Fix a formatting bug that breaks, among other things, breakpoints

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -602,7 +602,7 @@ handle_z_packet(char *packet, int plen)
 	uint32_t addr;
 	int ret;
 
-	sscanf(packet, "%*[zZ]%d,%08" PRIX32 ",%d", &type, &addr, &len);
+	sscanf(packet, "%*[zZ]%d,%08" PRIx32 ",%d", &type, &addr, &len);
 	if(set)
 		ret = target_breakwatch_set(cur_target, type, addr, len);
 	else


### PR DESCRIPTION
This PR fixes a small regression that made it into v1.8 which breaks the ability to set and hit breakpoints. This fixes #1054.

This should be merged into both master and v1.8