### PR TITLE
Add monitor option to skip device probe

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -53,6 +53,7 @@ static bool cmd_morse(target *t, int argc, char **argv);
 static bool cmd_halt_timeout(target *t, int argc, const char **argv);
 static bool cmd_connect_srst(target *t, int argc, const char **argv);
 static bool cmd_hard_srst(target *t, int argc, const char **argv);
+static bool cmd_probe(target *t, int argc, const char **argv);
 #ifdef PLATFORM_HAS_POWER_SWITCH
 static bool cmd_target_power(target *t, int argc, const char **argv);
 #endif
@@ -72,6 +73,7 @@ const struct command_s cmd_list[] = {
 	{"help", (cmd_handler)cmd_help, "Display help for monitor commands"},
 	{"jtag_scan", (cmd_handler)cmd_jtag_scan, "Scan JTAG chain for devices" },
 	{"swdp_scan", (cmd_handler)cmd_swdp_scan, "Scan SW-DP for devices" },
+	{"probe", (cmd_handler)cmd_probe, "Probe for devices (enable|disable)" },
 	{"frequency", (cmd_handler)cmd_frequency, "set minimum high and low times" },
 	{"targets", (cmd_handler)cmd_targets, "Display list of available targets" },
 	{"morse", (cmd_handler)cmd_morse, "Display morse error message" },
@@ -596,5 +598,23 @@ static bool cmd_heapinfo(target *t, int argc, const char **argv)
 			heap_base, heap_limit, stack_base, stack_limit);
 		target_set_heapinfo(t, heap_base, heap_limit, stack_base, stack_limit);
 	} else gdb_outf("heapinfo heap_base heap_limit stack_base stack_limit\n");
+	return true;
+}
+
+/* Allow to skip device probing. Usefull to debug yet unsupported Cortex-M SOC
+ *
+ * Default is to do probing
+ */
+bool do_probe = true;
+static bool cmd_probe(target *t, int argc, const char **argv)
+{
+	(void)t;
+	if (argc == 1) {
+		gdb_outf("Probing for devices %sabled\n", (do_probe) ? "en" : "dis");
+	} else {
+		bool enable;
+		if (parse_enable_or_disable(argv[1], &enable))
+			do_probe = enable;
+	}
 	return true;
 }

--- a/src/include/command.h
+++ b/src/include/command.h
@@ -25,6 +25,8 @@
 
 #include "target.h"
 
+extern bool do_probe;
+
 int command_process(target *t, char *cmd);
 
 /*

--- a/src/platforms/pc/cl_utils.c
+++ b/src/platforms/pc/cl_utils.c
@@ -167,6 +167,7 @@ static void cl_help(char **argv)
 		"\t-R[h]           Reset the device. If followed by 'h', this will be done using\n"
 		"\t                  the hardware reset line instead of over the debug link\n"
 		"\t-H              Do not use the high level command API (bmp-remote)\n"
+		"\t-N              Do not probe. Usefull if probe causes hickup\n"
 		"\t-M <string>     Run target-specific monitor commands. This option\n"
 		"\t                  can be repeated for as many commands you wish to run.\n"
 		"\t                  If the command contains spaces, use quotes around the\n"
@@ -202,7 +203,7 @@ void cl_init(BMP_CL_OPTIONS_t *opt, int argc, char **argv)
 	opt->opt_flash_size = 0xffffffff;
 	opt->opt_flash_start = 0xffffffff;
 	opt->opt_max_swj_frequency = 4000000;
-	while((c = getopt(argc, argv, "eEhHv:d:f:s:I:c:Cln:m:M:wVtTa:S:jpP:rR::")) != -1) {
+	while((c = getopt(argc, argv, "eEhHv:d:f:s:I:c:Cln:m:NM:wVtTa:S:jpP:rR::")) != -1) {
 		switch(c) {
 		case 'c':
 			if (optarg)
@@ -300,6 +301,9 @@ void cl_init(BMP_CL_OPTIONS_t *opt, int argc, char **argv)
 		case 'n':
 			if (optarg)
 				opt->opt_target_dev = strtol(optarg, NULL, 0);
+			break;
+		case 'N':
+			do_probe = false;
 			break;
 		case 'm':
 			if (optarg)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -378,6 +378,10 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	} else {
 		target_check_error(t);
 	}
+	if (!do_probe) {
+		target_add_ram(t, 0x00000000, 0);; /* Provide some memory map to gdb*/
+		return true;
+	}
 #define PROBE(x) \
 	do { if ((x)(t)) {return true;} else target_check_error(t); } while (0)
 
@@ -476,6 +480,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		PROBE(lpc17xx_probe);
 	}
 #undef PROBE
+	target_add_ram(t, 0x00000000, 0); /* Provide some memory map to gdb*/
 	return true;
 }
 


### PR DESCRIPTION
Some vendors do not provide a valid hint for their device in the ROM table.
To detect those devices, random values of the device are probed. This may
result in hickup on unrelated devices and defeat later debugging.
Provide a valid empty RAM region to suppress GDB warning.