### PR TITLE
BMP V2.3: Fix outdated ADC reads.

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -285,7 +285,7 @@ static void adc_init(void)
 	adc_set_single_conversion_mode(ADC1);
 	adc_disable_external_trigger_regular(ADC1);
 	adc_set_right_aligned(ADC1);
-	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_28DOT5CYC);
+	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_239DOT5CYC);
 
 	adc_power_on(ADC1);
 
@@ -316,6 +316,8 @@ uint32_t platform_target_voltage_sense(void)
 	while (!adc_eoc(ADC1));
 
 	uint32_t val = adc_read_regular(ADC1); /* 0-4095 */
+	/* Clear EOC bit. The GD32F103 does not automatically reset it on ADC read. */
+	ADC_SR(ADC1) &= ~ADC_SR_EOC;
 	return (val * 99) / 8191;
 }
 


### PR DESCRIPTION
We are using GD32F103 on the BMP V2.3 hardware. The GD32F103 has an
errata for the ADC where the end of conversion (EOC) bit is not reset
when reading the ADC result. This resulted in us not waiting for the new
value to be acquired and reading an old value instead. The solution for
that is resetting the EOC bit manually after reading the ADC result, so
that on the next acquisision we wait for the conversion to finish.

This patch also increases the sampling time as the GD32 have lower ADC
impedance than the STM32 and this should help us read a more accuarate
target voltage.