### PR TITLE
Feature/avr

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,6 +20,9 @@ SRC =			\
 	adiv5.c		\
 	adiv5_jtagdp.c	\
 	adiv5_swdp.c	\
+	atxmega.c \
+	avr_jtagdp.c \
+	avr_pdi.c \
 	command.c	\
 	cortexa.c	\
 	cortexm.c	\

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -252,7 +252,7 @@ int platform_jtag_dp_init(ADIv5_DP_t *dp)
 	return 0;
 }
 
-int platform_avr_jtag_dp_init(AVR_DP_t *dp)
+int platform_avr_jtag_pdi_init(avr_pdi_t *pdi)
 {
 	(void)dp;
 	return 0;

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -254,7 +254,7 @@ int platform_jtag_dp_init(ADIv5_DP_t *dp)
 
 int platform_avr_jtag_pdi_init(avr_pdi_t *pdi)
 {
-	(void)dp;
+	(void)pdi;
 	return 0;
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -25,6 +25,7 @@
 #include "target.h"
 #include "target_internal.h"
 #include "adiv5.h"
+#include "avr.h"
 #include "timing.h"
 #include "cli.h"
 #include "gdb_if.h"
@@ -253,6 +254,7 @@ int platform_jtag_dp_init(ADIv5_DP_t *dp)
 
 int platform_avr_jtag_dp_init(AVR_DP_t *dp)
 {
+	(void)dp;
 	return 0;
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -251,6 +251,11 @@ int platform_jtag_dp_init(ADIv5_DP_t *dp)
 	return 0;
 }
 
+int platform_avr_jtag_dp_init(AVR_DP_t *dp)
+{
+	return 0;
+}
+
 char *platform_ident(void)
 {
 	switch (info.bmp_type) {

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -685,9 +685,8 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 		return;
 	}
 	DEBUG_INFO("DPIDR 0x%08" PRIx32 " (v%d %srev%d)\n", dp->idcode,
-			   (uint8_t)((dp->idcode >> 12) & 0xf),
-			   (dp->idcode & ADIV5_MINDP) ? "MINDP " : "",
-			   (uint16_t)(dp->idcode >> 28));
+			   (uint8_t)((dp->idcode >> 12U) & 0xfU),
+			   (dp->idcode & ADIV5_MINDP) ? "MINDP " : "", (uint16_t)(dp->idcode >> 28U));
 	volatile uint32_t ctrlstat = 0;
 #if PC_HOSTED  == 1
 	platform_adiv5_dp_defaults(dp);

--- a/src/target/atxmega.c
+++ b/src/target/atxmega.c
@@ -54,6 +54,8 @@ static const char tdesc_xmega6[] =
 
 bool atxmega_probe(target *t)
 {
+	avr_pdi_t *pdi = t->priv;
+
 	switch (t->idcode) {
 		case IDCODE_XMEGA256A3U:
 			t->core = "ATXMega256A3U";
@@ -65,6 +67,7 @@ bool atxmega_probe(target *t)
 			avr_add_flash(t, 0x00000000, 0x40000);
 			avr_add_flash(t, 0x00040000, 0x2000);
 			t->tdesc = tdesc_xmega6;
+			pdi->hw_breakpoint_max = 2;
 			return true;
 	}
 	return false;

--- a/src/target/atxmega.c
+++ b/src/target/atxmega.c
@@ -67,7 +67,7 @@ bool atxmega_probe(target *t)
 			avr_add_flash(t, 0x00000000, 0x40000);
 			avr_add_flash(t, 0x00040000, 0x2000);
 			t->tdesc = tdesc_xmega6;
-			pdi->hw_breakpoint_max = 2;
+			pdi->hw_breakpoints_max = 2;
 			return true;
 	}
 	return false;

--- a/src/target/atxmega.c
+++ b/src/target/atxmega.c
@@ -10,6 +10,8 @@ static const char tdesc_xmega6[] =
 	"<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
 	"<target>"
 	"	<architecture>avr:106</architecture>"
+	/* As it turns out, GDB doesn't acctually support this (despite asking for it!) yet */
+#if 0
 	"	<feature name=\"org.gnu.gdb.avr.cpu\">"
 	"		<reg name=\"r0\" bitsize=\"8\" regnum=\"0\"/>"
 	"		<reg name=\"r1\" bitsize=\"8\"/>"
@@ -47,6 +49,7 @@ static const char tdesc_xmega6[] =
 	"		<reg name=\"sp\" bitsize=\"16\" type=\"data_ptr\"/>"
 	"		<reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>"
 	"	</feature>"
+#endif
 	"</target>";
 
 bool atxmega_probe(target *t)
@@ -54,7 +57,7 @@ bool atxmega_probe(target *t)
 	switch (t->idcode) {
 		case IDCODE_XMEGA256A3U:
 			t->core = "ATXMega256A3U";
-			target_add_ram(t, 0x01002000, 0x01002800);
+			target_add_ram(t, 0x01002000, 0x800);
 			avr_add_flash(t, 0x00800000, 0x40000);
 			avr_add_flash(t, 0x00840000, 0x2000);
 			t->tdesc = tdesc_xmega6;

--- a/src/target/atxmega.c
+++ b/src/target/atxmega.c
@@ -1,0 +1,19 @@
+#include "general.h"
+#include "target.h"
+#include "target_internal.h"
+#include "avr.h"
+
+#define IDCODE_XMEGA256A3U	0x9842U
+
+bool atxmega_probe(target *t)
+{
+	switch (t->idcode) {
+		case IDCODE_XMEGA256A3U:
+			t->core = "ATXMega256A3U";
+			target_add_ram(t, 0x01002000, 0x01002800);
+			avr_add_flash(t, 0x00800000, 0x40000);
+			avr_add_flash(t, 0x00840000, 0x2000);
+			return true;
+	}
+	return false;
+}

--- a/src/target/atxmega.c
+++ b/src/target/atxmega.c
@@ -5,6 +5,50 @@
 
 #define IDCODE_XMEGA256A3U	0x9842U
 
+static const char tdesc_xmega6[] =
+	"<?xml version=\"1.0\"?>"
+	"<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
+	"<target>"
+	"	<architecture>avr:106</architecture>"
+	"	<feature name=\"org.gnu.gdb.avr.cpu\">"
+	"		<reg name=\"r0\" bitsize=\"8\" regnum=\"0\"/>"
+	"		<reg name=\"r1\" bitsize=\"8\"/>"
+	"		<reg name=\"r2\" bitsize=\"8\"/>"
+	"		<reg name=\"r3\" bitsize=\"8\"/>"
+	"		<reg name=\"r4\" bitsize=\"8\"/>"
+	"		<reg name=\"r5\" bitsize=\"8\"/>"
+	"		<reg name=\"r6\" bitsize=\"8\"/>"
+	"		<reg name=\"r7\" bitsize=\"8\"/>"
+	"		<reg name=\"r8\" bitsize=\"8\"/>"
+	"		<reg name=\"r9\" bitsize=\"8\"/>"
+	"		<reg name=\"r10\" bitsize=\"8\"/>"
+	"		<reg name=\"r11\" bitsize=\"8\"/>"
+	"		<reg name=\"r12\" bitsize=\"8\"/>"
+	"		<reg name=\"r13\" bitsize=\"8\"/>"
+	"		<reg name=\"r14\" bitsize=\"8\"/>"
+	"		<reg name=\"r15\" bitsize=\"8\"/>"
+	"		<reg name=\"r16\" bitsize=\"8\"/>"
+	"		<reg name=\"r17\" bitsize=\"8\"/>"
+	"		<reg name=\"r18\" bitsize=\"8\"/>"
+	"		<reg name=\"r19\" bitsize=\"8\"/>"
+	"		<reg name=\"r20\" bitsize=\"8\"/>"
+	"		<reg name=\"r21\" bitsize=\"8\"/>"
+	"		<reg name=\"r22\" bitsize=\"8\"/>"
+	"		<reg name=\"r23\" bitsize=\"8\"/>"
+	"		<reg name=\"r24\" bitsize=\"8\"/>"
+	"		<reg name=\"r25\" bitsize=\"8\"/>"
+	"		<reg name=\"r26\" bitsize=\"8\"/>"
+	"		<reg name=\"r27\" bitsize=\"8\"/>"
+	"		<reg name=\"r28\" bitsize=\"8\"/>"
+	"		<reg name=\"r29\" bitsize=\"8\"/>"
+	"		<reg name=\"r30\" bitsize=\"8\"/>"
+	"		<reg name=\"r31\" bitsize=\"8\"/>"
+	"		<reg name=\"sreg\" bitsize=\"8\"/>"
+	"		<reg name=\"sp\" bitsize=\"16\" type=\"data_ptr\"/>"
+	"		<reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>"
+	"	</feature>"
+	"</target>";
+
 bool atxmega_probe(target *t)
 {
 	switch (t->idcode) {
@@ -13,6 +57,7 @@ bool atxmega_probe(target *t)
 			target_add_ram(t, 0x01002000, 0x01002800);
 			avr_add_flash(t, 0x00800000, 0x40000);
 			avr_add_flash(t, 0x00840000, 0x2000);
+			t->tdesc = tdesc_xmega6;
 			return true;
 	}
 	return false;

--- a/src/target/atxmega.c
+++ b/src/target/atxmega.c
@@ -57,7 +57,9 @@ bool atxmega_probe(target *t)
 	switch (t->idcode) {
 		case IDCODE_XMEGA256A3U:
 			t->core = "ATXMega256A3U";
-			target_add_ram(t, 0x01002000, 0x800);
+			// RAM is actually at 0x01002000, but this is done to keep things right for GDB
+			// - internally we add 0x00800000 to get to the PDI mapped address.
+			target_add_ram(t, 0x00802000, 0x800);
 			// These are mapped here to make things make sense to GDB
 			// - internally we add 0x00800000 to get to the PDI mapped address.
 			avr_add_flash(t, 0x00000000, 0x40000);

--- a/src/target/atxmega.c
+++ b/src/target/atxmega.c
@@ -58,8 +58,10 @@ bool atxmega_probe(target *t)
 		case IDCODE_XMEGA256A3U:
 			t->core = "ATXMega256A3U";
 			target_add_ram(t, 0x01002000, 0x800);
-			avr_add_flash(t, 0x00800000, 0x40000);
-			avr_add_flash(t, 0x00840000, 0x2000);
+			// These are mapped here to make things make sense to GDB
+			// - internally we add 0x00800000 to get to the PDI mapped address.
+			avr_add_flash(t, 0x00000000, 0x40000);
+			avr_add_flash(t, 0x00040000, 0x2000);
 			t->tdesc = tdesc_xmega6;
 			return true;
 	}

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -10,12 +10,18 @@ enum avr_error_e
 	pdi_failure,
 };
 
-typedef struct Atmel_DP_s {
+#define AVR_MAX_BREAKPOINTS 2
+
+typedef struct avr_pdi_s {
 	uint32_t idcode;
 
 	uint8_t dp_jd_index;
 	enum target_halt_reason halt_reason;
 	enum avr_error_e error_state;
+	target_addr programCounter;
+
+	bool hw_breakpoint[AVR_MAX_BREAKPOINTS];
+	uint8_t hw_breakpoint_max;
 } avr_pdi_t;
 
 bool avr_pdi_init(avr_pdi_t *pdi);

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -20,7 +20,8 @@ typedef struct avr_pdi_s {
 	enum avr_error_e error_state;
 	target_addr programCounter;
 
-	bool hw_breakpoint[AVR_MAX_BREAKPOINTS];
+	target_addr hw_breakpoint[AVR_MAX_BREAKPOINTS];
+	uint8_t hw_breakpoint_enabled;
 	uint8_t hw_breakpoint_max;
 } avr_pdi_t;
 

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -27,7 +27,7 @@ typedef struct avr_pdi_s {
 
 bool avr_pdi_init(avr_pdi_t *pdi);
 
-void avr_jtag_pdi_handler(uint8_t jd_index, uint32_t j_idcode);
+void avr_jtag_pdi_handler(uint8_t jd_index);
 int platform_avr_jtag_pdi_init(avr_pdi_t *pdi);
 
 bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din);

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -5,8 +5,6 @@
 #include "target.h"
 
 typedef struct Atmel_DP_s {
-	int refcnt;
-
 	uint32_t idcode;
 
 	uint8_t dp_jd_index;

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -21,8 +21,8 @@ typedef struct avr_pdi_s {
 	target_addr programCounter;
 
 	target_addr hw_breakpoint[AVR_MAX_BREAKPOINTS];
-	uint8_t hw_breakpoint_enabled;
-	uint8_t hw_breakpoint_max;
+	uint32_t hw_breakpoints_enabled;
+	uint32_t hw_breakpoints_max;
 } avr_pdi_t;
 
 bool avr_pdi_init(avr_pdi_t *pdi);

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -11,9 +11,12 @@ typedef struct Atmel_DP_s {
 	uint8_t dp_jd_index;
 } AVR_DP_t;
 
-void avr_dp_init(AVR_DP_t *dp);
+bool avr_dp_init(AVR_DP_t *dp);
 
 void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
 int platform_avr_jtag_dp_init(AVR_DP_t *dp);
+
+bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value);
+uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg);
 
 #endif /*ATMEL___H*/

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -18,6 +18,7 @@ void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
 int platform_avr_jtag_dp_init(AVR_DP_t *dp);
 void avr_add_flash(target *t, uint32_t start, size_t length);
 
+bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din);
 bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value);
 uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg);
 

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -4,11 +4,18 @@
 #include "jtag_scan.h"
 #include "target.h"
 
