### PR TITLE
Add homebrew include so that libusb headers found.

### DIFF
--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -45,6 +45,7 @@ else ifneq (, $(findstring cygwin, $(SYS)))
 else ifneq (filter, macosx darwin, $(SYS))
 	SRC += serial_unix.c
 	LDFLAGS += -framework CoreFoundation
+	CFLAGS += -I /opt/homebrew/include -I /opt/homebrew/include/libusb-1.0
 endif
 
 ifneq ($(HOSTED_BMP_ONLY), 1)


### PR DESCRIPTION
When building BMPA with HOSTED_BMP_ONLY=0 build will fail on the Mac (ARM64, at least) since the compilation does not find the libusb headers. This patch adds appropriate include. Maybe a better place to add this to the file. If there are strong feels let me know and I can move it as directed.