### PR TITLE
Fix: main branch CI

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -4,7 +4,7 @@ name: build and upload
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ master ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,7 +4,7 @@ name: build PR
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Fixed the push and pull_request branch requirements for our CI to run. The branch rename yesterday silently broke this. This re-enables CI on the project