### PR TITLE
Fix: nRF52 mass erase

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -222,6 +222,8 @@ static int nrf51_flash_write(struct target_flash *f,
 
 static bool nrf51_mass_erase(target *t)
 {
+	target_reset(t);
+
 	/* Enable erase */
 	target_mem_write32(t, NRF51_NVMC_CONFIG, NRF51_NVMC_CONFIG_EEN);
 


### PR DESCRIPTION
Under certain conditions outlined below, mass erase on nRF51/nRF52 targets fails. This PR fixes that issue.

For the bug to be reproduced, one must meet the following conditions:

* Be attached
* Have run the target (using the GDB run command)
* Interrupt the target (Ctrl + C)

If one tries mass erasing the target after meeting these conditions, it will appear to work but do nothing.

Many thanks to Discord user giobauermeister for reporting this