### PR TITLE
Fix: BMDA lib detect

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,7 +32,7 @@ jobs:
         run: make clean
 
       - name: Install BMDA dependencies
-        run: sudo apt-get -y install libftdi1-dev libhidapi-dev
+        run: sudo apt-get -y install libusb-dev libftdi1-dev libhidapi-dev
 
       - name: Build full BMDA binary
         run: make PROBE_HOST=hosted

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -49,8 +49,10 @@ else ifneq (filter, macosx darwin, $(SYS))
 endif
 
 ifneq ($(HOSTED_BMP_ONLY), 1)
-    $(shell pkg-config --exists libftdi1)
-    ifneq ($(.SHELLSTATUS), 0)
+    ifneq ($(shell pkg-config --exists libusb; echo $$?), 0)
+        $(error Please install libusb dependency or set HOSTED_BMP_ONLY to 1)
+    endif
+    ifneq ($(shell pkg-config --exists libftdi1; echo $$?), 0)
         $(error Please install libftdi1 dependency or set HOSTED_BMP_ONLY to 1)
     endif
     LDFLAGS += -lusb-1.0
@@ -62,8 +64,7 @@ endif
 ifneq ($(HOSTED_BMP_ONLY), 1)
     CFLAGS  +=  -DCMSIS_DAP
     SRC += cmsis_dap.c dap.c
-    $(shell pkg-config --exists $(HIDAPILIB))
-    ifneq ($(.SHELLSTATUS), 0)
+    ifneq ($(shell pkg-config --exists $(HIDAPILIB); echo $$?), 0)
         $(error Please install $(HIDAPILIB) dependency or set HOSTED_BMP_ONLY to 1)
     endif
     CFLAGS += $(shell pkg-config --cflags $(HIDAPILIB))

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -12,72 +12,72 @@ CFLAGS +=-I ./target
 # footprint. Specifically no requirement to link against libftdi1, libusb1, or
 # hidapi (hidapi-hidraw on Linux). This makes building on Windows in particular easier.
 ifneq (, $(findstring linux, $(SYS)))
-	HOSTED_BMP_ONLY ?= 0
+    HOSTED_BMP_ONLY ?= 0
 else
-	HOSTED_BMP_ONLY ?= 1
+    HOSTED_BMP_ONLY ?= 1
 endif
 CFLAGS += -DHOSTED_BMP_ONLY=$(HOSTED_BMP_ONLY)
 
 ifeq ($(ASAN), 1)
-	CFLAGS += -fsanitize=address  -Wno-format-truncation
-	LDFLAGS += -fsanitize=address
+    CFLAGS += -fsanitize=address  -Wno-format-truncation
+    LDFLAGS += -fsanitize=address
 endif
 
 HIDAPILIB = hidapi
 ifneq (, $(findstring linux, $(SYS)))
-	SRC += serial_unix.c
-	HIDAPILIB = hidapi-hidraw
+    SRC += serial_unix.c
+    HIDAPILIB = hidapi-hidraw
 else ifneq (, $(findstring mingw, $(SYS)))
-	# Build for windows versions Vista, and above, where the
-	# 'SetupDiGetDevicePropertyW()' function is available
-	CFLAGS += -D_WIN32_WINNT=0x600
-	SRC += 	 serial_win.c
-	LDFLAGS += -lws2_32
-	LDFLAGS += -lsetupapi
+    # Build for windows versions Vista, and above, where the
+    # 'SetupDiGetDevicePropertyW()' function is available
+    CFLAGS += -D_WIN32_WINNT=0x600
+    SRC += serial_win.c
+    LDFLAGS += -lws2_32
+    LDFLAGS += -lsetupapi
 else ifneq (, $(findstring cygwin, $(SYS)))
