### PR TITLE
target/sam3x: saner uninitialized variable prevention

### DIFF
--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -622,6 +622,9 @@ static bool sam_cmd_gpnvm(target *t, int argc, const char **argv)
 		gpnvm_mask = 0x1BF;
 		base = SAMX7X_EEFC_BASE;
 		break;
+	default:
+		/* unknown / invalid driver*/
+		goto bad_usage;
 	}
 
 	uint32_t mask = 0, values = 0;


### PR DESCRIPTION
in #1076 we initialized variables to 0, but in the event that a new driver is added and not properly handled, we would try to do GPNVM bit operations on a flash peripheral with address 0x0, I think this is a saner approach, where if a driver is not known the command immediately fails

Signed-off-by: Rafael Silva <perigoso@riseup.net> 