### PR TITLE
Fix: kinetis Flash control correctness

### DIFF
--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -466,7 +466,7 @@ static int kinetis_flash_cmd_write(struct target_flash *f, target_addr dest, con
 		write_cmd = FTFx_CMD_PROGRAM_LONGWORD;
 
 	while (len) {
-		if (kinetis_fccob_cmd(f->t, write_cmd, dest, src, 1)) {
+		if (kinetis_fccob_cmd(f->t, write_cmd, dest, src, kf->write_len >> 2U)) {
 			if (len > kf->write_len)
 				len -= kf->write_len;
 			else

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -493,16 +493,16 @@ static int kinetis_flash_done(struct target_flash *const f)
 	 * vs 4 byte phrases).
 	 */
 	if (kf->write_len == K64_WRITE_LEN) {
-		uint32_t vals[2];
-		vals[0] = target_mem_read32(f->t, FLASH_SECURITY_BYTE_ADDRESS - 4);
-		vals[1] = target_mem_read32(f->t, FLASH_SECURITY_BYTE_ADDRESS);
-		vals[1] = (vals[1] & 0xffffff00) | FLASH_SECURITY_BYTE_UNSECURED;
+		uint32_t vals[2] = {
+			target_mem_read32(f->t, FLASH_SECURITY_BYTE_ADDRESS - 4),
+			target_mem_read32(f->t, FLASH_SECURITY_BYTE_ADDRESS)
+		};
+		vals[1] = (vals[1] & 0xffffff00U) | FLASH_SECURITY_BYTE_UNSECURED;
 		kinetis_fccob_cmd(f->t, FTFx_CMD_PROGRAM_PHRASE, FLASH_SECURITY_BYTE_ADDRESS - 4, vals, 2);
 	} else {
-		uint32_t vals[1];
-		vals[0] = target_mem_read32(f->t, FLASH_SECURITY_BYTE_ADDRESS);
-		vals[0] = (vals[0] & 0xffffff00) | FLASH_SECURITY_BYTE_UNSECURED;
-		kinetis_fccob_cmd(f->t, FTFx_CMD_PROGRAM_LONGWORD, FLASH_SECURITY_BYTE_ADDRESS, vals, 1);
+		uint32_t val = target_mem_read32(f->t, FLASH_SECURITY_BYTE_ADDRESS);
+		val = (val & 0xffffff00U) | FLASH_SECURITY_BYTE_UNSECURED;
+		kinetis_fccob_cmd(f->t, FTFx_CMD_PROGRAM_LONGWORD, FLASH_SECURITY_BYTE_ADDRESS, &val, 1);
 	}
 
 	return 0;

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -407,13 +407,15 @@ static bool kinetis_fccob_cmd(target *t, uint8_t cmd, uint32_t addr, const uint3
 	} while (!(fstat & FTFx_FSTAT_CCIF));
 
 	/* Write command to FCCOB */
-	addr &= 0xffffff;
-	addr |= (uint32_t)cmd << 24;
+	addr &= 0x00ffffffU;
+	addr |= cmd << 24U;
 	target_mem_write32(t, FTFx_FCCOB0, addr);
-	if (data) {
+	if (data && n_items) {
 		target_mem_write32(t, FTFx_FCCOB4, data[0]);
 		if (n_items > 1)
 			target_mem_write32(t, FTFx_FCCOB8, data[1]);
+		else
+			target_mem_write32(t, FTFx_FCCOB8, 0);
 	}
 
 	/* Enable execution by clearing CCIF */


### PR DESCRIPTION
This PR fixes a part-killing regression found by xobs. It does this by reworking the Kinetis Flash command generation and issuing routines so more closely match the behaviour of the v1.7 ones while retaining the benefits of the revamped approach.

This closes #1029 and should be merged both to main and to v1.8.