### PR TITLE
Fix: SWDP and JTAG TAP routine types and understandability

### DIFF
--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -46,7 +46,7 @@ typedef struct jtag_proc_s {
 	 * - DO may be point to the same address as DI.
 	 */
 	void (*jtagtap_tdi_tdo_seq)(uint8_t *data_out, const uint8_t final_tms, const uint8_t *data_in, int clock_cycles);
-	void (*jtagtap_tdi_seq)(const uint8_t final_tms, const uint8_t *DI, int clock_cycles);
+	void (*jtagtap_tdi_seq)(const uint8_t final_tms, const uint8_t *data_in, int clock_cycles);
 } jtag_proc_t;
 
 extern jtag_proc_t jtag_proc;

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -21,53 +21,52 @@
 #ifndef __JTAGTAP_H
 #define __JTAGTAP_H
 
+#include <stdint.h>
+
 typedef struct jtag_proc_s {
-/* Note: Signal names are as for the device under test. */
+	/* Note: Signal names are as for the device under test. */
 
 	void (*jtagtap_reset)(void);
 
+	/*
+	 * tap_next executes one state transision in the JTAG TAP state machine:
+	 * - Ensure TCK is low
+	 * - Assert the values of TMS and TDI
+	 * - Assert TCK (TMS and TDO are latched on rising edge
+	 * - Caputure the value on TDO
+	 * - Release TCK.
+	 */
 	uint8_t (*jtagtap_next)(const uint8_t TMS, const uint8_t TDI);
-/* tap_next executes one state transision in the JTAG TAP state machine:
- * - Ensure TCK is low
- * - Assert the values of TMS and TDI
- * - Assert TCK (TMS and TDO are latched on rising edge
- * - Caputure the value on TDO
- * - Release TCK.
- */
-
 	void (*jtagtap_tms_seq)(uint32_t MS, int ticks);
-	void (*jtagtap_tdi_tdo_seq)
-	(uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks);
-/* Shift out a sequence on MS and DI, capture data to DO.
- * - This is not endian safe: First byte will always be first shifted out.
- * - DO may be NULL to ignore captured data.
- * - DO may be point to the same address as DI.
- */
-	void (*jtagtap_tdi_seq)
-	(const uint8_t final_tms, const uint8_t *DI, int ticks);
+
+	/*
+	 * Shift out a sequence on MS and DI, capture data to DO.
+	 * - This is not endian safe: First byte will always be first shifted out.
+	 * - DO may be NULL to ignore captured data.
+	 * - DO may be point to the same address as DI.
+	 */
+	void (*jtagtap_tdi_tdo_seq)(uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks);
+	void (*jtagtap_tdi_seq)(const uint8_t final_tms, const uint8_t *DI, int ticks);
 } jtag_proc_t;
+
 extern jtag_proc_t jtag_proc;
 
 /* generic soft reset: 1, 1, 1, 1, 1, 0 */
-#define jtagtap_soft_reset()	\
-	jtag_proc.jtagtap_tms_seq(0x1F, 6)
+#define jtagtap_soft_reset() jtag_proc.jtagtap_tms_seq(0x1F, 6)
 
 /* Goto Shift-IR: 1, 1, 0, 0 */
-#define jtagtap_shift_ir()		\
-	jtag_proc.jtagtap_tms_seq(0x03, 4)
+#define jtagtap_shift_ir() jtag_proc.jtagtap_tms_seq(0x03, 4)
 
 /* Goto Shift-DR: 1, 0, 0 */
-#define jtagtap_shift_dr()		\
-	jtag_proc.jtagtap_tms_seq(0x01, 3)
+#define jtagtap_shift_dr() jtag_proc.jtagtap_tms_seq(0x01, 3)
 
 /* Goto Run-test/Idle: 1, 1, 0 */
-#define jtagtap_return_idle()	\
-	jtag_proc.jtagtap_tms_seq(0x01, 2)
+#define jtagtap_return_idle() jtag_proc.jtagtap_tms_seq(0x01, 2)
 
-# if PC_HOSTED == 1
+#if PC_HOSTED == 1
 int platform_jtagtap_init(void);
-# else
+#else
 int jtagtap_init(void);
-# endif
 #endif
 