+enum avr_error_e
+{
+	pdi_ok,
+	pdi_failure,
+};
+
 typedef struct Atmel_DP_s {
 	uint32_t idcode;
 
 	uint8_t dp_jd_index;
 	enum target_halt_reason halt_reason;
+	enum avr_error_e error_state;
 } AVR_DP_t;
 
 bool avr_dp_init(AVR_DP_t *dp);

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -1,0 +1,19 @@
+#ifndef ATMEL___H
+#define ATMEL___H
+
+#include "jtag_scan.h"
+
+typedef struct Atmel_DP_s {
+	int refcnt;
+
+	uint32_t idcode;
+
+	uint8_t dp_jd_index;
+} AVR_DP_t;
+
+void avr_dp_init(AVR_DP_t *dp);
+
+void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
+int platform_avr_jtag_dp_init(AVR_DP_t *dp);
+
+#endif /*ATMEL___H*/

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -16,16 +16,16 @@ typedef struct Atmel_DP_s {
 	uint8_t dp_jd_index;
 	enum target_halt_reason halt_reason;
 	enum avr_error_e error_state;
-} AVR_DP_t;
+} avr_pdi_t;
 
-bool avr_dp_init(AVR_DP_t *dp);
+bool avr_pdi_init(avr_pdi_t *pdi);
 
-void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
-int platform_avr_jtag_dp_init(AVR_DP_t *dp);
+void avr_jtag_pdi_handler(uint8_t jd_index, uint32_t j_idcode);
+int platform_avr_jtag_pdi_init(avr_pdi_t *pdi);
 
 bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din);
-bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value);
-uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg);
+bool avr_pdi_reg_write(avr_pdi_t *pdi, uint8_t reg, uint8_t value);
+uint8_t avr_pdi_reg_read(avr_pdi_t *pdi, uint8_t reg);
 
 bool avr_attach(target *t);
 void avr_detach(target *t);

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -16,10 +16,13 @@ bool avr_dp_init(AVR_DP_t *dp);
 
 void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
 int platform_avr_jtag_dp_init(AVR_DP_t *dp);
-void avr_add_flash(target *t, uint32_t start, size_t length);
 
 bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din);
 bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value);
 uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg);
+
+bool avr_attach(target *t);
+void avr_detach(target *t);
+void avr_add_flash(target *t, uint32_t start, size_t length);
 
 #endif /*ATMEL___H*/

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -2,6 +2,7 @@
 #define ATMEL___H
 
 #include "jtag_scan.h"
+#include "target.h"
 
 typedef struct Atmel_DP_s {
 	int refcnt;
@@ -15,6 +16,7 @@ bool avr_dp_init(AVR_DP_t *dp);
 
 void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode);
 int platform_avr_jtag_dp_init(AVR_DP_t *dp);
+void avr_add_flash(target *t, uint32_t start, size_t length);
 
 bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value);
 uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg);

--- a/src/target/avr.h
+++ b/src/target/avr.h
@@ -10,6 +10,7 @@ typedef struct Atmel_DP_s {
 	uint32_t idcode;
 
 	uint8_t dp_jd_index;
+	enum target_halt_reason halt_reason;
 } AVR_DP_t;
 
 bool avr_dp_init(AVR_DP_t *dp);

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -43,5 +43,6 @@ bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const u
 	for (uint8_t i = 0; i < 8; ++i)
 		result ^= (data[0] >> i) & 1U;
 	*dout = data[0];
+	DEBUG_INFO("Sent 0x%x to target, response was 0x%x (0x%x)\n", din, data[0], data[1]);
 	return result == data[1];
 }

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -18,6 +18,7 @@ void avr_jtag_pdi_handler(uint8_t jd_index, uint32_t j_idcode)
 	pdi->dp_jd_index = jd_index;
 	pdi->idcode = jtag_devs[jd_index].jd_idcode;
 	pdi->error_state = pdi_ok;
+	pdi->hw_breakpoint_enabled = 0;
 	if ((PC_HOSTED == 0) || (!platform_avr_jtag_pdi_init(pdi))) {
 		//
 	}

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -51,6 +51,6 @@ bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const u
 	for (uint8_t i = 0; i < 8; ++i)
 		result ^= (data[0] >> i) & 1U;
 	*dout = data[0];
-	DEBUG_INFO("Sent 0x%x to target, response was 0x%x (0x%x)\n", din, data[0], data[1]);
+	DEBUG_INFO("Sent 0x%02x to target, response was 0x%02x (0x%x)\n", din, data[0], data[1]);
 	return result == data[1];
 }

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -16,7 +16,7 @@ void avr_jtag_pdi_handler(uint8_t jd_index)
 	pdi->dp_jd_index = jd_index;
 	pdi->idcode = jtag_devs[jd_index].jd_idcode;
 	pdi->error_state = pdi_ok;
-	pdi->hw_breakpoint_enabled = 0;
+	pdi->hw_breakpoints_enabled = 0;
 	if ((PC_HOSTED == 0) || (!platform_avr_jtag_pdi_init(pdi))) {
 		//
 	}

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -6,15 +6,13 @@
 
 #define PDI_DELAY	0xDBU
 
