### PR TITLE
Fix: Tiva-C/Stelaris device probing issues

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -392,16 +392,14 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		DEBUG_INFO("Calling " STRINGIFY(x) "\n"); \
 		if ((x)(t)) \
 			return true; \
-		else \
-			target_check_error(t); \
+		target_check_error(t); \
 	} while (0)
 #else
 #define PROBE(x) \
 	do { \
 		if ((x)(t)) \
 			return true; \
-		else \
-			target_check_error(t); \
+		target_check_error(t); \
 	} while (0)
 #endif
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -460,6 +460,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 				PROBE(rp_probe);
 			PROBE(lpc11xx_probe); /* LPC8 */
 		} else if (ap->ap_partno == 0x4c3)  { /* Cortex-M3 ROM */
+			PROBE(lmi_probe);
 			PROBE(ch32f1_probe);
 			PROBE(stm32f1_probe); /* Care for other STM32F1 clones (?) */
 			PROBE(lpc15xx_probe); /* Thanks to JojoS for testing */
@@ -468,6 +469,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 			PROBE(lpc11xx_probe); /* LPC24C11 */
 			PROBE(lpc43xx_probe);
 		} else if (ap->ap_partno == 0x4c4) { /* Cortex-M4 ROM */
+			PROBE(lmi_probe);
 			/* The LPC546xx and LPC43xx parts present with the same AP ROM Part
 			Number, so we need to probe both. Unfortunately, when probing for
 			the LPC43xx when the target is actually an LPC546xx, the memory
@@ -486,7 +488,6 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		}
 		/* Info on PIDR of these parts wanted! */
 		PROBE(sam3x_probe);
-		PROBE(lmi_probe);
 		PROBE(ke04_probe);
 		PROBE(lpc17xx_probe);
 	}

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -89,6 +89,10 @@ bool lm3s_probe(target *const t, const uint16_t did1)
 		target_add_ram(t, 0x20000000U, 0x10000U);
 		lmi_add_flash(t, 0x20000U);
 		break;
+	case 0x1096: /* LM3S5732 */
+		target_add_ram(t, 0x2000000U, 0x10000U);
+		lmi_add_flash(t, 0x20000U);
+		break;
 	default:
 		t->driver = driver;
 		return false;

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -43,6 +43,13 @@
 #define DID0_CLASS_STELLARIS_DUST 0x00030000U
 #define DID0_CLASS_TIVA           0x00050000U
 
+#define DID1_LM3S3748        0x1049U
+#define DID1_LM3S5732        0x1096U
+#define DID1_LM3S8962        0x10A6U
+#define DID1_TM4C123GH6PM    0x10A1U
+#define DID1_TM4C1230C3PM    0x1022U
+#define DID1_TM4C1294NCPDT   0x101FU
+
 #define LMI_FLASH_BASE       0x400FD000
 #define LMI_FLASH_FMA        (LMI_FLASH_BASE + 0x000)
 #define LMI_FLASH_FMC        (LMI_FLASH_BASE + 0x008)
