### PR TITLE
Feature: ST-Link SWIM-UART switchability

### DIFF
--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -25,6 +25,10 @@ else
 LDFLAGS += --specs=nosys.specs
 endif
 
+ifeq ($(SWIM_AS_UART), 1)
+CFLAGS += -DSWIM_AS_UART=1
+endif
+
 VPATH += platforms/stm32
 
 SRC += 	cdcacm.c	\
@@ -47,4 +51,3 @@ blackmagic_dfu.elf: usbdfu.o dfucore.o dfu_f1.o stlink_common.o serialno.o
 
 host_clean:
 	-$(Q)$(RM) *.bin *elf *hex
-

--- a/src/platforms/stlink/README.md
+++ b/src/platforms/stlink/README.md
@@ -1,6 +1,7 @@
 # Blackmagic for ST-Link Adapters
 
-ST-Link v3, ST-Link v2-1 and v2 with original, recent ST firmware can can use the hosted branch, running the GDB server on PC.
+With recent ST firmware, the ST-Link v2, ST-Link v2-1 and v3 can be used with
+Black Magic Debug App rather than having to flash this firmware to the adaptor.
 
 Running the BMP firmware on ST-Link v2 and ST-Link v2-1 provides:
 
@@ -10,6 +11,12 @@ Running the BMP firmware on ST-Link v2 and ST-Link v2-1 provides:
 * no mass storage device (MSD). A MSD may collide with company policies.
 
 For all commands below, unplug all other BMP/ST-Link beside the target(*1)
+
+If your adaptor offers SWIM pins on the connector (many of clones of the official adaptors do this)
+then they often don't provide a UART interface. In this case, build the firmware with
+`SWIM_AS_UART=1` to repurpose the pins as the UART interface provided to the host over USB.
+
+Note: on some clones, SWIM is strongly pulled up by a 680 Ohm resistor.
 
 ## Upload BMP Firmware
 

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -81,6 +81,12 @@ void platform_init(void)
 	if (rev > 1) /* Reconnect USB */
 		gpio_set(GPIOA, GPIO15);
 	cdcacm_init();
+
+#ifdef SWIM_AS_UART
+	gpio_primary_remap(AFIO_MAPR_SWJ_CFG_FULL_SWJ,
+			   AFIO_MAPR_USART1_REMAP);
+#endif
+
 	/* Don't enable UART if we're being debugged. */
 	if (!(SCS_DEMCR & SCS_DEMCR_TRCENA))
 		usbuart_init();

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -105,15 +105,24 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define IRQ_PRI_USB_VBUS	(14 << 4)
 #define IRQ_PRI_SWO_DMA			(0 << 4)
 
+#ifdef SWIM_AS_UART
+#define USBUSART USART1
+#define USBUSART_CR1 USART1_CR1
+#define USBUSART_DR USART1_DR
+#define USBUSART_IRQ NVIC_USART1_IRQ
+#define USBUSART_CLK RCC_USART1
+#define USBUSART_ISR(x) usart1_isr(x)
+#else
 #define USBUSART USART2
 #define USBUSART_CR1 USART2_CR1
 #define USBUSART_DR USART2_DR
 #define USBUSART_IRQ NVIC_USART2_IRQ
 #define USBUSART_CLK RCC_USART2
+#define USBUSART_ISR(x) usart2_isr(x)
+#endif
 #define USBUSART_PORT GPIOA
 #define USBUSART_TX_PIN GPIO2
 #define USBUSART_RX_PIN GPIO3
-#define USBUSART_ISR(x) usart2_isr(x)
 
 #define USBUSART_DMA_BUS DMA1
 #define USBUSART_DMA_CLK RCC_DMA1
@@ -178,6 +187,5 @@ extern uint32_t detect_rev(void);
 #else
 #define snprintf sniprintf
 #endif
-
 
 #endif


### PR DESCRIPTION
This PR replaces #396 which appears to have become abandoned.

This enables using the stlink platform with ST-Link clones that have no UART interface, only SWIM. By specifying `SWIM_AS_UART=1` when building, it repurposes the SWIM_RST and SWIM pins as UART TX and RX respectively.