+#endif /*__JTAGTAP_H*/

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -37,7 +37,7 @@ typedef struct jtag_proc_s {
 	 * - Release TCK.
 	 */
 	uint8_t (*jtagtap_next)(const uint8_t tms, const uint8_t tdi);
-	void (*jtagtap_tms_seq)(uint32_t tms_states, int ticks);
+	void (*jtagtap_tms_seq)(uint32_t tms_states, int clock_cycles);
 
 	/*
 	 * Shift out a sequence on MS and DI, capture data to DO.
@@ -45,8 +45,8 @@ typedef struct jtag_proc_s {
 	 * - DO may be NULL to ignore captured data.
 	 * - DO may be point to the same address as DI.
 	 */
-	void (*jtagtap_tdi_tdo_seq)(uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks);
-	void (*jtagtap_tdi_seq)(const uint8_t final_tms, const uint8_t *DI, int ticks);
+	void (*jtagtap_tdi_tdo_seq)(uint8_t *data_out, const uint8_t final_tms, const uint8_t *data_in, int clock_cycles);
+	void (*jtagtap_tdi_seq)(const uint8_t final_tms, const uint8_t *DI, int clock_cycles);
 } jtag_proc_t;
 
 extern jtag_proc_t jtag_proc;

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -36,8 +36,8 @@ typedef struct jtag_proc_s {
 	 * - Caputure the value on TDO
 	 * - Release TCK.
 	 */
-	uint8_t (*jtagtap_next)(const uint8_t TMS, const uint8_t TDI);
-	void (*jtagtap_tms_seq)(uint32_t MS, int ticks);
+	uint8_t (*jtagtap_next)(const uint8_t tms, const uint8_t tdi);
+	void (*jtagtap_tms_seq)(uint32_t tms_states, int ticks);
 
 	/*
 	 * Shift out a sequence on MS and DI, capture data to DO.

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -22,6 +22,8 @@
 #define __JTAGTAP_H
 
 #include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 typedef struct jtag_proc_s {
 	/* Note: Signal names are as for the device under test. */
@@ -36,8 +38,8 @@ typedef struct jtag_proc_s {
 	 * - Caputure the value on TDO
 	 * - Release TCK.
 	 */
-	uint8_t (*jtagtap_next)(const uint8_t tms, const uint8_t tdi);
-	void (*jtagtap_tms_seq)(uint32_t tms_states, int clock_cycles);
+	bool (*jtagtap_next)(const bool tms, const bool tdi);
+	void (*jtagtap_tms_seq)(uint32_t tms_states, size_t clock_cycles);
 
 	/*
 	 * Shift out a sequence on MS and DI, capture data to DO.
@@ -45,8 +47,8 @@ typedef struct jtag_proc_s {
 	 * - DO may be NULL to ignore captured data.
 	 * - DO may be point to the same address as DI.
 	 */
-	void (*jtagtap_tdi_tdo_seq)(uint8_t *data_out, const uint8_t final_tms, const uint8_t *data_in, int clock_cycles);
-	void (*jtagtap_tdi_seq)(const uint8_t final_tms, const uint8_t *data_in, int clock_cycles);
+	void (*jtagtap_tdi_tdo_seq)(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t clock_cycles);
+	void (*jtagtap_tdi_seq)(const bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 } jtag_proc_t;
 
 extern jtag_proc_t jtag_proc;

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -30,25 +30,24 @@ jtag_proc_t jtag_proc;
 
 static void jtagtap_reset(void);
 static void jtagtap_tms_seq(uint32_t MS, int ticks);
-static void jtagtap_tdi_tdo_seq(
-	uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks);
-static void jtagtap_tdi_seq(
-	const uint8_t final_tms, const uint8_t *DI, int ticks);
-static uint8_t jtagtap_next(uint8_t dTMS, uint8_t dTDI);
+static void jtagtap_tdi_tdo_seq(uint8_t *DO, uint8_t final_tms, const uint8_t *DI, int ticks);
+static void jtagtap_tdi_seq(uint8_t final_tms, const uint8_t *DI, int ticks);
+static uint8_t jtagtap_next(uint8_t tms, uint8_t tdi);
 
 int jtagtap_init()
 {
 	TMS_SET_MODE();
 
 	jtag_proc.jtagtap_reset = jtagtap_reset;
-	jtag_proc.jtagtap_next =jtagtap_next;
+	jtag_proc.jtagtap_next = jtagtap_next;
 	jtag_proc.jtagtap_tms_seq = jtagtap_tms_seq;
 	jtag_proc.jtagtap_tdi_tdo_seq = jtagtap_tdi_tdo_seq;
 	jtag_proc.jtagtap_tdi_seq = jtagtap_tdi_seq;
 
 	/* Go to JTAG mode for SWJ-DP */
-	for(int i = 0; i <= 50; i++) jtagtap_next(1, 0); /* Reset SW-DP */
-	jtagtap_tms_seq(0xE73C, 16);		/* SWD to JTAG sequence */
+	for (size_t i = 0; i <= 50U; ++i)
+		jtagtap_next(1, 0);      /* Reset SW-DP */
+	jtagtap_tms_seq(0xe73cU, 16U); /* SWD to JTAG sequence */
 	jtagtap_soft_reset();
 
 	return 0;
@@ -58,98 +57,104 @@ static void jtagtap_reset(void)
 {
 #ifdef TRST_PORT
 	if (platform_hwversion() == 0) {
-		volatile int i;
 		gpio_clear(TRST_PORT, TRST_PIN);
-		for(i = 0; i < 10000; i++) asm("nop");
+		for (volatile size_t i = 0; i < 10000; i++)
+			asm("nop");
 		gpio_set(TRST_PORT, TRST_PIN);
 	}
 #endif
 	jtagtap_soft_reset();
 }
 
-static uint8_t jtagtap_next(uint8_t dTMS, uint8_t dTDI)
+static uint8_t jtagtap_next(const uint8_t tms, const uint8_t tdi)
 {
-	uint16_t ret;
 	register volatile int32_t cnt;
 
-	gpio_set_val(TMS_PORT, TMS_PIN, dTMS);
-	gpio_set_val(TDI_PORT, TDI_PIN, dTDI);
+	gpio_set_val(TMS_PORT, TMS_PIN, tms);
+	gpio_set_val(TDI_PORT, TDI_PIN, tdi);
 	gpio_set(TCK_PORT, TCK_PIN);
-	for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
-	ret = gpio_get(TDO_PORT, TDO_PIN);
+	for (cnt = swd_delay_cnt - 2U; cnt > 0; cnt--)
+		continue;
+	const uint16_t result = gpio_get(TDO_PORT, TDO_PIN);
 	gpio_clear(TCK_PORT, TCK_PIN);
-	for(cnt = swd_delay_cnt - 2; cnt > 0; cnt--);
+	for (cnt = swd_delay_cnt - 2U; cnt > 0; cnt--)
+		continue;
 
-	//DEBUG("jtagtap_next(TMS = %d, TDI = %d) = %d\n", dTMS, dTDI, ret);
+	//DEBUG("jtagtap_next(TMS = %u, TDI = %u) = %u\n", tms, tdi, result);
 
-	return ret != 0;
+	return result != 0;
 }
 
 static void jtagtap_tms_seq(uint32_t MS, int ticks)
 {
 	gpio_set_val(TDI_PORT, TDI_PIN, 1);
-	int data = MS & 1;
+	bool state = MS & 1;
 	register volatile int32_t cnt;
 	if (swd_delay_cnt) {
-		while(ticks) {
-			gpio_set_val(TMS_PORT, TMS_PIN, data);
+		while (ticks) {
+			gpio_set_val(TMS_PORT, TMS_PIN, state);
 			gpio_set(TCK_PORT, TCK_PIN);
-			for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
+			for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+				continue;
 			MS >>= 1;
-			data = MS & 1;
+			state = MS & 1;
 			ticks--;
 			gpio_clear(TCK_PORT, TCK_PIN);
-			for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
+			for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+				continue;
 		}
 	} else {
-		while(ticks) {
-			gpio_set_val(TMS_PORT, TMS_PIN, data);
+		while (ticks) {
+			gpio_set_val(TMS_PORT, TMS_PIN, state);
 			gpio_set(TCK_PORT, TCK_PIN);
 			MS >>= 1;
-			data = MS & 1;
+			state = MS & 1;
 			ticks--;
 			gpio_clear(TCK_PORT, TCK_PIN);
 		}
 	}
 }
 
-static void jtagtap_tdi_tdo_seq(
-	uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks)
+static void jtagtap_tdi_tdo_seq(uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks)
 {
 	uint8_t index = 1;
 	gpio_set_val(TMS_PORT, TMS_PIN, 0);
 	uint8_t res = 0;
 	register volatile int32_t cnt;
 	if (swd_delay_cnt) {
-		while(ticks > 1) {
+		while (ticks > 1) {
 			gpio_set_val(TDI_PORT, TDI_PIN, *DI & index);
 			gpio_set(TCK_PORT, TCK_PIN);
-			for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
+			for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+				;
 			if (gpio_get(TDO_PORT, TDO_PIN)) {
 				res |= index;
 			}
-			if(!(index <<= 1)) {
+			if (!(index <<= 1)) {
 				*DO = res;
 				res = 0;
 				index = 1;
-				DI++; DO++;
+				DI++;
+				DO++;
 			}
 			ticks--;
 			gpio_clear(TCK_PORT, TCK_PIN);
-			for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
+			for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+				;
 		}
 	} else {
-		while(ticks > 1) {
+		while (ticks > 1) {
 			gpio_set_val(TDI_PORT, TDI_PIN, *DI & index);
 			gpio_set(TCK_PORT, TCK_PIN);
 			if (gpio_get(TDO_PORT, TDO_PIN)) {
 				res |= index;
 			}
-			if(!(index <<= 1)) {
+			if (!(index <<= 1)) {
 				*DO = res;
 				res = 0;
 				index = 1;
-				DI++; DO++;
+				DI++;
+				DO++;
 			}
 			ticks--;
 			gpio_clear(TCK_PORT, TCK_PIN);
@@ -158,13 +163,15 @@ static void jtagtap_tdi_tdo_seq(
 	gpio_set_val(TMS_PORT, TMS_PIN, final_tms);
 	gpio_set_val(TDI_PORT, TDI_PIN, *DI & index);
 	gpio_set(TCK_PORT, TCK_PIN);
-			for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
+	for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+		;
 	if (gpio_get(TDO_PORT, TDO_PIN)) {
 		res |= index;
 	}
 	*DO = res;
 	gpio_clear(TCK_PORT, TCK_PIN);
-	for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
+	for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+		;
 }
 
 static void jtagtap_tdi_seq(const uint8_t final_tms, const uint8_t *DI, int ticks)
@@ -172,24 +179,26 @@ static void jtagtap_tdi_seq(const uint8_t final_tms, const uint8_t *DI, int tick
 	uint8_t index = 1;
 	register volatile int32_t cnt;
 	if (swd_delay_cnt) {
-		while(ticks--) {
-			gpio_set_val(TMS_PORT, TMS_PIN, ticks? 0 : final_tms);
+		while (ticks--) {
+			gpio_set_val(TMS_PORT, TMS_PIN, ticks ? 0 : final_tms);
 			gpio_set_val(TDI_PORT, TDI_PIN, *DI & index);
 			gpio_set(TCK_PORT, TCK_PIN);
-			for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
-			if(!(index <<= 1)) {
+			for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+				;
+			if (!(index <<= 1)) {
 				index = 1;
 				DI++;
 			}
 			gpio_clear(TCK_PORT, TCK_PIN);
-			for(cnt = swd_delay_cnt -2 ; cnt > 0; cnt--);
+			for (cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
+				;
 		}
 	} else {
-		while(ticks--) {
-			gpio_set_val(TMS_PORT, TMS_PIN, ticks? 0 : final_tms);
+		while (ticks--) {
+			gpio_set_val(TMS_PORT, TMS_PIN, ticks ? 0 : final_tms);
 			gpio_set_val(TDI_PORT, TDI_PIN, *DI & index);
 			gpio_set(TCK_PORT, TCK_PIN);
-			if(!(index <<= 1)) {
+			if (!(index <<= 1)) {
 				index = 1;
 				DI++;
 			}

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -113,7 +113,7 @@ static void jtagtap_tms_seq_no_delay(uint32_t tms_states, size_t ticks)
 	}
 }
 
-static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks)
+static void jtagtap_tms_seq(const uint32_t tms_states, const size_t ticks)
 {
 	gpio_set(TDI_PORT, TDI_PIN);
 	if (swd_delay_cnt)
@@ -122,7 +122,7 @@ static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks)
 		jtagtap_tms_seq_no_delay(tms_states, ticks);
 }
 
-static void jtagtap_tdi_tdo_seq_swd_delay(const uint8_t *data_in, uint8_t *data_out, const bool final_tms, size_t clock_cycles)
+static void jtagtap_tdi_tdo_seq_swd_delay(const uint8_t *const data_in, uint8_t *const data_out, const bool final_tms, size_t clock_cycles)
 {
 	size_t byte = 0;
 	size_t index = 0;
@@ -152,7 +152,7 @@ static void jtagtap_tdi_tdo_seq_swd_delay(const uint8_t *data_in, uint8_t *data_
 		data_out[byte] = value;
 }
 
-static void jtagtap_tdi_tdo_seq_no_delay(const uint8_t *data_in, uint8_t *data_out, const bool final_tms, size_t clock_cycles)
+static void jtagtap_tdi_tdo_seq_no_delay(const uint8_t *const data_in, uint8_t *const data_out, const bool final_tms, size_t clock_cycles)
 {
 	size_t byte = 0;
 	size_t index = 0;
@@ -179,7 +179,7 @@ static void jtagtap_tdi_tdo_seq_no_delay(const uint8_t *data_in, uint8_t *data_o
 		data_out[byte] = value;
 }
 
-static void jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t ticks)
+static void jtagtap_tdi_tdo_seq(uint8_t *const data_out, const bool final_tms, const uint8_t *const data_in, size_t ticks)
 {
 	gpio_clear(TDI_PORT, TDI_PIN);
 	if (swd_delay_cnt)
@@ -188,7 +188,7 @@ static void jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const u
 		jtagtap_tdi_tdo_seq_no_delay(data_in, data_out, final_tms, ticks);
 }
 
-static void jtagtap_tdi_seq_swd_delay(const uint8_t *data_in, const bool final_tms, size_t clock_cycles)
+static void jtagtap_tdi_seq_swd_delay(const uint8_t *const data_in, const bool final_tms, size_t clock_cycles)
 {
 	size_t byte = 0;
 	size_t index = 0;
@@ -212,7 +212,7 @@ static void jtagtap_tdi_seq_swd_delay(const uint8_t *data_in, const bool final_t
 	}
 }
 
-static void jtagtap_tdi_seq_no_delay(const uint8_t *data_in, const bool final_tms, size_t clock_cycles)
+static void jtagtap_tdi_seq_no_delay(const uint8_t *const data_in, const bool final_tms, size_t clock_cycles)
 {
 	size_t byte = 0;
 	size_t index = 0;
@@ -232,7 +232,7 @@ static void jtagtap_tdi_seq_no_delay(const uint8_t *data_in, const bool final_tm
 	}
 }
 
-static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *data_in, size_t ticks)
+static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *const data_in, const size_t ticks)
 {
 	if (swd_delay_cnt)
 		jtagtap_tdi_seq_swd_delay(data_in, final_tms, ticks);

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -29,10 +29,10 @@
 jtag_proc_t jtag_proc;
 
 static void jtagtap_reset(void);
-static void jtagtap_tms_seq(uint32_t tms_states, int ticks);
-static void jtagtap_tdi_tdo_seq(uint8_t *data_out, uint8_t final_tms, const uint8_t *data_in, int ticks);
-static void jtagtap_tdi_seq(uint8_t final_tms, const uint8_t *data_in, int ticks);
-static uint8_t jtagtap_next(uint8_t tms, uint8_t tdi);
+static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks);
+static void jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t ticks);
+static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t ticks);
+static bool jtagtap_next(bool tms, bool tdi);
 
 int jtagtap_init()
 {
@@ -66,7 +66,7 @@ static void jtagtap_reset(void)
 	jtagtap_soft_reset();
 }
 
-static uint8_t jtagtap_next(const uint8_t tms, const uint8_t tdi)
+static bool jtagtap_next(const bool tms, const bool tdi)
 {
 	register volatile int32_t cnt;
 
@@ -113,7 +113,7 @@ static void jtagtap_tms_seq_no_delay(uint32_t tms_states, size_t ticks)
 	}
 }
 
-static void jtagtap_tms_seq(uint32_t tms_states, int ticks)
+static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks)
 {
 	gpio_set(TDI_PORT, TDI_PIN);
 	if (swd_delay_cnt)
@@ -179,7 +179,7 @@ static void jtagtap_tdi_tdo_seq_no_delay(const uint8_t *data_in, uint8_t *data_o
 		data_out[byte] = value;
 }
 
-static void jtagtap_tdi_tdo_seq(uint8_t *data_out, const uint8_t final_tms, const uint8_t *data_in, int ticks)
+static void jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t ticks)
 {
 	gpio_clear(TDI_PORT, TDI_PIN);
 	if (swd_delay_cnt)
@@ -232,7 +232,7 @@ static void jtagtap_tdi_seq_no_delay(const uint8_t *data_in, const bool final_tm
 	}
 }
 
-static void jtagtap_tdi_seq(const uint8_t final_tms, const uint8_t *data_in, int ticks)
+static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *data_in, size_t ticks)
 {
 	if (swd_delay_cnt)
 		jtagtap_tdi_seq_swd_delay(data_in, final_tms, ticks);

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -29,8 +29,8 @@
 jtag_proc_t jtag_proc;
 
 static void jtagtap_reset(void);
-static void jtagtap_tms_seq(uint32_t MS, int ticks);
-static void jtagtap_tdi_tdo_seq(uint8_t *DO, uint8_t final_tms, const uint8_t *DI, int ticks);
+static void jtagtap_tms_seq(uint32_t tms_states, int ticks);
+static void jtagtap_tdi_tdo_seq(uint8_t *data_out, uint8_t final_tms, const uint8_t *data_in, int ticks);
 static void jtagtap_tdi_seq(uint8_t final_tms, const uint8_t *DI, int ticks);
 static uint8_t jtagtap_next(uint8_t tms, uint8_t tdi);
 
@@ -113,13 +113,13 @@ static void jtagtap_tms_seq_no_delay(uint32_t tms_states, size_t ticks)
 	}
 }
 
-static void jtagtap_tms_seq(uint32_t MS, int ticks)
+static void jtagtap_tms_seq(uint32_t tms_states, int ticks)
 {
-	gpio_set_val(TDI_PORT, TDI_PIN, true);
+	gpio_set(TDI_PORT, TDI_PIN);
 	if (swd_delay_cnt)
-		jtagtap_tms_seq_swd_delay(MS, ticks);
+		jtagtap_tms_seq_swd_delay(tms_states, ticks);
 	else
-		jtagtap_tms_seq_no_delay(MS, ticks);
+		jtagtap_tms_seq_no_delay(tms_states, ticks);
 }
 
 static void jtagtap_tdi_tdo_seq_swd_delay(const uint8_t *data_in, uint8_t *data_out, const bool final_tms, size_t clock_cycles)
@@ -181,13 +181,13 @@ static void jtagtap_tdi_tdo_seq_no_delay(const uint8_t *data_in, uint8_t *data_o
 		data_out[byte] = value;
 }
 
-static void jtagtap_tdi_tdo_seq(uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks)
+static void jtagtap_tdi_tdo_seq(uint8_t *data_out, const uint8_t final_tms, const uint8_t *data_in, int ticks)
 {
 	gpio_clear(TDI_PORT, TDI_PIN);
 	if (swd_delay_cnt)
-		jtagtap_tdi_tdo_seq_swd_delay(DI, DO, final_tms, ticks);
+		jtagtap_tdi_tdo_seq_swd_delay(data_in, data_out, final_tms, ticks);
 	else
-		jtagtap_tdi_tdo_seq_no_delay(DI, DO, final_tms, ticks);
+		jtagtap_tdi_tdo_seq_no_delay(data_in, data_out, final_tms, ticks);
 }
 
 static void jtagtap_tdi_seq(const uint8_t final_tms, const uint8_t *DI, int ticks)

--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -59,12 +59,12 @@ static void swdptap_turnaround(const swdio_status_t dir)
 		SWDIO_MODE_DRIVE();
 }
 
-static uint32_t swdptap_seq_in_swd_delay(size_t clock_cycles) __attribute__((optimize(3)));
-static uint32_t swdptap_seq_in_swd_delay(size_t clock_cycles)
+static uint32_t swdptap_seq_in_swd_delay(const size_t clock_cycles) __attribute__((optimize(3)));
+static uint32_t swdptap_seq_in_swd_delay(const size_t clock_cycles)
 {
 	size_t index = 0;
 	uint32_t value = 0;
-	while (clock_cycles--) {
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
 		if (gpio_get(SWDIO_PORT, SWDIO_PIN))
 			value |= (1U << index);
 		gpio_set(SWCLK_PORT, SWCLK_PIN);
@@ -78,12 +78,12 @@ static uint32_t swdptap_seq_in_swd_delay(size_t clock_cycles)
 	return value;
 }
 
-static uint32_t swdptap_seq_in_no_delay(size_t clock_cycles) __attribute__((optimize(3)));
-static uint32_t swdptap_seq_in_no_delay(size_t clock_cycles)
+static uint32_t swdptap_seq_in_no_delay(const size_t clock_cycles) __attribute__((optimize(3)));
+static uint32_t swdptap_seq_in_no_delay(const size_t clock_cycles)
 {
 	size_t index = 0;
 	uint32_t value = 0;
-	while (clock_cycles--) {
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
 		if (gpio_get(SWDIO_PORT, SWDIO_PIN))
 			value |= (1U << index);
 		gpio_set(SWCLK_PORT, SWCLK_PIN);

--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -59,18 +59,17 @@ static void swdptap_turnaround(const swdio_status_t dir)
 		SWDIO_MODE_DRIVE();
 }
 
-static uint32_t swdptap_seq_in_swd_delay(const size_t clock_cycles) __attribute__((optimize(3)));
+static uint32_t swdptap_seq_in_swd_delay(size_t clock_cycles) __attribute__((optimize(3)));
 static uint32_t swdptap_seq_in_swd_delay(const size_t clock_cycles)
 {
-	size_t index = 0;
 	uint32_t value = 0;
-	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+	for (size_t cycle = 0; cycle < clock_cycles;) {
 		if (gpio_get(SWDIO_PORT, SWDIO_PIN))
-			value |= (1U << index);
+			value |= (1U << cycle);
 		gpio_set(SWCLK_PORT, SWCLK_PIN);
 		for (volatile int32_t cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
 			continue;
-		++index;
+		++cycle;
 		gpio_clear(SWCLK_PORT, SWCLK_PIN);
 		for (volatile int32_t cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
 			continue;
@@ -78,16 +77,15 @@ static uint32_t swdptap_seq_in_swd_delay(const size_t clock_cycles)
 	return value;
 }
 
-static uint32_t swdptap_seq_in_no_delay(const size_t clock_cycles) __attribute__((optimize(3)));
+static uint32_t swdptap_seq_in_no_delay(size_t clock_cycles) __attribute__((optimize(3)));
 static uint32_t swdptap_seq_in_no_delay(const size_t clock_cycles)
 {
-	size_t index = 0;
 	uint32_t value = 0;
-	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+	for (size_t cycle = 0; cycle < clock_cycles;) {
 		if (gpio_get(SWDIO_PORT, SWDIO_PIN))
-			value |= (1U << index);
+			value |= (1U << cycle);
 		gpio_set(SWCLK_PORT, SWCLK_PIN);
-		++index;
+		++cycle;
 		gpio_clear(SWCLK_PORT, SWCLK_PIN);
 	}
 	return value;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -442,24 +442,24 @@ static void cmsis_dap_jtagtap_reset(void)
 	/* Is there a way to know if TRST is available?*/
 }
 
-static void cmsis_dap_jtagtap_tms_seq(const uint32_t tms_states, const size_t ticks)
+static void cmsis_dap_jtagtap_tms_seq(const uint32_t tms_states, const size_t clock_cycles)
 {
 	const uint8_t tms[4] = {
 		(uint8_t)tms_states, (uint8_t)(tms_states >> 8U), (uint8_t)(tms_states >> 16U), (uint8_t)(tms_states >> 24U)};
-	dap_jtagtap_tdi_tdo_seq(NULL, false, tms, NULL, ticks);
-	DEBUG_PROBE("tms_seq data_in %08x %zu\n", tms_states, ticks);
+	dap_jtagtap_tdi_tdo_seq(NULL, false, tms, NULL, clock_cycles);
+	DEBUG_PROBE("tms_seq data_in %08x %zu\n", tms_states, clock_cycles);
 }
 
-static void cmsis_dap_jtagtap_tdi_tdo_seq(uint8_t *const data_out, const bool final_tms, const uint8_t *const data_in, const size_t ticks)
+static void cmsis_dap_jtagtap_tdi_tdo_seq(uint8_t *const data_out, const bool final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
-	dap_jtagtap_tdi_tdo_seq(data_out, final_tms, NULL, data_in, ticks);
-	DEBUG_PROBE("jtagtap_tdi_tdo_seq %zu, %02x-> %02x\n", ticks, data_in[0], data_out ? data_out[0] : 0);
+	dap_jtagtap_tdi_tdo_seq(data_out, final_tms, NULL, data_in, clock_cycles);
+	DEBUG_PROBE("jtagtap_tdi_tdo_seq %zu, %02x-> %02x\n", clock_cycles, data_in[0], data_out ? data_out[0] : 0);
 }
 
-static void cmsis_dap_jtagtap_tdi_seq(const bool final_tms, const uint8_t *const data_in, const size_t ticks)
+static void cmsis_dap_jtagtap_tdi_seq(const bool final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
-	dap_jtagtap_tdi_tdo_seq(NULL, final_tms, NULL, data_in, ticks);
-	DEBUG_PROBE("jtagtap_tdi_seq %zu, %02x\n", ticks, data_in[0]);
+	dap_jtagtap_tdi_tdo_seq(NULL, final_tms, NULL, data_in, clock_cycles);
+	DEBUG_PROBE("jtagtap_tdi_seq %zu, %02x\n", clock_cycles, data_in[0]);
 }
 
 static bool cmsis_dap_jtagtap_next(const bool tms, const bool tdi)
@@ -467,7 +467,7 @@ static bool cmsis_dap_jtagtap_next(const bool tms, const bool tdi)
 	const uint8_t tms_byte = tms ? 1 : 0;
 	const uint8_t tdi_byte = tdi ? 1 : 0;
 	uint8_t tdo = 0;
-	dap_jtagtap_tdi_tdo_seq(&tdo, false, &tms_byte, &tdi_byte, 1);
+	dap_jtagtap_tdi_tdo_seq(&tdo, false, &tms_byte, &tdi_byte, 1U);
 	DEBUG_PROBE("next tms %02x tdi %02x tdo %02x\n", tms, tdi, tdo);
 	return tdo;
 }

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -764,7 +764,7 @@ int dap_jtag_configure(void)
 	return 0;
 }
 
-void dap_swdptap_seq_out(uint32_t tms_states, int clock_cycles)
+void dap_swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
 {
 	/* clang-format off */
 	uint8_t buf[64] = {
@@ -781,7 +781,7 @@ void dap_swdptap_seq_out(uint32_t tms_states, int clock_cycles)
 		DEBUG_WARN("dap_swdptap_seq_out error\n");
 }
 
-void dap_swdptap_seq_out_parity(uint32_t tms_states, int clock_cycles)
+void dap_swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 {
 	/* clang-format off */
 	uint8_t buf[] = {

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -83,7 +83,7 @@ void dap_write_single(ADIv5_AP_t *ap, uint32_t dest, const void *src, enum align
 int dbg_dap_cmd(uint8_t *data, int size, int rsize);
 void dap_jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);
-void dap_swdptap_seq_out(uint32_t tms_states, int clock_cycles);
-void dap_swdptap_seq_out_parity(uint32_t tms_states, int clock_cycles);
+void dap_swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
+void dap_swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
 #endif // _DAP_H_

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -81,9 +81,9 @@ void dap_ap_write(ADIv5_AP_t *ap, uint16_t addr, uint32_t value);
 void dap_read_single(ADIv5_AP_t *ap, void *dest, uint32_t src, enum align align);
 void dap_write_single(ADIv5_AP_t *ap, uint32_t dest, const void *src, enum align align);
 int dbg_dap_cmd(uint8_t *data, int size, int rsize);
-void dap_jtagtap_tdi_tdo_seq(uint8_t *DO, bool final_tms, const uint8_t *TMS, const uint8_t *DI, int ticks);
+void dap_jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);
-void dap_swdptap_seq_out(uint32_t MS, int ticks);
-void dap_swdptap_seq_out_parity(uint32_t MS, int ticks);
+void dap_swdptap_seq_out(uint32_t tms_states, int clock_cycles);
+void dap_swdptap_seq_out_parity(uint32_t tms_states, int clock_cycles);
 
 #endif // _DAP_H_

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -628,8 +628,7 @@ int libftdi_buffer_read(uint8_t *data, int size)
 	return size;
 }
 
-void libftdi_jtagtap_tdi_tdo_seq(
-	uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks)
+void libftdi_jtagtap_tdi_tdo_seq(uint8_t *DO, const bool final_tms, const uint8_t *DI, size_t ticks)
 {
 	int rsize, rticks;
 

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -588,11 +588,12 @@ static struct ftdi_transfer_control *tc_write = NULL;
 	bufptr = 0;
 }
 
-int libftdi_buffer_write(const uint8_t *data, int size)
+size_t libftdi_buffer_write(const uint8_t *data, size_t size)
 {
-	if((bufptr + size) / BUF_SIZE > 0) libftdi_buffer_flush();
+	if ((bufptr + size) / BUF_SIZE > 0)
+		libftdi_buffer_flush();
 	DEBUG_WIRE("Write %d bytes:", size);
-	for (int i = 0; i < size; i++) {
+	for (size_t i = 0; i < size; i++) {
 		DEBUG_WIRE(" %02x", data[i]);
 		if (i && (i & 0xf) == 0xf)
 			DEBUG_WIRE("\n\t");

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -106,7 +106,7 @@ int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info) { return -1; }
 int libftdi_swdptap_init(ADIv5_DP_t *dp) { return -1; }
 int libftdi_jtagtap_init(jtag_proc_t *jtag_proc) { return 0; }
 void libftdi_buffer_flush(void) { }
-int libftdi_buffer_write(const uint8_t *data, int size) { return size; }
+size_t libftdi_buffer_write(const uint8_t *data, size_t size) { return size; }
 int libftdi_buffer_read(uint8_t *data, int size) { return size; }
 const char *libftdi_target_voltage(void) { return "ERROR"; }
 void libftdi_jtagtap_tdi_tdo_seq(uint8_t *const data_out, const bool final_tms,
@@ -128,7 +128,7 @@ int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info);
 int libftdi_swdptap_init(ADIv5_DP_t *dp);
 int libftdi_jtagtap_init(jtag_proc_t *jtag_proc);
 void libftdi_buffer_flush(void);
-int libftdi_buffer_write(const uint8_t *data, int size);
+size_t libftdi_buffer_write(const uint8_t *data, size_t size);
 int libftdi_buffer_read(uint8_t *data, int size);
 const char *libftdi_target_voltage(void);
 void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t ticks);

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -109,8 +109,8 @@ void libftdi_buffer_flush(void) { }
 int libftdi_buffer_write(const uint8_t *data, int size) { return size; }
 int libftdi_buffer_read(uint8_t *data, int size) { return size; }
 const char *libftdi_target_voltage(void) { return "ERROR"; }
-void libftdi_jtagtap_tdi_tdo_seq(
-	uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks) { }
+void libftdi_jtagtap_tdi_tdo_seq(uint8_t *const data_out, const bool final_tms,
+	const uint8_t *const data_in, const size_t ticks) { }
 bool  libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd) { return false; }
 void libftdi_max_frequency_set(uint32_t freq) { }
 uint32_t libftdi_max_frequency_get(void) { return 0; }
@@ -131,8 +131,7 @@ void libftdi_buffer_flush(void);
 int libftdi_buffer_write(const uint8_t *data, int size);
 int libftdi_buffer_read(uint8_t *data, int size);
 const char *libftdi_target_voltage(void);
-void libftdi_jtagtap_tdi_tdo_seq(
-	uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks);
+void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t ticks);
 bool  libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd);
 void libftdi_max_frequency_set(uint32_t freq);
 uint32_t libftdi_max_frequency_get(void);

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -36,12 +36,10 @@
 #include "bmp_remote.h"
 
 static void jtagtap_reset(void);
-static void jtagtap_tms_seq(uint32_t MS, int ticks);
-static void jtagtap_tdi_tdo_seq(
-	uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks);
-static void jtagtap_tdi_seq(
-	const uint8_t final_tms, const uint8_t *DI, int ticks);
-static uint8_t jtagtap_next(uint8_t dTMS, uint8_t dTDI);
+static void jtagtap_tms_seq(uint32_t MS, size_t ticks);
+static void jtagtap_tdi_tdo_seq(uint8_t *DO, bool final_tms, const uint8_t *DI, size_t ticks);
+static void jtagtap_tdi_seq(bool final_tms, const uint8_t *DI, size_t ticks);
+static bool jtagtap_next(bool dTMS, bool dTDI);
 
 int remote_jtagtap_init(jtag_proc_t *jtag_proc)
 {
@@ -87,7 +85,7 @@ static void jtagtap_reset(void)
     }
 }
 
-static void jtagtap_tms_seq(uint32_t MS, int ticks)
+static void jtagtap_tms_seq(uint32_t MS, size_t ticks)
 {
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;
@@ -110,8 +108,7 @@ static void jtagtap_tms_seq(uint32_t MS, int ticks)
  * FIXME: Provide and test faster call and keep fallback
  * for old firmware
  */
-static void jtagtap_tdi_tdo_seq(
-	uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks)
+static void jtagtap_tdi_tdo_seq(uint8_t *DO, const bool final_tms, const uint8_t *DI, size_t ticks)
 {
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;
@@ -159,14 +156,12 @@ static void jtagtap_tdi_tdo_seq(
 	}
 }
 
-static void jtagtap_tdi_seq(
-	const uint8_t final_tms, const uint8_t *DI, int ticks)
+static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *DI, size_t ticks)
 {
 	return jtagtap_tdi_tdo_seq(NULL,  final_tms, DI, ticks);
 }
 
-
-static uint8_t jtagtap_next(uint8_t dTMS, uint8_t dTDI)
+static bool jtagtap_next(bool dTMS, bool dTDI)
 {
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;

--- a/src/remote.c
+++ b/src/remote.c
@@ -236,11 +236,11 @@ static void remotePacketProcessJTAG(unsigned i, char *packet)
 		break;
 
     case REMOTE_NEXT: /* JN = NEXT ======================================== */
-		if (i!=4) {
-			_respond(REMOTE_RESP_ERR,REMOTE_ERROR_WRONGLEN);
-		} else {
-			uint32_t dat=jtag_proc.jtagtap_next( (packet[2]=='1'), (packet[3]=='1'));
-			_respond(REMOTE_RESP_OK,dat);
+		if (i != 4)
+			_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
+		else {
+			uint32_t dat = jtag_proc.jtagtap_next(packet[2] == '1', packet[3] == '1');
+			_respond(REMOTE_RESP_OK, dat);
 		}
 		break;
 

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -171,10 +171,10 @@ typedef struct ADIv5_DP_s {
 	uint32_t idcode;
 	uint32_t targetid;  /* Contains IDCODE for DPv2 devices.*/
 
-	void (*seq_out)(uint32_t MS, int ticks);
-	void (*seq_out_parity)(uint32_t MS, int ticks);
-	uint32_t (*seq_in)(int ticks);
-	bool (*seq_in_parity)(uint32_t *ret, int ticks);
+	void (*seq_out)(uint32_t tms_states, size_t clock_cycles);
+	void (*seq_out_parity)(uint32_t tms_states, size_t clock_cycles);
+	uint32_t (*seq_in)(size_t clock_cycles);
+	bool (*seq_in_parity)(uint32_t *ret, size_t clock_cycles);
 	/* dp_low_write returns true if no OK resonse, but ignores errors */
 	bool (*dp_low_write)(struct ADIv5_DP_s *dp, uint16_t addr,
 						 const uint32_t data);


### PR DESCRIPTION
In this PR we address a few aspects of the SWDP and JTAG TAP routines which were less than ideal. This resulted in over 400 bytes of Flash saved and what should be much more understandable routines to maintain moving forward.

The first major thing we addressed was the type confusion (`uint8_t` instead of `bool`) and inappropriate use of `int` for values that must not be negative. The second was refactoring out the delayed and non-delayed paths that can be taken. The third was creating a much higher degree of re-use and re-usability where possible with clarified names for parameters to better indicate what they do.

This also applies clang-format to many of the files involved, bringing the code base closer to formatting unity.

This has been tested on a couple of flavors of STM32 target (many thanks to @mubes), and Tiva-C (JTAG and SWD) without any sign of regressions caused by it.