### PR TITLE
Feature: monitor command reformatting and cleanup

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -587,19 +587,17 @@ static bool cmd_traceswo(target *t, int argc, const char **argv)
 			}
 		}
 	}
-#if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0) && defined(ENABLE_DEBUG)
-	if (debug_bmp) {
+
 #if TRACESWO_PROTOCOL == 2
-		gdb_outf("baudrate: %lu ", baudrate);
+	gdb_outf("Baudrate: %lu ", baudrate);
 #endif
-		gdb_outf("channel mask: ");
-		for (size_t i = 0; i < 32; ++i) {
-			const uint32_t bit = (swo_channelmask >> (31U - i)) & 1U;
-			gdb_outf("%" PRIu32, bit);
-		}
-		gdb_outf("\n");
+	gdb_outf("Channel mask: ");
+	for (size_t i = 0; i < 32; ++i) {
+		const uint32_t bit = (swo_channelmask >> (31U - i)) & 1U;
+		gdb_outf("%" PRIu32, bit);
 	}
-#endif
+	gdb_outf("\n");
+
 #if TRACESWO_PROTOCOL == 2
 	traceswo_init(baudrate, swo_channelmask);
 #else
@@ -608,7 +606,7 @@ static bool cmd_traceswo(target *t, int argc, const char **argv)
 
 	char serial_no[DFU_SERIAL_LENGTH];
 	serial_no_read(serial_no);
-	gdb_outf("Trace enabled for serial %s, USB EP 5\n", serial_no);
+	gdb_outf("Trace enabled for BMP serial %s, USB EP 5\n", serial_no);
 	return true;
 }
 #endif

--- a/src/command.c
+++ b/src/command.c
@@ -458,9 +458,9 @@ static bool cmd_tdi_low_reset(target *t, int argc, const char **argv)
 static bool cmd_target_power(target *t, int argc, const char **argv)
 {
 	(void)t;
-	if (argc == 1) {
+	if (argc == 1)
 		gdb_outf("Target Power: %s\n", platform_target_get_power() ? "enabled" : "disabled");
-	} else if (argc == 2) {
+	else if (argc == 2) {
 		bool want_enable = false;
 		if (parse_enable_or_disable(argv[1], &want_enable)) {
 			if (want_enable && !platform_target_get_power() &&
@@ -472,9 +472,8 @@ static bool cmd_target_power(target *t, int argc, const char **argv)
 				gdb_outf("%s target power\n", want_enable ? "Enabling" : "Disabling");
 			}
 		}
-	} else {
+	} else
 		gdb_outf("Unrecognized command format\n");
-	}
 	return true;
 }
 #endif

--- a/src/command.c
+++ b/src/command.c
@@ -356,14 +356,13 @@ bool cmd_frequency(target *t, int argc, const char **argv)
 static void display_target(int i, target *t, void *context)
 {
 	(void)context;
-	if (!strcmp(target_driver_name(t), "ARM Cortex-M")) {
-		gdb_outf("***%2d%sUnknown %s Designer 0x%03x Partno 0x%03x %s\n", i, target_attached(t) ? " * " : " ",
-			target_driver_name(t), target_designer(t), target_idcode(t),
-			(target_core_name(t)) ? target_core_name(t) : "");
-	} else {
-		gdb_outf("%2d   %c  %s %s\n", i, target_attached(t) ? '*' : ' ', target_driver_name(t),
-			(target_core_name(t)) ? target_core_name(t) : "");
-	}
+	const char attached = target_attached(t) ? '*' : ' ';
+	const char *const core_name = target_core_name(t);
+	if (!strcmp(target_driver_name(t), "ARM Cortex-M"))
+		gdb_outf("***%2d %c Unknown %s Designer 0x%03x Partno 0x%03x %s\n", i, attached, target_driver_name(t),
+			target_designer(t), target_idcode(t), core_name ? core_name : "");
+	else
+		gdb_outf("%2d   %c  %s %s\n", i, attached, target_driver_name(t), core_name ? core_name : "");
 }
 
 bool cmd_targets(target *t, int argc, const char **argv)

