### PR TITLE
Feature: JTAG TAP RISC-V prep

### DIFF
--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -49,6 +49,7 @@ typedef struct jtag_proc_s {
 	 */
 	void (*jtagtap_tdi_tdo_seq)(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 	void (*jtagtap_tdi_seq)(const bool final_tms, const uint8_t *data_in, size_t clock_cycles);
+	void (*jtagtap_cycle)(const bool tms, const bool tdi, const size_t clock_cycles);
 } jtag_proc_t;
 
 extern jtag_proc_t jtag_proc;

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -50,6 +50,13 @@ typedef struct jtag_proc_s {
 	void (*jtagtap_tdi_tdo_seq)(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 	void (*jtagtap_tdi_seq)(const bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 	void (*jtagtap_cycle)(const bool tms, const bool tdi, const size_t clock_cycles);
+
+	/*
+	 * Some debug controllers such as the RISC-V debug controller use idle
+	 * cycles during operations as part of their function, while others
+	 * allow the desirable skipping of the entire state under some circumstances.
+	 */
+	uint8_t tap_idle_cycles;
 } jtag_proc_t;
 
 extern jtag_proc_t jtag_proc;
@@ -64,7 +71,7 @@ extern jtag_proc_t jtag_proc;
 #define jtagtap_shift_dr() jtag_proc.jtagtap_tms_seq(0x01, 3)
 
 /* Goto Run-test/Idle: 1, 1, 0 */
-#define jtagtap_return_idle() jtag_proc.jtagtap_tms_seq(0x01, 2)
+#define jtagtap_return_idle(cycles) jtag_proc.jtagtap_tms_seq(0x01, (cycles) + 1U)
 
 #if PC_HOSTED == 1
 int platform_jtagtap_init(void);

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -45,6 +45,7 @@ int jtagtap_init()
 	jtag_proc.jtagtap_tdi_tdo_seq = jtagtap_tdi_tdo_seq;
 	jtag_proc.jtagtap_tdi_seq = jtagtap_tdi_seq;
 	jtag_proc.jtagtap_cycle = jtagtap_cycle;
+	jtag_proc.tap_idle_cycles = 1;
 
 	/* Go to JTAG mode for SWJ-DP */
 	for (size_t i = 0; i <= 50U; ++i)

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -139,7 +139,7 @@ static void jtagtap_tdi_tdo_seq(uint8_t *const data_out, const bool final_tms, c
 
 		length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
 		if (!length || buffer[0] == REMOTE_RESP_ERR) {
-			DEBUG_WARN("jtagtap_tms_seq failed, error %s\n", length ? buffer + 1 : "unknown");
+			DEBUG_WARN("jtagtap_tdi_tdo_seq failed, error %s\n", length ? buffer + 1 : "unknown");
 			exit(-1);
 		}
 		if (data_out) {

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -48,19 +48,17 @@ int remote_jtagtap_init(jtag_proc_t *jtag_proc)
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;
 
-	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "%s",
-				 REMOTE_JTAG_INIT_STR);
+	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_JTAG_INIT_STR);
 	platform_buffer_write(construct, s);
 
 	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
-      DEBUG_WARN("jtagtap_init failed, error %s\n",
-			  s ? (char *)&(construct[1]) : "unknown");
-      exit(-1);
-    }
+		DEBUG_WARN("jtagtap_init failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
+		exit(-1);
+	}
 
 	jtag_proc->jtagtap_reset = jtagtap_reset;
-	jtag_proc->jtagtap_next =jtagtap_next;
+	jtag_proc->jtagtap_next = jtagtap_next;
 	jtag_proc->jtagtap_tms_seq = jtagtap_tms_seq;
 	jtag_proc->jtagtap_tdi_tdo_seq = jtagtap_tdi_tdo_seq;
 	jtag_proc->jtagtap_tdi_seq = jtagtap_tdi_seq;
@@ -82,16 +80,14 @@ static void jtagtap_reset(void)
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;
 
-	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "%s",
-				 REMOTE_JTAG_RESET_STR);
+	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_JTAG_RESET_STR);
 	platform_buffer_write(construct, s);
 
 	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("jtagtap_reset failed, error %s\n",
-				s ? (char *)&(construct[1]) : "unknown");
+		DEBUG_WARN("jtagtap_reset failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
 		exit(-1);
-    }
+	}
 }
 
 static void jtagtap_tms_seq(uint32_t MS, size_t ticks)
@@ -99,16 +95,14 @@ static void jtagtap_tms_seq(uint32_t MS, size_t ticks)
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;
 