-void avr_jtag_pdi_handler(uint8_t jd_index, uint32_t j_idcode)
+void avr_jtag_pdi_handler(uint8_t jd_index)
 {
 	avr_pdi_t *pdi = calloc(1, sizeof(*pdi));
 	if (!pdi) {			/* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
-	(void)j_idcode;
-
 	pdi->dp_jd_index = jd_index;
 	pdi->idcode = jtag_devs[jd_index].jd_idcode;
 	pdi->error_state = pdi_ok;

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -3,7 +3,6 @@
 #include "avr.h"
 #include "jtag_scan.h"
 #include "jtagtap.h"
-#include "gdb_packet.h"
 
 void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
 {

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -1,0 +1,22 @@
+#include "general.h"
+#include "exception.h"
+#include "avr.h"
+#include "jtag_scan.h"
+#include "jtagtap.h"
+#include "gdb_packet.h"
+
+void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
+{
+	AVR_DP_t *dp = calloc(1, sizeof(*dp));
+	if (!dp) {			/* calloc failed: heap exhaustion */
+		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	dp->dp_jd_index = jd_index;
+	dp->idcode = j_idcode;
+	if ((PC_HOSTED == 0) || (!platform_avr_jtag_dp_init(dp))) {
+		//
+	}
+	avr_dp_init(dp);
+}

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -6,22 +6,22 @@
 
 #define PDI_DELAY	0xDBU
 
-void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
+void avr_jtag_pdi_handler(uint8_t jd_index, uint32_t j_idcode)
 {
-	AVR_DP_t *dp = calloc(1, sizeof(*dp));
-	if (!dp) {			/* calloc failed: heap exhaustion */
+	avr_pdi_t *pdi = calloc(1, sizeof(*pdi));
+	if (!pdi) {			/* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
 	(void)j_idcode;
 
-	dp->dp_jd_index = jd_index;
-	dp->idcode = jtag_devs[jd_index].jd_idcode;
-	dp->error_state = pdi_ok;
-	if ((PC_HOSTED == 0) || (!platform_avr_jtag_dp_init(dp))) {
+	pdi->dp_jd_index = jd_index;
+	pdi->idcode = jtag_devs[jd_index].jd_idcode;
+	pdi->error_state = pdi_ok;
+	if ((PC_HOSTED == 0) || (!platform_avr_jtag_pdi_init(pdi))) {
 		//
 	}
-	avr_dp_init(dp);
+	avr_pdi_init(pdi);
 }
 
 bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din)

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -4,6 +4,8 @@
 #include "jtag_scan.h"
 #include "jtagtap.h"
 
+#define PDI_DELAY	0xDBU
+
 void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
 {
 	AVR_DP_t *dp = calloc(1, sizeof(*dp));
@@ -26,19 +28,24 @@ bool avr_jtag_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const u
 	jtag_dev_t *d = &jtag_devs[jd_index];
 	uint8_t result = 0;
 	uint16_t request = 0, response = 0;
-	uint8_t *data = (uint8_t *)&request;
+	uint8_t *data;
 	if (!dout)
 		return false;
-	jtagtap_shift_dr();
-	jp->jtagtap_tdi_seq(0, ones, d->dr_prescan);
-	data[0] = din;
-	// Calculate the parity bit
-	for (uint8_t i = 0; i < 8; ++i)
-		data[1] ^= (din >> i) & 1U;
-	jp->jtagtap_tdi_tdo_seq((uint8_t *)&response, 1, (uint8_t *)&request, 9);
-	jp->jtagtap_tdi_seq(1, ones, d->dr_postscan);
-	jtagtap_return_idle();
-	data = (uint8_t *)&response;
+	do
+	{
+		data = (uint8_t *)&request;
+		jtagtap_shift_dr();
+		jp->jtagtap_tdi_seq(0, ones, d->dr_prescan);
+		data[0] = din;
+		// Calculate the parity bit
+		for (uint8_t i = 0; i < 8; ++i)
+			data[1] ^= (din >> i) & 1U;
+		jp->jtagtap_tdi_tdo_seq((uint8_t *)&response, 1, (uint8_t *)&request, 9);
+		jp->jtagtap_tdi_seq(1, ones, d->dr_postscan);
+		jtagtap_return_idle();
+		data = (uint8_t *)&response;
+	}
+	while (data[0] == PDI_DELAY && data[1] == 1);
 	// Calculate the parity bit
 	for (uint8_t i = 0; i < 8; ++i)
 		result ^= (data[0] >> i) & 1U;

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -11,9 +11,10 @@ void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
+	(void)j_idcode;
 
 	dp->dp_jd_index = jd_index;
-	dp->idcode = j_idcode;
+	dp->idcode = jtag_devs[jd_index].jd_idcode;
 	if ((PC_HOSTED == 0) || (!platform_avr_jtag_dp_init(dp))) {
 		//
 	}

--- a/src/target/avr_jtagdp.c
+++ b/src/target/avr_jtagdp.c
@@ -17,6 +17,7 @@ void avr_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
 
 	dp->dp_jd_index = jd_index;
 	dp->idcode = jtag_devs[jd_index].jd_idcode;
+	dp->error_state = pdi_ok;
 	if ((PC_HOSTED == 0) || (!platform_avr_jtag_dp_init(dp))) {
 		//
 	}

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -17,9 +17,9 @@
 #define PDI_STS		0x40U
 #define PDI_ST		0x60U
 #define PDI_LDCS	0x80U
-#define PDI_REPEAT	0xa0U
-#define PDI_STCS	0xc0U
-#define PDI_KEY		0xe0U
+#define PDI_REPEAT	0xA0U
+#define PDI_STCS	0xC0U
+#define PDI_KEY		0xE0U
 
 #define PDI_DATA_8	0x00U
 #define PDI_DATA_16	0x01U
@@ -29,13 +29,13 @@
 #define PDI_ADDR_8	0x00U
 #define PDI_ADDR_16	0x04U
 #define PDI_ADDR_24	0x08U
-#define PDI_ADDR_32	0x0cU
+#define PDI_ADDR_32	0x0CU
 
 #define PDI_MODE_IND_PTR	0x00U
 #define PDI_MODE_IND_INCPTR	0x04U
 #define PDI_MODE_DIR_PTR	0x08U
-#define PDI_MODE_DIR_INCPTR	0x0cU // "Reserved"
-#define PDI_MODE_MASK		0xf3U
+#define PDI_MODE_DIR_INCPTR	0x0CU // "Reserved"
+#define PDI_MODE_MASK		0xF3U
 
 #define PDI_REG_STATUS	0U
 #define PDI_REG_RESET	1U
@@ -49,11 +49,11 @@
 
 #define AVR_ADDR_DBG_CTR		0x00000000U
 #define AVR_ADDR_DBG_PC			0x00000004U
-#define AVR_ADDR_DBG_CTRL		0x0000000aU
-#define AVR_ADDR_DBG_SPECIAL	0x0000000cU
+#define AVR_ADDR_DBG_CTRL		0x0000000AU
+#define AVR_ADDR_DBG_SPECIAL	0x0000000CU
 
-#define AVR_DBG_READ_REGS	0x11U
-#define AVR_NUM_REGS		32
+#define AVR_DBG_READ_REGS		0x11U
+#define AVR_NUM_REGS			32
 
 #define AVR_ADDR_CPU_SPL		0x0100003DU
 

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -386,8 +386,7 @@ static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch)
 static bool avr_check_error(target *t)
 {
 	AVR_DP_t *dp = t->priv;
-	(void)dp;
-	return false;
+	return dp->error_state != pdi_ok;
 }
 
 static void avr_mem_read(target *t, void *dest, target_addr src, size_t len)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -37,6 +37,14 @@ static void avr_reset(target *t);
 static void avr_halt_request(target *t);
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch);
 
+static const uint32_t regnum_avr[] = {
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, // r0-r15
+	16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, // r16-31
+	32, // SREG
+	33, // SP
+	34, // PC
+};
+
 static void avr_dp_ref(AVR_DP_t *dp)
 {
 	dp->refcnt++;
@@ -79,6 +87,7 @@ bool avr_dp_init(AVR_DP_t *dp)
 	t->reset = avr_reset;
 	t->halt_request = avr_halt_request;
 	t->halt_poll = avr_halt_poll;
+	t->regs_size = sizeof(regnum_avr);
 
 	if (atxmega_probe(t))
 		return true;

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -98,6 +98,7 @@ const struct command_s avr_cmd_list[] = {
 
 static void avr_reset(target *t);
 static void avr_halt_request(target *t);
+static void avr_halt_resume(target *t, bool step);
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch);
 
 static bool avr_check_error(target *t);
@@ -467,9 +468,54 @@ static void avr_halt_request(target *t)
 	pdi->halt_reason = TARGET_HALT_REQUEST;
 }
 
+static void avr_halt_resume(target *t, bool step)
+{
+	avr_pdi_t *pdi = t->priv;
+	if (step)
+	{
+		const target_addr currentPC = pdi->programCounter;
+		const target_addr nextPC = currentPC + 1U;
+		/* To do a single step, we run the following steps:
+		 * Write the debug control register to 4, which puts the processor in a temporary breakpoint mode
+		 * Write the debug counter register with the address to stop execution on
+		 * Write the program counter with the address to resume execution on
+		 */
+		if (avr_pdi_reg_read(pdi, PDI_REG_R3) != 0x04U ||
+			!avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_DBG_CTRL, 4) ||
+			!avr_pdi_write(pdi, PDI_DATA_32, AVR_ADDR_DBG_CTR, nextPC) ||
+			!avr_pdi_write(pdi, PDI_DATA_32, AVR_ADDR_DBG_PC, currentPC) ||
+			!avr_pdi_reg_write(pdi, PDI_REG_R4, 1) ||
+			avr_pdi_reg_read(pdi, PDI_REG_R3) != 0x04U ||
+			avr_pdi_reg_read(pdi, PDI_REG_STATUS) != 0x06U)
+			raise_exception(EXCEPTION_ERROR, "Error resuming device, device in incorrect state");
+		pdi->halt_reason = TARGET_HALT_STEPPING;
+	}
+	else
+	{
+		/* To resume the processor we go through the following specific steps:
+		 * Write the program counter to ensure we start where we expect
+		 * Then we release the externally (PDI) applied reset
+		 * We then poke the debug control register to indicate debug-supervised run
+		 * Ensure that PDI is still in debug mode (r4 = 1)
+		 * Read r3 to see that the processor is resuming
+		 */
+		if (avr_pdi_reg_read(pdi, PDI_REG_R3) != 0x04U ||
+			!avr_config_breakpoints(pdi) ||
+			!avr_pdi_write(pdi, PDI_DATA_32, AVR_ADDR_DBG_PC, pdi->programCounter) ||
+			!avr_pdi_reg_write(pdi, PDI_REG_RESET, 0) ||
+			!avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_DBG_CTRL, 0) ||
+			!avr_pdi_reg_write(pdi, PDI_REG_R4, 1))
+			raise_exception(EXCEPTION_ERROR, "Error resuming device, device in incorrect state");
+		pdi->halt_reason = TARGET_HALT_RUNNING;
+	}
+}
+
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch)
 {
 	avr_pdi_t *pdi = t->priv;
+	if (pdi->halt_reason == TARGET_HALT_RUNNING &&
+		avr_pdi_reg_read(pdi, PDI_REG_R3) == 0x04U)
+		pdi->halt_reason = TARGET_HALT_BREAKPOINT;
 	(void)watch;
 	return pdi->halt_reason;
 }

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -1,0 +1,16 @@
+#include "general.h"
+#include "target.h"
+#include "target_internal.h"
+#include "avr.h"
+#include "exception.h"
+
+static void avr_dp_unref(AVR_DP_t *dp)
+{
+	if (--(dp->refcnt) == 0)
+		free(dp);
+}
+
+void avr_dp_init(AVR_DP_t *dp)
+{
+	(void)dp;
+}

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -68,38 +68,13 @@ void avr_add_flash(target *t, uint32_t start, size_t length)
 	target_add_flash(t, f);
 }
 
