### PR TITLE
Feature: mass erase progress indication

### DIFF
--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -42,7 +42,6 @@
 #include "target_internal.h"
 #include "cortexm.h"
 #include "adiv5.h"
-#include "gdb_packet.h"
 
 #define SRAM_BASE		0x20000000
 #define STUB_BUFFER_BASE	ALIGN(SRAM_BASE + sizeof(efm32_flash_write_stub), 4)
@@ -764,11 +763,7 @@ static bool efm32_mass_erase(target *t)
 	while ((target_mem_read32(t, EFM32_MSC_STATUS(msc)) & EFM32_MSC_STATUS_BUSY)) {
 		if (target_check_error(t))
 			return false;
-
-		if (platform_timeout_is_expired(&timeout)) {
-			gdb_out(".");
-			platform_timeout_set(&timeout, 500);
-		}
+		target_print_progress(&timeout);
 	}
 
 	/* Relock mass erase */
@@ -1037,10 +1032,7 @@ static bool efm32_aap_mass_erase(target *t)
 	/* Read until 0, probably should have a timeout here... */
 	do {
 		status = adiv5_ap_read(ap, AAP_STATUS);
-		if (platform_timeout_is_expired(&timeout)) {
-			gdb_out(".");
-			platform_timeout_set(&timeout, 500);
-		}
+		target_print_progress(&timeout);
 	} while (status & AAP_STATUS_ERASEBUSY);
 
 	/* Read status */

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -93,6 +93,18 @@ struct lpc_flash *lpc_add_flash(target *t, target_addr addr, size_t length)
 	return lf;
 }
 
+static uint8_t lpc_sector_for_addr(struct lpc_flash *f, uint32_t addr)
+{
+	return f->base_sector + (addr - f->f.start) / f->f.blocksize;
+}
+
+static inline bool lpc_is_full_erase(struct lpc_flash *f, const uint32_t begin, const uint32_t end)
+{
+	const target_addr addr = f->f.start;
+	const size_t len = f->f.length;
+	return begin == lpc_sector_for_addr(f, addr) && end == lpc_sector_for_addr(f, addr + len - 1U);
+}
+
 enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd, ...)
 {
 	target *t = f->f.t;
@@ -133,10 +145,15 @@ enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd
 	regs[REG_PC] = f->iap_entry;
 	target_regs_write(t, regs);
 
+	platform_timeout timeout;
+	platform_timeout_set(&timeout, 500);
+	const bool full_erase = cmd == IAP_CMD_ERASE && lpc_is_full_erase(f, param.words[0], param.words[1]);
 	/* start the target and wait for it to halt again */
 	target_halt_resume(t, false);
-	while (!target_halt_poll(t, NULL))
-		continue;
+	while (!target_halt_poll(t, NULL)) {
+		if (full_erase)
+			target_print_progress(&timeout);
+	}
 
 	/* copy back just the parameters structure */
 	target_mem_read(t, &param, f->iap_ram, sizeof(param));
@@ -163,28 +180,23 @@ enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd
 	return param.status;
 }
 
