### PR TITLE
VSCode extension recomendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"ms-vscode.cpptools",
+		"notskm.clang-tidy"
+	]
+}


### PR DESCRIPTION
This is a follow-up PR to #1078 which comes about from a suggestion by Esden on Discord that to help with clang-tidy and clang-format use and enforcement, the project should come with extension recommendations as appropriate to reduce the barriers to entry.

This adds recommendations for VSCode extensions to be used with the project