-static bool avr_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din)
-{
-	jtag_dev_t *d = &jtag_devs[jd_index];
-	uint8_t result = 0;
-	uint16_t request = 0, response = 0;
-	uint8_t *data = (uint8_t *)&request;
-	if (!dout)
-		return false;
-	jtagtap_shift_dr();
-	jp->jtagtap_tdi_seq(0, ones, d->dr_prescan);
-	data[0] = din;
-	// Calculate the parity bit
-	for (uint8_t i = 0; i < 8; ++i)
-		data[1] ^= (din >> i) & 1U;
-	jp->jtagtap_tdi_tdo_seq((uint8_t *)&response, 1, (uint8_t *)&request, 9);
-	jp->jtagtap_tdi_seq(1, ones, d->dr_postscan);
-	jtagtap_return_idle();
-	data = (uint8_t *)&response;
-	// Calculate the parity bit
-	for (uint8_t i = 0; i < 8; ++i)
-		result ^= (data[0] >> i) & 1U;
-	*dout = data[0];
-	return result == data[1];
-}
-
 bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value)
 {
 	uint8_t result = 0, command = PDI_STCS | reg;
 	if (reg >= 16 ||
-		avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) ||
+		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) ||
 		result != PDI_EMPTY ||
-		avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, value))
+		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, value))
 		return false;
 	return result == PDI_EMPTY;
 }
@@ -108,9 +83,9 @@ uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg)
 {
 	uint8_t result = 0, command = PDI_LDCS | reg;
 	if (reg >= 16 ||
-		avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) ||
+		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) ||
 		result != PDI_EMPTY ||
-		!avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command))
+		!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command))
 		return 0xFFU; // TODO - figure out a better way to indicate failure.
 	return result;
 }

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -339,9 +339,13 @@ void avr_detach(target *t)
 static void avr_reset(target *t)
 {
 	AVR_DP_t *dp = t->priv;
-	if (!avr_pdi_reg_write(dp, PDI_REG_RESET, PDI_RESET) ||
-		avr_pdi_reg_read(dp, PDI_REG_STATUS) != 0x00)
+	if (!avr_pdi_reg_write(dp, PDI_REG_RESET, PDI_RESET))
 		raise_exception(EXCEPTION_ERROR, "Error resetting device, device in incorrect state");
+	if (avr_pdi_reg_read(dp, PDI_REG_STATUS) != 0x00)
+	{
+		avr_disable(dp, PDI_NVM);
+		avr_disable(dp, PDI_DEBUG);
+	}
 }
 
 static void avr_halt_request(target *t)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -147,6 +147,9 @@ bool avr_attach(target *t)
 {
 	AVR_DP_t *dp = t->priv;
 	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_PDI);
+	target_reset(t);
+	avr_enable(dp, PDI_DEBUG);
+	target_halt_request(t);
 
 	return true;
 }
@@ -154,6 +157,8 @@ bool avr_attach(target *t)
 void avr_detach(target *t)
 {
 	AVR_DP_t *dp = t->priv;
+
+	avr_disable(dp, PDI_DEBUG);
 	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_BYPASS);
 }
 

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -52,6 +52,9 @@
 #define AVR_ADDR_DBG_CTRL		0x0000000AU
 #define AVR_ADDR_DBG_SPECIAL	0x0000000CU
 
+#define AVR_DBG_BREAK_ENABLED	0x80000000U
+#define AVR_DBG_BREAK_MASK		0x00FFFFFFU
+
 #define AVR_DBG_READ_REGS		0x11U
 #define AVR_NUM_REGS			32
 
@@ -100,6 +103,9 @@ static void avr_regs_read(target *t, void *data);
 static int avr_flash_erase(struct target_flash *f, target_addr addr, size_t len);
 static int avr_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
 
+static int avr_breakwatch_set(target *t, struct breakwatch *bw);
+static int avr_breakwatch_clear(target *t, struct breakwatch *bw);
+
 typedef struct __attribute__((packed))
 {
 	uint8_t general[32]; // r0-r31
@@ -143,10 +149,14 @@ bool avr_pdi_init(avr_pdi_t *pdi)
 
 	t->reset = avr_reset;
 	t->halt_request = avr_halt_request;
+	t->halt_resume = avr_halt_resume;
 	t->halt_poll = avr_halt_poll;
 	// Unlike on an ARM processor, where this is the length of a table, here we return the size of
 	// a suitable registers structure.
 	t->regs_size = sizeof(avr_regs);
+
+	t->breakwatch_set = avr_breakwatch_set;
+	t->breakwatch_clear = avr_breakwatch_clear;
 
 	target_add_commands(t, avr_cmd_list, "Atmel AVR");
 
@@ -536,6 +546,57 @@ static int avr_flash_write(struct target_flash *f, target_addr dest, const void 
 			return 1;
 	}
 	return 0;
+}
+
+static int avr_breakwatch_set(target *t, struct breakwatch *bw)
+{
+	avr_pdi_t *pdi = t->priv;
+	switch (bw->type)
+	{
+		case TARGET_BREAK_HARD:
+		{
+			const uint8_t bp = pdi->hw_breakpoint_enabled;
+			if (bp == pdi->hw_breakpoint_max)
+				return -1;
+			pdi->hw_breakpoint[bp] = AVR_DBG_BREAK_ENABLED | bw->addr;
+			bw->reserved[0] = pdi->hw_breakpoint[bp];
+			++pdi->hw_breakpoint_enabled;
+			return 0;
+		}
+		default:
+			return 1;
+	}
+}
+
+static int avr_breakwatch_clear(target *t, struct breakwatch *bw)
+{
+	avr_pdi_t *pdi = t->priv;
+	switch (bw->type)
+	{
+		case TARGET_BREAK_HARD:
+		{
+			uint8_t bp = 0;
+			// Locate the breakpoint
+			for (; bp < pdi->hw_breakpoint_max; ++bp)
+			{
+				if (pdi->hw_breakpoint[bp] == bw->reserved[0])
+					break;
+			}
+			// Fail if we cannot find it
+			if (bp == pdi->hw_breakpoint_max)
+				return -1;
+			// Shuffle the remaining breakpoints.
+			for (; bp < (pdi->hw_breakpoint_enabled - 1U); ++bp)
+				pdi->hw_breakpoint[bp] = pdi->hw_breakpoint[bp + 1];
+			// Cleanup by disabling the breakpoint and fixing the count
+			pdi->hw_breakpoint[bp] = 0;
+			bw->reserved[0] = 0;
+			--pdi->hw_breakpoint_enabled;
+			return 0;
+		}
+		default:
+			return 1;
+	}
 }
 
 static bool avr_erase(target *t, int argc, char **argv)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -4,13 +4,77 @@
 #include "avr.h"
 #include "exception.h"
 
+#define IR_PDI		0x7U
+#define PDI_BREAK	0xBBU
+#define PDI_DELAY	0xDBU
+#define PDI_EMPTY	0xEBU
+
+#define PDI_LDCS	0x80U
+#define PDI_STCS	0xC0U
+
 static void avr_dp_unref(AVR_DP_t *dp)
 {
 	if (--(dp->refcnt) == 0)
 		free(dp);
 }
 
-void avr_dp_init(AVR_DP_t *dp)
+bool avr_dp_init(AVR_DP_t *dp)
 {
-	(void)dp;
+	/* Check for a valid part number in the IDCode */
+	if ((dp->idcode & 0x0FFFF000) == 0) {
+		DEBUG_WARN("Invalid DP idcode %08" PRIx32 "\n", dp->idcode);
+		free(dp);
+		return false;
+	}
+	DEBUG_INFO("AVR ID 0x%08" PRIx32 " (v%d)\n", dp->idcode,
+		(uint8_t)((dp->idcode >> 28U) & 0xfU));
+	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_PDI);
+	return true;
+}
+
+static bool avr_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din)
+{
+	jtag_dev_t *d = &jtag_devs[jd_index];
+	uint8_t result = 0;
+	uint16_t request = 0, response = 0;
+	uint8_t *data = (uint8_t *)&request;
+	if (!dout)
+		return false;
+	jtagtap_shift_dr();
+	jp->jtagtap_tdi_seq(0, ones, d->dr_prescan);
+	data[0] = din;
+	// Calculate the parity bit
+	for (uint8_t i = 0; i < 8; ++i)
+		data[1] ^= (din >> i) & 1U;
+	jp->jtagtap_tdi_tdo_seq((uint8_t *)&response, 1, (uint8_t *)&request, 9);
+	jp->jtagtap_tdi_seq(1, ones, d->dr_postscan);
+	jtagtap_return_idle();
+	data = (uint8_t *)&response;
+	// Calculate the parity bit
+	for (uint8_t i = 0; i < 8; ++i)
+		result ^= (data[0] >> i) & 1U;
+	*dout = data[0];
+	return result == data[1];
+}
+
+bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value)
+{
+	uint8_t result = 0, command = PDI_STCS | reg;
+	if (reg >= 16 ||
+		avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) ||
+		result != PDI_EMPTY ||
+		avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, value))
+		return false;
+	return result == PDI_EMPTY;
+}
+
+uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg)
+{
+	uint8_t result = 0, command = PDI_LDCS | reg;
+	if (reg >= 16 ||
+		avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) ||
+		result != PDI_EMPTY ||
+		!avr_dev_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command))
+		return 0xFFU; // TODO - figure out a better way to indicate failure.
+	return result;
 }

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -32,6 +32,21 @@ bool avr_dp_init(AVR_DP_t *dp)
 	return true;
 }
 