-static uint8_t lpc_sector_for_addr(struct lpc_flash *f, uint32_t addr)
-{
-	return f->base_sector + (addr - f->f.start) / f->f.blocksize;
-}
-
 #define LPX80X_SECTOR_SIZE 0x400
 #define LPX80X_PAGE_SIZE    0x40
 
 int lpc_flash_erase(struct target_flash *tf, target_addr addr, size_t len)
 {
 	struct lpc_flash *f = (struct lpc_flash *)tf;
-	uint32_t start = lpc_sector_for_addr(f, addr);
-	uint32_t end = lpc_sector_for_addr(f, addr + len - 1);
+	const uint32_t start = lpc_sector_for_addr(f, addr);
+	const uint32_t end = lpc_sector_for_addr(f, addr + len - 1U);
 	uint32_t last_full_sector = end;
 
 	if (lpc_iap_call(f, NULL, IAP_CMD_PREPARE, start, end, f->bank))
 		return -1;
 
 	/* Only LPC80x has reserved pages!*/
-	if (f->reserved_pages && ((addr + len) >=  tf->length - 0x400) ) {
-		last_full_sector -= 1;
-	}
+	if (f->reserved_pages && addr + len >= tf->length - 0x400U)
+		--last_full_sector;
+
 	if (start <= last_full_sector) {
 		/* Sector erase */
 		if (lpc_iap_call(f, NULL, IAP_CMD_ERASE, start, last_full_sector, CPU_CLK_KHZ, f->bank))
@@ -194,9 +206,11 @@ int lpc_flash_erase(struct target_flash *tf, target_addr addr, size_t len)
 		if (lpc_iap_call(f, NULL, IAP_CMD_BLANKCHECK, start, last_full_sector, f->bank))
 			return -3;
 	}
+
 	if (last_full_sector != end) {
-		uint32_t page_start = (addr + len - LPX80X_SECTOR_SIZE) / LPX80X_PAGE_SIZE;
-		uint32_t page_end = page_start +  LPX80X_SECTOR_SIZE/LPX80X_PAGE_SIZE - 1 - f->reserved_pages;
+		const uint32_t page_start = (addr + len - LPX80X_SECTOR_SIZE) / LPX80X_PAGE_SIZE;
+		const uint32_t page_end = page_start + LPX80X_SECTOR_SIZE / LPX80X_PAGE_SIZE - 1 - f->reserved_pages;
+
 		if (lpc_iap_call(f, NULL, IAP_CMD_PREPARE, end, end, f->bank))
 			return -1;
 

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -135,7 +135,8 @@ enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd
 
 	/* start the target and wait for it to halt again */
 	target_halt_resume(t, false);
-	while (!target_halt_poll(t, NULL));
+	while (!target_halt_poll(t, NULL))
+		continue;
 
 	/* copy back just the parameters structure */
 	target_mem_read(t, &param, f->iap_ram, sizeof(param));
@@ -151,7 +152,7 @@ enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd
 #if defined(ENABLE_DEBUG)
 	if (param.status != IAP_STATUS_CMD_SUCCESS) {
 		if (param.status > (sizeof(iap_error) / sizeof(char*)))
-			DEBUG_WARN("IAP  cmd %d : %" PRId32 "\n", cmd, param.status);
+			DEBUG_WARN("IAP  cmd %d : %" PRIu32 "\n", cmd, param.status);
 		else
 			DEBUG_WARN("IAP  cmd %d : %s\n", cmd, iap_error[param.status]);
 		DEBUG_WARN("return parameters: %08" PRIx32 " %08" PRIx32 " %08" PRIx32

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -166,19 +166,18 @@ static int nrf51_flash_erase(struct target_flash *f, target_addr addr, size_t le
 			return -1;
 
 	while (len) {
-		if (addr == NRF51_UICR) { // Special Case
+		if (addr == NRF51_UICR) // Special Case
 			/* Write to the ERASE_UICR register to erase */
 			target_mem_write32(t, NRF51_NVMC_ERASEUICR, 0x1);
-
-		} else { // Standard Flash Page
+		else // Standard Flash Page
 			/* Write address of first word in page to erase it */
 			target_mem_write32(t, NRF51_NVMC_ERASEPAGE, addr);
-		}
 
 		/* Poll for NVMC_READY */
-		while (target_mem_read32(t, NRF51_NVMC_READY) == 0)
-			if(target_check_error(t))
+		while (target_mem_read32(t, NRF51_NVMC_READY) == 0) {
+			if (target_check_error(t))
 				return -1;
+		}
 
 		addr += f->blocksize;
 		if (len > f->blocksize)
@@ -191,9 +190,10 @@ static int nrf51_flash_erase(struct target_flash *f, target_addr addr, size_t le
 	target_mem_write32(t, NRF51_NVMC_CONFIG, NRF51_NVMC_CONFIG_REN);
 
 	/* Poll for NVMC_READY */
-	while (target_mem_read32(t, NRF51_NVMC_READY) == 0)
-		if(target_check_error(t))
+	while (target_mem_read32(t, NRF51_NVMC_READY) == 0) {
+		if (target_check_error(t))
 			return -1;
+	}
 
 	return 0;
 }

--- a/src/target/nxpke04.c
+++ b/src/target/nxpke04.c
@@ -39,7 +39,6 @@
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
-#include "gdb_packet.h"
 
 /* KE04 registers and constants */
 
@@ -317,10 +316,8 @@ static bool ke04_command(target *t, uint8_t cmd, uint32_t addr, const uint8_t da
 		if (fstat & (FTMRE_FSTAT_ACCERR | FTMRE_FSTAT_FPVIOL))
 			return false;
 
-		if (cmd == CMD_ERASE_ALL_BLOCKS && platform_timeout_is_expired(&timeout)) {
-			gdb_out(".");
-			platform_timeout_set(&timeout, 500);
-		}
+		if (cmd == CMD_ERASE_ALL_BLOCKS)
+			target_print_progress(&timeout);
 	} while (!(fstat & FTMRE_FSTAT_CCIF));
 
 	return true;

--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -400,21 +400,15 @@ bool samx5x_probe(target *t)
 	default:
 	case 18:
 		target_add_ram(t, 0x20000000, 0x20000);
-		samx5x_add_flash(t, 0x00000000, 0x40000,
-				 SAMX5X_BLOCK_SIZE,
-				 SAMX5X_PAGE_SIZE);
+		samx5x_add_flash(t, 0x00000000, 0x40000, SAMX5X_BLOCK_SIZE, SAMX5X_PAGE_SIZE);
 		break;
 	case 19:
 		target_add_ram(t, 0x20000000, 0x30000);
-		samx5x_add_flash(t, 0x00000000, 0x80000,
-				 SAMX5X_BLOCK_SIZE,
-				 SAMX5X_PAGE_SIZE);
+		samx5x_add_flash(t, 0x00000000, 0x80000, SAMX5X_BLOCK_SIZE, SAMX5X_PAGE_SIZE);
 		break;
 	case 20:
 		target_add_ram(t, 0x20000000, 0x40000);
-		samx5x_add_flash(t, 0x00000000, 0x100000,
-				 SAMX5X_BLOCK_SIZE,
-				 SAMX5X_PAGE_SIZE);
+		samx5x_add_flash(t, 0x00000000, 0x100000, SAMX5X_BLOCK_SIZE, SAMX5X_PAGE_SIZE);
 		break;
 	}
 
@@ -458,19 +452,14 @@ static void samx5x_unlock_current_address(target *t)
  */
 static void samx5x_print_nvm_error(uint16_t errs)
 {
-	if (errs & SAMX5X_INTFLAG_ADDRE) {
+	if (errs & SAMX5X_INTFLAG_ADDRE)
 		DEBUG_WARN(" ADDRE");
-	}
-	if (errs & SAMX5X_INTFLAG_PROGE) {
+	if (errs & SAMX5X_INTFLAG_PROGE)
 		DEBUG_WARN(" PROGE");
-	}
-	if (errs & SAMX5X_INTFLAG_LOCKE) {
+	if (errs & SAMX5X_INTFLAG_LOCKE)
 		DEBUG_WARN(" LOCKE");
-	}
-	if (errs & SAMX5X_INTFLAG_NVME) {
+	if (errs & SAMX5X_INTFLAG_NVME)
 		DEBUG_WARN(" NVME");
-	}
-
 	DEBUG_WARN("\n");
 }
 
@@ -680,7 +669,7 @@ static int samx5x_update_user_word(target *t, uint32_t addr, uint32_t value,
 		0xFF, 0xFF, 0xFF, 0xFF };
 
 	uint8_t buffer[SAMX5X_PAGE_SIZE];
-	uint32_t current_word, new_word;
+	uint32_t current_word;
 
 	target_mem_read(t, buffer, SAMX5X_NVM_USER_PAGE, SAMX5X_PAGE_SIZE);
 	memcpy(&current_word, buffer + addr, 4);
@@ -690,20 +679,18 @@ static int samx5x_update_user_word(target *t, uint32_t addr, uint32_t value,
 	for (int i = 0; !force && i < 4 && addr + i < 20; i++)
 		factory_word |= (uint32_t)factory_bits[addr + i] << (i * 8);
 
-	new_word = current_word & factory_word;
+	uint32_t new_word = current_word & factory_word;
 	new_word |= value & ~factory_word;
 	if (value_written != NULL)
 		*value_written = new_word;
 
 	if (new_word != current_word) {
-		DEBUG_INFO("Writing user page word 0x%08"PRIx32
-				   " at offset 0x%03"PRIx32"\n", new_word, addr);
+		DEBUG_INFO("Writing user page word 0x%08" PRIx32 " at offset 0x%03"PRIx32"\n", new_word, addr);
 		memcpy(buffer + addr, &new_word, 4);
 		return samx5x_write_user_page(t, buffer);
 	}
-	else {
+	else
 		DEBUG_INFO("Skipping user page write as no change would be made");
-	}
 
 	return 0;
 }
@@ -815,16 +802,12 @@ static bool samx5x_cmd_read_userpage(target *t, int argc, const char **argv)
 	(void)argc;
 	(void)argv;
 	uint8_t buffer[SAMX5X_PAGE_SIZE];
-	int i = 0;
 
 	target_mem_read(t, buffer, SAMX5X_NVM_USER_PAGE, SAMX5X_PAGE_SIZE);
 
 	tc_printf(t, "User Page:\n");
-	while (i < SAMX5X_PAGE_SIZE) {
-		tc_printf(t, "%02x%c", buffer[i],
-			  (i + 1) % 16 == 0 ? '\n' : ' ');
-		i++;
-	}
+	for (size_t i = 0; i < SAMX5X_PAGE_SIZE; ++i)
+		tc_printf(t, "%02x%c", buffer[i], (i + 1) % 16 == 0 ? '\n' : ' ');
 	return true;
 }
 
@@ -864,9 +847,7 @@ static bool samx5x_cmd_ssb(target *t, int argc, const char **argv)
 		if (target_check_error(t))
 			return -1;
 
-	tc_printf(t, "Set the security bit! "
-		  "You will need to issue 'monitor erase_mass' "
-		  "to clear this.\n");
+	tc_printf(t, "Set the security bit!\nYou will need to issue 'monitor erase_mass' to clear this.\n");
 
 	return true;
 }

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -38,7 +38,6 @@
 #include "target.h"
 #include "target_internal.h"
 #include "cortexm.h"
-#include "gdb_packet.h"
 
 static bool stm32f1_cmd_option(target *t, int argc, const char **argv);
 
@@ -404,11 +403,7 @@ static bool stm32f1_mass_erase(target *t)
 	while (target_mem_read32(t, FLASH_SR) & FLASH_SR_BSY) {
 		if (target_check_error(t))
 			return false;
-
-		if (platform_timeout_is_expired(&timeout)) {
-			gdb_out(".");
-			platform_timeout_set(&timeout, 500);
-		}
+		target_print_progress(&timeout);
 	}
 
 	/* Check for error */

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -78,162 +78,149 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
-#define STM32Lx_NVM_PECR(p)     ((p) + 0x04)
-#define STM32Lx_NVM_PEKEYR(p)   ((p) + 0x0C)
-#define STM32Lx_NVM_PRGKEYR(p)  ((p) + 0x10)
-#define STM32Lx_NVM_OPTKEYR(p)  ((p) + 0x14)
-#define STM32Lx_NVM_SR(p)       ((p) + 0x18)
-#define STM32Lx_NVM_OPTR(p)     ((p) + 0x1C)
+#define STM32Lx_NVM_PECR(p)    ((p) + 0x04)
+#define STM32Lx_NVM_PEKEYR(p)  ((p) + 0x0C)
+#define STM32Lx_NVM_PRGKEYR(p) ((p) + 0x10)
+#define STM32Lx_NVM_OPTKEYR(p) ((p) + 0x14)
+#define STM32Lx_NVM_SR(p)      ((p) + 0x18)
+#define STM32Lx_NVM_OPTR(p)    ((p) + 0x1C)
 
 #define STM32L0_NVM_PHYS             (0x40022000ul)
 #define STM32L0_NVM_OPT_SIZE         (12)
-#define STM32L0_NVM_EEPROM_CAT1_SIZE (1*512)
-#define STM32L0_NVM_EEPROM_CAT2_SIZE (1*1024)
-#define STM32L0_NVM_EEPROM_CAT3_SIZE (2*1024)
-#define STM32L0_NVM_EEPROM_CAT5_SIZE (6*1024)
+#define STM32L0_NVM_EEPROM_CAT1_SIZE (1 * 512)
+#define STM32L0_NVM_EEPROM_CAT2_SIZE (1 * 1024)
+#define STM32L0_NVM_EEPROM_CAT3_SIZE (2 * 1024)
+#define STM32L0_NVM_EEPROM_CAT5_SIZE (6 * 1024)
 
-#define STM32L1_NVM_PHYS             (0x40023c00ul)
-#define STM32L1_NVM_OPT_SIZE         (32)
-#define STM32L1_NVM_EEPROM_SIZE      (16*1024)
+#define STM32L1_NVM_PHYS        (0x40023c00ul)
+#define STM32L1_NVM_OPT_SIZE    (32)
+#define STM32L1_NVM_EEPROM_SIZE (16 * 1024)
 
-#define STM32Lx_NVM_OPT_PHYS         0x1ff80000ul
-#define STM32Lx_NVM_EEPROM_PHYS      0x08080000ul
+#define STM32Lx_NVM_OPT_PHYS    0x1ff80000ul
+#define STM32Lx_NVM_EEPROM_PHYS 0x08080000ul
 
-#define STM32Lx_NVM_PEKEY1           (0x89abcdeful)
-#define STM32Lx_NVM_PEKEY2           (0x02030405ul)
-#define STM32Lx_NVM_PRGKEY1          (0x8c9daebful)
-#define STM32Lx_NVM_PRGKEY2          (0x13141516ul)
-#define STM32Lx_NVM_OPTKEY1          (0xfbead9c8ul)
-#define STM32Lx_NVM_OPTKEY2          (0x24252627ul)
+#define STM32Lx_NVM_PEKEY1  (0x89abcdeful)
+#define STM32Lx_NVM_PEKEY2  (0x02030405ul)
+#define STM32Lx_NVM_PRGKEY1 (0x8c9daebful)
+#define STM32Lx_NVM_PRGKEY2 (0x13141516ul)
+#define STM32Lx_NVM_OPTKEY1 (0xfbead9c8ul)
+#define STM32Lx_NVM_OPTKEY2 (0x24252627ul)
 
-#define STM32Lx_NVM_PECR_OBL_LAUNCH  (1<<18)
-#define STM32Lx_NVM_PECR_ERRIE       (1<<17)
-#define STM32Lx_NVM_PECR_EOPIE       (1<<16)
-#define STM32Lx_NVM_PECR_FPRG        (1<<10)
-#define STM32Lx_NVM_PECR_ERASE       (1<< 9)
-#define STM32Lx_NVM_PECR_FIX         (1<< 8) /* FTDW */
-#define STM32Lx_NVM_PECR_DATA        (1<< 4)
-#define STM32Lx_NVM_PECR_PROG        (1<< 3)
-#define STM32Lx_NVM_PECR_OPTLOCK     (1<< 2)
-#define STM32Lx_NVM_PECR_PRGLOCK     (1<< 1)
-#define STM32Lx_NVM_PECR_PELOCK      (1<< 0)
+#define STM32Lx_NVM_PECR_OBL_LAUNCH (1 << 18)
+#define STM32Lx_NVM_PECR_ERRIE      (1 << 17)
+#define STM32Lx_NVM_PECR_EOPIE      (1 << 16)
+#define STM32Lx_NVM_PECR_FPRG       (1 << 10)
+#define STM32Lx_NVM_PECR_ERASE      (1 << 9)
+#define STM32Lx_NVM_PECR_FIX        (1 << 8) /* FTDW */
+#define STM32Lx_NVM_PECR_DATA       (1 << 4)
+#define STM32Lx_NVM_PECR_PROG       (1 << 3)
+#define STM32Lx_NVM_PECR_OPTLOCK    (1 << 2)
+#define STM32Lx_NVM_PECR_PRGLOCK    (1 << 1)
+#define STM32Lx_NVM_PECR_PELOCK     (1 << 0)
 
-#define STM32Lx_NVM_SR_NOTZEROERR    (1<<16)
-#define STM32Lx_NVM_SR_SIZERR        (1<<10)
-#define STM32Lx_NVM_SR_PGAERR        (1<<9)
-#define STM32Lx_NVM_SR_WRPERR        (1<<8)
-#define STM32Lx_NVM_SR_EOP           (1<<1)
-#define STM32Lx_NVM_SR_BSY           (1<<0)
-#define STM32Lx_NVM_SR_ERR_M         (STM32Lx_NVM_SR_WRPERR | \
-                                      STM32Lx_NVM_SR_PGAERR | \
-                                      STM32Lx_NVM_SR_SIZERR | \
-                                      STM32Lx_NVM_SR_NOTZEROERR)
+#define STM32Lx_NVM_SR_NOTZEROERR (1 << 16)
+#define STM32Lx_NVM_SR_SIZERR     (1 << 10)
+#define STM32Lx_NVM_SR_PGAERR     (1 << 9)
+#define STM32Lx_NVM_SR_WRPERR     (1 << 8)
+#define STM32Lx_NVM_SR_EOP        (1 << 1)
+#define STM32Lx_NVM_SR_BSY        (1 << 0)
+#define STM32Lx_NVM_SR_ERR_M \
+	(STM32Lx_NVM_SR_WRPERR | STM32Lx_NVM_SR_PGAERR | STM32Lx_NVM_SR_SIZERR | STM32Lx_NVM_SR_NOTZEROERR)
 
-#define STM32L0_NVM_OPTR_BOOT1       (1<<31)
-#define STM32Lx_NVM_OPTR_WDG_SW      (1<<20)
-#define STM32L0_NVM_OPTR_WPRMOD      (1<<8)
-#define STM32Lx_NVM_OPTR_RDPROT_S    (0)
-#define STM32Lx_NVM_OPTR_RDPROT_M    (0xff)
-#define STM32Lx_NVM_OPTR_RDPROT_0    (0xaa)
-#define STM32Lx_NVM_OPTR_RDPROT_2    (0xcc)
+#define STM32L0_NVM_OPTR_BOOT1    (1 << 31)
+#define STM32Lx_NVM_OPTR_WDG_SW   (1 << 20)
+#define STM32L0_NVM_OPTR_WPRMOD   (1 << 8)
+#define STM32Lx_NVM_OPTR_RDPROT_S (0)
+#define STM32Lx_NVM_OPTR_RDPROT_M (0xff)
+#define STM32Lx_NVM_OPTR_RDPROT_0 (0xaa)
+#define STM32Lx_NVM_OPTR_RDPROT_2 (0xcc)
 
-#define STM32L1_NVM_OPTR_nBFB2       (1<<23)
-#define STM32L1_NVM_OPTR_nRST_STDBY  (1<<22)
-#define STM32L1_NVM_OPTR_nRST_STOP   (1<<21)
-#define STM32L1_NVM_OPTR_BOR_LEV_S   (16)
-#define STM32L1_NVM_OPTR_BOR_LEV_M   (0xf)
-#define STM32L1_NVM_OPTR_SPRMOD      (1<<8)
+#define STM32L1_NVM_OPTR_nBFB2      (1 << 23)
+#define STM32L1_NVM_OPTR_nRST_STDBY (1 << 22)
+#define STM32L1_NVM_OPTR_nRST_STOP  (1 << 21)
+#define STM32L1_NVM_OPTR_BOR_LEV_S  (16)
+#define STM32L1_NVM_OPTR_BOR_LEV_M  (0xf)
+#define STM32L1_NVM_OPTR_SPRMOD     (1 << 8)
 
-static int stm32lx_nvm_prog_erase(struct target_flash* f,
-                                  target_addr addr, size_t len);
-static int stm32lx_nvm_prog_write(struct target_flash* f,
-                                  target_addr destination,
-                                  const void* src,
-                                  size_t size);
+static int stm32lx_nvm_prog_erase(struct target_flash *f, target_addr addr, size_t len);
+static int stm32lx_nvm_prog_write(struct target_flash *f, target_addr destination, const void *src, size_t size);
 
-static int stm32lx_nvm_data_erase(struct target_flash* f,
-                                  target_addr addr, size_t len);
-static int stm32lx_nvm_data_write(struct target_flash* f,
-                                  target_addr destination,
-                                  const void* source,
-                                  size_t size);
+static int stm32lx_nvm_data_erase(struct target_flash *f, target_addr addr, size_t len);
+static int stm32lx_nvm_data_write(struct target_flash *f, target_addr destination, const void *source, size_t size);
 
-static bool stm32lx_cmd_option     (target* t, int argc, char** argv);
-static bool stm32lx_cmd_eeprom     (target* t, int argc, char** argv);
+static bool stm32lx_cmd_option(target *t, int argc, char **argv);
+static bool stm32lx_cmd_eeprom(target *t, int argc, char **argv);
 
 static const struct command_s stm32lx_cmd_list[] = {
-        { "option",		(cmd_handler) stm32lx_cmd_option,
-          "Manipulate option bytes"},
-        { "eeprom",		(cmd_handler) stm32lx_cmd_eeprom,
-          "Manipulate EEPROM(NVM data) memory"},
-        { NULL, NULL, NULL },
+	{"option", (cmd_handler)stm32lx_cmd_option, "Manipulate option bytes"},
+	{"eeprom", (cmd_handler)stm32lx_cmd_eeprom, "Manipulate EEPROM(NVM data) memory"},
+	{NULL, NULL, NULL},
 };
 
-enum {
-        STM32L0_DBGMCU_IDCODE_PHYS = 0x40015800,
-        STM32L1_DBGMCU_IDCODE_PHYS = 0xe0042000,
+enum stm32l_idcode_e {
+	STM32L0_DBGMCU_IDCODE_PHYS = 0x40015800,
+	STM32L1_DBGMCU_IDCODE_PHYS = 0xe0042000,
 };
 
-static bool stm32lx_is_stm32l1(target* t)
+static bool stm32lx_is_stm32l1(target *t)
 {
-        switch (t->idcode) {
-        case 0x457:                   /* STM32L0xx Cat1 */
-        case 0x425:                   /* STM32L0xx Cat2 */
-        case 0x417:                   /* STM32L0xx Cat3 */
-        case 0x447:                   /* STM32L0xx Cat5 */
-               return false;
-        default:                      /* STM32L1xx */
-                return true;
-        }
+	switch (t->idcode) {
+	case 0x457: /* STM32L0xx Cat1 */
+	case 0x425: /* STM32L0xx Cat2 */
+	case 0x417: /* STM32L0xx Cat3 */
+	case 0x447: /* STM32L0xx Cat5 */
+		return false;
+	default: /* STM32L1xx */
+		return true;
+	}
 }
 
 static uint32_t stm32lx_nvm_eeprom_size(target *t)
 {
-        switch (t->idcode) {
-        case 0x457:                   /* STM32L0xx Cat1 */
-                return STM32L0_NVM_EEPROM_CAT1_SIZE;
-        case 0x425:                   /* STM32L0xx Cat2 */
-                return STM32L0_NVM_EEPROM_CAT2_SIZE;
-        case 0x417:                   /* STM32L0xx Cat3 */
-                return STM32L0_NVM_EEPROM_CAT3_SIZE;
-        case 0x447:                   /* STM32L0xx Cat5 */
-                return STM32L0_NVM_EEPROM_CAT5_SIZE;
-        default:                      /* STM32L1xx */
-                return STM32L1_NVM_EEPROM_SIZE;
-        }
+	switch (t->idcode) {
+	case 0x457: /* STM32L0xx Cat1 */
+		return STM32L0_NVM_EEPROM_CAT1_SIZE;
+	case 0x425: /* STM32L0xx Cat2 */
+		return STM32L0_NVM_EEPROM_CAT2_SIZE;
+	case 0x417: /* STM32L0xx Cat3 */
+		return STM32L0_NVM_EEPROM_CAT3_SIZE;
+	case 0x447: /* STM32L0xx Cat5 */
+		return STM32L0_NVM_EEPROM_CAT5_SIZE;
+	default: /* STM32L1xx */
+		return STM32L1_NVM_EEPROM_SIZE;
+	}
 }
 
 static uint32_t stm32lx_nvm_phys(target *t)
 {
-        switch (t->idcode) {
-        case 0x457:                   /* STM32L0xx Cat1 */
-        case 0x425:                   /* STM32L0xx Cat2 */
-        case 0x417:                   /* STM32L0xx Cat3 */
-        case 0x447:                   /* STM32L0xx Cat5 */
-                return STM32L0_NVM_PHYS;
-        default:                      /* STM32L1xx */
-                return STM32L1_NVM_PHYS;
-        }
+	switch (t->idcode) {
+	case 0x457: /* STM32L0xx Cat1 */
+	case 0x425: /* STM32L0xx Cat2 */
+	case 0x417: /* STM32L0xx Cat3 */
+	case 0x447: /* STM32L0xx Cat5 */
+		return STM32L0_NVM_PHYS;
+	default: /* STM32L1xx */
+		return STM32L1_NVM_PHYS;
+	}
 }
 
 static uint32_t stm32lx_nvm_option_size(target *t)
 {
-        switch (t->idcode) {
-        case 0x457:                   /* STM32L0xx Cat1 */
-        case 0x425:                   /* STM32L0xx Cat2 */
-        case 0x417:                   /* STM32L0xx Cat3 */
-        case 0x447:                   /* STM32L0xx Cat5 */
-                return STM32L0_NVM_OPT_SIZE;
-        default:                      /* STM32L1xx */
-                return STM32L1_NVM_OPT_SIZE;
-        }
+	switch (t->idcode) {
+	case 0x457: /* STM32L0xx Cat1 */
+	case 0x425: /* STM32L0xx Cat2 */
+	case 0x417: /* STM32L0xx Cat3 */
+	case 0x447: /* STM32L0xx Cat5 */
+		return STM32L0_NVM_OPT_SIZE;
+	default: /* STM32L1xx */
+		return STM32L1_NVM_OPT_SIZE;
+	}
 }
 
-static void stm32l_add_flash(target *t,
-                             uint32_t addr, size_t length, size_t erasesize)
+static void stm32l_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
-	if (!f) {			/* calloc failed: heap exhaustion */
+	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
@@ -243,14 +230,14 @@ static void stm32l_add_flash(target *t,
 	f->blocksize = erasesize;
 	f->erase = stm32lx_nvm_prog_erase;
 	f->write = stm32lx_nvm_prog_write;
-	f->buf_size = erasesize/2;
+	f->buf_size = erasesize / 2;
 	target_add_flash(t, f);
 }
 
 static void stm32l_add_eeprom(target *t, uint32_t addr, size_t length)
 {
 	struct target_flash *f = calloc(1, sizeof(*f));
-	if (!f) {			/* calloc failed: heap exhaustion */
+	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
@@ -266,24 +253,24 @@ static void stm32l_add_eeprom(target *t, uint32_t addr, size_t length)
 /** Query MCU memory for an indication as to whether or not the
     currently attached target is served by this module.  We detect the
     STM32L0xx parts as well as the STM32L1xx's. */
-bool stm32l0_probe(target* t)
+bool stm32l0_probe(target *t)
 {
 	switch (t->idcode) {
-	case 0x416:                   /* CAT. 1 device */
-	case 0x429:                   /* CAT. 2 device */
-	case 0x427:                   /* CAT. 3 device */
-	case 0x436:                   /* CAT. 4 device */
-	case 0x437:                   /* CAT. 5 device  */
+	case 0x416: /* CAT. 1 device */
+	case 0x429: /* CAT. 2 device */
+	case 0x427: /* CAT. 3 device */
+	case 0x436: /* CAT. 4 device */
+	case 0x437: /* CAT. 5 device  */
 		t->driver = "STM32L1x";
 		target_add_ram(t, 0x20000000, 0x14000);
 		stm32l_add_flash(t, 0x8000000, 0x80000, 0x100);
 		//stm32l_add_eeprom(t, 0x8080000, 0x4000);
 		target_add_commands(t, stm32lx_cmd_list, "STM32L1x");
 		return true;
-	case 0x457:                   /* STM32L0xx Cat1 */
-	case 0x425:                   /* STM32L0xx Cat2 */
-	case 0x417:                   /* STM32L0xx Cat3 */
-	case 0x447:                   /* STM32L0xx Cat5 */
+	case 0x457: /* STM32L0xx Cat1 */
+	case 0x425: /* STM32L0xx Cat2 */
+	case 0x417: /* STM32L0xx Cat3 */
+	case 0x447: /* STM32L0xx Cat5 */
 		t->driver = "STM32L0x";
 		target_add_ram(t, 0x20000000, 0x5000);
 		stm32l_add_flash(t, 0x8000000, 0x10000, 0x80);
@@ -297,68 +284,60 @@ bool stm32l0_probe(target* t)
 	return false;
 }
 
-
 /** Lock the NVM control registers preventing writes or erases. */
 static void stm32lx_nvm_lock(target *t, uint32_t nvm)
 {
-        target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_PELOCK);
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_PELOCK);
 }
-
 
 /** Unlock the NVM control registers for modifying program or
     data flash.  Returns true if the unlock succeeds. */
-static bool stm32lx_nvm_prog_data_unlock(target* t, uint32_t nvm)
+static bool stm32lx_nvm_prog_data_unlock(target *t, uint32_t nvm)
 {
-        /* Always lock first because that's the only way to know that the
+	/* Always lock first because that's the only way to know that the
            unlock can succeed on the STM32L0's. */
-        target_mem_write32(t, STM32Lx_NVM_PECR(nvm),  STM32Lx_NVM_PECR_PELOCK);
-        target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY1);
-        target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY2);
-        target_mem_write32(t, STM32Lx_NVM_PRGKEYR(nvm), STM32Lx_NVM_PRGKEY1);
-        target_mem_write32(t, STM32Lx_NVM_PRGKEYR(nvm), STM32Lx_NVM_PRGKEY2);
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_PELOCK);
+	target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm), STM32Lx_NVM_PEKEY1);
+	target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm), STM32Lx_NVM_PEKEY2);
+	target_mem_write32(t, STM32Lx_NVM_PRGKEYR(nvm), STM32Lx_NVM_PRGKEY1);
+	target_mem_write32(t, STM32Lx_NVM_PRGKEYR(nvm), STM32Lx_NVM_PRGKEY2);
 
