### PR TITLE
misc: Added the libusb-dev BMDA to the GHA main build workflow

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: numworks/setup-arm-toolchain@2020-q4
 
       - name: Install BMDA dependencies
-        run: sudo apt-get -y install libftdi1-dev libhidapi-dev
+        run: sudo apt-get -y install libusb-dev libftdi1-dev libhidapi-dev
 
       # Runs a single command using the runners shell
       - name: Build all platform firmwares and Linux BMDA


### PR DESCRIPTION
During cleanup of the BMDA build system, a proper dependency on libusb was established, but no added to the main branch GHA workflow. This PR rectifies that.