### PR TITLE
Feature: clang-tidy and clang-format support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,14 @@
 ---
 AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: DontAlign
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AllowAllArgumentsOnNextLine: true
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
 # This is currently broken:
 # https://github.com/llvm/llvm-project/issues/53442
 #AlignArrayOfStructures: Left
@@ -22,15 +26,23 @@ BraceWrapping:
   IndentBraces: false
 BreakBeforeBraces: Linux
 BasedOnStyle: LLVM
+BinPackArguments: true
+BinPackParameters: true
 ColumnLimit: 120
-Cpp11BracedListStyle: false
+Cpp11BracedListStyle: true
 IndentCaseLabels: false
-IndentWidth: 8
+IndentWidth: 4
+ContinuationIndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: false
+FixNamespaceComments: true
+ForEachMacros: ['TRY_CATCH']
+#QualifierAlignment: Custom
+#QualifierOrder: ['inline', 'static', 'const', 'volatile', 'type']
+SpaceAroundPointerQualifiers: After
 
 # Taken from git's rules
 #PenaltyBreakAssignment: 10 # Unknown to clang-format-4.0
-PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakBeforeFirstCallParameter: 50
 PenaltyBreakComment: 10
 PenaltyBreakFirstLessLess: 0
 PenaltyBreakString: 10
@@ -41,5 +53,5 @@ PointerAlignment: Right
 ReflowComments: false
 SpacesBeforeTrailingComments: 1
 SortIncludes: false
-TabWidth: 8
-UseTab: Always
+TabWidth: 4
+UseTab: AlignWithSpaces

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,29 @@
+---
+Checks: 'bugprone-*,cert-*,clang-analyzer-*,misc-*,modernize-*,portability-*,performance-*,readability-*,-readability-magic-numbers'
+FormatStyle: 'none'
+HeaderFilterRegex: '(src|upgrade)/.+'
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:   cert-dcl16-c.NewSuffixes
+    value: 'L;LL;UL;ULL'
+  - key:   cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value: '0'
+  - key:   cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value: '0'
+  - key:   cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: '1'
+  - key:   modernize-loop-convert.MaxCopySize
+    value: '16'
+  - key:   modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key:   modernize-loop-convert.NamingStyle
+    value: camelBack
+  - key:   modernize-pass-by-value.IncludeStyle
+    value: llvm
+  - key:   modernize-replace-auto-ptr.IncludeStyle
+    value: llvm
+  - key:   modernize-use-nullptr.NullMacros
+    value: 'NULL'
+  - key:   readability-braces-around-statements.ShortStatementLines
+    value: '2'
+...

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,7 @@ endif
 clang-tidy:
 	$(Q)scripts/run-clang-tidy.py -s "$(PWD)"
 
-.PHONY: clean all_platforms clang-tidy
+clang-format:
+	$(Q)$(MAKE) $(MFLAGS) -C src $@
+
+.PHONY: clean all_platforms clang-tidy clang-format

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,13 @@ endif
 all_platforms:
 	$(Q)$(MAKE) $(MFLAGS) -C src $@
 
-
 clean:
 ifndef NO_LIBOPENCM3
 	$(Q)$(MAKE) $(MFLAGS) -C libopencm3 $@
 endif
 	$(Q)$(MAKE) $(MFLAGS) -C src $@
 
-.PHONY: clean all_platforms
+clang-tidy:
+	$(Q)scripts/run-clang-tidy.py -s "$(PWD)"
+
+.PHONY: clean all_platforms clang-tidy

--- a/scripts/run-clang-tidy.py
+++ b/scripts/run-clang-tidy.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+from argparse import ArgumentParser
+from pathlib import Path
+from subprocess import run
+from concurrent.futures import ThreadPoolExecutor
+from sys import exit
+
+parser = ArgumentParser(
+	description = 'Light-weight wrapper around clang-tidy to enable `make clang-tidy` or ' +
+		'`ninja clang-tidy` to function properly',
+	allow_abbrev = False
+)
+parser.add_argument('-s', required = True, type = str, metavar = 'sourcePath',
+	dest = 'sourcePath', help = 'Path to the source directory to run clang-tidy in')
+parser.add_argument('-p', type = str, metavar = 'buildPath',
+	dest = 'buildPath', help = 'Path to the build directory containing a compile_commands.json')
+args = parser.parse_args()
+
+def globFiles():
+	srcDir = Path(args.sourcePath)
+	paths = set(('src', 'upgrade'))
+	suffixes = set(('c', 'h'))
+	for path in paths:
+		for suffix in suffixes:
+			yield srcDir.glob('{}/**/*.{}'.format(path, suffix))
+
+def gatherFiles():
+	for fileGlob in globFiles():
+		for file in fileGlob:
+			yield file
+
+extraArgs = [
+	'-Isrc/target', '-Isrc', '-Isrc/include', '-Isrc/platforms/native',
+	'-Ilibopencm3/include', '-Isrc/platforms/stm32'
+]
+for i, arg in enumerate(extraArgs):
+	extraArgs[i] = f'--extra-arg={arg}'
+
+if args.buildPath is not None:
+	print(f'Adding build path "{args.buildPath}" to extraArgs')
+	extraArgs += ['-p', args.buildPath]
+
+futures = []
+returncode = 0
+with ThreadPoolExecutor() as pool:
+	for file in gatherFiles():
+		futures.append(pool.submit(run, ['clang-tidy'] + extraArgs + [str(file)]))
+	returncode = max((future.result().returncode for future in futures))
+exit(returncode)

--- a/src/Makefile
+++ b/src/Makefile
@@ -128,7 +128,7 @@ ifndef PC_HOSTED
 	$(Q)$(OBJCOPY) -O ihex $^ $@
 endif
 
-.PHONY:	clean host_clean all_platforms FORCE
+.PHONY:	clean host_clean all_platforms clang-format FORCE
 
 clean:	host_clean
 	$(Q)echo "  CLEAN"
@@ -190,5 +190,8 @@ else
 		echo '$(VERSION_HEADER)' > $@; \
 	fi
 endif
+
+clang-format:
+	$(Q)clang-format -i *.c */*.c */*/*.c *.h */*.h */*/*.h
 
 -include *.d


### PR DESCRIPTION
This adds:

* support for clang-tidy, a script for parallel running it on the code base, and a Makefile target to trigger it
* support for clang-format, and a Makefile target to trigger it

For IDEs like VSCode, the clang-tidy extension by notskm should automatically pick the new configuration up and display linting inline. Likewise, the clang-format extension by xaver can be used to automatically enforce the formatting requirements this provides by enabling format-on-save (`"editor.formatOnSave": true` in settings.json).

In a future PR we will introduce a PR-time CI job that will validate code meets the formatting requirements and add a CI job that runs clang-tidy on merge to main to help with tracking progress on linting cleanup