-        return !(target_mem_read32(t, STM32Lx_NVM_PECR(nvm))
-                 & STM32Lx_NVM_PECR_PRGLOCK);
+	return !(target_mem_read32(t, STM32Lx_NVM_PECR(nvm)) & STM32Lx_NVM_PECR_PRGLOCK);
 }
-
 
 /** Unlock the NVM control registers for modifying option bytes.
     Returns true if the unlock succeeds. */
 static bool stm32lx_nvm_opt_unlock(target *t, uint32_t nvm)
 {
-        /* Always lock first because that's the only way to know that the
+	/* Always lock first because that's the only way to know that the
            unlock can succeed on the STM32L0's. */
-        target_mem_write32(t, STM32Lx_NVM_PECR(nvm),  STM32Lx_NVM_PECR_PELOCK);
-        target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY1);
-        target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm),  STM32Lx_NVM_PEKEY2);
-        target_mem_write32(t, STM32Lx_NVM_OPTKEYR(nvm), STM32Lx_NVM_OPTKEY1);
-        target_mem_write32(t, STM32Lx_NVM_OPTKEYR(nvm), STM32Lx_NVM_OPTKEY2);
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_PELOCK);
+	target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm), STM32Lx_NVM_PEKEY1);
+	target_mem_write32(t, STM32Lx_NVM_PEKEYR(nvm), STM32Lx_NVM_PEKEY2);
+	target_mem_write32(t, STM32Lx_NVM_OPTKEYR(nvm), STM32Lx_NVM_OPTKEY1);
+	target_mem_write32(t, STM32Lx_NVM_OPTKEYR(nvm), STM32Lx_NVM_OPTKEY2);
 
