### PR TITLE
Feature: Switch to C11

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: 'bugprone-*,cert-*,clang-analyzer-*,misc-*,modernize-*,portability-*,performance-*,readability-*,-readability-magic-numbers,-readability-braces-around-statements'
+Checks: 'bugprone-*,cert-*,clang-analyzer-*,misc-*,modernize-*,portability-*,performance-*,readability-*,-readability-magic-numbers,-readability-braces-around-statements,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
 FormatStyle: 'none'
 HeaderFilterRegex: '(src|upgrade)/.+'
 AnalyzeTemporaryDtors: false

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ Q := @
 endif
 
 CFLAGS += -Wall -Wextra -Werror -Wno-char-subscripts \
-	-std=gnu99 -g3 -MD -I./target \
+	-std=c11 -g3 -MD -I./target \
 	-I. -Iinclude -I$(PLATFORM_DIR)
 
 ifeq ($(ENABLE_DEBUG), 1)

--- a/src/command.c
+++ b/src/command.c
@@ -42,6 +42,8 @@
 #	include "traceswo.h"
 #endif
 
+#include <alloca.h>
+
 static bool cmd_version(target *t, int argc, char **argv);
 static bool cmd_help(target *t, int argc, char **argv);
 
@@ -117,6 +119,9 @@ int command_process(target *t, char *cmd)
 	for(char *s = cmd; *s; s++)
 		if((*s == ' ') || (*s == '\t')) argc++;
 
+	/* This needs replacing with something more sensible.
+	 * It should be pinging -Wvla among other things, and it failing is straight-up UB
+	 */
 	argv = alloca(sizeof(const char *) * argc);
 
 	/* Tokenize cmd to find argv */

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -39,6 +39,8 @@
 #include "rtt.h"
 #endif
 
+#include <alloca.h>
+
 enum gdb_signal {
 	GDB_SIGINT = 2,
 	GDB_SIGTRAP = 5,
@@ -361,6 +363,8 @@ static void exec_q_rcmd(const char *packet,int len)
 
 	/* calculate size and allocate buffer for command */
 	datalen = len / 2;
+	// This needs replacing with something more sensible.
+	// It should be pinging -Wvla among other things, and it failing is straight-up UB
 	data = alloca(datalen + 1);
 	/* dehexify command */
 	unhexify(data, packet, datalen);

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -21,9 +21,8 @@
 #ifndef __GENERAL_H
 #define __GENERAL_H
 
-#if !defined(_GNU_SOURCE)
-# define _GNU_SOURCE
-#endif
+#define _GNU_SOURCE
+#define _DEFAULT_SOURCE
 #if !defined(__USE_MINGW_ANSI_STDIO)
 # define __USE_MINGW_ANSI_STDIO 1
 #endif

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -59,7 +59,7 @@ static void jtagtap_reset(void)
 	if (platform_hwversion() == 0) {
 		gpio_clear(TRST_PORT, TRST_PIN);
 		for (volatile size_t i = 0; i < 10000; i++)
-			asm("nop");
+			__asm__("nop");
 		gpio_set(TRST_PORT, TRST_PIN);
 	}
 #endif

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -92,7 +92,7 @@ void platform_nrst_set_val(bool assert)
 	volatile int i;
 	if (assert) {
 		gpio_clear(NRST_PORT, NRST_PIN);
-		for(i = 0; i < 10000; i++) asm("nop");
+		for(i = 0; i < 10000; i++) __asm__("nop");
 	} else {
 		gpio_set(NRST_PORT, NRST_PIN);
 	}

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -108,7 +108,7 @@ int platform_hwversion(void)
 		gpio_set(GPIOB, hwversion_pins);
 
 		/* Wait a little to make sure the pull up is in effect... */
-		for(int i = 0; i < 100; i++) asm("nop");
+		for(int i = 0; i < 100; i++) __asm__("nop");
 
 		/* Get all pins that are pulled low in hardware.
 		 * This also sets all the "unused" pins to 1.
@@ -119,7 +119,7 @@ int platform_hwversion(void)
 		gpio_clear(GPIOB, hwversion_pins);
 
 		/* Wait a little to make sure the pull down is in effect... */
-		for(int i = 0; i < 100; i++) asm("nop");
+		for(int i = 0; i < 100; i++) __asm__("nop");
 
 		/* Get all the pins that are pulled high in hardware. */
 		uint16_t pins_positive = gpio_get(GPIOB, hwversion_pins);
@@ -243,7 +243,7 @@ void platform_nrst_set_val(bool assert)
 		gpio_set_val(NRST_PORT, NRST_PIN, !assert);
 	}
 	if (assert) {
-		for(int i = 0; i < 10000; i++) asm("nop");
+		for(int i = 0; i < 10000; i++) __asm__("nop");
 	}
 }
 