+void avr_add_flash(target *t, uint32_t start, size_t length)
+{
+	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f->start = start;
+	f->length = length;
+	f->blocksize = 0x100;
+	f->erased = 0xff;
+	target_add_flash(t, f);
+}
+
 static bool avr_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t din)
 {
 	jtag_dev_t *d = &jtag_devs[jd_index];

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -391,6 +391,9 @@ void avr_detach(target *t)
 static void avr_reset(target *t)
 {
 	avr_pdi_t *pdi = t->priv;
+	// We only actually want to do this if the target is not presently attached as this resets the NVM and debug enables
+	if (target_attached(t))
+		return;
 	if (!avr_pdi_reg_write(pdi, PDI_REG_RESET, PDI_RESET))
 		raise_exception(EXCEPTION_ERROR, "Error resetting device, device in incorrect state");
 	if (avr_pdi_reg_read(pdi, PDI_REG_STATUS) != 0x00)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -392,11 +392,19 @@ static bool avr_check_error(target *t)
 static void avr_mem_read(target *t, void *dest, target_addr src, size_t len)
 {
 	AVR_DP_t *dp = t->priv;
-	// This presently assumes src is a Flash address.
-	if (!avr_pdi_write(dp, PDI_DATA_8, AVR_ADDR_NVM_CMD, AVR_NVM_CMD_READ_NVM) ||
-		!avr_pdi_read_ind(dp, src | PDI_FLASH_OFFSET, PDI_MODE_IND_INCPTR, dest, len) ||
-		!avr_ensure_nvm_idle(dp))
-		return; // TODO: set an error indicator for avr_check_error.
+	if (target_flash_for_addr(t, src) != NULL)
+	{
+		// This presently assumes src is a Flash address.
+		if (!avr_pdi_write(dp, PDI_DATA_8, AVR_ADDR_NVM_CMD, AVR_NVM_CMD_READ_NVM) ||
+			!avr_pdi_read_ind(dp, src | PDI_FLASH_OFFSET, PDI_MODE_IND_INCPTR, dest, len) ||
+			!avr_ensure_nvm_idle(dp))
+			dp->error_state = pdi_failure;
+	}
+	else if (src >= 0x00800000U)
+	{
+		if (!avr_pdi_read_ind(dp, src + 0x00800000U, PDI_MODE_IND_INCPTR, dest, len))
+			dp->error_state = pdi_failure;
+	}
 }
 
 static void avr_regs_read(target *t, void *data)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -15,6 +15,8 @@
 #define PDI_LDCS	0x80U
 #define PDI_STCS	0xC0U
 
+static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch);
+
 static void avr_dp_ref(AVR_DP_t *dp)
 {
 	dp->refcnt++;
@@ -53,9 +55,11 @@ bool avr_dp_init(AVR_DP_t *dp)
 
 	t->attach = avr_attach;
 	t->detach = avr_detach;
+	t->halt_poll = avr_halt_poll;
 
 	if (atxmega_probe(t))
 		return true;
+	dp->halt_reason = TARGET_HALT_RUNNING;
 	return true;
 }
 
@@ -108,4 +112,11 @@ void avr_detach(target *t)
 {
 	AVR_DP_t *dp = t->priv;
 	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_BYPASS);
+}
+
+static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch)
+{
+	AVR_DP_t *dp = t->priv;
+	(void)watch;
+	return dp->halt_reason;
 }

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -80,17 +80,6 @@ typedef struct __attribute__((packed))
 	uint32_t pc; // r34
 } avr_regs;
 
-static void avr_dp_ref(AVR_DP_t *dp)
-{
-	dp->refcnt++;
-}
-
-static void avr_dp_unref(AVR_DP_t *dp)
-{
-	if (--(dp->refcnt) == 0)
-		free(dp);
-}
-
 bool avr_dp_init(AVR_DP_t *dp)
 {
 	target *t;
@@ -108,13 +97,13 @@ bool avr_dp_init(AVR_DP_t *dp)
 	t = target_new();
 	if (!t)
 		return false;
-	avr_dp_ref(dp);
 
 	t->cpuid = dp->idcode;
 	t->idcode = (dp->idcode >> 12) & 0xFFFFU;
-	t->priv = dp;
 	t->driver = "Atmel AVR";
 	t->core = "AVR";
+	t->priv = dp;
+	t->priv_free = free;
 
 	t->attach = avr_attach;
 	t->detach = avr_detach;

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -75,6 +75,7 @@ bool avr_dp_init(AVR_DP_t *dp)
 
 	t->attach = avr_attach;
 	t->detach = avr_detach;
+
 	t->reset = avr_reset;
 	t->halt_request = avr_halt_request;
 	t->halt_poll = avr_halt_poll;
@@ -102,7 +103,7 @@ uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg)
 	if (reg >= 16 ||
 		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) ||
 		result != PDI_EMPTY ||
-		!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command))
+		!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, 0))
 		return 0xFFU; // TODO - figure out a better way to indicate failure.
 	return result;
 }
@@ -146,12 +147,16 @@ void avr_add_flash(target *t, uint32_t start, size_t length)
 bool avr_attach(target *t)
 {
 	AVR_DP_t *dp = t->priv;
+	volatile struct exception e;
 	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_PDI);
-	target_reset(t);
-	avr_enable(dp, PDI_DEBUG);
-	target_halt_request(t);
 
-	return true;
+	TRY_CATCH (e, EXCEPTION_ALL) {
+		target_reset(t);
+		if (!avr_enable(dp, PDI_DEBUG))
+			return false;
+		target_halt_request(t);
+	}
+	return !e.type;
 }
 
 void avr_detach(target *t)
@@ -167,7 +172,7 @@ static void avr_reset(target *t)
 	AVR_DP_t *dp = t->priv;
 	if (!avr_pdi_reg_write(dp, PDI_REG_RESET, PDI_RESET) ||
 		avr_pdi_reg_read(dp, PDI_REG_STATUS) != 0x00)
-		raise_exception(EXCEPTION_ERROR, "Error resetting device, device in incorrect state\n");
+		raise_exception(EXCEPTION_ERROR, "Error resetting device, device in incorrect state");
 }
 
 static void avr_halt_request(target *t)
@@ -186,7 +191,7 @@ static void avr_halt_request(target *t)
 		!avr_pdi_reg_write(dp, PDI_REG_RESET, 0) ||
 		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x14U ||
 		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x04U)
-		raise_exception(EXCEPTION_ERROR, "Error halting device, device in incorrect state\n");
+		raise_exception(EXCEPTION_ERROR, "Error halting device, device in incorrect state");
 	dp->halt_reason = TARGET_HALT_REQUEST;
 }
 

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -6,6 +6,8 @@
 #include "gdb_packet.h"
 
 #define IR_PDI		0x7U
+#define IR_BYPASS	0xFU
+
 #define PDI_BREAK	0xBBU
 #define PDI_DELAY	0xDBU
 #define PDI_EMPTY	0xEBU
@@ -36,7 +38,7 @@ bool avr_dp_init(AVR_DP_t *dp)
 	}
 	DEBUG_INFO("AVR ID 0x%08" PRIx32 " (v%d)\n", dp->idcode,
 		(uint8_t)((dp->idcode >> 28U) & 0xfU));
-	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_PDI);
+	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_BYPASS);
 
 	t = target_new();
 	if (!t)
@@ -48,24 +50,13 @@ bool avr_dp_init(AVR_DP_t *dp)
 	t->priv = dp;
 	t->driver = "Atmel AVR";
 	t->core = "AVR";
+
+	t->attach = avr_attach;
+	t->detach = avr_detach;
+
 	if (atxmega_probe(t))
 		return true;
 	return true;
-}
-
-void avr_add_flash(target *t, uint32_t start, size_t length)
-{
-	struct target_flash *f = calloc(1, sizeof(*f));
-	if (!f) {			/* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
-		return;
-	}
-
-	f->start = start;
-	f->length = length;
-	f->blocksize = 0x100;
-	f->erased = 0xff;
-	target_add_flash(t, f);
 }
 
 bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value)
@@ -88,4 +79,33 @@ uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg)
 		!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command))
 		return 0xFFU; // TODO - figure out a better way to indicate failure.
 	return result;
+}
+
+void avr_add_flash(target *t, uint32_t start, size_t length)
+{
+	struct target_flash *f = calloc(1, sizeof(*f));
+	if (!f) {			/* calloc failed: heap exhaustion */
+		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		return;
+	}
+
+	f->start = start;
+	f->length = length;
+	f->blocksize = 0x100;
+	f->erased = 0xff;
+	target_add_flash(t, f);
+}
+
+bool avr_attach(target *t)
+{
+	AVR_DP_t *dp = t->priv;
+	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_PDI);
+
+	return true;
+}
+
+void avr_detach(target *t)
+{
+	AVR_DP_t *dp = t->priv;
+	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_BYPASS);
 }

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -24,6 +24,7 @@
 #define PDI_RESET	0x59U
 
 static void avr_reset(target *t);
+static void avr_halt_request(target *t);
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch);
 
 static void avr_dp_ref(AVR_DP_t *dp)
@@ -64,6 +65,8 @@ bool avr_dp_init(AVR_DP_t *dp)
 
 	t->attach = avr_attach;
 	t->detach = avr_detach;
+	t->reset = avr_reset;
+	t->halt_request = avr_halt_request;
 	t->halt_poll = avr_halt_poll;
 
 	if (atxmega_probe(t))
@@ -129,6 +132,26 @@ static void avr_reset(target *t)
 	if (!avr_pdi_reg_write(dp, PDI_REG_RESET, PDI_RESET) ||
 		avr_pdi_reg_read(dp, PDI_REG_STATUS) != 0x00)
 		raise_exception(EXCEPTION_ERROR, "Error resetting device, device in incorrect state\n");
+}
+
+static void avr_halt_request(target *t)
+{
+	AVR_DP_t *dp = t->priv;
+	/* To halt the processor we go through a few really specific steps:
+	 * Write r4 to 1 to indicate we want to put the processor into debug-based pause
+	 * Read r3 and check it's 0x10 which indicates the processor is held in reset and no debugging is active
+	 * Releae reset
+	 * Read r3 twice more, the first time should respond 0x14 to indicate the processor is still reset
+	 * but that debug pause is requested, and the second should respond 0x04 to indicate the processor is now
+	 * in debug pause state (halted)
+	 */
+	if (!avr_pdi_reg_write(dp, PDI_REG_R4, 1) ||
+		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x10U ||
+		!avr_pdi_reg_write(dp, PDI_REG_RESET, 0) ||
+		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x14U ||
+		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x04U)
+		raise_exception(EXCEPTION_ERROR, "Error halting device, device in incorrect state\n");
+	dp->halt_reason = TARGET_HALT_REQUEST;
 }
 
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -90,29 +90,29 @@ typedef struct __attribute__((packed))
 	uint32_t pc; // r34
 } avr_regs;
 
-bool avr_dp_init(AVR_DP_t *dp)
+bool avr_pdi_init(avr_pdi_t *pdi)
 {
 	target *t;
 
 	/* Check for a valid part number in the IDCode */
-	if ((dp->idcode & 0x0FFFF000) == 0) {
-		DEBUG_WARN("Invalid DP idcode %08" PRIx32 "\n", dp->idcode);
-		free(dp);
+	if ((pdi->idcode & 0x0FFFF000) == 0) {
+		DEBUG_WARN("Invalid PDI idcode %08" PRIx32 "\n", pdi->idcode);
+		free(pdi);
 		return false;
 	}
-	DEBUG_INFO("AVR ID 0x%08" PRIx32 " (v%d)\n", dp->idcode,
-		(uint8_t)((dp->idcode >> 28U) & 0xfU));
-	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_BYPASS);
+	DEBUG_INFO("AVR ID 0x%08" PRIx32 " (v%d)\n", pdi->idcode,
+		(uint8_t)((pdi->idcode >> 28U) & 0xfU));
+	jtag_dev_write_ir(&jtag_proc, pdi->dp_jd_index, IR_BYPASS);
 
 	t = target_new();
 	if (!t)
 		return false;
 
-	t->cpuid = dp->idcode;
-	t->idcode = (dp->idcode >> 12) & 0xFFFFU;
+	t->cpuid = pdi->idcode;
+	t->idcode = (pdi->idcode >> 12) & 0xFFFFU;
 	t->driver = "Atmel AVR";
 	t->core = "AVR";
-	t->priv = dp;
+	t->priv = pdi;
 	t->priv_free = free;
 
 	t->attach = avr_attach;
@@ -132,31 +132,31 @@ bool avr_dp_init(AVR_DP_t *dp)
 
 	if (atxmega_probe(t))
 		return true;
-	dp->halt_reason = TARGET_HALT_RUNNING;
+	pdi->halt_reason = TARGET_HALT_RUNNING;
 	return true;
 }
 