-        return !(target_mem_read32(t, STM32Lx_NVM_PECR(nvm))
-                 & STM32Lx_NVM_PECR_OPTLOCK);
+	return !(target_mem_read32(t, STM32Lx_NVM_PECR(nvm)) & STM32Lx_NVM_PECR_OPTLOCK);
 }
 
 /** Erase a region of program flash using operations through the debug
     interface.  This is slower than stubbed versions(see NOTES).  The
     flash array is erased for all pages from addr to addr+len
     inclusive.  NVM register file address chosen from target. */
-static int stm32lx_nvm_prog_erase(struct target_flash* f,
-                                  target_addr addr, size_t len)
+static int stm32lx_nvm_prog_erase(struct target_flash *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	const size_t page_size = f->blocksize;
 	const uint32_t nvm = stm32lx_nvm_phys(t);
 
 	if (!stm32lx_nvm_prog_data_unlock(t, nvm))
-	        return -1;
+		return -1;
 
 	/* Flash page erase instruction */
-	target_mem_write32(t, STM32Lx_NVM_PECR(nvm),
-	                   STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_PROG);
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_PROG);
 
 	uint32_t pecr = target_mem_read32(t, STM32Lx_NVM_PECR(nvm));
-	if ((pecr & (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
-	   != (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
+	if ((pecr & (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE)) != (STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_ERASE))
 		return -1;
 
 	/* Clear errors.  Note that this only works when we wait for the NVM
@@ -369,7 +348,7 @@ static int stm32lx_nvm_prog_erase(struct target_flash* f,
 		/* Write first word of page to 0 */
 		target_mem_write32(t, addr, 0);
 		if (len > page_size)
-			len  -= page_size;
+			len -= page_size;
 		else
 			len = 0;
 		addr += page_size;
@@ -384,36 +363,29 @@ static int stm32lx_nvm_prog_erase(struct target_flash* f,
 		sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
 	} while (sr & STM32Lx_NVM_SR_BSY);
 
-	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) ||
-	    target_check_error(t))
-			return -1;
+	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) || target_check_error(t))
+		return -1;
 
 	return 0;
 }
 