--- a/src/platforms/stm32/dfu_f1.c
+++ b/src/platforms/stm32/dfu_f1.c
@@ -105,10 +105,9 @@ void dfu_jump_app_if_valid(void)
 		/* Set vector table base address */
 		SCB_VTOR = app_address & 0x1FFFFF; /* Max 2 MByte Flash*/
 		/* Initialise master stack pointer */
-		asm volatile ("msr msp, %0"::"g"
+		__asm__ volatile("msr msp, %0"::"g"
 				(*(volatile uint32_t*)app_address));
 		/* Jump to application */
 		(*(void(**)())(app_address + 4))();
 	}
 }
-

--- a/src/platforms/stm32/dfu_f4.c
+++ b/src/platforms/stm32/dfu_f4.c
@@ -101,10 +101,9 @@ void dfu_jump_app_if_valid(void)
 		SCB_VTOR = app_address & 0x1FFFFF; /* Max 2 MByte Flash*/
 #endif
 		/* Initialise master stack pointer */
-		asm volatile ("msr msp, %0"::"g"
+		__asm__ volatile("msr msp, %0"::"g"
 		              (*(volatile uint32_t*)app_address));
 		/* Jump to application */
 		(*(void(**)())(app_address + 4))();
 	}
 }
-

--- a/src/platforms/stm32/gdb_if.c
+++ b/src/platforms/stm32/gdb_if.c
@@ -81,7 +81,7 @@ static void gdb_if_update_buf(void)
 {
 	while (cdcacm_get_config() != 1);
 #ifdef STM32F4
-	asm volatile ("cpsid i; isb");
+	__asm__ volatile("cpsid i; isb");
 	if (count_new) {
 		memcpy(buffer_out, double_buffer_out, count_new);
 		count_out = count_new;
@@ -89,7 +89,7 @@ static void gdb_if_update_buf(void)
 		out_ptr = 0;
 		usbd_ep_nak_set(usbdev, CDCACM_GDB_ENDPOINT, 0);
 	}
-	asm volatile ("cpsie i; isb");
+	__asm__ volatile("cpsie i; isb");
 #else
 	count_out = usbd_ep_read_packet(usbdev, CDCACM_GDB_ENDPOINT,
 	                                buffer_out, CDCACM_PACKET_SIZE);
@@ -129,4 +129,3 @@ unsigned char gdb_if_getchar_to(int timeout)
 
 	return -1;
 }
-

--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -629,7 +629,7 @@ void debug_monitor_handler_c(struct ex_frame *sp)
 
 }
 
-asm(".globl debug_monitor_handler\n"
+__asm__(".globl debug_monitor_handler\n"
     ".thumb_func\n"
     "debug_monitor_handler: \n"
     "    mov r0, sp\n"

--- a/src/target/flashstub/stub.h
+++ b/src/target/flashstub/stub.h
@@ -23,8 +23,7 @@
 static inline void __attribute__((always_inline))
 stub_exit(const int code)
 {
-	asm("bkpt %0"::"i"(code));
+	__asm__("bkpt %0"::"i"(code));
 }
 
 #endif
-

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -466,10 +466,10 @@ static bool rp_attach(target *t)
 	if (!cortexm_attach(t))
 		return false;
 
-	struct rp_priv_s *ps = (struct rp_priv_s *)t->target_storage;
-	uint16_t *table = alloca(RP_MAX_TABLE_SIZE);
-	uint16_t table_offset = target_mem_read32(t, BOOTROM_MAGIC_ADDR + 4);
-	if (!table || target_mem_read(t, table, table_offset, RP_MAX_TABLE_SIZE))
+	struct rp_priv_s *ps = (struct rp_priv_s*)t->target_storage;
+	uint16_t table[RP_MAX_TABLE_SIZE];
+	uint16_t table_offset = target_mem_read32( t, BOOTROM_MAGIC_ADDR + 4);
+	if (target_mem_read(t, table, table_offset, RP_MAX_TABLE_SIZE))
 		return false;
 	if (rp2040_fill_table(ps, table, RP_MAX_TABLE_SIZE))
 		return false;


### PR DESCRIPTION
This PR splits PR #1092 to stage and merge the switch to C11 component, which then also fixes #1120.

Fairly straight-forwardly, this fixes up standards violations that prevent the clean compilation of the code in C11 mode without changing what anything is doing. This includes upgrading libopencm3 and bringing consistency to how we write inline assembly statements.

The other major thing that had to be changed was including the proper header for alloca and marking all presently un-fixable uses as a bug due to the dangers of accidentally overflowing or smashing the stack with alloca.

Sorting out a setup to test the code in #1092 is proving time-consuming and difficult, so this gets the biggest pre-requisite part of that PR out the way.