### PR TITLE
black pill with stm32f401cc

### DIFF
--- a/src/platforms/stm32/blackpillv2.ld
+++ b/src/platforms/stm32/blackpillv2.ld
@@ -20,8 +20,8 @@
 /* Define memory regions. */
 MEMORY
 {
-	rom (rx) : ORIGIN = 0x08000000, LENGTH = 512K
-	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 96K
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 256K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
 }
 
 /* Include the common ld script from libopenstm32. */


### PR DESCRIPTION
Linker script for black pill with stm32f401cc processor (256kbyte flash, 64kbyte ram).
Build with:
```
make PROBE_HOST=blackpillv2 BLACKPILL_F401CC=1
```