-	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE,
-				 REMOTE_JTAG_TMS_STR, ticks, MS);
+	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_TMS_STR, ticks, MS);
 	platform_buffer_write(construct, s);
 
 	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("jtagtap_tms_seq failed, error %s\n",
-				s ? (char *)&(construct[1]) : "unknown");
+		DEBUG_WARN("jtagtap_tms_seq failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
 		exit(-1);
-    }
+	}
 }
 
 /* At least up to v1.7.1-233, remote handles only up to 32 ticks in one
@@ -122,7 +116,7 @@ static void jtagtap_tdi_tdo_seq(uint8_t *DO, const bool final_tms, const uint8_t
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;
 
-	if(!ticks || (!DI && !DO))
+	if (!ticks || (!DI && !DO))
 		return;
 	while (ticks) {
 		int chunk;
@@ -142,17 +136,13 @@ static void jtagtap_tdi_tdo_seq(uint8_t *DO, const bool final_tms, const uint8_t
 			}
 		}
 		/* PRIx64 differs with system. Use it explicit in the format string*/
-		s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE,
-					 "!J%c%02x%" PRIx64 "%c",
-					 (!ticks && final_tms) ?
-					 REMOTE_TDITDO_TMS : REMOTE_TDITDO_NOTMS,
-					 chunk, di, REMOTE_EOM);
-		platform_buffer_write(construct,s);
+		s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "!J%c%02x%" PRIx64 "%c",
+			(!ticks && final_tms) ? REMOTE_TDITDO_TMS : REMOTE_TDITDO_NOTMS, chunk, di, REMOTE_EOM);
+		platform_buffer_write(construct, s);
 
 		s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 		if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
-			DEBUG_WARN("jtagtap_tms_seq failed, error %s\n",
-					   s ? (char *)&(construct[1]) : "unknown");
+			DEBUG_WARN("jtagtap_tms_seq failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
 			exit(-1);
 		}
 		if (DO) {
@@ -167,7 +157,7 @@ static void jtagtap_tdi_tdo_seq(uint8_t *DO, const bool final_tms, const uint8_t
 
 static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *DI, size_t ticks)
 {
-	return jtagtap_tdi_tdo_seq(NULL,  final_tms, DI, ticks);
+	return jtagtap_tdi_tdo_seq(NULL, final_tms, DI, ticks);
 }
 
 static bool jtagtap_next(bool dTMS, bool dTDI)
@@ -175,17 +165,15 @@ static bool jtagtap_next(bool dTMS, bool dTDI)
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s;
 
-	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_NEXT,
-				 dTMS ? '1' : '0', dTDI ? '1' : '0');
+	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_NEXT, dTMS ? '1' : '0', dTDI ? '1' : '0');
 
 	platform_buffer_write(construct, s);
 
 	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("jtagtap_next failed, error %s\n",
-				s ? (char *)&(construct[1]) : "unknown");
+		DEBUG_WARN("jtagtap_next failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
 		exit(-1);
-    }
+	}
 
 	return remotehston(-1, (char *)&construct[1]);
 }

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -50,15 +50,13 @@ static inline unsigned int bool_to_int(const bool value)
 
 int remote_jtagtap_init(jtag_proc_t *jtag_proc)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
-	int s;
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_JTAG_INIT_STR);
+	platform_buffer_write((uint8_t *)buffer, length);
 
