### PR TITLE
Fix: target Flash buffer lifetime bounding

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -280,6 +280,11 @@ int target_flash_write(target *t,
 		dest += tmplen;
 		src += tmplen;
 		len -= tmplen;
+		/* If the current chunk of Flash is now full from this operation
+		 * then finish operations on the Flash chunk and free the internal buffer.
+		 */
+		if (dest == f->start + f->length)
+			ret |= target_flash_done_buffered(f);
 	}
 	return ret;
 }


### PR DESCRIPTION
Make the buffers used to program a target's Flash better bounded in lifetime and memory usage.

In the old setup, if the user requested the programming of, say, 3 unique Flash regions, we would allocate 3 buffers, work away programming the regions, and only at the very end run `target_flash_done_buffered` on each region to clean up - making the final writes possibly out of order, and meaning we gradually grow memory usage with quite large buffers till we finally de-allocate them all in one shot. This clearly causes issues on some targets as we're memory constrained, and they can have large buffer requirements and many Flash regions.

In this new regime, as we get to the end of each Flash region when running `target_flash_write`, we run `target_flash_done_buffered` to clean up. This won't catch all possible combinations of writes and allocations, but it should bound writes that fill Flash regions and step into new regions.

This partially fixes #960. If we can figure out a way to catch partial regions which won't be filled further, we will amend the PR so we can fully bound all temporary Flash buffers and the resulting memory usage.