### PR TITLE
Fix several errors in the main project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Black Magic Probe
-=================
+# Black Magic Probe
 
 [![Discord](https://img.shields.io/discord/613131135903596547?logo=discord)](https://discord.gg/P7FYThy)
 
@@ -17,31 +16,31 @@ Serial Wire Output (SWO) allows the target to write tracing and logging to the h
 without using usb or serial port. Decoding SWO in the probe itself
 makes [SWO viewing as simple as connecting to a serial port](https://github.com/blackmagic-debug/blackmagic/wiki/Serial-Wire-Output).
 
+## Resources
 
-Resources
-=========
+* [Documentation](https://github.com/blackmagic-debug/blackmagic/wiki)
+* [Binary builds](http://builds.blacksphere.co.nz/blackmagic)
 
- * [Documentation](https://github.com/blackmagic-debug/blackmagic/wiki)
- * [Binary builds](http://builds.blacksphere.co.nz/blackmagic)
+## Toolchain specific remarks
 
-
-Toolchain specific remarks
-==========================
-Most firmware building is done with the most recent suite from https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm.
+Building the firmware is done with the most recent toolchain available from
+[ARM's GNU-RM toolchains](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm).
 If you have a toolchain from other sources and find problems, check if it is a failure of your toolchain and if not open an issue or better provide a pull request with a fix.
 
-OS specific remarks for BMP-Hosted
-==================================
-Most hosted building is done on and for Linux. BMP-hosted for windows can also be build with Mingw on Linux.<br>
-Building hosted for BMP firmware probes only with "make PROBE_HOST HOSTED_BMP_ONLY=1" does not require libusb, libftdi and evt. libhidapi development headers and libraries for running.<br>
-On BSD/Macos, using dev/tty.usbmodemXXX should work but unresolved discussions indicate a hanging open() call on the second invocation. If that happens, try with cu.usbmodemXXX.<br>
+## OS specific remarks for BMP-Hosted
 
-Reporting problems
-==================
+Most hosted building is done on and for Linux. BMP-hosted for windows can also be build with Mingw on Linux.
+
+Building hosted for BMP firmware probes only with "make PROBE_HOST=hosted HOSTED_BMP_ONLY=1" does not require libusb, libftdi and evt. libhidapi development headers and libraries for running.
+
+On BSD/Macos, using dev/tty.usbmodemXXX should work but unresolved discussions indicate a hanging open() call on the second invocation. If that happens, try with cu.usbmodemXXX.
+
+## Reporting problems
+
 Before reporting issues, check against the latest git version. If possible, test against another target /and/or debug probe. Consider broken USB cables and connectors. Try to reproduce with bmp-hosted with at least debug bit 1 set (blackmagic -v 1 ...), as debug messages will be dumped to the starting console. When reporting issues, be as specific as possible!
 
-Sample Session
-=============
+## Sample Session
+
 ```console
 > arm-none-eabi-gdb gpio.elf
 ...<GDB Copyright message>
@@ -64,7 +63,7 @@ Transfer rate: 31 KB/sec, 919 bytes/write.
 (gdb) b main
 Breakpoint 1 at 0x80000e8: file /devel/en_apps/gpio/f4_discovery/../gpio.c, line 70.
 (gdb) r
-Starting program: /devel/en_apps/gpio/f4_discovery/gpio.elf 
+Starting program: /devel/en_apps/gpio/f4_discovery/gpio.elf
 Note: automatically using hardware breakpoints for read-only addresses.
 
 Breakpoint 1, main () at /devel/en_apps/gpio/f4_discovery/../gpio.c:70

--- a/README.md
+++ b/README.md
@@ -71,23 +71,24 @@ Breakpoint 1, main () at /devel/en_apps/gpio/f4_discovery/../gpio.c:70
 70      {
 ```
 
-BLACKMAGIC
-==========
+## Black Magic Debug App
 
-You can also build blackmagic as a PC hosted application
-"make PROBE_HOST=hosted"
+You can also build the Black Magic Debug suite as a PC program called Black Magic Debug App
+by running `make PROBE_HOST=hosted`
 
-This builds the same GDB server, that is running on the Black Magic Probe.
+This builds the same GDB server that is running on the Black Magic Probe.
 While connection to the Black Magic Probe GDB server is via serial line,
-connection to the PC-Hosted GDB server is via TCP port 2000 for the first
+connection to the Black Magic Debug App is via TCP port 2000 for the first
 GDB server and higher for more invokations. Use "tar(get) ext(ented) :2000"
 to connect.
-PC-hosted BMP GDB server can talk to
-- Black Magic Probe firmware probes via the USB-serial port
-- ST-LinkV2 and V3 with recent firmware
-- CMSIS-DAP compatible probes
-- JLINK probes
-- FTDI MPSSE based probe.
+
+Black Magic Debug App can talk to
+
+* Black Magic Probe firmware probes via the USB-serial port
+* ST-LinkV2 and V3 with recent firmware
+* CMSIS-DAP compatible probes
+* JLINK probes
+* FTDI MPSSE based probe.
 
 When connected to a single BMP supported probe, starting "blackmagic" w/o any
 arguments starts the server. When several BMP supported probes are connected,
@@ -96,6 +97,7 @@ Add "-P (position)" to the next invocation to select one.
 For the setup from the sample session above:
 
 In another terminal:
+
 ```console
 > blackmagic
 Black Magic Debug App v1.8.0
@@ -106,6 +108,7 @@ Listening on TCP: 2000
 ```
 
 And in the GDB terminal:
+
 ```console
 (gdb) tar ext :2000
 Remote debugging using :2000
@@ -113,7 +116,6 @@ Remote debugging using :2000
 ...
 ```
 
-PC hosted BMP also allows to flash, read and verify a binary file, by default
-starting at lowest flash address. The "-t" argument displays information about the
-connected target. Use "-h " to get a list of supported options.
-
+Black Magic Debug App also provides for Flashing, reading and verification of a binary file,
+by default starting at lowest flash address. The `-t` argument displays information about the
+connected target. Use `-h`/`--help` to get a list of supported options.


### PR DESCRIPTION
This PR addresses a couple of problems with the project README:

* The BMDA section at the bottom being a bit all over the place in naming and inconsitent with the current project naming scheme
* Links being inconsistent (sometimes proper Markdown links, other times just raw URLs)
* The build instructions for full BMDA being wrong
* Headings in the document violating Markdown rules and being inconsistent

This came to our attention because of user alvarop on Discord
