### PR TITLE
blackpillv2: clarify how to enter to bootloader mode

### DIFF
--- a/src/platforms/blackpillv2/Readme.md
+++ b/src/platforms/blackpillv2/Readme.md
@@ -36,7 +36,7 @@ make PROBE_HOST=blackpillv2
   * 2) Force the F4 into system bootloader mode by keeping BOOT0 button pressed while pressing and releasing NRST button. System bootloader should appear.
   * 3) `dfu-util -a 0 --dfuse-address 0x08000000 -D blackmagic.bin`
 
-To exit from dfu mode press a "key" and "reset", release reset. BMP firmware should appear
+To exit from dfu mode just press and release NRST. The newly Flashed BMP firmware should boot and enumerate.
 
 ## 10 pin male from pins
 

--- a/src/platforms/blackpillv2/Readme.md
+++ b/src/platforms/blackpillv2/Readme.md
@@ -33,7 +33,7 @@ make PROBE_HOST=blackpillv2
 
 * After build:
   * 1) `apt install dfu-util`
-  * 2) Force the F4 into system bootloader mode by jumpering "BOOT0" to "3V3" and "PB2/BOOT1" to "GND" and reset (RESET button). System bootloader should appear.
+  * 2) Force the F4 into system bootloader mode by keeping BOOT0 button pressed while pressing and releasing NRST button. System bootloader should appear.
   * 3) `dfu-util -a 0 --dfuse-address 0x08000000 -D blackmagic.bin`
 
 To exit from dfu mode press a "key" and "reset", release reset. BMP firmware should appear


### PR DESCRIPTION
According to [1] all PCB revisions have BOOT0 and NRST labels near
buttons. Reference those in README for ease of use.

PB2/BOOT1 has a 10k pull-down on PCB (in all revisions, according to
[1]), so there is no need to do anything on the board (like "jumpering
to GND") unless the board was modified by user. Hence don't reference
PB2/BOOT1 in the README, as it was just confusing to the user.

[1] https://github.com/WeActTC/MiniSTM32F4x1/tree/master/HDK