-bool avr_pdi_reg_write(AVR_DP_t *dp, uint8_t reg, uint8_t value)
+bool avr_pdi_reg_write(avr_pdi_t *pdi, uint8_t reg, uint8_t value)
 {
 	uint8_t result = 0, command = PDI_STCS | reg;
 	if (reg >= 16 ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, value))
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, command) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, value))
 		return false;
 	return result == PDI_EMPTY;
 }
 
-uint8_t avr_pdi_reg_read(AVR_DP_t *dp, uint8_t reg)
+uint8_t avr_pdi_reg_read(avr_pdi_t *pdi, uint8_t reg)
 {
 	uint8_t result = 0, command = PDI_LDCS | reg;
 	if (reg >= 16 ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) || result != PDI_EMPTY ||
-		!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, 0))
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, command) || result != PDI_EMPTY ||
+		!avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, 0))
 		return 0xFFU; // TODO - figure out a better way to indicate failure.
 	return result;
 }
 
-static bool avr_pdi_write(AVR_DP_t *dp, uint8_t bytes, uint32_t reg, uint32_t value)
+static bool avr_pdi_write(avr_pdi_t *pdi, uint8_t bytes, uint32_t reg, uint32_t value)
 {
 	uint8_t result = 0;
 	uint8_t command = PDI_STS | PDI_ADDR_32 | bytes;
@@ -167,36 +167,36 @@ static bool avr_pdi_write(AVR_DP_t *dp, uint8_t bytes, uint32_t reg, uint32_t va
 		(value >> 24U) & 0xffU
 	};
 
-	if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, reg & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (reg >> 8U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (reg >> 16U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (reg >> 24U) & 0xffU) || result != PDI_EMPTY)
+	if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, command) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, reg & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (reg >> 8U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (reg >> 16U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (reg >> 24U) & 0xffU) || result != PDI_EMPTY)
 		return false;
 	// This is intentionally <= to avoid `bytes + 1` silliness
 	for (uint8_t i = 0; i <= bytes; ++i)
 	{
-		if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, data_bytes[i]) || result != PDI_EMPTY)
+		if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, data_bytes[i]) || result != PDI_EMPTY)
 			return false;
 	}
 	return true;
 }
 
-static bool avr_pdi_read(AVR_DP_t *dp, uint8_t bytes, uint32_t reg, uint32_t *value)
+static bool avr_pdi_read(avr_pdi_t *pdi, uint8_t bytes, uint32_t reg, uint32_t *value)
 {
 	uint8_t result = 0;
 	uint8_t command = PDI_LDS | PDI_ADDR_32 | bytes;
 	uint8_t data_bytes[4];
 	uint32_t data = 0xffffffffU;
-	if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, reg & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (reg >> 8U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (reg >> 16U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (reg >> 24U) & 0xffU) || result != PDI_EMPTY)
+	if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, command) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, reg & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (reg >> 8U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (reg >> 16U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (reg >> 24U) & 0xffU) || result != PDI_EMPTY)
 		return false;
 	for (uint8_t i = 0; i <= bytes; ++i)
 	{
-		if (!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &data_bytes[i], 0))
+		if (!avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &data_bytes[i], 0))
 			return false;
 	}
 	data = data_bytes[0];
@@ -210,31 +210,31 @@ static bool avr_pdi_read(AVR_DP_t *dp, uint8_t bytes, uint32_t reg, uint32_t *va
 	return true;
 }
 
-static inline bool avr_pdi_read8(AVR_DP_t *dp, uint32_t reg, uint8_t *value)
+static inline bool avr_pdi_read8(avr_pdi_t *pdi, uint32_t reg, uint8_t *value)
 {
 	uint32_t data;
-	const bool result = avr_pdi_read(dp, PDI_DATA_8, reg, &data);
+	const bool result = avr_pdi_read(pdi, PDI_DATA_8, reg, &data);
 	if (result)
 		*value = data;
 	return result;
 }
 
-static inline bool avr_pdi_read16(AVR_DP_t *dp, uint32_t reg, uint16_t *value)
+static inline bool avr_pdi_read16(avr_pdi_t *pdi, uint32_t reg, uint16_t *value)
 {
 	uint32_t data;
-	const bool result = avr_pdi_read(dp, PDI_DATA_16, reg, &data);
+	const bool result = avr_pdi_read(pdi, PDI_DATA_16, reg, &data);
 	if (result)
 		*value = data;
 	return result;
 }
 
-static inline bool avr_pdi_read24(AVR_DP_t *dp, uint32_t reg, uint32_t *value)
-	{ return avr_pdi_read(dp, PDI_DATA_24, reg, value); }
+static inline bool avr_pdi_read24(avr_pdi_t *pdi, uint32_t reg, uint32_t *value)
+	{ return avr_pdi_read(pdi, PDI_DATA_24, reg, value); }
 
-static inline bool avr_pdi_read32(AVR_DP_t *dp, uint32_t reg, uint32_t *value)
-	{ return avr_pdi_read(dp, PDI_DATA_32, reg, value); }
+static inline bool avr_pdi_read32(avr_pdi_t *pdi, uint32_t reg, uint32_t *value)
+	{ return avr_pdi_read(pdi, PDI_DATA_32, reg, value); }
 
-static bool avr_pdi_read_ind(const AVR_DP_t *const dp, const uint32_t addr, const uint8_t ptr_mode,
+static bool avr_pdi_read_ind(const avr_pdi_t *const pdi, const uint32_t addr, const uint8_t ptr_mode,
 	void *const dst, const uint32_t count)
 {
 	const uint32_t repeat = count - 1U;
@@ -244,56 +244,56 @@ static bool avr_pdi_read_ind(const AVR_DP_t *const dp, const uint32_t addr, cons
 		return false;
 	// Run `st ptr <addr>`
 	command = PDI_ST | PDI_MODE_DIR_PTR | PDI_DATA_32;
-	if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, addr & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (addr >> 8U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (addr >> 16U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (addr >> 24U) & 0xffU) || result != PDI_EMPTY)
+	if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, command) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, addr & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (addr >> 8U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (addr >> 16U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (addr >> 24U) & 0xffU) || result != PDI_EMPTY)
 		return false;
 	// Run `repeat <count - 1>`
 	command = PDI_REPEAT | PDI_DATA_32;
-	if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, repeat & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (repeat >> 8U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (repeat >> 16U) & 0xffU) || result != PDI_EMPTY ||
-		avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, (repeat >> 24U) & 0xffU) || result != PDI_EMPTY)
+	if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, command) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, repeat & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (repeat >> 8U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (repeat >> 16U) & 0xffU) || result != PDI_EMPTY ||
+		avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, (repeat >> 24U) & 0xffU) || result != PDI_EMPTY)
 		return false;
 	// Run `ld <ptr_mode>`
 	command = PDI_LD | ptr_mode;
-	if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, command) || result != PDI_EMPTY)
+	if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, command) || result != PDI_EMPTY)
 		return false;
 	for (uint32_t i = 0; i < count; ++i)
 	{
-		if (!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, data + i, 0))
+		if (!avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, data + i, 0))
 			return false;
 	}
 	return true;
 }
 
-static bool avr_enable(AVR_DP_t *dp, pdi_key_e what)
+static bool avr_enable(avr_pdi_t *pdi, pdi_key_e what)
 {
 	const char *const key = what == PDI_DEBUG ? pdi_key_debug : pdi_key_nvm;
 	uint8_t result = 0;
-	if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, PDI_KEY) || result != PDI_EMPTY)
+	if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, PDI_KEY) || result != PDI_EMPTY)
 		return false;
 	for (uint8_t i = 0; i < 8; ++i)
 	{
-		if (avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &result, key[i]) || result != PDI_EMPTY)
+		if (avr_jtag_shift_dr(&jtag_proc, pdi->dp_jd_index, &result, key[i]) || result != PDI_EMPTY)
 			return false;
 	}
 	if (what == PDI_NVM)
 	{
-		while ((avr_pdi_reg_read(dp, PDI_REG_STATUS) & what) != what)
+		while ((avr_pdi_reg_read(pdi, PDI_REG_STATUS) & what) != what)
 			continue;
 		return true;
 	}
 	else
-		return (avr_pdi_reg_read(dp, PDI_REG_STATUS) & what) == what;
+		return (avr_pdi_reg_read(pdi, PDI_REG_STATUS) & what) == what;
 }
 
-static bool avr_disable(AVR_DP_t *dp, pdi_key_e what)
+static bool avr_disable(avr_pdi_t *pdi, pdi_key_e what)
 {
-	return avr_pdi_reg_write(dp, PDI_REG_STATUS, ~what);
+	return avr_pdi_reg_write(pdi, PDI_REG_STATUS, ~what);
 }
 
 void avr_add_flash(target *t, uint32_t start, size_t length)
@@ -311,25 +311,25 @@ void avr_add_flash(target *t, uint32_t start, size_t length)
 	target_add_flash(t, f);
 }
 
