### PR TITLE
Fix: ADIv5 AP scan early bailout

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -773,9 +773,9 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 
 	/* Probe for APs on this DP */
 	uint32_t last_base = 0;
-	size_t void_aps = 0;
+	size_t invalid_aps = 0;
 	dp->refcnt++;
-	for (size_t i = 0; i < 256 && void_aps < 8; ++i) {
+	for (size_t i = 0; i < 256 && invalid_aps < 8; ++i) {
 		ADIv5_AP_t *ap = NULL;
 #if PC_HOSTED == 1
 		if ((!dp->ap_setup) || dp->ap_setup(i))
@@ -788,7 +788,7 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 			if (dp->ap_cleanup)
 				dp->ap_cleanup(i);
 #endif
-			if (++void_aps == 8) {
+			if (++invalid_aps == 8) {
 				adiv5_dp_unref(dp);
 				return;
 			}

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -773,9 +773,9 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 
 	/* Probe for APs on this DP */
 	uint32_t last_base = 0;
-	int void_aps = 0;
+	size_t void_aps = 0;
 	dp->refcnt++;
-	for (int i = 0; (i < 256) && (void_aps < 8); i++) {
+	for (size_t i = 0; i < 256 && void_aps < 8; ++i) {
 		ADIv5_AP_t *ap = NULL;
 #if PC_HOSTED == 1
 		if ((!dp->ap_setup) || dp->ap_setup(i))
@@ -784,17 +784,15 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 		ap = adiv5_new_ap(dp, i);
 #endif
 		if (ap == NULL) {
-			void_aps++;
 #if PC_HOSTED == 1
 			if (dp->ap_cleanup)
 				dp->ap_cleanup(i);
 #endif
-			if (i == 0) {
+			if (++void_aps == 8) {
 				adiv5_dp_unref(dp);
 				return;
-			} else {
-				continue;
 			}
+			continue;
 		}
 		if (ap->base == last_base) {
 			DEBUG_WARN("AP %d: Duplicate base\n", i);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -618,7 +618,6 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, const size_t re
 				dev_type, arch_id);
 		}
 	}
-	return;
 }
 
 ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel)


### PR DESCRIPTION
the ADIv5 AP scan bails out too early (on the first encountered invalid AP) rather than after 8 invalid APs.

This was a regression introduced by cda83d30 because that commit checks the wrong loop variable, and then checks the variable against the wrong value. We also fixed the nomenclature up as the code was a litte hard to understand.

This PR fixes this behaviour, fixing #1134.