### PR TITLE
dap: Allow recovery from protocol errors

### DIFF
--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -333,7 +333,7 @@ static uint32_t wait_word(uint8_t *buf, int size, int len, uint8_t *dp_fault)
 			break;
 	} while (buf[1] == DAP_TRANSFER_WAIT);
 
-	if(buf[1] == SWDP_ACK_FAULT) {
+	if (buf[1] != DAP_TRANSFER_OK && buf[1] != DAP_TRANSFER_NO_TARGET) {
 		*dp_fault = 1;
 		return 0;
 	}


### PR DESCRIPTION
Tested with picoprobe against another Pico and code that casual injected
errors, 09 as in #1105 and 2 for wait. Exception for NO_TARGET is needed to
detect the recovery AP of the RP2040.