### PR TITLE
blackpillv2: fix PROBE_HOST in Readme.md

### DIFF
--- a/src/platforms/blackpillv2/Readme.md
+++ b/src/platforms/blackpillv2/Readme.md
@@ -26,7 +26,7 @@ https://github.com/WeActTC/MiniSTM32F4x1
 ```sh
 cd blackmagic
 make clean
-make PROBE_HOST=blackpill
+make PROBE_HOST=blackpillv2
 ```
 
 ## How to Flash with dfu


### PR DESCRIPTION
After renaming directory with s/blackpill/blackpillv2/, Readme.md still
contained the old 'blackpill' name in PROBE_HOST. Fix that by replacing
it with 'blackpillv2'.

Fixes: 3ccb0af21c02 ("blackpillv2: Renamed blackpill to blackpillv2 to
  prevent ambiguity.")