-
 /** Write to program flash using operations through the debug
     interface. */
-static int stm32lx_nvm_prog_write(struct target_flash *f,
-                                  target_addr dest,
-                                  const void* src,
-                                  size_t size)
+static int stm32lx_nvm_prog_write(struct target_flash *f, target_addr dest, const void *src, size_t size)
 {
 	target *t = f->t;
 	const uint32_t nvm = stm32lx_nvm_phys(t);
 
 	if (!stm32lx_nvm_prog_data_unlock(t, nvm))
-	        return -1;
+		return -1;
 
 	/* Wait for BSY to clear because we cannot write the PECR until
 	   the previous operation completes on STM32Lxxx. */
-	while (target_mem_read32(t, STM32Lx_NVM_SR(nvm))
-	       & STM32Lx_NVM_SR_BSY)
+	while (target_mem_read32(t, STM32Lx_NVM_SR(nvm)) & STM32Lx_NVM_SR_BSY)
 		if (target_check_error(t))
 			return -1;
 
-	target_mem_write32(t, STM32Lx_NVM_PECR(nvm),
-	                   STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_FPRG);
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_PROG | STM32Lx_NVM_PECR_FPRG);
 	target_mem_write(t, dest, src, size);
 
 	/* Disable further programming by locking PECR */
@@ -425,9 +397,8 @@ static int stm32lx_nvm_prog_write(struct target_flash *f,
 		sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
 	} while (sr & STM32Lx_NVM_SR_BSY);
 
-	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) ||
-	    target_check_error(t))
-			return -1;
+	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) || target_check_error(t))
+		return -1;
 
 	return 0;
 }
@@ -436,8 +407,7 @@ static int stm32lx_nvm_prog_write(struct target_flash *f,
     interface .  The flash is erased for all pages from addr to
     addr+len, inclusive, on a word boundary.  NVM register file
     address chosen from target. */
-static int stm32lx_nvm_data_erase(struct target_flash *f,
-                                  target_addr addr, size_t len)
+static int stm32lx_nvm_data_erase(struct target_flash *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	const size_t page_size = f->blocksize;
@@ -451,12 +421,10 @@ static int stm32lx_nvm_data_erase(struct target_flash *f,
 		return -1;
 
 	/* Flash data erase instruction */
-	target_mem_write32(t, STM32Lx_NVM_PECR(nvm),
-	                   STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA);
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA);
 
 	uint32_t pecr = target_mem_read32(t, STM32Lx_NVM_PECR(nvm));
-	if ((pecr & (STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA))
-	   != (STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA))
+	if ((pecr & (STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA)) != (STM32Lx_NVM_PECR_ERASE | STM32Lx_NVM_PECR_DATA))
 		return -1;
 
 	while (len > 0) {
@@ -464,7 +432,7 @@ static int stm32lx_nvm_data_erase(struct target_flash *f,
 		target_mem_write32(t, addr, 0);
 
 		if (len > page_size)
-			len  -= page_size;
+			len -= page_size;
 		else
 			len = 0;
 		addr += page_size;
@@ -479,33 +447,27 @@ static int stm32lx_nvm_data_erase(struct target_flash *f,
 		sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
 	} while (sr & STM32Lx_NVM_SR_BSY);
 
-	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) ||
-	    target_check_error(t))
-			return -1;
+	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) || target_check_error(t))
+		return -1;
 
 	return 0;
 }
-
 
 /** Write to data flash using operations through the debug interface.
     NVM register file address chosen from target.  Unaligned
     destination writes are supported (though unaligned sources are
     not). */
