### PR TITLE
Fix: Unable to detect non-conforming JTAG processors

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -224,7 +224,7 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 		break;
 	}
 
-	if (devs <= 0) {
+	if (devs == 0) {
 		platform_nrst_set_val(false);
 		gdb_out("JTAG device scan failed!\n");
 		return false;

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -39,7 +39,7 @@ int platform_adiv5_swdp_scan(uint32_t targetid);
 int platform_jtag_scan(const uint8_t *lrlens);
 #endif
 int adiv5_swdp_scan(uint32_t targetid);
-int jtag_scan(const uint8_t *lrlens);
+uint32_t jtag_scan(const uint8_t *lrlens);
 
 int target_foreach(void (*cb)(int i, target *t, void *context), void *context);
 void target_list_free(void);

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -384,7 +384,7 @@ void remote_adiv5_dp_defaults(ADIv5_DP_t *dp)
 	dp->mem_write_sized = remote_ap_mem_write_sized;
 }
 
-void remote_add_jtag_dev(int i, const jtag_dev_t *jtag_dev)
+void remote_add_jtag_dev(uint32_t i, const jtag_dev_t *jtag_dev)
 {
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
 	int s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE,

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -40,6 +40,6 @@ void remote_max_frequency_set(uint32_t freq);
 uint32_t remote_max_frequency_get(void);
 const char *platform_target_voltage(void);
 void remote_adiv5_dp_defaults(ADIv5_DP_t *dp);
-void remote_add_jtag_dev(int i, const jtag_dev_t *jtag_dev);
+void remote_add_jtag_dev(uint32_t i, const jtag_dev_t *jtag_dev);
 #define __BMP_REMOTE_H_
 #endif

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -748,7 +748,7 @@ void dap_jtagtap_tdi_tdo_seq(
 int dap_jtag_configure(void)
 {
 	uint8_t buf[64], *p = &buf[2];
-	int i = 0;
+	uint32_t i = 0;
 	for (; i < jtag_dev_count; i++) {
 		struct jtag_dev_s *jtag_dev = &jtag_devs[i];
 		*p++ = jtag_dev->ir_len;

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -172,7 +172,7 @@ int swdptap_init(ADIv5_DP_t *dp)
 	return -1;
 }
 
-void platform_add_jtag_dev(int i, const jtag_dev_t *jtag_dev)
+void platform_add_jtag_dev(uint32_t i, const jtag_dev_t *jtag_dev)
 {
 	if (info.bmp_type == BMP_TYPE_BMP)
 		remote_add_jtag_dev(i, jtag_dev);

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1029,10 +1029,10 @@ int jtag_scan_stlinkv2(bmp_info_t *info, const uint8_t *irlens)
 		return 0;
 	jtag_dev_count = stlink_read_idcodes(info, idcodes);
 	/* Check for known devices and handle accordingly */
-	for(int i = 0; i < jtag_dev_count; i++)
+	for(uint32_t i = 0; i < jtag_dev_count; i++)
 		jtag_devs[i].jd_idcode = idcodes[i];
-	for(int i = 0; i < jtag_dev_count; i++)
-		for(int j = 0; dev_descr[j].idcode; j++)
+	for(uint32_t i = 0; i < jtag_dev_count; i++)
+		for(size_t j = 0; dev_descr[j].idcode; j++)
 			if((jtag_devs[i].jd_idcode & dev_descr[j].idmask) ==
 			   dev_descr[j].idcode) {
 				if(dev_descr[j].handler)

--- a/src/remote.c
+++ b/src/remote.c
@@ -254,7 +254,7 @@ static void remotePacketProcessJTAG(unsigned i, char *packet)
 			remote_respond(REMOTE_RESP_ERR,REMOTE_ERROR_WRONGLEN);
 		} else {
 			memset(&jtag_dev, 0, sizeof(jtag_dev));
-			uint8_t index        = remotehston(2, &packet[ 2]);
+			const uint32_t index = remotehston(2, &packet[ 2]);
 			jtag_dev.dr_prescan  = remotehston(2, &packet[ 4]);
 			jtag_dev.dr_postscan = remotehston(2, &packet[ 6]);
 			jtag_dev.ir_len      = remotehston(2, &packet[ 8]);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -318,7 +318,7 @@ ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel);
 void remote_jtag_dev(const jtag_dev_t *jtag_dev);
 void adiv5_ap_ref(ADIv5_AP_t *ap);
 void adiv5_ap_unref(ADIv5_AP_t *ap);
-void platform_add_jtag_dev(const int dev_index, const jtag_dev_t *jtag_dev);
+void platform_add_jtag_dev(uint32_t dev_index, const jtag_dev_t *jtag_dev);
 
 void adiv5_jtag_dp_handler(uint8_t jd_index);
 int platform_jtag_dp_init(ADIv5_DP_t *dp);

--- a/src/target/jtag_devs.h
+++ b/src/target/jtag_devs.h
@@ -25,4 +25,3 @@ typedef const struct jtag_dev_descr_s {
 	void (*const handler)(uint8_t jd_index);
 } jtag_dev_descr_t;
 extern jtag_dev_descr_t dev_descr[];
-

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -215,21 +215,20 @@ uint32_t jtag_scan(const uint8_t *irlens)
 		DEBUG_INFO("\n");
 	}
 
-	size_t i;
-	uint32_t j;
 	/* Check for known devices and handle accordingly */
-	for(i = 0; i < jtag_dev_count; i++)
-		for(j = 0; dev_descr[j].idcode; j++)
-			if((jtag_devs[i].jd_idcode & dev_descr[j].idmask) ==
-			   dev_descr[j].idcode) {
-				jtag_devs[i].current_ir = -1;
+	for (size_t device = 0; device < jtag_dev_count; device++) {
+		for (size_t descr = 0; dev_descr[descr].idcode; descr++) {
+			if ((jtag_devs[device].jd_idcode & dev_descr[descr].idmask) == dev_descr[descr].idcode) {
+				jtag_devs[device].current_ir = -1;
 				/* Save description in table */
-				jtag_devs[i].jd_descr = dev_descr[j].descr;
+				jtag_devs[device].jd_descr = dev_descr[descr].descr;
 				/* Call handler to initialise/probe device further */
-				if(dev_descr[j].handler)
-					dev_descr[j].handler(i);
+				if (dev_descr[descr].handler)
+					dev_descr[descr].handler(device);
 				break;
 			}
+		}
+	}
 
 	return jtag_dev_count;
 }

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -99,10 +99,10 @@ int jtag_scan(const uint8_t *irlens)
 			if(*irlens == 0)
 				break;
 			jtag_proc.jtagtap_tdi_tdo_seq((uint8_t*)&irout, 0, ones, *irlens);
-			if (!(irout & 1)) {
+			/* IEEE 1149.1 requires the first bit to be a 1, but not all devices conform (see #1130 on GH) */
+			if (!(irout & 1))
 				DEBUG_WARN("check failed: IR[0] != 1\n");
-				return -1;
-			}
+
 			jtag_devs[jtag_dev_count].ir_len = *irlens;
 			jtag_devs[jtag_dev_count].ir_prescan = j;
 			jtag_devs[jtag_dev_count].jd_dev = jtag_dev_count;
@@ -115,12 +115,10 @@ int jtag_scan(const uint8_t *irlens)
 		jtagtap_shift_ir();
 
 		DEBUG_INFO("Scanning out IRs\n");
-		if(!jtag_proc.jtagtap_next(0, 1)) {
-			DEBUG_WARN("jtag_scan: Sanity check failed: IR[0] shifted out "
-					   "as 0\n");
-			jtag_dev_count = -1;
-			return -1; /* must be 1 */
-		}
+		/* IEEE 1149.1 requires the first bit to be a 1, but not all devices conform (see #1130 on GH) */
+		if (!jtag_proc.jtagtap_next(0, 1))
+			DEBUG_WARN("jtag_scan: Sanity check failed: IR[0] shifted out as 0\n");
+
 		jtag_devs[0].ir_len = 1; j = 1;
 		while((jtag_dev_count <= JTAG_MAX_DEVS) &&
 		      (jtag_devs[jtag_dev_count].ir_len <= JTAG_MAX_IR_LEN)) {

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -38,7 +38,7 @@ uint32_t jtag_dev_count = 0;
 static const uint8_t ones[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 #if PC_HOSTED == 0
-void jtag_add_device(const int dev_index, const jtag_dev_t *jtag_dev)
+void jtag_add_device(const uint32_t dev_index, const jtag_dev_t *jtag_dev)
 {
 	if (dev_index == 0)
 		memset(&jtag_devs, 0, sizeof(jtag_devs));
@@ -64,7 +64,7 @@ void jtag_add_device(const int dev_index, const jtag_dev_t *jtag_dev)
  *	continue to next device. If this is one shift out the remaining 31 bits
  *	of the IDCODE register.
  */
-int jtag_scan(const uint8_t *irlens)
+uint32_t jtag_scan(const uint8_t *irlens)
 {
 	target_list_free();
 
@@ -140,14 +140,14 @@ int jtag_scan(const uint8_t *irlens)
 
 		if (jtag_dev_count > JTAG_MAX_DEVS) {
 			DEBUG_WARN("jtag_scan: Maximum device count exceeded\n");
-			jtag_dev_count = -1;
-			return -1;
+			jtag_dev_count = 0;
+			return 0;
 		}
 
 		if (jtag_devs[jtag_dev_count].ir_len > JTAG_MAX_IR_LEN) {
 			DEBUG_WARN("jtag_scan: Maximum IR length exceeded\n");
-			jtag_dev_count = -1;
-			return -1;
+			jtag_dev_count = 0;
+			return 0;
 		}
 	}
 
@@ -166,8 +166,8 @@ int jtag_scan(const uint8_t *irlens)
 
 	if (device != jtag_dev_count) {
 		DEBUG_WARN("jtag_scan: Sanity check failed: BYPASS dev count doesn't match IR scan\n");
-		jtag_dev_count = -1;
-		return -1;
+		jtag_dev_count = 0;
+		return 0;
 	}
 
 	DEBUG_INFO("Return to Run-Test/Idle\n");

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -250,15 +250,16 @@ void jtag_dev_write_ir(jtag_proc_t *jp, const uint8_t jd_index, const uint32_t i
 	jtagtap_return_idle(1);
 }
 
-void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks)
+void jtag_dev_shift_dr(
+	jtag_proc_t *jp, const uint8_t jd_index, uint8_t *dout, const uint8_t *din, const size_t clock_cycles)
 {
 	jtag_dev_t *d = &jtag_devs[jd_index];
 	jtagtap_shift_dr();
-	jp->jtagtap_tdi_seq(0, ones, d->dr_prescan);
-	if(dout)
-		jp->jtagtap_tdi_tdo_seq((void*)dout, d->dr_postscan?0:1, (void*)din, ticks);
+	jp->jtagtap_tdi_seq(false, ones, d->dr_prescan);
+	if (dout)
+		jp->jtagtap_tdi_tdo_seq((uint8_t *)dout, !d->dr_postscan, (const uint8_t *)din, clock_cycles);
 	else
-		jp->jtagtap_tdi_seq(d->dr_postscan?0:1, (void*)din, ticks);
-	jp->jtagtap_tdi_seq(1, ones, d->dr_postscan);
+		jp->jtagtap_tdi_seq(!d->dr_postscan, (const uint8_t *)din, clock_cycles);
+	jp->jtagtap_tdi_seq(true, ones, d->dr_postscan);
 	jtagtap_return_idle(1);
 }

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -66,9 +66,6 @@ void jtag_add_device(const int dev_index, const jtag_dev_t *jtag_dev)
  */
 int jtag_scan(const uint8_t *irlens)
 {
-	size_t i;
-	uint32_t j;
-
 	target_list_free();
 
 	jtag_dev_count = 0;
@@ -202,23 +199,24 @@ int jtag_scan(const uint8_t *irlens)
 	jtagtap_return_idle(jtag_proc.tap_idle_cycles);
 
 #if PC_HOSTED == 1
-	/*Transfer needed device information to firmware jtag_devs*/
-	for(i = 0; i < jtag_dev_count; i++)
-		platform_add_jtag_dev(i, &jtag_devs[i]);
-	for(i = 0; i < jtag_dev_count; i++) {
-		DEBUG_INFO("Idcode 0x%08" PRIx32, jtag_devs[i].jd_idcode);
-		for(j = 0; dev_descr[j].idcode; j++) {
-			if((jtag_devs[i].jd_idcode & dev_descr[j].idmask) ==
-			   dev_descr[j].idcode) {
-				DEBUG_INFO(": %s",
-						  (dev_descr[j].descr) ? dev_descr[j].descr : "unknown");
+	/*Transfer needed device information to firmware jtag_devs */
+	for (size_t device = 0; device < jtag_dev_count; ++device)
+		platform_add_jtag_dev(device, jtag_devs + device);
+#endif
+
+	for (size_t device = 0; device < jtag_dev_count; ++device) {
+		DEBUG_INFO("IDCode 0x%08" PRIx32, jtag_devs[device].jd_idcode);
+		for (size_t descr = 0; dev_descr[descr].idcode; ++descr) {
+			if ((jtag_devs[device].jd_idcode & dev_descr[descr].idmask) == dev_descr[descr].idcode) {
+				DEBUG_INFO(": %s", dev_descr[descr].descr ? dev_descr[descr].descr : "Unknown");
 				break;
 			}
 		}
 		DEBUG_INFO("\n");
 	}
-#endif
 
+	size_t i;
+	uint32_t j;
 	/* Check for known devices and handle accordingly */
 	for(i = 0; i < jtag_dev_count; i++)
 		for(j = 0; dev_descr[j].idcode; j++)

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -46,5 +46,6 @@ extern uint32_t jtag_dev_count;
 
 void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
 void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks);
-void jtag_add_device(const int dev_index, const jtag_dev_t *jtag_dev);
-#endif
+void jtag_add_device(uint32_t dev_index, const jtag_dev_t *jtag_dev);
+
+#endif /*__JTAG_SCAN_H*/

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -27,6 +27,10 @@
 #define JTAG_MAX_IR_LEN	16
 
 typedef struct jtag_dev_s {
+	const char *jd_descr;
+	uint32_t jd_idcode;
+	uint32_t current_ir;
+
 	union {
 		uint8_t jd_dev;
 		uint8_t dr_prescan;
@@ -36,9 +40,6 @@ typedef struct jtag_dev_s {
 	uint8_t ir_len;
 	uint8_t ir_prescan;
 	uint8_t ir_postscan;
-	uint32_t jd_idcode;
-	const char *jd_descr;
-	uint32_t current_ir;
 } jtag_dev_t;
 
 extern struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1];

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -17,10 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <jtagtap.h>
-
 #ifndef __JTAG_SCAN_H
 #define __JTAG_SCAN_H
+
+#include <stddef.h>
+#include "jtagtap.h"
 
 #define JTAG_MAX_DEVS	32
 #define JTAG_MAX_IR_LEN	16
@@ -40,11 +41,10 @@ typedef struct jtag_dev_s {
 	uint32_t current_ir;
 } jtag_dev_t;
 
-extern struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS+1];
-extern int jtag_dev_count;
+extern struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1];
+extern uint32_t jtag_dev_count;
 
 void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
 void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks);
 void jtag_add_device(const int dev_index, const jtag_dev_t *jtag_dev);
 #endif
-

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -45,7 +45,7 @@ extern struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1];
 extern uint32_t jtag_dev_count;
 
 void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
-void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, int ticks);
+void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, size_t ticks);
 void jtag_add_device(uint32_t dev_index, const jtag_dev_t *jtag_dev);
 
 #endif /*__JTAG_SCAN_H*/


### PR DESCRIPTION
In this PR we address that some processors don't have conforming implementations of IEEE 1149.1 (JTAG) which prevents jtag_scan() from functioning correctly for them.

We relax the conformance checks to warnings, and address the state of the JTAG scan code, performing type fixes and nomenclature cleanup.

This has been tested against STM32F4, LPC3470, and TM4C.

This fixes #1130.