-bool avr_ensure_nvm_idle(AVR_DP_t *dp)
+bool avr_ensure_nvm_idle(avr_pdi_t *pdi)
 {
-	return avr_pdi_write(dp, PDI_DATA_8, AVR_ADDR_NVM_CMD, 0) &&
-		avr_pdi_write(dp, PDI_DATA_8, AVR_ADDR_NVM_DATA, 0xFFU);
+	return avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_NVM_CMD, 0) &&
+		avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_NVM_DATA, 0xFFU);
 }
 
 bool avr_attach(target *t)
 {
-	AVR_DP_t *dp = t->priv;
+	avr_pdi_t *pdi = t->priv;
 	volatile struct exception e;
-	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_PDI);
+	jtag_dev_write_ir(&jtag_proc, pdi->dp_jd_index, IR_PDI);
 
 	TRY_CATCH (e, EXCEPTION_ALL) {
 		target_reset(t);
-		if (!avr_enable(dp, PDI_DEBUG))
+		if (!avr_enable(pdi, PDI_DEBUG))
 			return false;
 		target_halt_request(t);
-		if (!avr_enable(dp, PDI_NVM) ||
-			!avr_ensure_nvm_idle(dp))
+		if (!avr_enable(pdi, PDI_NVM) ||
+			!avr_ensure_nvm_idle(pdi))
 			return false;
 	}
 	return !e.type;
@@ -337,28 +337,28 @@ bool avr_attach(target *t)
 
 void avr_detach(target *t)
 {
-	AVR_DP_t *dp = t->priv;
+	avr_pdi_t *pdi = t->priv;
 
-	avr_disable(dp, PDI_NVM);
-	avr_disable(dp, PDI_DEBUG);
-	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_BYPASS);
+	avr_disable(pdi, PDI_NVM);
+	avr_disable(pdi, PDI_DEBUG);
+	jtag_dev_write_ir(&jtag_proc, pdi->dp_jd_index, IR_BYPASS);
 }
 
 static void avr_reset(target *t)
 {
-	AVR_DP_t *dp = t->priv;
-	if (!avr_pdi_reg_write(dp, PDI_REG_RESET, PDI_RESET))
+	avr_pdi_t *pdi = t->priv;
+	if (!avr_pdi_reg_write(pdi, PDI_REG_RESET, PDI_RESET))
 		raise_exception(EXCEPTION_ERROR, "Error resetting device, device in incorrect state");
-	if (avr_pdi_reg_read(dp, PDI_REG_STATUS) != 0x00)
+	if (avr_pdi_reg_read(pdi, PDI_REG_STATUS) != 0x00)
 	{
-		avr_disable(dp, PDI_NVM);
-		avr_disable(dp, PDI_DEBUG);
+		avr_disable(pdi, PDI_NVM);
+		avr_disable(pdi, PDI_DEBUG);
 	}
 }
 
 static void avr_halt_request(target *t)
 {
-	AVR_DP_t *dp = t->priv;
+	avr_pdi_t *pdi = t->priv;
 	/* To halt the processor we go through a few really specific steps:
 	 * Write r4 to 1 to indicate we want to put the processor into debug-based pause
 	 * Read r3 and check it's 0x10 which indicates the processor is held in reset and no debugging is active
@@ -367,58 +367,58 @@ static void avr_halt_request(target *t)
 	 * but that debug pause is requested, and the second should respond 0x04 to indicate the processor is now
 	 * in debug pause state (halted)
 	 */
-	if (!avr_pdi_reg_write(dp, PDI_REG_R4, 1) ||
-		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x10U ||
-		!avr_pdi_reg_write(dp, PDI_REG_RESET, 0) ||
-		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x14U ||
-		avr_pdi_reg_read(dp, PDI_REG_R3) != 0x04U)
+	if (!avr_pdi_reg_write(pdi, PDI_REG_R4, 1) ||
+		avr_pdi_reg_read(pdi, PDI_REG_R3) != 0x10U ||
+		!avr_pdi_reg_write(pdi, PDI_REG_RESET, 0) ||
+		avr_pdi_reg_read(pdi, PDI_REG_R3) != 0x14U ||
+		avr_pdi_reg_read(pdi, PDI_REG_R3) != 0x04U)
 		raise_exception(EXCEPTION_ERROR, "Error halting device, device in incorrect state");
-	dp->halt_reason = TARGET_HALT_REQUEST;
+	pdi->halt_reason = TARGET_HALT_REQUEST;
 }
 
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch)
 {
-	AVR_DP_t *dp = t->priv;
+	avr_pdi_t *pdi = t->priv;
 	(void)watch;
-	return dp->halt_reason;
+	return pdi->halt_reason;
 }
 
 static bool avr_check_error(target *t)
 {
-	AVR_DP_t *dp = t->priv;
-	return dp->error_state != pdi_ok;
+	avr_pdi_t *pdi = t->priv;
+	return pdi->error_state != pdi_ok;
 }
 
 static void avr_mem_read(target *t, void *dest, target_addr src, size_t len)
 {
-	AVR_DP_t *dp = t->priv;
+	avr_pdi_t *pdi = t->priv;
 	if (target_flash_for_addr(t, src) != NULL)
 	{
 		// This presently assumes src is a Flash address.
-		if (!avr_pdi_write(dp, PDI_DATA_8, AVR_ADDR_NVM_CMD, AVR_NVM_CMD_READ_NVM) ||
-			!avr_pdi_read_ind(dp, src | PDI_FLASH_OFFSET, PDI_MODE_IND_INCPTR, dest, len) ||
-			!avr_ensure_nvm_idle(dp))
-			dp->error_state = pdi_failure;
+		if (!avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_NVM_CMD, AVR_NVM_CMD_READ_NVM) ||
+			!avr_pdi_read_ind(pdi, src | PDI_FLASH_OFFSET, PDI_MODE_IND_INCPTR, dest, len) ||
+			!avr_ensure_nvm_idle(pdi))
+			pdi->error_state = pdi_failure;
 	}
 	else if (src >= 0x00800000U)
 	{
-		if (!avr_pdi_read_ind(dp, src + 0x00800000U, PDI_MODE_IND_INCPTR, dest, len))
-			dp->error_state = pdi_failure;
+		if (!avr_pdi_read_ind(pdi, src + 0x00800000U, PDI_MODE_IND_INCPTR, dest, len))
+			pdi->error_state = pdi_failure;
 	}
 }
 
 static void avr_regs_read(target *t, void *data)
 {
-	AVR_DP_t *dp = t->priv;
+	avr_pdi_t *pdi = t->priv;
 	avr_regs *regs = (avr_regs *)data;
 	uint8_t status[3];
 	uint32_t pc = 0;
-	if (!avr_pdi_read32(dp, AVR_ADDR_DBG_PC, &pc) ||
-		!avr_pdi_read_ind(dp, AVR_ADDR_CPU_SPL, PDI_MODE_IND_INCPTR, status, 3) ||
-		!avr_pdi_write(dp, PDI_DATA_8, AVR_ADDR_DBG_CTRL, AVR_DBG_READ_REGS) ||
-		!avr_pdi_write(dp, PDI_DATA_32, AVR_ADDR_DBG_CTR, AVR_NUM_REGS) ||
-		!avr_pdi_reg_write(dp, PDI_REG_R4, 1) ||
-		!avr_pdi_read_ind(dp, AVR_ADDR_DBG_SPECIAL, PDI_MODE_IND_PTR, regs->general, 32))
+	if (!avr_pdi_read32(pdi, AVR_ADDR_DBG_PC, &pc) ||
+		!avr_pdi_read_ind(pdi, AVR_ADDR_CPU_SPL, PDI_MODE_IND_INCPTR, status, 3) ||
+		!avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_DBG_CTRL, AVR_DBG_READ_REGS) ||
+		!avr_pdi_write(pdi, PDI_DATA_32, AVR_ADDR_DBG_CTR, AVR_NUM_REGS) ||
+		!avr_pdi_reg_write(pdi, PDI_REG_R4, 1) ||
+		!avr_pdi_read_ind(pdi, AVR_ADDR_DBG_SPECIAL, PDI_MODE_IND_PTR, regs->general, 32))
 		raise_exception(EXCEPTION_ERROR, "Error reading registers");
 	// These aren't in the reads above because regs is a packed struct, which results in compiler errors
 	// Additionally, the program counter is stored in words and points to the next instruction to be executed

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -219,7 +219,8 @@ static inline bool avr_pdi_read24(AVR_DP_t *dp, uint32_t reg, uint32_t *value)
 static inline bool avr_pdi_read32(AVR_DP_t *dp, uint32_t reg, uint32_t *value)
 	{ return avr_pdi_read(dp, PDI_DATA_32, reg, value); }
 
-static bool avr_pdi_read_ind(AVR_DP_t *dp, uint32_t addr, uint8_t ptr_mode, void *dst, uint32_t count)
+static bool avr_pdi_read_ind(const AVR_DP_t *const dp, const uint32_t addr, const uint8_t ptr_mode,
+	void *const dst, const uint32_t count)
 {
 	const uint32_t repeat = count - 1U;
 	uint8_t result = 0, command;
@@ -248,7 +249,7 @@ static bool avr_pdi_read_ind(AVR_DP_t *dp, uint32_t addr, uint8_t ptr_mode, void
 		return false;
 	for (uint32_t i = 0; i < count; ++i)
 	{
-		if (!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, &data[i], 0))
+		if (!avr_jtag_shift_dr(&jtag_proc, dp->dp_jd_index, data + i, 0))
 			return false;
 	}
 	return true;

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -380,7 +380,7 @@ void avr_add_flash(target *t, uint32_t start, size_t length)
 	target_add_flash(t, f);
 }
 
-bool avr_ensure_nvm_idle(avr_pdi_t *pdi)
+static bool avr_ensure_nvm_idle(avr_pdi_t *pdi)
 {
 	return avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_NVM_CMD, 0) &&
 		avr_pdi_write(pdi, PDI_DATA_8, AVR_ADDR_NVM_DATA, 0xFFU);
@@ -468,7 +468,7 @@ static void avr_halt_request(target *t)
 	pdi->halt_reason = TARGET_HALT_REQUEST;
 }
 