-static int stm32lx_nvm_data_write(struct target_flash *f,
-                                  target_addr destination,
-                                  const void* src,
-                                  size_t size)
+static int stm32lx_nvm_data_write(struct target_flash *f, target_addr destination, const void *src, size_t size)
 {
 	target *t = f->t;
 	const uint32_t nvm = stm32lx_nvm_phys(t);
 	const bool is_stm32l1 = stm32lx_is_stm32l1(t);
-	uint32_t* source = (uint32_t*) src;
+	uint32_t *source = (uint32_t *)src;
 
 	if (!stm32lx_nvm_prog_data_unlock(t, nvm))
 		return -1;
 
-	target_mem_write32(t, STM32Lx_NVM_PECR(nvm),
-	                   is_stm32l1 ? 0 : STM32Lx_NVM_PECR_DATA);
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), is_stm32l1 ? 0 : STM32Lx_NVM_PECR_DATA);
 
 	while (size) {
 		size -= 4;
@@ -526,13 +488,11 @@ static int stm32lx_nvm_data_write(struct target_flash *f,
 		sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
 	} while (sr & STM32Lx_NVM_SR_BSY);
 
-	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) ||
-	    target_check_error(t))
-			return -1;
+	if ((sr & STM32Lx_NVM_SR_ERR_M) || !(sr & STM32Lx_NVM_SR_EOP) || target_check_error(t))
+		return -1;
 
 	return 0;
 }
-
 
 /** Write one option word.  The address is the physical address of the
     word and the value is a complete word value.  The caller is
@@ -542,20 +502,19 @@ static int stm32lx_nvm_data_write(struct target_flash *f,
     The return value is true if the write succeeded. */
 static bool stm32lx_option_write(target *t, uint32_t address, uint32_t value)
 {
-        const uint32_t nvm = stm32lx_nvm_phys(t);
+	const uint32_t nvm = stm32lx_nvm_phys(t);
 
-        /* Erase and program option in one go. */
-        target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_FIX);
-        target_mem_write32(t, address, value);
+	/* Erase and program option in one go. */
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_FIX);
+	target_mem_write32(t, address, value);
 
-        uint32_t sr;
-        do {
-                sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
-        } while (sr & STM32Lx_NVM_SR_BSY);
+	uint32_t sr;
+	do {
+		sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
+	} while (sr & STM32Lx_NVM_SR_BSY);
 
-        return !(sr & STM32Lx_NVM_SR_ERR_M);
+	return !(sr & STM32Lx_NVM_SR_ERR_M);
 }
-
 
 /** Write one eeprom value.  This version is more flexible than that
     bulk version used for writing data from the executable file.  The
@@ -564,206 +523,180 @@ static bool stm32lx_option_write(target *t, uint32_t address, uint32_t value)
     complete.  The return value is true if the write succeeded.
     FWIW, byte writing isn't supported because the adiv5 layer
     doesn't support byte-level operations. */
-static bool stm32lx_eeprom_write(target *t, uint32_t address,
-                                 size_t cb, uint32_t value)
+static bool stm32lx_eeprom_write(target *t, uint32_t address, size_t cb, uint32_t value)
 {
-        const uint32_t nvm        = stm32lx_nvm_phys(t);
-        const bool     is_stm32l1 = stm32lx_is_stm32l1(t);
+	const uint32_t nvm = stm32lx_nvm_phys(t);
+	const bool is_stm32l1 = stm32lx_is_stm32l1(t);
 
-        /* Clear errors. */
-        target_mem_write32(t, STM32Lx_NVM_SR(nvm), STM32Lx_NVM_SR_ERR_M);
+	/* Clear errors. */
+	target_mem_write32(t, STM32Lx_NVM_SR(nvm), STM32Lx_NVM_SR_ERR_M);
 
-        /* Erase and program option in one go. */
-        target_mem_write32(t, STM32Lx_NVM_PECR(nvm),
-                           (is_stm32l1 ? 0 : STM32Lx_NVM_PECR_DATA)
-                           | STM32Lx_NVM_PECR_FIX);
-        if (cb == 4)
-                target_mem_write32(t, address, value);
-        else if (cb == 2)
-                target_mem_write16(t, address, value);
-        else if (cb == 1)
-                target_mem_write8(t, address, value);
-        else
-                return false;
+	/* Erase and program option in one go. */
+	target_mem_write32(t, STM32Lx_NVM_PECR(nvm), (is_stm32l1 ? 0 : STM32Lx_NVM_PECR_DATA) | STM32Lx_NVM_PECR_FIX);
+	if (cb == 4)
+		target_mem_write32(t, address, value);
+	else if (cb == 2)
+		target_mem_write16(t, address, value);
+	else if (cb == 1)
+		target_mem_write8(t, address, value);
+	else
+		return false;
 
-        uint32_t sr;
-        do {
-                sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
-        } while (sr & STM32Lx_NVM_SR_BSY);
+	uint32_t sr;
+	do {
+		sr = target_mem_read32(t, STM32Lx_NVM_SR(nvm));
+	} while (sr & STM32Lx_NVM_SR_BSY);
 
-        return !(sr & STM32Lx_NVM_SR_ERR_M);
+	return !(sr & STM32Lx_NVM_SR_ERR_M);
 }
 
