### PR TITLE
Fix: DAP SWDP init

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -392,9 +392,7 @@ static void dap_mem_read(ADIv5_AP_t *ap, void *dest, uint32_t src, size_t len)
     DEBUG_WIRE("memread res last data %08" PRIx32 "\n", ((uint32_t*)dest)[-1]);
 }
 
-static void dap_mem_write_sized(
-	ADIv5_AP_t *ap, uint32_t dest, const void *src,
-							size_t len, enum align align)
+static void dap_mem_write_sized( ADIv5_AP_t *ap, uint32_t dest, const void *src, size_t len, enum align align)
 {
 	if (len == 0)
 		return;
@@ -452,15 +450,13 @@ static void cmsis_dap_jtagtap_tms_seq(uint32_t MS, int ticks)
 	DEBUG_PROBE("tms_seq DI %08x %d\n", MS, ticks);
 }
 
-static void cmsis_dap_jtagtap_tdi_tdo_seq(uint8_t *DO, const uint8_t final_tms,
-										  const uint8_t *DI, int ticks)
+static void cmsis_dap_jtagtap_tdi_tdo_seq(uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks)
 {
 	dap_jtagtap_tdi_tdo_seq(DO, (final_tms), NULL, DI, ticks);
 	DEBUG_PROBE("jtagtap_tdi_tdo_seq %d, %02x-> %02x\n", ticks, DI[0], (DO)? DO[0] : 0);
 }
 
-static void  cmsis_dap_jtagtap_tdi_seq(const uint8_t final_tms,
-									   const uint8_t *DI, int ticks)
+static void  cmsis_dap_jtagtap_tdi_seq(const uint8_t final_tms, const uint8_t *DI, int ticks)
 {
 	dap_jtagtap_tdi_tdo_seq(NULL, (final_tms), NULL, DI, ticks);
 	DEBUG_PROBE("jtagtap_tdi_seq %d, %02x\n", ticks, DI[0]);
@@ -541,12 +537,11 @@ int dap_swdptap_init(ADIv5_DP_t *dp)
 	dap_connect(false);
 	dap_led(0, 1);
 	dap_reset_link(false);
-	if ((has_swd_sequence)  && dap_sequence_test()) {
+	if (has_swd_sequence)
 		/* DAP_SWD_SEQUENCE does not do auto turnaround, use own!*/
 		dp->dp_low_write = dap_dp_low_write;
-	} else {
+	else
 		dp->dp_low_write = NULL;
-	}
 	dp->seq_out = dap_swdptap_seq_out;
 	dp->dp_read = dap_dp_read_reg;
 	/* For error() use the TARGETID switching firmware_swdp_error */

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -489,7 +489,7 @@ void dap_reset_link(bool jtag)
 		*p++ = 0x3c;
 		*p++ = 0xe7;
 		*p++ = 0x1f;
-		buf[1] = ((p - &buf[2]) * 8) - 2;
+		buf[1] = ((p - buf + 2) * 8) - 2;
 	} else {
 		*p++ = 0x9e;
 		*p++ = 0xe7;
@@ -501,7 +501,7 @@ void dap_reset_link(bool jtag)
 		*p++ = 0xff;
 		*p++ = 0xff;
 		*p++ = 0x00;
-		buf[1] = (p - &buf[2]) * 8;
+		buf[1] = (p - buf + 2) * 8;
 	}
 	dbg_dap_cmd(buf, sizeof(buf), p - buf);
 

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -415,11 +415,12 @@ unsigned int dap_read_block(ADIv5_AP_t *ap, void *dest, uint32_t src,
 		DEBUG_WARN("dap_read_block @ %08" PRIx32 " fault -> line reset\n", src);
 		dap_line_reset();
 	}
-	if (sz != transferred) {
+	if (sz != transferred)
 		return 1;
-	} else if (align > ALIGN_HALFWORD) {
+
+	if (align > ALIGN_HALFWORD)
 		memcpy(dest, &buf[3], len);
-	} else {
+	else {
 		uint32_t *p = (uint32_t *)&buf[3];
 		while(sz) {
 			dest = extract(dest, src, *p, align);
@@ -794,18 +795,6 @@ void dap_swdptap_seq_out_parity(uint32_t MS, int ticks)
 	dbg_dap_cmd(buf, 1, sizeof(buf));
 	if (buf[0])
 		DEBUG_WARN("dap_swdptap_seq_out error\n");
-}
-
-bool dap_sequence_test(void)
-{
-	uint8_t buf[4] = {
-		ID_DAP_SWD_SEQUENCE,
-		0x1,
-		0x81, /* Read one bit */
-		0     /* one idle cycle */
-	};
-	dbg_dap_cmd(buf, sizeof(buf), 3);
-	return (buf[0] == DAP_OK);
 }
 
 #define SWD_SEQUENCE_IN 0x80

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -85,6 +85,5 @@ void dap_jtagtap_tdi_tdo_seq(uint8_t *DO, bool final_tms, const uint8_t *TMS, co
 int dap_jtag_configure(void);
 void dap_swdptap_seq_out(uint32_t MS, int ticks);
 void dap_swdptap_seq_out_parity(uint32_t MS, int ticks);
-bool dap_sequence_test(void);
 
 #endif // _DAP_H_


### PR DESCRIPTION
With the help of @mubes, this addresses a CMSIS-DAP protocol compliance issue which was breaking use of BMDA with some CMSIS-DAP debuggers but was otherwise shielded/hidden by the immediate link reset that occurs following the removed sequence test code.

This improves our compatibility with DragonProbe.