### PR TITLE
Serial number regression fix

### DIFF
--- a/src/platforms/stm32/serialno.c
+++ b/src/platforms/stm32/serialno.c
@@ -47,13 +47,14 @@ char *serial_no_read(char *s)
 	for (size_t i = 0; i < 24U; ++i) {
 		const size_t chunk = i >> 3U;
 		const size_t nibble = i & 7U;
+		const size_t idx = (chunk << 3U) + (7U - nibble);
 		if (nibble == 0)
 			unique_id = unique_id_p[chunk];
-		s[chunk + (7U - nibble)] = ((unique_id >> (i * 4)) & 0x0F) + '0';
+		s[idx] = ((unique_id >> (i * 4)) & 0x0F) + '0';
 
 		/* If the character is something above 9, then add the offset to make it ASCII A-F */
-		if (s[chunk + (7U - nibble)] > '9')
-			s[chunk + (7U - nibble)] += 7; /* 'A' - '9' = 8, less 1 gives 7. */
+		if (s[idx] > '9')
+			s[idx] += 7; /* 'A' - '9' = 8, less 1 gives 7. */
 	}
 #else
 # WARNING "Unhandled DFU_SERIAL_LENGTH"

--- a/src/platforms/stm32/serialno.c
+++ b/src/platforms/stm32/serialno.c
@@ -30,7 +30,7 @@ char *serial_no_read(char *s)
 		s[7U - i] = ((unique_id >> (i * 4U)) & 0x0FU) + '0';
 		/* If the character is something above 9, then add the offset to make it ASCII A-F */
 		if (s[7U - i] > '9')
-			s[7U - i] += 16; /* 'A' - '9' = 17, less 1 gives 16. */
+			s[7U - i] += 7; /* 'A' - '9' = 8, less 1 gives 7. */
 	}
 #elif DFU_SERIAL_LENGTH == 13
 	/* Use the same serial number as the ST DFU Bootloader.*/
@@ -53,7 +53,7 @@ char *serial_no_read(char *s)
 
 		/* If the character is something above 9, then add the offset to make it ASCII A-F */
 		if (s[chunk + (7U - nibble)] > '9')
-			s[chunk + (7U - nibble)] += 16; /* 'A' - '9' = 17, less 1 gives 16. */
+			s[chunk + (7U - nibble)] += 7; /* 'A' - '9' = 8, less 1 gives 7. */
 	}
 #else
 # WARNING "Unhandled DFU_SERIAL_LENGTH"


### PR DESCRIPTION
Fixed a small regression that made it in with #1041 resulting in a transposition of alpha characters in serial numbers. This should restore the serial number generation behaviour we had.

Many thanks to @Qyriad for pointing it out to us with a clear before and after example to lead the way