--- a/src/command.c
+++ b/src/command.c
@@ -410,15 +410,13 @@ static bool cmd_connect_reset(target *t, int argc, const char **argv)
 {
 	(void)t;
 	bool print_status = false;
-	if (argc == 1) {
+	if (argc == 1)
 		print_status = true;
-	} else if (argc == 2) {
-		if (parse_enable_or_disable(argv[1], &connect_assert_nrst)) {
+	else if (argc == 2) {
+		if (parse_enable_or_disable(argv[1], &connect_assert_nrst))
 			print_status = true;
-		}
-	} else {
-		gdb_outf("Unrecognized command format\n");
-	}
+	} else
+		gdb_out("Unrecognized command format\n");
 
 	if (print_status) {
 		gdb_outf("Assert nRST during connect: %s\n", connect_assert_nrst ? "enabled" : "disabled");

--- a/src/command.c
+++ b/src/command.c
@@ -329,23 +329,27 @@ bool cmd_frequency(target *t, int argc, const char **argv)
 {
 	(void)t;
 	if (argc == 2) {
-		char *p;
-		uint32_t frequency = strtol(argv[1], &p, 10);
-		switch (*p) {
+		char *multiplier = NULL;
+		uint32_t frequency = strtoul(argv[1], &multiplier, 10);
+		if (!multiplier) {
+			gdb_outf("Frequency must be an integral value possibly followed by 'k' or 'M'");
+			return false;
+		}
+		switch (*multiplier) {
 		case 'k':
-			frequency *= 1000;
+			frequency *= 1000U;
 			break;
 		case 'M':
-			frequency *= 1000 * 1000;
+			frequency *= 1000U * 1000U;
 			break;
 		}
 		platform_max_frequency_set(frequency);
 	}
-	uint32_t freq = platform_max_frequency_get();
+	const uint32_t freq = platform_max_frequency_get();
 	if (freq == FREQ_FIXED)
 		gdb_outf("SWJ freq fixed\n");
 	else
-		gdb_outf("Max SWJ freq %08" PRIx32 "\n", freq);
+		gdb_outf("Current SWJ freq %" PRIu32 "Hz\n", freq);
 	return true;
 }
 

--- a/src/command.c
+++ b/src/command.c
@@ -193,8 +193,8 @@ static bool cmd_jtag_scan(target *t, int argc, const char **argv)
 
 	if (argc > 1) {
 		/* Accept a list of IR lengths on command line */
-		for (int i = 1; i < argc; i++)
-			irlens[i - 1] = atoi(argv[i]);
+		for (size_t i = 1; i < (size_t)argc; i++)
+			irlens[i - 1] = strtoul(argv[i], NULL, 0);
 		irlens[argc - 1] = 0;
 	}
 

--- a/src/command.c
+++ b/src/command.c
@@ -45,15 +45,15 @@
 
 #include <alloca.h>
 
-static bool cmd_version(target *t, int argc, char **argv);
-static bool cmd_help(target *t, int argc, char **argv);
+static bool cmd_version(target *t, int argc, const char **argv);
+static bool cmd_help(target *t, int argc, const char **argv);
 
-static bool cmd_jtag_scan(target *t, int argc, char **argv);
-static bool cmd_swdp_scan(target *t, int argc, char **argv);
-static bool cmd_auto_scan(target *t, int argc, char **argv);
-static bool cmd_frequency(target *t, int argc, char **argv);
-static bool cmd_targets(target *t, int argc, char **argv);
-static bool cmd_morse(target *t, int argc, char **argv);
+static bool cmd_jtag_scan(target *t, int argc, const char **argv);
+static bool cmd_swdp_scan(target *t, int argc, const char **argv);
+static bool cmd_auto_scan(target *t, int argc, const char **argv);
+static bool cmd_frequency(target *t, int argc, const char **argv);
+static bool cmd_targets(target *t, int argc, const char **argv);
+static bool cmd_morse(target *t, int argc, const char **argv);
 static bool cmd_halt_timeout(target *t, int argc, const char **argv);
 static bool cmd_connect_reset(target *t, int argc, const char **argv);
 static bool cmd_reset(target *t, int argc, const char **argv);
@@ -73,34 +73,34 @@ static bool cmd_debug_bmp(target *t, int argc, const char **argv);
 #endif
 
 const command_t cmd_list[] = {
-	{"version", (cmd_handler)cmd_version, "Display firmware version info"},
-	{"help", (cmd_handler)cmd_help, "Display help for monitor commands"},
-	{"jtag_scan", (cmd_handler)cmd_jtag_scan, "Scan JTAG chain for devices"},
-	{"swdp_scan", (cmd_handler)cmd_swdp_scan, "Scan SW-DP for devices"},
-	{"auto_scan", (cmd_handler)cmd_auto_scan, "Automatically scan all chain types for devices"},
-	{"frequency", (cmd_handler)cmd_frequency, "set minimum high and low times"},
-	{"targets", (cmd_handler)cmd_targets, "Display list of available targets"},
-	{"morse", (cmd_handler)cmd_morse, "Display morse error message"},
-	{"halt_timeout", (cmd_handler)cmd_halt_timeout, "Timeout (ms) to wait until Cortex-M is halted: (Default 2000)"},
-	{"connect_rst", (cmd_handler)cmd_connect_reset, "Configure connect under reset: (enable|disable)"},
-	{"reset", (cmd_handler)cmd_reset, "Pulse the nRST line - disconnects target"},
-	{"tdi_low_reset", (cmd_handler)cmd_tdi_low_reset, "Pulse nRST with TDI set low to attempt to wake certain targets up (eg LPC82x)"},
+	{"version", cmd_version, "Display firmware version info"},
+	{"help", cmd_help, "Display help for monitor commands"},
+	{"jtag_scan", cmd_jtag_scan, "Scan JTAG chain for devices"},
+	{"swdp_scan", cmd_swdp_scan, "Scan SW-DP for devices"},
+	{"auto_scan", cmd_auto_scan, "Automatically scan all chain types for devices"},
+	{"frequency", cmd_frequency, "set minimum high and low times"},
+	{"targets", cmd_targets, "Display list of available targets"},
+	{"morse", cmd_morse, "Display morse error message"},
+	{"halt_timeout", cmd_halt_timeout, "Timeout (ms) to wait until Cortex-M is halted: (Default 2000)"},
+	{"connect_rst", cmd_connect_reset, "Configure connect under reset: (enable|disable)"},
+	{"reset", cmd_reset, "Pulse the nRST line - disconnects target"},
+	{"tdi_low_reset", cmd_tdi_low_reset, "Pulse nRST with TDI set low to attempt to wake certain targets up (eg LPC82x)"},
 #ifdef PLATFORM_HAS_POWER_SWITCH
-	{"tpwr", (cmd_handler)cmd_target_power, "Supplies power to the target: (enable|disable)"},
+	{"tpwr", cmd_target_power, "Supplies power to the target: (enable|disable)"},
 #endif
 #ifdef ENABLE_RTT
-	{"rtt", (cmd_handler)cmd_rtt, "enable|disable|status|channel 0..15|ident (str)|cblock|poll maxms minms maxerr"},
+	{"rtt", cmd_rtt, "enable|disable|status|channel 0..15|ident (str)|cblock|poll maxms minms maxerr"},
 #endif
 #ifdef PLATFORM_HAS_TRACESWO
 #if defined TRACESWO_PROTOCOL && TRACESWO_PROTOCOL == 2
-	{"traceswo", (cmd_handler)cmd_traceswo, "Start trace capture, NRZ mode: (baudrate) (decode channel ...)"},
+	{"traceswo", cmd_traceswo, "Start trace capture, NRZ mode: (baudrate) (decode channel ...)"},
 #else
-	{"traceswo", (cmd_handler)cmd_traceswo, "Start trace capture, Manchester mode: (decode channel ...)"},
+	{"traceswo", cmd_traceswo, "Start trace capture, Manchester mode: (decode channel ...)"},
 #endif
 #endif
-	{"heapinfo", (cmd_handler)cmd_heapinfo, "Set semihosting heapinfo"},
+	{"heapinfo", cmd_heapinfo, "Set semihosting heapinfo"},
 #if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
-	{"debug_bmp", (cmd_handler)cmd_debug_bmp, "Output BMP \"debug\" strings to the second vcom: (enable|disable)"},
+	{"debug_bmp", cmd_debug_bmp, "Output BMP \"debug\" strings to the second vcom: (enable|disable)"},
 #endif
 	{NULL, NULL, NULL},
 };
@@ -146,7 +146,7 @@ int command_process(target *t, char *cmd)
 
 #define BOARD_IDENT "Black Magic Probe" PLATFORM_IDENT FIRMWARE_VERSION
 
-bool cmd_version(target *t, int argc, char **argv)
+bool cmd_version(target *t, int argc, const char **argv)
 {
 	(void)t;
 	(void)argc;
@@ -166,7 +166,7 @@ bool cmd_version(target *t, int argc, char **argv)
 	return true;
 }
 
-bool cmd_help(target *t, int argc, char **argv)
+bool cmd_help(target *t, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
@@ -185,7 +185,7 @@ bool cmd_help(target *t, int argc, char **argv)
 	return true;
 }
 
-static bool cmd_jtag_scan(target *t, int argc, char **argv)
+static bool cmd_jtag_scan(target *t, int argc, const char **argv)
 {
 	(void)t;
 	uint8_t irlens[argc];
@@ -232,7 +232,7 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 	return true;
 }
 
-bool cmd_swdp_scan(target *t, int argc, char **argv)
+bool cmd_swdp_scan(target *t, int argc, const char **argv)
 {
 	(void)t;
 	volatile uint32_t targetid = 0;
@@ -273,7 +273,7 @@ bool cmd_swdp_scan(target *t, int argc, char **argv)
 	return true;
 }
 
-bool cmd_auto_scan(target *t, int argc, char **argv)
+bool cmd_auto_scan(target *t, int argc, const char **argv)
 {
 	(void)t;
 	(void)argc;
@@ -327,7 +327,7 @@ bool cmd_auto_scan(target *t, int argc, char **argv)
 	return true;
 }
 
-bool cmd_frequency(target *t, int argc, char **argv)
+bool cmd_frequency(target *t, int argc, const char **argv)
 {
 	(void)t;
 	if (argc == 2) {
@@ -364,7 +364,7 @@ static void display_target(int i, target *t, void *context)
 	}
 }
 
-bool cmd_targets(target *t, int argc, char **argv)
+bool cmd_targets(target *t, int argc, const char **argv)
 {
 	(void)t;
 	(void)argc;
@@ -379,7 +379,7 @@ bool cmd_targets(target *t, int argc, char **argv)
 	return true;
 }
 
-bool cmd_morse(target *t, int argc, char **argv)
+bool cmd_morse(target *t, int argc, const char **argv)
 {
 	(void)t;
 	(void)argc;

--- a/src/command.c
+++ b/src/command.c
@@ -428,8 +428,8 @@ static bool cmd_halt_timeout(target *t, int argc, const char **argv)
 {
 	(void)t;
 	if (argc > 1)
-		cortexm_wait_timeout = atol(argv[1]);
-	gdb_outf("Cortex-M timeout to wait for device haltes: %d\n", cortexm_wait_timeout);
+		cortexm_wait_timeout = strtoul(argv[1], NULL, 0);
+	gdb_outf("Cortex-M timeout to wait for device halts: %d\n", cortexm_wait_timeout);
 	return true;
 }
 

--- a/src/command.c
+++ b/src/command.c
@@ -389,6 +389,8 @@ bool cmd_morse(target *t, int argc, const char **argv)
 		gdb_outf("%s\n", morse_msg);
 		DEBUG_WARN("%s\n", morse_msg);
 	}
+	else
+		gdb_out("No message\n");
 	return true;
 }
 

--- a/src/command.c
+++ b/src/command.c
@@ -399,20 +399,18 @@ bool cmd_morse(target *t, int argc, char **argv)
 	return true;
 }
 
-bool parse_enable_or_disable(const char *s, bool *out) {
-	if (strlen(s) == 0) {
-		gdb_outf("'enable' or 'disable' argument must be provided\n");
-		return false;
-	} else if (!strncmp(s, "enable", strlen(s))) {
+bool parse_enable_or_disable(const char *value, bool *out)
+{
+	const size_t value_len = strlen(value);
+	if (value_len && !strncmp(value, "enable", value_len))
 		*out = true;
-		return true;
-	} else if (!strncmp(s, "disable", strlen(s))) {
+	else if (value_len && !strncmp(value, "disable", value_len))
 		*out = false;
-		return true;
-	} else {
-		gdb_outf("Argument '%s' not recognized as 'enable' or 'disable'\n", s);
+	else {
+		gdb_out("'enable' or 'disable' argument must be provided\n");
 		return false;
 	}
+	return true;
 }
 
 static bool cmd_connect_reset(target *t, int argc, const char **argv)

--- a/src/command.c
+++ b/src/command.c
@@ -615,23 +615,20 @@ static bool cmd_traceswo(target *t, int argc, const char **argv)
 static bool cmd_debug_bmp(target *t, int argc, const char **argv)
 {
 	(void)t;
-	bool print_status = false;
-	if (argc == 1) {
-		print_status = true;
-	} else if (argc == 2) {
-		if (parse_enable_or_disable(argv[1], &debug_bmp)) {
-			print_status = true;
-		}
-	} else {
-		gdb_outf("Unrecognized command format\n");
+	if (argc == 2) {
+		if (!parse_enable_or_disable(argv[1], &debug_bmp))
+			return false;
+	}
+	else if (argc > 2) {
+		gdb_outf("usage: monitor debug [enable|disable]\n");
+		return false;
 	}
 
-	if (print_status) {
-		gdb_outf("Debug mode is %s\n", debug_bmp ? "enabled" : "disabled");
-	}
+	gdb_outf("Debug mode is %s\n", debug_bmp ? "enabled" : "disabled");
 	return true;
 }
 #endif
+
 static bool cmd_heapinfo(target *t, int argc, const char **argv)
 {
 	if (t == NULL)

--- a/src/command.c
+++ b/src/command.c
@@ -40,7 +40,7 @@
 #endif
 
 #ifdef PLATFORM_HAS_TRACESWO
-#	include "traceswo.h"
+#include "traceswo.h"
 #endif
 
 #include <alloca.h>
@@ -75,34 +75,34 @@ static bool cmd_debug_bmp(target *t, int argc, const char **argv);
 const struct command_s cmd_list[] = {
 	{"version", (cmd_handler)cmd_version, "Display firmware version info"},
 	{"help", (cmd_handler)cmd_help, "Display help for monitor commands"},
-	{"jtag_scan", (cmd_handler)cmd_jtag_scan, "Scan JTAG chain for devices" },
-	{"swdp_scan", (cmd_handler)cmd_swdp_scan, "Scan SW-DP for devices" },
+	{"jtag_scan", (cmd_handler)cmd_jtag_scan, "Scan JTAG chain for devices"},
+	{"swdp_scan", (cmd_handler)cmd_swdp_scan, "Scan SW-DP for devices"},
 	{"auto_scan", (cmd_handler)cmd_auto_scan, "Automatically scan all chain types for devices"},
-	{"frequency", (cmd_handler)cmd_frequency, "set minimum high and low times" },
-	{"targets", (cmd_handler)cmd_targets, "Display list of available targets" },
-	{"morse", (cmd_handler)cmd_morse, "Display morse error message" },
-	{"halt_timeout", (cmd_handler)cmd_halt_timeout, "Timeout (ms) to wait until Cortex-M is halted: (Default 2000)" },
-	{"connect_rst", (cmd_handler)cmd_connect_reset, "Configure connect under reset: (enable|disable)" },
-	{"reset", (cmd_handler)cmd_reset, "Pulse the nRST line - disconnects target" },
+	{"frequency", (cmd_handler)cmd_frequency, "set minimum high and low times"},
+	{"targets", (cmd_handler)cmd_targets, "Display list of available targets"},
+	{"morse", (cmd_handler)cmd_morse, "Display morse error message"},
+	{"halt_timeout", (cmd_handler)cmd_halt_timeout, "Timeout (ms) to wait until Cortex-M is halted: (Default 2000)"},
+	{"connect_rst", (cmd_handler)cmd_connect_reset, "Configure connect under reset: (enable|disable)"},
+	{"reset", (cmd_handler)cmd_reset, "Pulse the nRST line - disconnects target"},
 	{"tdi_low_reset", (cmd_handler)cmd_tdi_low_reset, "Pulse nRST with TDI set low to attempt to wake certain targets up (eg LPC82x)"},
 #ifdef PLATFORM_HAS_POWER_SWITCH
 	{"tpwr", (cmd_handler)cmd_target_power, "Supplies power to the target: (enable|disable)"},
 #endif
 #ifdef ENABLE_RTT
-	{"rtt", (cmd_handler)cmd_rtt, "enable|disable|status|channel 0..15|ident (str)|cblock|poll maxms minms maxerr" },
+	{"rtt", (cmd_handler)cmd_rtt, "enable|disable|status|channel 0..15|ident (str)|cblock|poll maxms minms maxerr"},
 #endif
 #ifdef PLATFORM_HAS_TRACESWO
 #if defined TRACESWO_PROTOCOL && TRACESWO_PROTOCOL == 2
-	{"traceswo", (cmd_handler)cmd_traceswo, "Start trace capture, NRZ mode: (baudrate) (decode channel ...)" },
+	{"traceswo", (cmd_handler)cmd_traceswo, "Start trace capture, NRZ mode: (baudrate) (decode channel ...)"},
 #else
-	{"traceswo", (cmd_handler)cmd_traceswo, "Start trace capture, Manchester mode: (decode channel ...)" },
+	{"traceswo", (cmd_handler)cmd_traceswo, "Start trace capture, Manchester mode: (decode channel ...)"},
 #endif
 #endif
-	{"heapinfo", (cmd_handler)cmd_heapinfo, "Set semihosting heapinfo" },
+	{"heapinfo", (cmd_handler)cmd_heapinfo, "Set semihosting heapinfo"},
 #if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
 	{"debug_bmp", (cmd_handler)cmd_debug_bmp, "Output BMP \"debug\" strings to the second vcom: (enable|disable)"},
 #endif
-	{NULL, NULL, NULL}
+	{NULL, NULL, NULL},
 };
 
 bool connect_assert_nrst;
@@ -119,8 +119,9 @@ int command_process(target *t, char *cmd)
 	const char *part;
 
 	/* Initial estimate for argc */
-	for(char *s = cmd; *s; s++)
-		if((*s == ' ') || (*s == '\t')) argc++;
+	for (char *s = cmd; *s; s++)
+		if ((*s == ' ') || (*s == '\t'))
+			argc++;
 
 	/* This needs replacing with something more sensible.
 	 * It should be pinging -Wvla among other things, and it failing is straight-up UB
@@ -133,7 +134,7 @@ int command_process(target *t, char *cmd)
 		argv[argc++] = part;
 
 	/* Look for match and call handler */
-	for(c = cmd_list; c->cmd; c++) {
+	for (c = cmd_list; c->cmd; c++) {
 		/* Accept a partial match as GDB does.
 		 * So 'mon ver' will match 'monitor version'
 		 */
@@ -177,7 +178,7 @@ bool cmd_help(target *t, int argc, char **argv)
 
 	if (!t || t->tc->destroy_callback) {
 		gdb_out("General commands:\n");
-		for(c = cmd_list; c->cmd; c++)
+		for (c = cmd_list; c->cmd; c++)
 			gdb_outf("\t%s -- %s\n", c->cmd, c->help);
 	}
 	if (!t)
@@ -199,8 +200,8 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 	if (argc > 1) {
 		/* Accept a list of IR lengths on command line */
 		for (int i = 1; i < argc; i++)
-			irlens[i-1] = atoi(argv[i]);
-		irlens[argc-1] = 0;
+			irlens[i - 1] = atoi(argv[i]);
+		irlens[argc - 1] = 0;
 	}
 
 	if (connect_assert_nrst)
@@ -208,7 +209,7 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 
 	int devs = -1;
 	volatile struct exception e;
-	TRY_CATCH(e, EXCEPTION_ALL) {
+	TRY_CATCH (e, EXCEPTION_ALL) {
 #if PC_HOSTED == 1
 		devs = platform_jtag_scan(argc > 1 ? irlens : NULL);
 #else
@@ -240,7 +241,7 @@ bool cmd_swdp_scan(target *t, int argc, char **argv)
 	(void)t;
 	volatile uint32_t targetid = 0;
 	if (argc > 1)
-		targetid  = strtol(argv[1], NULL, 0);
+		targetid = strtol(argv[1], NULL, 0);
 	if (platform_target_voltage())
 		gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
@@ -249,13 +250,13 @@ bool cmd_swdp_scan(target *t, int argc, char **argv)
 
 	int devs = -1;
 	volatile struct exception e;
-	TRY_CATCH(e, EXCEPTION_ALL) {
+	TRY_CATCH (e, EXCEPTION_ALL) {
 #if PC_HOSTED == 1
 		devs = platform_adiv5_swdp_scan(targetid);
 #else
 		devs = adiv5_swdp_scan(targetid);
 #endif
-		}
+	}
 	switch (e.type) {
 	case EXCEPTION_TIMEOUT:
 		gdb_outf("Timeout during scan. Is target stuck in WFI?\n");
@@ -265,7 +266,7 @@ bool cmd_swdp_scan(target *t, int argc, char **argv)
 		break;
 	}
 
-	if(devs <= 0) {
+	if (devs <= 0) {
 		platform_nrst_set_val(false);
 		gdb_out("SW-DP scan failed!\n");
 		return false;
@@ -289,7 +290,7 @@ bool cmd_auto_scan(target *t, int argc, char **argv)
 
 	int devs = -1;
 	volatile struct exception e;
-	TRY_CATCH(e, EXCEPTION_ALL) {
+	TRY_CATCH (e, EXCEPTION_ALL) {
 #if PC_HOSTED == 1
 		devs = platform_jtag_scan(NULL);
 #else
@@ -341,7 +342,7 @@ bool cmd_frequency(target *t, int argc, char **argv)
 			frequency *= 1000;
 			break;
 		case 'M':
-			frequency *= 1000*1000;
+			frequency *= 1000 * 1000;
 			break;
 		}
 		platform_max_frequency_set(frequency);
@@ -352,23 +353,18 @@ bool cmd_frequency(target *t, int argc, char **argv)
 	else
 		gdb_outf("Max SWJ freq %08" PRIx32 "\n", freq);
 	return true;
-
 }
 
 static void display_target(int i, target *t, void *context)
 {
 	(void)context;
 	if (!strcmp(target_driver_name(t), "ARM Cortex-M")) {
-		gdb_outf("***%2d%sUnknown %s Designer 0x%03x Partno 0x%03x %s\n",
-				 i, target_attached(t)?" * ":" ",
-				 target_driver_name(t),
-				 target_designer(t),
-				 target_idcode(t),
-				 (target_core_name(t)) ? target_core_name(t): "");
+		gdb_outf("***%2d%sUnknown %s Designer 0x%03x Partno 0x%03x %s\n", i, target_attached(t) ? " * " : " ",
+			target_driver_name(t), target_designer(t), target_idcode(t),
+			(target_core_name(t)) ? target_core_name(t) : "");
 	} else {
-		gdb_outf("%2d   %c  %s %s\n", i, target_attached(t)?'*':' ',
-				 target_driver_name(t),
-				 (target_core_name(t)) ? target_core_name(t): "");
+		gdb_outf("%2d   %c  %s %s\n", i, target_attached(t) ? '*' : ' ', target_driver_name(t),
+			(target_core_name(t)) ? target_core_name(t) : "");
 	}
 }
 
@@ -428,8 +424,7 @@ static bool cmd_connect_reset(target *t, int argc, const char **argv)
 	}
 
 	if (print_status) {
-		gdb_outf("Assert nRST during connect: %s\n",
-			 connect_assert_nrst ? "enabled" : "disabled");
+		gdb_outf("Assert nRST during connect: %s\n", connect_assert_nrst ? "enabled" : "disabled");
 	}
 	return true;
 }
@@ -439,8 +434,7 @@ static bool cmd_halt_timeout(target *t, int argc, const char **argv)
 	(void)t;
 	if (argc > 1)
 		cortexm_wait_timeout = atol(argv[1]);
-	gdb_outf("Cortex-M timeout to wait for device haltes: %d\n",
-				 cortexm_wait_timeout);
+	gdb_outf("Cortex-M timeout to wait for device haltes: %d\n", cortexm_wait_timeout);
 	return true;
 }
 
@@ -470,14 +464,12 @@ static bool cmd_target_power(target *t, int argc, const char **argv)
 {
 	(void)t;
 	if (argc == 1) {
-		gdb_outf("Target Power: %s\n",
-			 platform_target_get_power() ? "enabled" : "disabled");
+		gdb_outf("Target Power: %s\n", platform_target_get_power() ? "enabled" : "disabled");
 	} else if (argc == 2) {
 		bool want_enable = false;
 		if (parse_enable_or_disable(argv[1], &want_enable)) {
-			if (want_enable
-				&& !platform_target_get_power()
-				&& platform_target_voltage_sense() > POWER_CONFLICT_THRESHOLD) {
+			if (want_enable && !platform_target_get_power() &&
+				platform_target_voltage_sense() > POWER_CONFLICT_THRESHOLD) {
 				/* want to enable target power, but VREF > 0.5V sensed -> cancel */
 				gdb_outf("Target already powered (%s)\n", platform_target_voltage());
 			} else {
@@ -493,8 +485,9 @@ static bool cmd_target_power(target *t, int argc, const char **argv)
 #endif
 
 #ifdef ENABLE_RTT
-const char* onoroffstr[2] = {"off", "on"};
-static const char* onoroff(bool bval) {
+const char *onoroffstr[2] = {"off", "on"};
+static const char *onoroff(bool bval)
+{
 	return bval ? onoroffstr[1] : onoroffstr[0];
 }
 
@@ -504,27 +497,25 @@ static bool cmd_rtt(target *t, int argc, const char **argv)
 	if ((argc == 1) || ((argc == 2) && !strncmp(argv[1], "enabled", strlen(argv[1])))) {
 		rtt_enabled = true;
 		rtt_found = false;
-	}
-	else if ((argc == 2) && !strncmp(argv[1], "disabled", strlen(argv[1]))) {
+	} else if ((argc == 2) && !strncmp(argv[1], "disabled", strlen(argv[1]))) {
 		rtt_enabled = false;
 		rtt_found = false;
-	}
-	else if ((argc == 2) && !strncmp(argv[1], "status", strlen(argv[1]))) {
-		gdb_outf("rtt: %s found: %s ident: ",
-			onoroff(rtt_enabled), rtt_found ? "yes" : "no");
+	} else if ((argc == 2) && !strncmp(argv[1], "status", strlen(argv[1]))) {
+		gdb_outf("rtt: %s found: %s ident: ", onoroff(rtt_enabled), rtt_found ? "yes" : "no");
 		if (rtt_ident[0] == '\0')
 			gdb_out("off");
 		else
 			gdb_outf("\"%s\"", rtt_ident);
 		gdb_outf(" halt: %s", onoroff(target_no_background_memory_access(t)));
 		gdb_out(" channels: ");
-		if (rtt_auto_channel) gdb_out("auto ");
+		if (rtt_auto_channel)
+			gdb_out("auto ");
 		for (uint32_t i = 0; i < MAX_RTT_CHAN; i++)
-			if (rtt_channel[i].is_enabled) gdb_outf("%d ", i);
-		gdb_outf("\nmax poll ms: %u min poll ms: %u max errs: %u\n",
-			rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
-	}
-	else if ((argc >= 2) && !strncmp(argv[1], "channel", strlen(argv[1]))) {
+			if (rtt_channel[i].is_enabled)
+				gdb_outf("%d ", i);
+		gdb_outf(
+			"\nmax poll ms: %u min poll ms: %u max errs: %u\n", rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
+	} else if ((argc >= 2) && !strncmp(argv[1], "channel", strlen(argv[1]))) {
 		/* mon rtt channel switches to auto rtt channel selection
 		   mon rtt channel number... selects channels given */
 		for (uint32_t i = 0; i < MAX_RTT_CHAN; i++)
@@ -539,42 +530,39 @@ static bool cmd_rtt(target *t, int argc, const char **argv)
 					rtt_channel[chan].is_enabled = true;
 			}
 		}
-	}
-	else if ((argc == 2) && !strncmp(argv[1], "ident", strlen(argv[1]))) {
+	} else if ((argc == 2) && !strncmp(argv[1], "ident", strlen(argv[1]))) {
 		rtt_ident[0] = '\0';
-	}
-	else if ((argc == 2) && !strncmp(argv[1], "poll", strlen(argv[1])))
+	} else if ((argc == 2) && !strncmp(argv[1], "poll", strlen(argv[1])))
 		gdb_outf("%u %u %u\n", rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
 	else if ((argc == 2) && !strncmp(argv[1], "cblock", strlen(argv[1]))) {
 		gdb_outf("cbaddr: 0x%x\n", rtt_cbaddr);
 		gdb_out("ch ena cfg i/o buf@        size head@      tail@      flg\n");
 		for (uint32_t i = 0; i < MAX_RTT_CHAN; i++) {
-			gdb_outf("%2d   %c   %c %s 0x%08x %5d 0x%08x 0x%08x   %d\n",
-			i, rtt_channel[i].is_enabled ? 'y' : 'n', rtt_channel[i].is_configured ? 'y' : 'n',
-			rtt_channel[i].is_output ? "out" : "in ", rtt_channel[i].buf_addr, rtt_channel[i].buf_size,
-			rtt_channel[i].head_addr, rtt_channel[i].tail_addr, rtt_channel[i].flag);
+			gdb_outf("%2d   %c   %c %s 0x%08x %5d 0x%08x 0x%08x   %d\n", i, rtt_channel[i].is_enabled ? 'y' : 'n',
+				rtt_channel[i].is_configured ? 'y' : 'n', rtt_channel[i].is_output ? "out" : "in ",
+				rtt_channel[i].buf_addr, rtt_channel[i].buf_size, rtt_channel[i].head_addr, rtt_channel[i].tail_addr,
+				rtt_channel[i].flag);
 		}
-	}
-	else if ((argc == 3) && !strncmp(argv[1], "ident", strlen(argv[1]))) {
+	} else if ((argc == 3) && !strncmp(argv[1], "ident", strlen(argv[1]))) {
 		strncpy(rtt_ident, argv[2], sizeof(rtt_ident));
-		rtt_ident[sizeof(rtt_ident)-1] = '\0';
+		rtt_ident[sizeof(rtt_ident) - 1] = '\0';
 		for (uint32_t i = 0; i < sizeof(rtt_ident); i++)
-			if (rtt_ident[i] == '_') rtt_ident[i] = ' ';
-	}
-	else if ((argc == 5) && !strncmp(argv[1], "poll", strlen(argv[1]))) {
+			if (rtt_ident[i] == '_')
+				rtt_ident[i] = ' ';
+	} else if ((argc == 5) && !strncmp(argv[1], "poll", strlen(argv[1]))) {
 		/* set polling params */
 		int32_t new_max_poll_ms = atoi(argv[2]);
 		int32_t new_min_poll_ms = atoi(argv[3]);
 		int32_t new_max_poll_errs = atoi(argv[4]);
-		if ((new_max_poll_ms >= 0) && (new_min_poll_ms >= 0) && (new_max_poll_errs >= 0)
-			 && (new_max_poll_ms >= new_min_poll_ms)) {
+		if ((new_max_poll_ms >= 0) && (new_min_poll_ms >= 0) && (new_max_poll_errs >= 0) &&
+			(new_max_poll_ms >= new_min_poll_ms)) {
 			rtt_max_poll_ms = new_max_poll_ms;
 			rtt_min_poll_ms = new_min_poll_ms;
 			rtt_max_poll_errs = new_max_poll_errs;
-		}
-		else gdb_out("how?\n");
-	}
-	else gdb_out("what?\n");
+		} else
+			gdb_out("how?\n");
+	} else
+		gdb_out("what?\n");
 	return true;
 }
 #endif
@@ -593,17 +581,18 @@ static bool cmd_traceswo(target *t, int argc, const char **argv)
 	/* argument: optional baud rate for async mode */
 	if ((argc > 1) && (*argv[1] >= '0') && (*argv[1] <= '9')) {
 		baudrate = atoi(argv[1]);
-		if (baudrate == 0) baudrate = SWO_DEFAULT_BAUD;
+		if (baudrate == 0)
+			baudrate = SWO_DEFAULT_BAUD;
 		decode_arg = 2;
 	}
 #endif
 	/* argument: 'decode' literal */
-	if((argc > decode_arg) &&  !strncmp(argv[decode_arg], "decode", strlen(argv[decode_arg]))) {
+	if ((argc > decode_arg) && !strncmp(argv[decode_arg], "decode", strlen(argv[decode_arg]))) {
 		swo_channelmask = 0xFFFFFFFF; /* decoding all channels */
 		/* arguments: channels to decode */
 		if (argc > decode_arg + 1) {
 			swo_channelmask = 0x0;
-			for (int i = decode_arg+1; i < argc; i++) { /* create bitmask of channels to decode */
+			for (int i = decode_arg + 1; i < argc; i++) { /* create bitmask of channels to decode */
 				int channel = atoi(argv[i]);
 				if ((channel >= 0) && (channel <= 31))
 					swo_channelmask |= (uint32_t)0x1 << channel;
@@ -616,7 +605,7 @@ static bool cmd_traceswo(target *t, int argc, const char **argv)
 		gdb_outf("baudrate: %lu ", baudrate);
 #endif
 		gdb_outf("channel mask: ");
-		for (int8_t i=31;i>=0;i--) {
+		for (int8_t i = 31; i >= 0; i--) {
 			uint8_t bit = (swo_channelmask >> i) & 0x1;
 			gdb_outf("%u", bit);
 		}
@@ -650,23 +639,24 @@ static bool cmd_debug_bmp(target *t, int argc, const char **argv)
 	}
 
 	if (print_status) {
-		gdb_outf("Debug mode is %s\n",
-			 debug_bmp ? "enabled" : "disabled");
+		gdb_outf("Debug mode is %s\n", debug_bmp ? "enabled" : "disabled");
 	}
 	return true;
 }
 #endif
 static bool cmd_heapinfo(target *t, int argc, const char **argv)
 {
-	if (t == NULL) gdb_out("not attached\n");
+	if (t == NULL)
+		gdb_out("not attached\n");
 	else if (argc == 5) {
 		target_addr heap_base = strtoul(argv[1], NULL, 16);
 		target_addr heap_limit = strtoul(argv[2], NULL, 16);
 		target_addr stack_base = strtoul(argv[3], NULL, 16);
 		target_addr stack_limit = strtoul(argv[4], NULL, 16);
-		gdb_outf("heapinfo heap_base: %p heap_limit: %p stack_base: %p stack_limit: %p\n",
-			heap_base, heap_limit, stack_base, stack_limit);
+		gdb_outf("heapinfo heap_base: %p heap_limit: %p stack_base: %p stack_limit: %p\n", heap_base, heap_limit,
+			stack_base, stack_limit);
 		target_set_heapinfo(t, heap_base, heap_limit, stack_base, stack_limit);
-	} else gdb_outf("heapinfo heap_base heap_limit stack_base stack_limit\n");
+	} else
+		gdb_outf("heapinfo heap_base heap_limit stack_base stack_limit\n");
 	return true;
 }

--- a/src/command.c
+++ b/src/command.c
@@ -479,82 +479,75 @@ static bool cmd_target_power(target *t, int argc, const char **argv)
 #endif
 
 #ifdef ENABLE_RTT
-const char *onoroffstr[2] = {"off", "on"};
-static const char *onoroff(bool bval)
+static const char *on_or_off(const bool value)
 {
-	return bval ? onoroffstr[1] : onoroffstr[0];
+	return value ? "on" : "off";
 }
 
 static bool cmd_rtt(target *t, int argc, const char **argv)
 {
 	(void)t;
-	if ((argc == 1) || ((argc == 2) && !strncmp(argv[1], "enabled", strlen(argv[1])))) {
+	const size_t command_len = strlen(argv[1]);
+	if (argc == 1 || (argc == 2 && !strncmp(argv[1], "enabled", command_len))) {
 		rtt_enabled = true;
 		rtt_found = false;
-	} else if ((argc == 2) && !strncmp(argv[1], "disabled", strlen(argv[1]))) {
+	} else if ((argc == 2) && !strncmp(argv[1], "disabled", command_len)) {
 		rtt_enabled = false;
 		rtt_found = false;
-	} else if ((argc == 2) && !strncmp(argv[1], "status", strlen(argv[1]))) {
-		gdb_outf("rtt: %s found: %s ident: ", onoroff(rtt_enabled), rtt_found ? "yes" : "no");
-		if (rtt_ident[0] == '\0')
-			gdb_out("off");
-		else
-			gdb_outf("\"%s\"", rtt_ident);
-		gdb_outf(" halt: %s", onoroff(target_no_background_memory_access(t)));
+	} else if ((argc == 2) && !strncmp(argv[1], "status", command_len)) {
+		gdb_outf("rtt: %s found: %s ident: \"%s\"", on_or_off(rtt_enabled), rtt_found ? "yes" : "no",
+			rtt_ident[0] == '\0' ? "off" : rtt_ident);
+		gdb_outf(" halt: %s", on_or_off(target_no_background_memory_access(t)));
 		gdb_out(" channels: ");
 		if (rtt_auto_channel)
 			gdb_out("auto ");
-		for (uint32_t i = 0; i < MAX_RTT_CHAN; i++)
+		for (size_t i = 0; i < MAX_RTT_CHAN; i++) {
 			if (rtt_channel[i].is_enabled)
 				gdb_outf("%d ", i);
+		}
 		gdb_outf(
 			"\nmax poll ms: %u min poll ms: %u max errs: %u\n", rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
-	} else if ((argc >= 2) && !strncmp(argv[1], "channel", strlen(argv[1]))) {
+	} else if (argc >= 2 && !strncmp(argv[1], "channel", command_len)) {
 		/* mon rtt channel switches to auto rtt channel selection
 		   mon rtt channel number... selects channels given */
-		for (uint32_t i = 0; i < MAX_RTT_CHAN; i++)
+		for (size_t i = 0; i < MAX_RTT_CHAN; i++)
 			rtt_channel[i].is_enabled = false;
-		if (argc == 2) {
+
+		if (argc == 2)
 			rtt_auto_channel = true;
-		} else {
+		else {
 			rtt_auto_channel = false;
-			for (int i = 2; i < argc; i++) {
-				int chan = atoi(argv[i]);
-				if ((chan >= 0) && (chan < MAX_RTT_CHAN))
-					rtt_channel[chan].is_enabled = true;
+			for (size_t i = 2; i < (size_t)argc; ++i) {
+				const uint32_t channel = strtoul(argv[i], NULL, 0);
+				if (channel < MAX_RTT_CHAN)
+					rtt_channel[channel].is_enabled = true;
 			}
 		}
-	} else if ((argc == 2) && !strncmp(argv[1], "ident", strlen(argv[1]))) {
+	} else if (argc == 2 && !strncmp(argv[1], "ident", command_len))
 		rtt_ident[0] = '\0';
-	} else if ((argc == 2) && !strncmp(argv[1], "poll", strlen(argv[1])))
+	else if (argc == 2 && !strncmp(argv[1], "poll", command_len))
 		gdb_outf("%u %u %u\n", rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
-	else if ((argc == 2) && !strncmp(argv[1], "cblock", strlen(argv[1]))) {
+	else if (argc == 2 && !strncmp(argv[1], "cblock", command_len)) {
 		gdb_outf("cbaddr: 0x%x\n", rtt_cbaddr);
 		gdb_out("ch ena cfg i/o buf@        size head@      tail@      flg\n");
-		for (uint32_t i = 0; i < MAX_RTT_CHAN; i++) {
-			gdb_outf("%2d   %c   %c %s 0x%08x %5d 0x%08x 0x%08x   %d\n", i, rtt_channel[i].is_enabled ? 'y' : 'n',
+		for (size_t i = 0; i < MAX_RTT_CHAN; ++i) {
+			gdb_outf("%2zu   %c   %c %s 0x%08x %5d 0x%08x 0x%08x   %d\n", i, rtt_channel[i].is_enabled ? 'y' : 'n',
 				rtt_channel[i].is_configured ? 'y' : 'n', rtt_channel[i].is_output ? "out" : "in ",
 				rtt_channel[i].buf_addr, rtt_channel[i].buf_size, rtt_channel[i].head_addr, rtt_channel[i].tail_addr,
 				rtt_channel[i].flag);
 		}
-	} else if ((argc == 3) && !strncmp(argv[1], "ident", strlen(argv[1]))) {
+	} else if (argc == 3 && !strncmp(argv[1], "ident", command_len)) {
 		strncpy(rtt_ident, argv[2], sizeof(rtt_ident));
 		rtt_ident[sizeof(rtt_ident) - 1] = '\0';
-		for (uint32_t i = 0; i < sizeof(rtt_ident); i++)
+		for (size_t i = 0; i < sizeof(rtt_ident); i++) {
 			if (rtt_ident[i] == '_')
 				rtt_ident[i] = ' ';
-	} else if ((argc == 5) && !strncmp(argv[1], "poll", strlen(argv[1]))) {
+		}
+	} else if (argc == 5 && !strncmp(argv[1], "poll", command_len)) {
 		/* set polling params */
-		int32_t new_max_poll_ms = atoi(argv[2]);
-		int32_t new_min_poll_ms = atoi(argv[3]);
-		int32_t new_max_poll_errs = atoi(argv[4]);
-		if ((new_max_poll_ms >= 0) && (new_min_poll_ms >= 0) && (new_max_poll_errs >= 0) &&
-			(new_max_poll_ms >= new_min_poll_ms)) {
-			rtt_max_poll_ms = new_max_poll_ms;
-			rtt_min_poll_ms = new_min_poll_ms;
-			rtt_max_poll_errs = new_max_poll_errs;
-		} else
-			gdb_out("how?\n");
+		rtt_max_poll_ms = strtoul(argv[2], NULL, 0);
+		rtt_min_poll_ms = strtoul(argv[3], NULL, 0);
+		rtt_max_poll_errs = strtoul(argv[4], NULL, 0);
 	} else
 		gdb_out("what?\n");
 	return true;

--- a/src/command.c
+++ b/src/command.c
@@ -170,18 +170,16 @@ bool cmd_help(target *t, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
-	const struct command_s *c;
 
 	if (!t || t->tc->destroy_callback) {
 		gdb_out("General commands:\n");
-		for (c = cmd_list; c->cmd; c++)
-			gdb_outf("\t%s -- %s\n", c->cmd, c->help);
+		for (const command_t *cmd = cmd_list; cmd->cmd; cmd++)
+			gdb_outf("\t%s -- %s\n", cmd->cmd, cmd->help);
+		if (!t)
+			return true;
 	}
-	if (!t)
-		return -1;
 
 	target_command_help(t);
-
 	return true;
 }
 

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -54,11 +54,11 @@ struct target_flash {
 
 typedef bool (*cmd_handler)(target *t, int argc, const char **argv);
 
-struct command_s {
+typedef struct command_s {
 	const char *cmd;
 	cmd_handler handler;
 	const char *help;
-};
+} command_t;
 
 struct target_command_s {
 	const char *specific_name;


### PR DESCRIPTION
In this PR we address the state of command.c with its various styles, formatting choices, type badness and general inconsistencies.

This PR cleans up the commands and improves their output to GDB to make for a nicer user experience while doing what it can to streamline the code to claw back a bit of space.

Tested working on both v2.1e and v2.3a hardware, and against TM4C and LPC43xx targets.