-static bool stm32lx_cmd_option(target* t, int argc, char** argv)
+static bool stm32lx_cmd_option(target *t, int argc, char **argv)
 {
-        const uint32_t nvm      = stm32lx_nvm_phys(t);
-        const size_t   opt_size = stm32lx_nvm_option_size(t);
+	const uint32_t nvm = stm32lx_nvm_phys(t);
+	const size_t opt_size = stm32lx_nvm_option_size(t);
 
-        if (!stm32lx_nvm_opt_unlock(t, nvm)) {
-                tc_printf(t, "unable to unlock NVM option bytes\n");
-                return true;
-        }
+	if (!stm32lx_nvm_opt_unlock(t, nvm)) {
+		tc_printf(t, "unable to unlock NVM option bytes\n");
+		return true;
+	}
 
-        if (argc < 2 )
-                 goto usage;
-        size_t cb = strlen(argv[1]);
+	if (argc < 2)
+		goto usage;
+	size_t cb = strlen(argv[1]);
 
-        if (argc == 2 && !strncasecmp(argv[1], "obl_launch", cb)) {
-                target_mem_write32(t, STM32Lx_NVM_PECR(nvm),
-                                   STM32Lx_NVM_PECR_OBL_LAUNCH);
-        }
-        else if (argc == 4 && !strncasecmp(argv[1], "raw", cb)) {
-                uint32_t addr = strtoul(argv[2], NULL, 0);
-                uint32_t val  = strtoul(argv[3], NULL, 0);
-                tc_printf(t, "raw %08x <- %08x\n", addr, val);
-                if (   addr <  STM32Lx_NVM_OPT_PHYS
-                    || addr >= STM32Lx_NVM_OPT_PHYS + opt_size
-                    || (addr & 3))
-                        goto usage;
-                if (!stm32lx_option_write(t, addr, val))
-                        tc_printf(t, "option write failed\n");
-        }
-        else if (argc == 4 && !strncasecmp(argv[1], "write", cb)) {
-                uint32_t addr = strtoul(argv[2], NULL, 0);
-                uint32_t val  = strtoul(argv[3], NULL, 0);
-                val = (val & 0xffff) | ((~val & 0xffff) << 16);
-                tc_printf(t, "write %08x <- %08x\n", addr, val);
-                if (   addr <  STM32Lx_NVM_OPT_PHYS
-                    || addr >= STM32Lx_NVM_OPT_PHYS + opt_size
-                    || (addr & 3))
-                        goto usage;
-                if (!stm32lx_option_write(t, addr, val))
-                        tc_printf(t, "option write failed\n");
-        }
+	if (argc == 2 && !strncasecmp(argv[1], "obl_launch", cb)) {
+		target_mem_write32(t, STM32Lx_NVM_PECR(nvm), STM32Lx_NVM_PECR_OBL_LAUNCH);
+	} else if (argc == 4 && !strncasecmp(argv[1], "raw", cb)) {
+		uint32_t addr = strtoul(argv[2], NULL, 0);
+		uint32_t val = strtoul(argv[3], NULL, 0);
+		tc_printf(t, "raw %08x <- %08x\n", addr, val);
+		if (addr < STM32Lx_NVM_OPT_PHYS || addr >= STM32Lx_NVM_OPT_PHYS + opt_size || (addr & 3))
+			goto usage;
+		if (!stm32lx_option_write(t, addr, val))
+			tc_printf(t, "option write failed\n");
+	} else if (argc == 4 && !strncasecmp(argv[1], "write", cb)) {
+		uint32_t addr = strtoul(argv[2], NULL, 0);
+		uint32_t val = strtoul(argv[3], NULL, 0);
+		val = (val & 0xffff) | ((~val & 0xffff) << 16);
+		tc_printf(t, "write %08x <- %08x\n", addr, val);
+		if (addr < STM32Lx_NVM_OPT_PHYS || addr >= STM32Lx_NVM_OPT_PHYS + opt_size || (addr & 3))
+			goto usage;
+		if (!stm32lx_option_write(t, addr, val))
+			tc_printf(t, "option write failed\n");
+	}
 
-        /* Report the current option values */
-        for(unsigned i = 0; i < opt_size; i += sizeof(uint32_t)) {
-                uint32_t addr = STM32Lx_NVM_OPT_PHYS + i;
-                uint32_t val = target_mem_read32(t, addr);
-                tc_printf(t, "0x%08x: 0x%04x 0x%04x %s\n",
-                          addr, val & 0xffff, (val >> 16) & 0xffff,
-                          ((val & 0xffff) == ((~val >> 16) & 0xffff))
-                          ? "OK" : "ERR");
-        }
+	/* Report the current option values */
+	for (unsigned i = 0; i < opt_size; i += sizeof(uint32_t)) {
+		uint32_t addr = STM32Lx_NVM_OPT_PHYS + i;
+		uint32_t val = target_mem_read32(t, addr);
+		tc_printf(t, "0x%08x: 0x%04x 0x%04x %s\n", addr, val & 0xffff, (val >> 16) & 0xffff,
+			((val & 0xffff) == ((~val >> 16) & 0xffff)) ? "OK" : "ERR");
+	}
 
-        if (stm32lx_is_stm32l1(t)) {
-                uint32_t optr   = target_mem_read32(t, STM32Lx_NVM_OPTR(nvm));
-                uint8_t  rdprot = (optr >> STM32Lx_NVM_OPTR_RDPROT_S)
-                        & STM32Lx_NVM_OPTR_RDPROT_M;
-                if (rdprot == STM32Lx_NVM_OPTR_RDPROT_0)
-                        rdprot = 0;
-                else if (rdprot == STM32Lx_NVM_OPTR_RDPROT_2)
-                        rdprot = 2;
-                else
-                        rdprot = 1;
-                tc_printf(t, "OPTR: 0x%08x, RDPRT %d, SPRMD %d, "
-                          "BOR %d, WDG_SW %d, nRST_STP %d, nRST_STBY %d, "
-                          "nBFB2 %d\n",
-                          optr, rdprot,
-                          (optr &  STM32L1_NVM_OPTR_SPRMOD)     ? 1 : 0,
-                          (optr >> STM32L1_NVM_OPTR_BOR_LEV_S)
-                           & STM32L1_NVM_OPTR_BOR_LEV_M,
-                          (optr &  STM32Lx_NVM_OPTR_WDG_SW)     ? 1 : 0,
-                          (optr &  STM32L1_NVM_OPTR_nRST_STOP)  ? 1 : 0,
-                          (optr &  STM32L1_NVM_OPTR_nRST_STDBY) ? 1 : 0,
-                          (optr &  STM32L1_NVM_OPTR_nBFB2)      ? 1 : 0);
-        }
-        else {
-                uint32_t optr   = target_mem_read32(t, STM32Lx_NVM_OPTR(nvm));
-                uint8_t  rdprot = (optr >> STM32Lx_NVM_OPTR_RDPROT_S)
-                        & STM32Lx_NVM_OPTR_RDPROT_M;
-                if (rdprot == STM32Lx_NVM_OPTR_RDPROT_0)
-                        rdprot = 0;
-                else if (rdprot == STM32Lx_NVM_OPTR_RDPROT_2)
-                        rdprot = 2;
-                else
-                        rdprot = 1;
-                tc_printf(t, "OPTR: 0x%08x, RDPROT %d, WPRMOD %d, WDG_SW %d, "
-                          "BOOT1 %d\n",
-                          optr, rdprot,
-                          (optr & STM32L0_NVM_OPTR_WPRMOD) ? 1 : 0,
-                          (optr & STM32Lx_NVM_OPTR_WDG_SW) ? 1 : 0,
-                          (optr & STM32L0_NVM_OPTR_BOOT1)  ? 1 : 0);
-        }
+	if (stm32lx_is_stm32l1(t)) {
+		uint32_t optr = target_mem_read32(t, STM32Lx_NVM_OPTR(nvm));
+		uint8_t rdprot = (optr >> STM32Lx_NVM_OPTR_RDPROT_S) & STM32Lx_NVM_OPTR_RDPROT_M;
+		if (rdprot == STM32Lx_NVM_OPTR_RDPROT_0)
+			rdprot = 0;
+		else if (rdprot == STM32Lx_NVM_OPTR_RDPROT_2)
+			rdprot = 2;
+		else
+			rdprot = 1;
+		tc_printf(t,
+			"OPTR: 0x%08x, RDPRT %d, SPRMD %d, "
+			"BOR %d, WDG_SW %d, nRST_STP %d, nRST_STBY %d, "
+			"nBFB2 %d\n",
+			optr, rdprot, (optr & STM32L1_NVM_OPTR_SPRMOD) ? 1 : 0,
+			(optr >> STM32L1_NVM_OPTR_BOR_LEV_S) & STM32L1_NVM_OPTR_BOR_LEV_M, (optr & STM32Lx_NVM_OPTR_WDG_SW) ? 1 : 0,
+			(optr & STM32L1_NVM_OPTR_nRST_STOP) ? 1 : 0, (optr & STM32L1_NVM_OPTR_nRST_STDBY) ? 1 : 0,
+			(optr & STM32L1_NVM_OPTR_nBFB2) ? 1 : 0);
+	} else {
+		uint32_t optr = target_mem_read32(t, STM32Lx_NVM_OPTR(nvm));
+		uint8_t rdprot = (optr >> STM32Lx_NVM_OPTR_RDPROT_S) & STM32Lx_NVM_OPTR_RDPROT_M;
+		if (rdprot == STM32Lx_NVM_OPTR_RDPROT_0)
+			rdprot = 0;
+		else if (rdprot == STM32Lx_NVM_OPTR_RDPROT_2)
+			rdprot = 2;
+		else
+			rdprot = 1;
+		tc_printf(t,
+			"OPTR: 0x%08x, RDPROT %d, WPRMOD %d, WDG_SW %d, "
+			"BOOT1 %d\n",
+			optr, rdprot, (optr & STM32L0_NVM_OPTR_WPRMOD) ? 1 : 0, (optr & STM32Lx_NVM_OPTR_WDG_SW) ? 1 : 0,
+			(optr & STM32L0_NVM_OPTR_BOOT1) ? 1 : 0);
+	}
 
-        goto done;
+	goto done;
 
 usage:
-        tc_printf(t, "usage: monitor option [ARGS]\n");
-        tc_printf(t, "  show                   - Show options in NVM and as"
-                  " loaded\n");
-        tc_printf(t, "  obl_launch             - Reload options from NVM\n");
-        tc_printf(t, "  write <addr> <value16> - Set option half-word; "
-                  "complement computed\n");
-        tc_printf(t, "  raw <addr> <value32>   - Set option word\n");
-        tc_printf(t, "The value of <addr> must be word aligned and from 0x%08x "
-                  "to +0x%x\n",
-                  STM32Lx_NVM_OPT_PHYS,
-                  STM32Lx_NVM_OPT_PHYS + opt_size - sizeof(uint32_t));
+	tc_printf(t, "usage: monitor option [ARGS]\n");
+	tc_printf(t, "  show                   - Show options in NVM and as"
+				 " loaded\n");
+	tc_printf(t, "  obl_launch             - Reload options from NVM\n");
+	tc_printf(t, "  write <addr> <value16> - Set option half-word; "
+				 "complement computed\n");
+	tc_printf(t, "  raw <addr> <value32>   - Set option word\n");
+	tc_printf(t,
+		"The value of <addr> must be word aligned and from 0x%08x "
+		"to +0x%x\n",
+		STM32Lx_NVM_OPT_PHYS, STM32Lx_NVM_OPT_PHYS + opt_size - sizeof(uint32_t));
 
 done:
-        stm32lx_nvm_lock(t, nvm);
-        return true;
+	stm32lx_nvm_lock(t, nvm);
+	return true;
 }
 
