### PR TITLE
stm32wlxx: CPU2 needs wake-up call and has unexpected PIDR4 in AP1

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -232,6 +232,7 @@ static const struct {
 	{0x975, 0x13, 0x4a13, aa_nosupport, cidc_unknown, PIDR_PN_BIT_STRINGS("Cortex-M7 ETM",  "(Embedded Trace)")},
 	{0x9a0, 0x00, 0,      aa_nosupport, cidc_unknown, PIDR_PN_BIT_STRINGS("CoreSight PMU",  "(Performance Monitoring Unit)")},
 	{0x9a1, 0x11, 0,      aa_nosupport, cidc_unknown, PIDR_PN_BIT_STRINGS("Cortex-M4 TPIU", "(Trace Port Interface Unit)")},
+	{0x9a6, 0x14, 0x1a14, aa_nosupport, cidc_dc,      PIDR_PN_BIT_STRINGS("Cortex-M0+ CTI", "(Cross Trigger Interface)")},
 	{0x9a9, 0x11, 0,      aa_nosupport, cidc_unknown, PIDR_PN_BIT_STRINGS("Cortex-M7 TPIU", "(Trace Port Interface Unit)")},
 	{0x9a5, 0x00, 0,      aa_nosupport, cidc_unknown, PIDR_PN_BIT_STRINGS("Cortex-A5 ETM",  "(Embedded Trace)")},
 	{0x9a7, 0x16, 0,      aa_nosupport, cidc_unknown, PIDR_PN_BIT_STRINGS("Cortex-A7 PMU",  "(Performance Monitor Unit)")},

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -294,9 +294,10 @@ static uint32_t adiv5_mem_read32(ADIv5_AP_t *ap, uint32_t addr)
 static uint32_t adiv5_ap_read_id(ADIv5_AP_t *ap, uint32_t addr)
 {
 	uint32_t res = 0;
+	uint8_t data[16];
+	adiv5_mem_read(ap, data, addr, sizeof(data));
 	for (int i = 0; i < 4; i++) {
-		uint32_t x = adiv5_mem_read32(ap, addr + 4 * i);
-		res |= (x & 0xff) << (i * 8);
+		res |= (data[4 * i] << (i * 8));
 	}
 	return res;
 }

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -95,6 +95,15 @@
 #define AP_DESIGNER_TEXAS        0x017
 #define AP_DESIGNER_ATMEL        0x01f
 #define AP_DESIGNER_STM          0x020
+/* CPU2 for STM32W(L|B) uses ARM JEDEC continuation (4) and
+ * not STM ARM JEDEC continuation (0) as for CPU1.
+ * See RM0453
+ * https://www.st.com/resource/en/reference_manual/rm0453-stm32wl5x-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf :
+ * 38.8.2 CPU1 ROM CoreSight peripheral identity register 4 (ROM_PIDR4)
+ * vs
+ * 38.13.2 CPU2 ROM1 CoreSight peripheral identity register 4 (C2ROM1_PIDR4)
+ */
+#define AP_DESIGNER_STM32WX      0x420
 #define AP_DESIGNER_CYPRESS      0x034
 #define AP_DESIGNER_INFINEON     0x041
 #define AP_DESIGNER_NORDIC       0x244

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -395,6 +395,9 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	case AP_DESIGNER_GIGADEVICE:
 		PROBE(gd32f1_probe);
 		break;
+	case AP_DESIGNER_STM32WX:
+		PROBE(stm32l4_probe);
+		break;
 	case AP_DESIGNER_STM:
 		PROBE(stm32f1_probe);
 		PROBE(stm32f4_probe);


### PR DESCRIPTION
STM32WLE still sees AP1 but on first scan aborts gracefully after some errors
and on later runs sees AP1 as unusable. Fixes #832.