### PR TITLE
general: check _DEFAULT_SOURCE and _GNU_SOURCE

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -21,8 +21,12 @@
 #ifndef __GENERAL_H
 #define __GENERAL_H
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
+#endif
 #if !defined(__USE_MINGW_ANSI_STDIO)
 # define __USE_MINGW_ANSI_STDIO 1
 #endif


### PR DESCRIPTION
The _DEFAULT_SOURCE and _GNU_SOURCE defines must exist in order to
enable certian glibc features. Therefore, it is common to define these
either in header files or on the command line.

Some platforms define these in their system headers. For example,
ESP-IDF defines this in their `features.h` file. This results in
a clash when blackmagic is compiled.

Check that these defines do not already exist prior to defining them.