-
-static bool stm32lx_cmd_eeprom(target* t, int argc, char** argv)
+static bool stm32lx_cmd_eeprom(target *t, int argc, char **argv)
 {
-        const uint32_t nvm = stm32lx_nvm_phys(t);
+	const uint32_t nvm = stm32lx_nvm_phys(t);
 
-        if (!stm32lx_nvm_prog_data_unlock(t, nvm)) {
-                tc_printf(t, "unable to unlock EEPROM\n");
-                return true;
-        }
+	if (!stm32lx_nvm_prog_data_unlock(t, nvm)) {
+		tc_printf(t, "unable to unlock EEPROM\n");
+		return true;
+	}
 
-        size_t cb = strlen(argv[1]);
+	size_t cb = strlen(argv[1]);
 
-        if (argc == 4) {
-                uint32_t addr = strtoul(argv[2], NULL, 0);
-                uint32_t val  = strtoul(argv[3], NULL, 0);
+	if (argc == 4) {
+		uint32_t addr = strtoul(argv[2], NULL, 0);
+		uint32_t val = strtoul(argv[3], NULL, 0);
 
-                if (   addr <  STM32Lx_NVM_EEPROM_PHYS
-                    || addr >= STM32Lx_NVM_EEPROM_PHYS
-                       	        + stm32lx_nvm_eeprom_size(t))
-                        goto usage;
+		if (addr < STM32Lx_NVM_EEPROM_PHYS || addr >= STM32Lx_NVM_EEPROM_PHYS + stm32lx_nvm_eeprom_size(t))
+			goto usage;
 
-                if (!strncasecmp(argv[1], "byte", cb)) {
-                        tc_printf(t, "write byte 0x%08x <- 0x%08x\n", addr, val);
-                        if (!stm32lx_eeprom_write(t, addr, 1, val))
-                                tc_printf(t, "eeprom write failed\n");
-                } else if (!strncasecmp(argv[1], "halfword", cb)) {
-                        val &= 0xffff;
-                        tc_printf(t, "write halfword 0x%08x <- 0x%04x\n",
-                                 addr, val);
-                        if (addr & 1)
-                                goto usage;
-                        if (!stm32lx_eeprom_write(t, addr, 2, val))
-                                tc_printf(t, "eeprom write failed\n");
-                } else if (!strncasecmp(argv[1], "word", cb)) {
-                        tc_printf(t, "write word 0x%08x <- 0x%08x\n", addr, val);
-                        if (addr & 3)
-                                goto usage;
-                        if (!stm32lx_eeprom_write(t, addr, 4, val))
-                                tc_printf(t, "eeprom write failed\n");
-                }
-                else
-                        goto usage;
-        }
-        else
-                goto usage;
+		if (!strncasecmp(argv[1], "byte", cb)) {
+			tc_printf(t, "write byte 0x%08x <- 0x%08x\n", addr, val);
+			if (!stm32lx_eeprom_write(t, addr, 1, val))
+				tc_printf(t, "eeprom write failed\n");
+		} else if (!strncasecmp(argv[1], "halfword", cb)) {
+			val &= 0xffff;
+			tc_printf(t, "write halfword 0x%08x <- 0x%04x\n", addr, val);
+			if (addr & 1)
+				goto usage;
+			if (!stm32lx_eeprom_write(t, addr, 2, val))
+				tc_printf(t, "eeprom write failed\n");
+		} else if (!strncasecmp(argv[1], "word", cb)) {
+			tc_printf(t, "write word 0x%08x <- 0x%08x\n", addr, val);
+			if (addr & 3)
+				goto usage;
+			if (!stm32lx_eeprom_write(t, addr, 4, val))
+				tc_printf(t, "eeprom write failed\n");
+		} else
+			goto usage;
+	} else
+		goto usage;
 
-        goto done;
+	goto done;
 
 usage:
-        tc_printf(t, "usage: monitor eeprom [ARGS]\n");
-        tc_printf(t, "  byte     <addr> <value8>  - Write a byte\n");
-        tc_printf(t, "  halfword <addr> <value16> - Write a half-word\n");
-        tc_printf(t, "  word     <addr> <value32> - Write a word\n");
-        tc_printf(t, "The value of <addr> must in the interval [0x%08x, 0x%x)\n",
-                  STM32Lx_NVM_EEPROM_PHYS,
-                  STM32Lx_NVM_EEPROM_PHYS + stm32lx_nvm_eeprom_size(t));
+	tc_printf(t, "usage: monitor eeprom [ARGS]\n");
+	tc_printf(t, "  byte     <addr> <value8>  - Write a byte\n");
+	tc_printf(t, "  halfword <addr> <value16> - Write a half-word\n");
+	tc_printf(t, "  word     <addr> <value32> - Write a word\n");
+	tc_printf(t, "The value of <addr> must in the interval [0x%08x, 0x%x)\n", STM32Lx_NVM_EEPROM_PHYS,
+		STM32Lx_NVM_EEPROM_PHYS + stm32lx_nvm_eeprom_size(t));
 
 done:
-        stm32lx_nvm_lock(t, nvm);
-        return true;
+	stm32lx_nvm_lock(t, nvm);
+	return true;
 }

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -358,6 +358,14 @@ int target_flash_done_buffered(struct target_flash *f)
 	return ret;
 }
 
+void target_print_progress(platform_timeout *const timeout)
+{
+	if (platform_timeout_is_expired(timeout)) {
+		gdb_out(".");
+		platform_timeout_set(timeout, 500);
+	}
+}
+
 /* Wrapper functions */
 void target_detach(target *t)
 {

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -20,6 +20,7 @@
 
 #include "general.h"
 #include "target_internal.h"
+#include "gdb_packet.h"
 
 #include <stdarg.h>
 
@@ -28,6 +29,12 @@ target *target_list = NULL;
 static int target_flash_write_buffered(struct target_flash *f,
                                        target_addr dest, const void *src, size_t len);
 static int target_flash_done_buffered(struct target_flash *f);
+static bool target_cmd_mass_erase(target *t, int argc, const char **argv);
+
+const struct command_s target_cmd_list[] = {
+	{"erase_mass", (cmd_handler)target_cmd_mass_erase, "Erase whole device Flash"},
+	{NULL, NULL, NULL}
+};
 
 static bool nop_function(void)
 {
@@ -72,6 +79,7 @@ target *target_new(void)
 
 	t->target_storage = NULL;
 
+	target_add_commands(t, target_cmd_list, "Target");
 	return t;
 }
 
@@ -500,6 +508,21 @@ int target_breakwatch_clear(target *t,
 		free(bw);
 	}
 	return ret;
+}
+
+/* Target-specific commands */
+static bool target_cmd_mass_erase(target *const t, const int argc, const char **const argv)
+{
+	(void)argc;
+	(void)argv;
+	if (!t || !t->mass_erase) {
+		gdb_out("Mass erase not implemented for target");
+		return true;
+	}
+	gdb_out("Erasing device Flash: ");
+	const bool result = t->mass_erase(t);
+	gdb_out("done\n");
+	return result;
 }
 
 /* Accessor functions */

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -21,6 +21,8 @@
 #ifndef __TARGET_INTERNAL_H
 #define __TARGET_INTERNAL_H
 
+#include "platform_support.h"
+
 extern target *target_list;
 target *target_new(void);
 
@@ -139,6 +141,7 @@ struct target_s {
 	void (*priv_free)(void *);
 };
 
+void target_print_progress(platform_timeout *timeout);
 void target_ram_map_free(target *t);
 void target_flash_map_free(target *t);
 void target_mem_map_free(target *t);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -109,6 +109,9 @@ struct target_s {
 	int (*breakwatch_clear)(target *t, struct breakwatch*);
 	struct breakwatch *bw_list;
 
+	/* Recovery functions */
+	bool (*mass_erase)(target *t);
+
 	/* target-defined options */
 	unsigned target_options;
 	uint16_t t_designer;


### PR DESCRIPTION
Targets which support an `erase_mass` monitor command and which take a while to complete the operation cause GDB issues by making it hit internal state timeouts for the GDB server likely having gone away ("Ignoring packet error, continuing...") but it trying to keep going regardless.

This makes for a poor user experience and gives no indication whether BMP has locked up or if the operation is just taking a while. This PR addresses that by refactoring the mass erase command into the target layer, and introducing new timeout-based reporting that lets the user know BMP is still working on it and hasn't crashed.

This has the benefit of letting GDB know we're alive too and resetting the state timeout that causes the error messages otherwise.

In a separate issue, we will bring up the issue of the command's naming and whether to change it in v2. Internally as of this PR, it's called mass_erase in the target structure and related places, but erase_mass to the user.