@@ -85,12 +92,12 @@ bool lm3s_probe(target *const t, const uint16_t did1)
 	const char *driver = t->driver;
 	t->driver = lmi_driver_str;
 	switch (did1) {
-	case 0x1049:	/* LM3S3748 */
-	case 0x1096: /* LM3S5732 */
+	case DID1_LM3S3748:
+	case DID1_LM3S5732:
 		target_add_ram(t, 0x20000000U, 0x10000U);
 		lmi_add_flash(t, 0x20000U);
 		break;
-	case 0x10A6: /* LM3S8962 */
+	case DID1_LM3S8962:
 		target_add_ram(t, 0x2000000U, 0x10000U);
 		lmi_add_flash(t, 0x40000U);
 		break;
@@ -107,7 +114,7 @@ bool tm4c_probe(target *const t, const uint16_t did1)
 	const char *driver = t->driver;
 	t->driver = lmi_driver_str;
 	switch (did1) {
-	case 0x10A1:	/* TM4C123GH6PM */
+	case DID1_TM4C123GH6PM:
 		target_add_ram(t, 0x20000000, 0x10000);
 		lmi_add_flash(t, 0x80000);
 		/* On Tiva targets, asserting nRST results in the debug
@@ -115,14 +122,12 @@ bool tm4c_probe(target *const t, const uint16_t did1)
 		 * only use the AIRCR SYSRESETREQ. */
 		t->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 		break;
-
-	case 0x1022:    /* TM4C1230C3PM */
+	case DID1_TM4C1230C3PM:
 		target_add_ram(t, 0x20000000, 0x6000);
 		lmi_add_flash(t, 0x10000);
 		t->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 		break;
-
-	case 0x101F:    /* TM4C1294NCPDT */
+	case DID1_TM4C1294NCPDT:
 		target_add_ram(t, 0x20000000, 0x40000);
 		lmi_add_flash(t, 0x100000);
 		t->target_options |= CORTEXM_TOPT_INHIBIT_NRST;

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -93,6 +93,10 @@ bool lm3s_probe(target *const t, const uint16_t did1)
 		target_add_ram(t, 0x2000000U, 0x10000U);
 		lmi_add_flash(t, 0x20000U);
 		break;
+	case 0x10A6: /* LM3S8962 */
+		target_add_ram(t, 0x2000000U, 0x10000U);
+		lmi_add_flash(t, 0x40000U);
+		break;
 	default:
 		t->driver = driver;
 		return false;

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -34,8 +34,12 @@
 
 #define BLOCK_SIZE           0x400
 
-#define LMI_SCB_BASE         0x400FE000
-#define LMI_SCB_DID1         (LMI_SCB_BASE + 0x004)
+#define LMI_SCB_BASE         0x400FE000U
+#define LMI_SCB_DID0         (LMI_SCB_BASE + 0x000U)
+#define LMI_SCB_DID1         (LMI_SCB_BASE + 0x004U)
+
+#define DID0_CLASS_MASK      0x00FF0000U
+#define DID0_CLASS_TIVA      0x00050000U
 
 #define LMI_FLASH_BASE       0x400FD000
 #define LMI_FLASH_FMA        (LMI_FLASH_BASE + 0x000)
@@ -76,7 +80,11 @@ static void lmi_add_flash(target *t, size_t length)
 
 bool lmi_probe(target *t)
 {
-	uint32_t did1 = target_mem_read32(t, LMI_SCB_DID1);
+	const uint32_t did0 = target_mem_read32(t, LMI_SCB_DID0);
+	if ((did0 & DID0_CLASS_MASK) != DID0_CLASS_TIVA)
+		return false;
+
+	const uint32_t did1 = target_mem_read32(t, LMI_SCB_DID1);
 	t->mass_erase = lmi_mass_erase;
 	switch (did1 >> 16) {
 	case 0x1049:	/* LM3S3748 */

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -86,8 +86,8 @@ bool lm3s_probe(target *const t, const uint16_t did1)
 	t->driver = lmi_driver_str;
 	switch (did1) {
 	case 0x1049:	/* LM3S3748 */
-		target_add_ram(t, 0x20000000, 0x8000);
-		lmi_add_flash(t, 0x40000);
+		target_add_ram(t, 0x20000000U, 0x10000U);
+		lmi_add_flash(t, 0x20000U);
 		break;
 	default:
 		t->driver = driver;

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -86,11 +86,8 @@ bool lm3s_probe(target *const t, const uint16_t did1)
 	t->driver = lmi_driver_str;
 	switch (did1) {
 	case 0x1049:	/* LM3S3748 */
-		target_add_ram(t, 0x20000000U, 0x10000U);
-		lmi_add_flash(t, 0x20000U);
-		break;
 	case 0x1096: /* LM3S5732 */
-		target_add_ram(t, 0x2000000U, 0x10000U);
+		target_add_ram(t, 0x20000000U, 0x10000U);
 		lmi_add_flash(t, 0x20000U);
 		break;
 	case 0x10A6: /* LM3S8962 */


### PR DESCRIPTION
In this PR we seek to address issues probing for TI Tiva-C and Stelaris devices which, because of where the probe routine is in the sequence, get put into a bad state and fail to scan under certain circumstances by the time the routine fires.

In addressing this we have inadvertantly ended up diving into the LM3S datasheets and adding support for a couple of new micros + fixing the Flash and RAM regions for another.

This fixes #958