-static void avr_halt_resume(target *t, bool step)
+static void avr_halt_resume(target *t, const bool step)
 {
 	avr_pdi_t *pdi = t->priv;
 	if (step)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -119,6 +119,8 @@ bool avr_dp_init(AVR_DP_t *dp)
 	t->attach = avr_attach;
 	t->detach = avr_detach;
 
+	t->regs_read = avr_regs_read;
+
 	t->reset = avr_reset;
 	t->halt_request = avr_halt_request;
 	t->halt_poll = avr_halt_poll;
@@ -265,7 +267,7 @@ static bool avr_pdi_read_ind(AVR_DP_t *dp, uint32_t addr, uint8_t ptr_mode, void
 	return true;
 }
 
-bool avr_enable(AVR_DP_t *dp, pdi_key_e what)
+static bool avr_enable(AVR_DP_t *dp, pdi_key_e what)
 {
 	const char *const key = what == PDI_DEBUG ? pdi_key_debug : pdi_key_prog;
 	uint8_t result = 0;
@@ -279,7 +281,7 @@ bool avr_enable(AVR_DP_t *dp, pdi_key_e what)
 	return (avr_pdi_reg_read(dp, PDI_REG_STATUS) & what) == what;
 }
 
-bool avr_disable(AVR_DP_t *dp, pdi_key_e what)
+static bool avr_disable(AVR_DP_t *dp, pdi_key_e what)
 {
 	return avr_pdi_reg_write(dp, PDI_REG_STATUS, ~what);
 }

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -81,6 +81,13 @@ typedef enum
 static const char pdi_key_nvm[] = {0xff, 0x88, 0xd8, 0xcd, 0x45, 0xab, 0x89, 0x12};
 static const char pdi_key_debug[] = {0x21, 0x81, 0x7c, 0x9f, 0xd4, 0x2d, 0x21, 0x3a};
 
+static bool avr_erase(target *t, int argc, char **argv);
+
+const struct command_s avr_cmd_list[] = {
+	{"erase", (cmd_handler)avr_erase, "Erase (part of) a device"},
+	{NULL, NULL, NULL}
+};
+
 static void avr_reset(target *t);
 static void avr_halt_request(target *t);
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch);
@@ -140,6 +147,8 @@ bool avr_pdi_init(avr_pdi_t *pdi)
 	// Unlike on an ARM processor, where this is the length of a table, here we return the size of
 	// a suitable registers structure.
 	t->regs_size = sizeof(avr_regs);
+
+	target_add_commands(t, avr_cmd_list, "Atmel AVR");
 
 	if (atxmega_probe(t))
 		return true;
@@ -522,4 +531,24 @@ static int avr_flash_write(struct target_flash *f, target_addr dest, const void 
 			return 1;
 	}
 	return 0;
+}
+
+static bool avr_erase(target *t, int argc, char **argv)
+{
+	if (argc < 2)
+		tc_printf(t, "usage: monitor erase (<start_address>) <length>\n");
+	else
+	{
+		target_addr begin = 0;
+		size_t length = 0;
+		if (argc >= 3)
+		{
+			begin = atol(argv[1]);
+			length = atol(argv[2]);
+		}
+		else
+			length = atol(argv[1]);
+		target_flash_erase(t, begin, length);
+	}
+	return true;
 }

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -15,6 +15,15 @@
 #define PDI_LDCS	0x80U
 #define PDI_STCS	0xC0U
 
+#define PDI_REG_STATUS	0U
+#define PDI_REG_RESET	1U
+#define PDI_REG_CTRL	2U
+#define PDI_REG_R3		3U
+#define PDI_REG_R4		4U
+
+#define PDI_RESET	0x59U
+
+static void avr_reset(target *t);
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch);
 
 static void avr_dp_ref(AVR_DP_t *dp)
@@ -112,6 +121,14 @@ void avr_detach(target *t)
 {
 	AVR_DP_t *dp = t->priv;
 	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_BYPASS);
+}
+
+static void avr_reset(target *t)
+{
+	AVR_DP_t *dp = t->priv;
+	if (!avr_pdi_reg_write(dp, PDI_REG_RESET, PDI_RESET) ||
+		avr_pdi_reg_read(dp, PDI_REG_STATUS) != 0x00)
+		raise_exception(EXCEPTION_ERROR, "Error resetting device, device in incorrect state\n");
 }
 
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch)

--- a/src/target/avr_pdi.c
+++ b/src/target/avr_pdi.c
@@ -37,13 +37,13 @@ static void avr_reset(target *t);
 static void avr_halt_request(target *t);
 static enum target_halt_reason avr_halt_poll(target *t, target_addr *watch);
 
-static const uint32_t regnum_avr[] = {
-	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, // r0-r15
-	16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, // r16-31
-	32, // SREG
-	33, // SP
-	34, // PC
-};
+typedef struct __attribute__((packed))
+{
+	uint8_t general[32]; // r0-r31
+	uint8_t sreg; // r32
+	uint16_t sp; // r33
+	uint32_t pc; // r34
+} avr_regs;
 
 static void avr_dp_ref(AVR_DP_t *dp)
 {
@@ -87,7 +87,9 @@ bool avr_dp_init(AVR_DP_t *dp)
 	t->reset = avr_reset;
 	t->halt_request = avr_halt_request;
 	t->halt_poll = avr_halt_poll;
-	t->regs_size = sizeof(regnum_avr);
+	// Unlike on an ARM processor, where this is the length of a table, here we return the size of
+	// a suitable registers structure.
+	t->regs_size = sizeof(avr_regs);
 
 	if (atxmega_probe(t))
 		return true;

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -22,6 +22,7 @@
 #include "general.h"
 #include "jtag_scan.h"
 #include "adiv5.h"
+#include "avr.h"
 #include "jtag_devs.h"
 
 jtag_dev_descr_t dev_descr[] = {
@@ -62,6 +63,9 @@ jtag_dev_descr_t dev_descr[] = {
 		.descr = "Xambala: RVDBG013."},
 	{.idcode = 0x000007A3, .idmask = 0x00000FFF,
 		.descr = "Gigadevice BSD."},
+	{.idcode = 0x0000003F, .idmask = 0x00000FFF,
+		.descr = "Atmel Limited: AVR JTAG-PDI port.",
+		.handler = avr_jtag_dp_handler},
 /* Just for fun, unsupported */
 	{.idcode = 0x8940303F, .idmask = 0xFFFFFFFF, .descr = "ATMega16."},
 	{.idcode = 0x0792603F, .idmask = 0xFFFFFFFF, .descr = "AT91SAM9261."},

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -65,7 +65,7 @@ jtag_dev_descr_t dev_descr[] = {
 		.descr = "Gigadevice BSD."},
 	{.idcode = 0x0000003F, .idmask = 0x00000FFF,
 		.descr = "Atmel Limited: AVR JTAG-PDI port.",
-		.handler = avr_jtag_dp_handler},
+		.handler = avr_jtag_pdi_handler},
 /* Just for fun, unsupported */
 	{.idcode = 0x8940303F, .idmask = 0xFFFFFFFF, .descr = "ATMega16."},
 	{.idcode = 0x0792603F, .idmask = 0xFFFFFFFF, .descr = "AT91SAM9261."},

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -207,8 +207,8 @@ int jtag_scan(const uint8_t *irlens)
 #endif
 
 	/* Check for known devices and handle accordingly */
-	for(i = 0; i < jtag_dev_count; i++)
-		for(j = 0; dev_descr[j].idcode; j++)
+	for(i = 0; i < jtag_dev_count; i++) {
+		for(j = 0; dev_descr[j].idcode; j++) {
 			if((jtag_devs[i].jd_idcode & dev_descr[j].idmask) ==
 			   dev_descr[j].idcode) {
 				jtag_devs[i].current_ir = -1;
@@ -219,6 +219,8 @@ int jtag_scan(const uint8_t *irlens)
 					dev_descr[j].handler(i);
 				break;
 			}
+		}
+	}
 
 	return jtag_dev_count;
 }

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -35,7 +35,7 @@ struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS+1];
 int jtag_dev_count;
 
 /* bucket of ones for don't care TDI */
-static const uint8_t ones[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+const uint8_t ones[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 #if PC_HOSTED == 0
 void jtag_add_device(const int dev_index, const jtag_dev_t *jtag_dev)

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -42,6 +42,7 @@ typedef struct jtag_dev_s {
 
 extern struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS+1];
 extern int jtag_dev_count;
+extern const uint8_t ones[9];
 
 void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
 void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks);

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -239,7 +239,7 @@ bool target_mem_map(target *t, char *tmp, size_t len)
 	return true;
 }
 
-static struct target_flash *flash_for_addr(target *t, uint32_t addr)
+struct target_flash *target_flash_for_addr(target *t, uint32_t addr)
 {
 	for (struct target_flash *f = t->flash; f; f = f->next)
 		if ((f->start <= addr) &&
@@ -252,7 +252,7 @@ int target_flash_erase(target *t, target_addr addr, size_t len)
 {
 	int ret = 0;
 	while (len) {
-		struct target_flash *f = flash_for_addr(t, addr);
+		struct target_flash *f = target_flash_for_addr(t, addr);
 		if (!f) {
 			DEBUG_WARN("Erase stopped at 0x%06" PRIx32 "\n", addr);
 			return ret;
@@ -271,7 +271,7 @@ int target_flash_write(target *t,
 {
 	int ret = 0;
 	while (len) {
-		struct target_flash *f = flash_for_addr(t, dest);
+		struct target_flash *f = target_flash_for_addr(t, dest);
 		if (!f)
 			return 1;
 		size_t tmptarget = MIN(dest + len, f->start + f->length);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -143,6 +143,8 @@ void target_add_commands(target *t, const struct command_s *cmds, const char *na
 void target_add_ram(target *t, target_addr start, uint32_t len);
 void target_add_flash(target *t, struct target_flash *f);
 
+struct target_flash *target_flash_for_addr(target *t, uint32_t addr);
+
 /* Convenience function for MMIO access */
 uint32_t target_mem_read32(target *t, uint32_t addr);
 uint16_t target_mem_read16(target *t, uint32_t addr);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -201,4 +201,6 @@ bool efm32_probe(target *t);
 bool msp432_probe(target *t);
 bool ke04_probe(target *t);
 bool rp_probe(target *t);
+
+bool atxmega_probe(target *t);
 #endif


### PR DESCRIPTION
This PR establishes support for several things related to the Atmel 8-bit AVR lineup:
* It establishes support for handling AVR parts separately from the rest.
* It establishes support for the JTAG-PDI protocol in BMPF.
* It establishes target support for the ATXMega256A3U processor based atop of this JTAG-PDI support.
* It establishes debug support for that same processor based on our [documentation work](https://dx-mon.github.io/tempest) for the PDI protocol w/ a focus on how debug works

It should be noted that the AVRs are pretty sensitive to how scan is completed which is why #978 had to land first, and the PDI controller is very sensitive to how data is clocked into the target. What the PDI controller does not care about is how fast we do so as JTAG on these parts is decoupled from CPU clock speed completely. You can run the PDI side of things at 10MHz on a processor running at 2 and nothing will hurt for that, except you getting a lot of PDI Delay Byte responses (which we make transparent to the target code for simplicity's sake).