-	# Build for windows versions Vista, and above, where the
-	# 'SetupDiGetDevicePropertyW()' function is available
-	CFLAGS += -D_WIN32_WINNT=0x600
-	SRC += 	 serial_win.c
-	LDFLAGS += -lws2_32
-	LDFLAGS += -lsetupapi
+    # Build for windows versions Vista, and above, where the
+    # 'SetupDiGetDevicePropertyW()' function is available
+    CFLAGS += -D_WIN32_WINNT=0x600
+    SRC += serial_win.c
+    LDFLAGS += -lws2_32
+    LDFLAGS += -lsetupapi
 # https://github.com/dmlc/xgboost/issues/1945 indicates macosx as indicator
 else ifneq (filter, macosx darwin, $(SYS))
-	SRC += serial_unix.c
-	LDFLAGS += -framework CoreFoundation
-	CFLAGS += -I /opt/homebrew/include -I /opt/homebrew/include/libusb-1.0
+    SRC += serial_unix.c
+    LDFLAGS += -framework CoreFoundation
+    CFLAGS += -I /opt/homebrew/include -I /opt/homebrew/include/libusb-1.0
 endif
 
 ifneq ($(HOSTED_BMP_ONLY), 1)
     $(shell pkg-config --exists libftdi1)
-	ifneq ($(.SHELLSTATUS), 0)
-		$(error Please install libftdi1 dependency or set HOSTED_BMP_ONLY to 1)
-	endif
-	LDFLAGS += -lusb-1.0
-	CFLAGS += $(shell pkg-config --cflags libftdi1)
-	LDFLAGS += $(shell pkg-config --libs libftdi1)
-	CFLAGS += -Wno-missing-field-initializers
+    ifneq ($(.SHELLSTATUS), 0)
+        $(error Please install libftdi1 dependency or set HOSTED_BMP_ONLY to 1)
+    endif
+    LDFLAGS += -lusb-1.0
+    CFLAGS += $(shell pkg-config --cflags libftdi1)
+    LDFLAGS += $(shell pkg-config --libs libftdi1)
+    CFLAGS += -Wno-missing-field-initializers
 endif
 
 ifneq ($(HOSTED_BMP_ONLY), 1)
-	CFLAGS  +=  -DCMSIS_DAP
-	SRC += cmsis_dap.c dap.c
+    CFLAGS  +=  -DCMSIS_DAP
+    SRC += cmsis_dap.c dap.c
     $(shell pkg-config --exists $(HIDAPILIB))
-	ifneq ($(.SHELLSTATUS), 0)
-		$(error Please install $(HIDAPILIB) dependency or set HOSTED_BMP_ONLY to 1)
-	endif
-	CFLAGS += $(shell pkg-config --cflags $(HIDAPILIB))
-	LDFLAGS += $(shell pkg-config --libs $(HIDAPILIB))
+    ifneq ($(.SHELLSTATUS), 0)
+        $(error Please install $(HIDAPILIB) dependency or set HOSTED_BMP_ONLY to 1)
+    endif
+    CFLAGS += $(shell pkg-config --cflags $(HIDAPILIB))
+    LDFLAGS += $(shell pkg-config --libs $(HIDAPILIB))
 endif
 
 SRC += timing.c cli.c utils.c
 SRC += bmp_remote.c remote_swdptap.c remote_jtagtap.c
 ifneq ($(HOSTED_BMP_ONLY), 1)
-	SRC += bmp_libusb.c stlinkv2.c
-	SRC += ftdi_bmp.c libftdi_swdptap.c libftdi_jtagtap.c
-	SRC += jlink.c jlink_adiv5_swdp.c jlink_jtagtap.c
+    SRC += bmp_libusb.c stlinkv2.c
+    SRC += ftdi_bmp.c libftdi_swdptap.c libftdi_jtagtap.c
+    SRC += jlink.c jlink_adiv5_swdp.c jlink_jtagtap.c
 else
-	SRC += bmp_serial.c
+    SRC += bmp_serial.c
 endif
 PC_HOSTED = 1
 


### PR DESCRIPTION
This patch set fixes some issues with the BMDA makefile.

Outside of targets we should use space indentation as tabs can be problematic. In this case when a library is not found the `$(error ...)` function is called. This fails as it is indented with tabs and make does not like that. So it is better to just generally indent everything outside of the target with spaces.

Older versions of make do not support the ` .SHELLSTATUS` variable. So we need to do some acrobatics to implement that with just the `$(shell ...)` function.