-	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_JTAG_INIT_STR);
-	platform_buffer_write(construct, s);
-
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("jtagtap_init failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
+	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	if ((!length) || (buffer[0] == REMOTE_RESP_ERR)) {
+		DEBUG_WARN("jtagtap_init failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 
@@ -69,8 +67,8 @@ int remote_jtagtap_init(jtag_proc_t *jtag_proc)
 	jtag_proc->jtagtap_tdi_seq = jtagtap_tdi_seq;
 
 	platform_buffer_write((uint8_t *)REMOTE_HL_CHECK_STR, sizeof(REMOTE_HL_CHECK_STR));
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if (!s || construct[0] == REMOTE_RESP_ERR || construct[0] == 1)
+	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	if (!length || buffer[0] == REMOTE_RESP_ERR || buffer[0] == 1)
 		PRINT_INFO("Firmware does not support newer JTAG commands, please update it.");
 	else
 		jtag_proc->jtagtap_cycle = jtagtap_cycle;

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -82,15 +82,11 @@ int remote_jtagtap_init(jtag_proc_t *jtag_proc)
 
 static void jtagtap_reset(void)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
-	int s;
-
-	s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_JTAG_RESET_STR);
-	platform_buffer_write(construct, s);
-
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("jtagtap_reset failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
+	platform_buffer_write((uint8_t *)REMOTE_JTAG_RESET_STR, sizeof(REMOTE_JTAG_RESET_STR));
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	const int length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	if (!length || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("jtagtap_reset failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 }

--- a/src/remote.h
+++ b/src/remote.h
@@ -146,8 +146,11 @@
 #define REMOTE_JTAG_CYCLE_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_CYCLE, '%', 'u', '%', 'u', \
 	'%', '0', '8', 'x', REMOTE_EOM, 0 }
 
-#define REMOTE_JTAG_NEXT (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_NEXT, \
-                                       '%','c','%','c',REMOTE_EOM, 0 }
+#define REMOTE_JTAG_NEXT                                                               \
+	(char[])                                                                           \
+	{                                                                                  \
+		REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_NEXT, '%', 'u', '%', 'u', REMOTE_EOM, 0 \
+	}
 /* HL protocol elements */
 #define HEX '%', '0', '2', 'x'
 #define HEX_U32(x) '%', '0', '8', 'x'

--- a/src/remote.h
+++ b/src/remote.h
@@ -24,7 +24,7 @@
 #include <inttypes.h>
 #include "general.h"
 
-#define REMOTE_HL_VERSION 1
+#define REMOTE_HL_VERSION 2
 
 /*
  * Commands to remote end, and responses
@@ -65,6 +65,7 @@
 #define REMOTE_START        'A'
 #define REMOTE_TDITDO_TMS   'D'
 #define REMOTE_TDITDO_NOTMS 'd'
+#define REMOTE_CYCLE        'c'
 #define REMOTE_IN_PAR       'I'
 #define REMOTE_FREQ_SET     'F'
 #define REMOTE_FREQ_GET     'f'
@@ -141,6 +142,9 @@
 
 #define REMOTE_JTAG_TDIDO_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, '%', 'c', \
       '%','0','2','x','%','l', 'x', REMOTE_EOM, 0 }
+
+#define REMOTE_JTAG_CYCLE_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_CYCLE, '%', 'u', '%', 'u', \
+	'%', '0', '8', 'x', REMOTE_EOM, 0 }
 
 #define REMOTE_JTAG_NEXT (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_NEXT, \
                                        '%','c','%','c',REMOTE_EOM, 0 }

--- a/src/remote.h
+++ b/src/remote.h
@@ -143,8 +143,11 @@
 #define REMOTE_JTAG_TDIDO_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, '%', 'c', \
       '%','0','2','x','%','l', 'x', REMOTE_EOM, 0 }
 
-#define REMOTE_JTAG_CYCLE_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_CYCLE, '%', 'u', '%', 'u', \
-	'%', '0', '8', 'x', REMOTE_EOM, 0 }
+#define REMOTE_JTAG_CYCLE_STR                                                                               \
+	(char[])                                                                                                \
+	{                                                                                                       \
+		REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_CYCLE, '%', 'u', '%', 'u', '%', '0', '8', 'x', REMOTE_EOM, 0 \
+	}
 
 #define REMOTE_JTAG_NEXT                                                               \
 	(char[])                                                                           \

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -146,7 +146,7 @@ int jtag_scan(const uint8_t *irlens)
 
 	DEBUG_INFO("Return to Run-Test/Idle\n");
 	jtag_proc.jtagtap_next(1, 1);
-	jtagtap_return_idle();
+	jtagtap_return_idle(1);
 
 	/* All devices should be in BYPASS now */
 
@@ -165,7 +165,7 @@ int jtag_scan(const uint8_t *irlens)
 
 	DEBUG_INFO("Return to Run-Test/Idle\n");
 	jtag_proc.jtagtap_next(1, 1);
-	jtagtap_return_idle();
+	jtagtap_return_idle(1);
 	if(!jtag_dev_count) {
 		return 0;
 	}
@@ -187,7 +187,7 @@ int jtag_scan(const uint8_t *irlens)
 	}
 	DEBUG_INFO("Return to Run-Test/Idle\n");
 	jtag_proc.jtagtap_next(1, 1);
-	jtagtap_return_idle();
+	jtagtap_return_idle(jtag_proc.tap_idle_cycles);
 #if PC_HOSTED == 1
 	/*Transfer needed device information to firmware jtag_devs*/
 	for(i = 0; i < jtag_dev_count; i++)
@@ -235,7 +235,7 @@ void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir)
 	jp->jtagtap_tdi_seq(0, ones, d->ir_prescan);
 	jp->jtagtap_tdi_seq(d->ir_postscan?0:1, (void*)&ir, d->ir_len);
 	jp->jtagtap_tdi_seq(1, ones, d->ir_postscan);
-	jtagtap_return_idle();
+	jtagtap_return_idle(1);
 }
 
 void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks)
@@ -248,6 +248,5 @@ void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const u
 	else
 		jp->jtagtap_tdi_seq(d->dr_postscan?0:1, (void*)din, ticks);
 	jp->jtagtap_tdi_seq(1, ones, d->dr_postscan);
-	jtagtap_return_idle();
+	jtagtap_return_idle(1);
 }
-


### PR DESCRIPTION
This PR finishes the cleanup of the JTAG TAP code and adds a couple of new things needed for supporting buggy targets and RISC-V debugging.

The two new items this introduces are:

* Support for running the JTAG clock for a number of cycles with fixed TDI and TMS pin values
* Support for skipping or dwelling in the JTAG Idle state as required

This should mark the last of the RISC-V support setup.