### PR TITLE
raspberry magic number begone

### DIFF
--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -173,10 +173,10 @@ int jlink_swdp_scan(bmp_info_t *info)
 		return 0;
 	volatile struct exception e;
 	TRY_CATCH (e, EXCEPTION_ALL) {
-		dp->idcode = jlink_adiv5_swdp_low_access(dp, 1, ADIV5_DP_IDCODE, 0);
+		dp->debug_port_id = jlink_adiv5_swdp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_DPIDR, 0);
 	}
 	if (e.type) {
-		DEBUG_WARN("DP not responding for IDCODE! Reset stuck low?\n");
+		DEBUG_WARN("DP not responding for DPIDR! Reset stuck low?\n");
 		free(dp);
 		return 0;
 	}

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1077,14 +1077,14 @@ int stlink_enter_debug_swd(bmp_info_t *info, ADIv5_DP_t *dp)
 	stlink_send_recv_retry(cmd, 16, data, 2);
 	if (stlink_usb_error_check(data, true))
 		exit( -1);
-	dp->idcode = stlink_read_coreid();
+	dp->debug_port_id = stlink_read_coreid();
 	dp->dp_read = stlink_dp_read;
 	dp->error = stlink_dp_error;
 	dp->low_access = stlink_dp_low_access;
 	dp->abort = stlink_dp_abort;
 
 	stlink_dp_error(dp);
-	if ((dp->idcode & ADIV5_DP_DPIDR_VERSION_MASK) == ADIV5_DP_DPIDR_VERSION_DPv2) {
+	if ((dp->debug_port_id & ADIV5_DP_DPIDR_VERSION_MASK) == ADIV5_DP_DPIDR_VERSION_DPv2) {
 		adiv5_dp_write(dp, ADIV5_DP_SELECT, 2);
 		dp->targetid = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
 		adiv5_dp_write(dp, ADIV5_DP_SELECT, 0);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -487,14 +487,15 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, const size_t re
 	if (pidr & PIDR_JEP106_USED) {
 		/* (OFFSET - 8) because we want it on bits 11:8 of new code, see "JEP-106 code list" */
 		designer_code = (pidr & PIDR_JEP106_CONT_MASK) >> (PIDR_JEP106_CONT_OFFSET - 8) |
-		           (pidr & PIDR_JEP106_CODE_MASK) >> PIDR_JEP106_CODE_OFFSET;
+		                (pidr & PIDR_JEP106_CODE_MASK) >> PIDR_JEP106_CODE_OFFSET;
 
 		if (designer_code == JEP106_MANUFACTURER_ERRATA_STM32WX || designer_code == JEP106_MANUFACTURER_ERRATA_CS) {
 			/**
 			 * see 'JEP-106 code list' for context, here we are aliasing codes that are non compliant with the
 			 * JEP-106 standard to their expected codes, this is later used to determine the correct probe function.
 			 */
-			DEBUG_WARN("Patching Designer code 0x%03" PRIx16 " -> 0x%03" PRIx16 "\n", designer_code, JEP106_MANUFACTURER_STM);
+			DEBUG_WARN(
+				"Patching Designer code 0x%03" PRIx16 " -> 0x%03" PRIx16 "\n", designer_code, JEP106_MANUFACTURER_STM);
 			designer_code = JEP106_MANUFACTURER_STM;
 		}
 	} else {

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -332,7 +332,7 @@ static uint32_t cortexm_initial_halt(ADIv5_AP_t *ap)
 
 	const uint32_t dhcsr_ctl = CORTEXM_DHCSR_DBGKEY | CORTEXM_DHCSR_C_DEBUGEN | CORTEXM_DHCSR_C_HALT;
 	const uint32_t dhcsr_valid = CORTEXM_DHCSR_S_HALT | CORTEXM_DHCSR_C_DEBUGEN;
-	const bool use_low_access = !(ap->dp->idcode & ADIV5_DP_DPIDR_MINDP);
+	const bool use_low_access = !(ap->dp->debug_port_id & ADIV5_DP_DPIDR_MINDP);
 
 	platform_timeout halt_timeout;
 	platform_timeout_set(&halt_timeout, cortexm_wait_timeout);
@@ -682,25 +682,24 @@ static void rp_rescue_setup(ADIv5_DP_t *dp)
 
 void adiv5_dp_init(ADIv5_DP_t *dp)
 {
-	/* Check IDCODE for a valid manufacturer and sensible PARTNO */
-	/* TODO: this needs clarification, as DPIDR != IDCODE */
-	if ((dp->idcode & ADIV5_DP_DPIDR_DESIGNER_MASK) == 0 ||
-		(dp->idcode & ADIV5_DP_DPIDR_PARTNO_MASK) == ADIV5_DP_DPIDR_PARTNO_MASK) {
-		DEBUG_WARN("Invalid DP DPIDR %08" PRIx32 "\n", dp->idcode);
+	/* Check DPIDR for a valid manufacturer and sensible PARTNO */
+	if ((dp->debug_port_id & ADIV5_DP_DPIDR_DESIGNER_MASK) == 0 ||
+		(dp->debug_port_id & ADIV5_DP_DPIDR_PARTNO_MASK) == ADIV5_DP_DPIDR_PARTNO_MASK) {
+		DEBUG_WARN("Invalid DP DPIDR %08" PRIx32 "\n", dp->debug_port_id);
 		free(dp);
 		return;
 	}
 
 	/* TODO: this could with a non 'magic number' */
-	if (dp->idcode == 0x10212927) {
+	if (dp->debug_port_id == 0x10212927) {
 		rp_rescue_setup(dp);
 		return;
 	}
 
-	DEBUG_INFO("DPIDR 0x%08" PRIx32 " (v%d %srev%d)\n", dp->idcode,
-		(uint8_t)((dp->idcode & ADIV5_DP_DPIDR_VERSION_MASK) >> ADIV5_DP_DPIDR_VERSION_OFFSET),
-		(dp->idcode & ADIV5_DP_DPIDR_MINDP) ? "MINDP " : "",
-		(uint8_t)((dp->idcode & ADIV5_DP_DPIDR_REVISION_MASK) >> ADIV5_DP_DPIDR_REVISION_OFFSET));
+	DEBUG_INFO("DPIDR 0x%08" PRIx32 " (v%d %srev%d)\n", dp->debug_port_id,
+		(uint8_t)((dp->debug_port_id & ADIV5_DP_DPIDR_VERSION_MASK) >> ADIV5_DP_DPIDR_VERSION_OFFSET),
+		(dp->debug_port_id & ADIV5_DP_DPIDR_MINDP) ? "MINDP " : "",
+		(uint8_t)((dp->debug_port_id & ADIV5_DP_DPIDR_REVISION_MASK) >> ADIV5_DP_DPIDR_REVISION_OFFSET));
 
 #if PC_HOSTED == 1
 	platform_adiv5_dp_defaults(dp);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -46,7 +46,7 @@
 #define ADIV5_DP_RDBUFF    ADIV5_DP_REG(0xCU)
 #define ADIV5_DP_TARGETSEL ADIV5_DP_REG(0xCU)
 
-/* AP DPIDR */
+/* DP DPIDR */
 #define ADIV5_DP_DPIDR_REVISION_OFFSET 28U
 #define ADIV5_DP_DPIDR_REVISION_MASK   (0xfU << ADIV5_DP_DPIDR_VERSION_OFFSET)
 #define ADIV5_DP_DPIDR_PARTNO_OFFSET   20U
@@ -59,6 +59,21 @@
 #define ADIV5_DP_DPIDR_VERSION_DPv2    (2U << ADIV5_DP_DPIDR_VERSION_OFFSET)
 #define ADIV5_DP_DPIDR_DESIGNER_OFFSET 1U
 #define ADIV5_DP_DPIDR_DESIGNER_MASK   (0x7ffU << ADIV5_DP_DPIDR_DESIGNER_OFFSET)
+
+/* DP TARGETID */
+#define ADIV5_DP_TARGETID_TREVISION_OFFSET 28U
+#define ADIV5_DP_TARGETID_TREVISION_MASK   (0xfU << ADIV5_DP_TARGETID_TREVISION_OFFSET)
+#define ADIV5_DP_TARGETID_TPARTNO_OFFSET   12U
+#define ADIV5_DP_TARGETID_TPARTNO_MASK     (0xffffU << ADIV5_DP_TARGETID_TPARTNO_OFFSET)
+#define ADIV5_DP_TARGETID_TDESIGNER_OFFSET 1U
+#define ADIV5_DP_TARGETID_TDESIGNER_MASK   (0x7ffU << ADIV5_DP_TARGETID_TDESIGNER_OFFSET)
+
+/* DP DPIDR/TARGETID DESIGNER */
+/* Bits 10:7 - JEP-106 Continuation code */
+/* Bits 6:0 - JEP-106 Identity code */
+#define ADIV5_DP_DESIGNER_JEP106_CONT_OFFSET 7U
+#define ADIV5_DP_DESIGNER_JEP106_CONT_MASK   (0xfU << ADIV5_DP_DESIGNER_JEP106_CONT_OFFSET)
+#define ADIV5_DP_DESIGNER_JEP106_CODE_MASK   (0x7fU)
 
 /* AP Abort Register (ABORT) */
 /* Bits 31:5 - Reserved */
@@ -167,7 +182,7 @@
 #define JEP106_MANUFACTURER_SPECULAR     0x501U /* LPC845 with code 501. Strange!? Specular Networks */
 #define JEP106_MANUFACTURER_ENERGY_MICRO 0x673U /* Energy Micro */
 #define JEP106_MANUFACTURER_GIGADEVICE   0x751U /* GigaDevice */
-#define JEP106_MANUFACTURER_RASPBERRY    0x927U /* Raspberry Pi */
+#define JEP106_MANUFACTURER_RASPBERRY    0x913U /* Raspberry Pi */
 
 /*
  * This code is not listed in the JEP106 standard, but is used by some stm32f1 clones
@@ -205,6 +220,10 @@ typedef struct ADIv5_DP_s {
 	int refcnt;
 
 	uint32_t debug_port_id;
+
+	uint16_t designer_code;
+	uint16_t partno;
+
 	uint32_t targetid; /* Contains IDCODE for DPv2 devices.*/
 
 	void (*seq_out)(uint32_t tms_states, size_t clock_cycles);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -38,7 +38,7 @@
 #define ADIV5_DP_BANK4 0x40U
 
 /* ADIv5 DP Register addresses */
-#define ADIV5_DP_IDCODE    ADIV5_DP_REG(0x0U)
+#define ADIV5_DP_DPIDR     ADIV5_DP_REG(0x0U)
 #define ADIV5_DP_ABORT     ADIV5_DP_REG(0x0U)
 #define ADIV5_DP_CTRLSTAT  ADIV5_DP_REG(0x4U)
 #define ADIV5_DP_TARGETID  (ADIV5_DP_BANK2 | ADIV5_DP_REG(0x4U))
@@ -204,7 +204,7 @@ typedef struct ADIv5_AP_s ADIv5_AP_t;
 typedef struct ADIv5_DP_s {
 	int refcnt;
 
-	uint32_t idcode;
+	uint32_t debug_port_id;
 	uint32_t targetid; /* Contains IDCODE for DPv2 devices.*/
 
 	void (*seq_out)(uint32_t tms_states, size_t clock_cycles);

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -48,7 +48,12 @@ void adiv5_jtag_dp_handler(uint8_t jd_index)
 	}
 
 	dp->dp_jd_index = jd_index;
-	dp->idcode = jtag_devs[jd_index].jd_idcode;
+	/* From the ADI spec :
+	 * The architecture does not require that the TAP IDCODE
+	 * register value and the DPIDR (ADIv5) value are the same
+	 * should read DPIDR here
+	 */
+	dp->debug_port_id = jtag_devs[jd_index].jd_idcode;
 	if ((PC_HOSTED == 0 ) || (!platform_jtag_dp_init(dp))) {
 		dp->dp_read = fw_adiv5_jtagdp_read;
 		dp->error = adiv5_jtagdp_error;

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -128,12 +128,19 @@ int adiv5_swdp_scan(uint32_t targetid)
 			target_id = adiv5_dp_read(initial_dp, ADIV5_DP_CTRLSTAT);
 			adiv5_dp_write(initial_dp, ADIV5_DP_SELECT, 0);
 			DEBUG_INFO("TARGETID %08" PRIx32 "\n", target_id);
-			switch (target_id) {
-			case 0x01002927: /* RP2040 */
+
+			const uint16_t tdesigner =
+				(target_id & ADIV5_DP_TARGETID_TDESIGNER_MASK) >> ADIV5_DP_TARGETID_TDESIGNER_OFFSET;
+			const uint16_t tpartno = (target_id & ADIV5_DP_TARGETID_TPARTNO_MASK) >> ADIV5_DP_TARGETID_TPARTNO_OFFSET;
+			/* convert it to our internal representation, See JEP-106 code list */
+			const uint16_t designer_code = (tdesigner & ADIV5_DP_DESIGNER_JEP106_CONT_MASK) << 1U |
+			                               (tdesigner & ADIV5_DP_DESIGNER_JEP106_CODE_MASK);
+			if (designer_code == JEP106_MANUFACTURER_RASPBERRY && tpartno == 0x2) {
+				/* RP2040 */
 				/* Release evt. handing RESCUE DP reset*/
 				adiv5_dp_write(initial_dp, ADIV5_DP_CTRLSTAT, 0);
-				break;
 			}
+
 			if (!initial_dp->dp_low_write) {
 				DEBUG_WARN("CMSIS_DAP < V1.2 can not handle multi-drop!\n");
 				/* E.g. CMSIS_DAP < V1.2 can not handle multi-drop!*/

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -456,7 +456,12 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 #endif
 		}
 		if (ap->ap_partno == 0x4c0) { /* Cortex-M0+ ROM */
-			if ((ap->dp->targetid & 0xfff) == JEP106_MANUFACTURER_RASPBERRY)
+			const uint16_t tdesigner =
+				(ap->dp->targetid & ADIV5_DP_TARGETID_TDESIGNER_MASK) >> ADIV5_DP_TARGETID_TDESIGNER_OFFSET;
+			/* convert it to our internal representation, See JEP-106 code list */
+			const uint16_t designer_code = (tdesigner & ADIV5_DP_DESIGNER_JEP106_CONT_MASK) << 1U |
+			                               (tdesigner & ADIV5_DP_DESIGNER_JEP106_CODE_MASK);
+			if (designer_code == JEP106_MANUFACTURER_RASPBERRY)
 				PROBE(rp_probe);
 			PROBE(lpc11xx_probe);            /* LPC8 */
 		} else if (ap->ap_partno == 0x4c3) { /* Cortex-M3 ROM */

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -68,12 +68,12 @@ const struct command_s cortexm_cmd_list[] = {
 #ifdef PLATFORM_HAS_USBUART
 	{"redirect_stdout", (cmd_handler)cortexm_redirect_stdout, "Redirect semihosting stdout to USB UART"},
 #endif
-	{NULL, NULL, NULL}
+	{NULL, NULL, NULL},
 };
 
 /* target options recognised by the Cortex-M target */
-#define	TOPT_FLAVOUR_V6M	(1<<0)	/* if not set, target is assumed to be v7m */
-#define	TOPT_FLAVOUR_V7MF	(1<<1)	/* if set, floating-point enabled. */
+#define TOPT_FLAVOUR_V6M  (1U << 0U) /* if not set, target is assumed to be v7m */
+#define TOPT_FLAVOUR_V7MF (1U << 1U) /* if set, floating-point enabled. */
 
 static void cortexm_regs_read(target *t, void *data);
 static void cortexm_regs_write(target *t, const void *data);
@@ -91,8 +91,8 @@ static int cortexm_breakwatch_set(target *t, struct breakwatch *);
 static int cortexm_breakwatch_clear(target *t, struct breakwatch *);
 static target_addr cortexm_check_watch(target *t);
 
-#define CORTEXM_MAX_WATCHPOINTS	4	/* architecture says up to 15, no implementation has > 4 */
-#define CORTEXM_MAX_BREAKPOINTS	8	/* architecture says up to 127, no implementation has > 8 */
+#define CORTEXM_MAX_WATCHPOINTS 4U /* architecture says up to 15, no implementation has > 4 */
+#define CORTEXM_MAX_BREAKPOINTS 8U /* architecture says up to 127, no implementation has > 8 */
 
 static int cortexm_hostio_request(target *t);
 
@@ -118,21 +118,22 @@ struct cortexm_priv {
 
 /* Register number tables */
 static const uint32_t regnum_cortex_m[] = {
-	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,	/* standard r0-r15 */
-	0x10,	/* xpsr */
-	0x11,	/* msp */
-	0x12,	/* psp */
-	0x14	/* special */
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, /* standard r0-r15 */
+	0x10,                                                 /* xpsr */
+	0x11,                                                 /* msp */
+	0x12,                                                 /* psp */
+	0x14                                                  /* special */
 };
 
 static const uint32_t regnum_cortex_mf[] = {
-	0x21,	/* fpscr */
-	0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,	/* s0-s7 */
-	0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f,	/* s8-s15 */
-	0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57,	/* s16-s23 */
-	0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f,	/* s24-s31 */
+	0x21,                                           /* fpscr */
+	0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, /* s0-s7 */
+	0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, /* s8-s15 */
+	0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, /* s16-s23 */
+	0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, /* s24-s31 */
 };
 
+/* clang-format off */
 static const char tdesc_cortex_m[] =
 	"<?xml version=\"1.0\"?>"
 	"<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
@@ -215,6 +216,7 @@ static const char tdesc_cortex_mf[] =
 	"    <reg name=\"d15\" bitsize=\"64\" type=\"float\"/>"
 	"  </feature>"
 	"</target>";
+/* clang-format on */
 
 ADIv5_AP_t *cortexm_ap(target *t)
 {
@@ -241,7 +243,7 @@ static void cortexm_cache_clean(target *t, target_addr addr, size_t len, bool in
 		if (mem_end < ram_end)
 			ram_end = mem_end;
 		/* intersection is [ram, ram_end) */
-		for (ram &= ~(minline-1); ram < ram_end; ram += minline)
+		for (ram &= ~(minline - 1); ram < ram_end; ram += minline)
 			adiv5_mem_write(cortexm_ap(t), cache_reg, &ram, 4);
 	}
 }
@@ -283,7 +285,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	t->designer_code = ap->designer_code;
 	t->idcode = ap->ap_partno;
 	struct cortexm_priv *priv = calloc(1, sizeof(*priv));
-	if (!priv) {			/* calloc failed: heap exhaustion */
+	if (!priv) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return false;
 	}
@@ -320,8 +322,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		break;
 	case CORTEX_M7:
 		t->core = "M7";
-		if (((t->cpuid & CPUID_REVISION_MASK) == 0) &&
-			(t->cpuid & CPUID_PATCH_MASK) < 2) {
+		if (((t->cpuid & CPUID_REVISION_MASK) == 0) && (t->cpuid & CPUID_PATCH_MASK) < 2) {
 			DEBUG_WARN("Silicon bug: Single stepping will enter pending "
 					   "exception handler with this M7 core revision!\n");
 		}
@@ -333,14 +334,11 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		t->core = "M0";
 		break;
 	default:
-		if (ap->designer_code != JEP106_MANUFACTURER_ATMEL) /* Protected Atmel device?*/{
+		if (ap->designer_code != JEP106_MANUFACTURER_ATMEL) /* Protected Atmel device?*/
 			DEBUG_WARN("Unexpected CortexM CPUID partno %04" PRIx32 "\n", cpuid_partno);
-		}
 	}
-	DEBUG_INFO("CPUID 0x%08" PRIx32 " (%s var %" PRIx32 " rev %" PRIx32 ")\n",
-			   t->cpuid,
-			   t->core, (t->cpuid & CPUID_REVISION_MASK) >> 20,
-			   t->cpuid & CPUID_PATCH_MASK);
+	DEBUG_INFO("CPUID 0x%08" PRIx32 " (%s var %" PRIx32 " rev %" PRIx32 ")\n", t->cpuid, t->core,
+		(t->cpuid & CPUID_REVISION_MASK) >> 20, t->cpuid & CPUID_PATCH_MASK);
 
 	t->attach = cortexm_attach;
 	t->detach = cortexm_detach;
@@ -374,8 +372,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	}
 
 	/* Default vectors to catch */
-	priv->demcr = CORTEXM_DEMCR_TRCENA | CORTEXM_DEMCR_VC_HARDERR |
-			CORTEXM_DEMCR_VC_CORERESET;
+	priv->demcr = CORTEXM_DEMCR_TRCENA | CORTEXM_DEMCR_VC_HARDERR | CORTEXM_DEMCR_VC_CORERESET;
 
 	/* Check cache type */
 	uint32_t ctr = target_mem_read32(t, CORTEXM_CTR);
@@ -387,18 +384,18 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	}
 #if PC_HOSTED
 #define STRINGIFY(x) #x
-#define PROBE(x) \
-	do { \
+#define PROBE(x)                                  \
+	do {                                          \
 		DEBUG_INFO("Calling " STRINGIFY(x) "\n"); \
-		if ((x)(t)) \
-			return true; \
-		target_check_error(t); \
+		if ((x)(t))                               \
+			return true;                          \
+		target_check_error(t);                    \
 	} while (0)
 #else
-#define PROBE(x) \
-	do { \
-		if ((x)(t)) \
-			return true; \
+#define PROBE(x)               \
+	do {                       \
+		if ((x)(t))            \
+			return true;       \
 		target_check_error(t); \
 	} while (0)
 #endif
@@ -450,23 +447,25 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		if (ap->designer_code != JEP106_MANUFACTURER_ARM) {
 			/* Report unexpected designers */
 #if PC_HOSTED == 0
-			gdb_outf("Please report probed device with Designer code 0x%3x and Partno 0x%3x\n", ap->designer_code, ap->ap_partno);
+			gdb_outf("Please report probed device with Designer code 0x%3x and Partno 0x%3x\n", ap->designer_code,
+				ap->ap_partno);
 #else
-			DEBUG_WARN("Please report probed device with Designer code 0x%3x and Partno 0x%3x\n", ap->designer_code, ap->ap_partno);
+			DEBUG_WARN("Please report probed device with Designer code 0x%3x and Partno 0x%3x\n", ap->designer_code,
+				ap->ap_partno);
 #endif
 		}
-		if (ap->ap_partno == 0x4c0)  { /* Cortex-M0+ ROM */
+		if (ap->ap_partno == 0x4c0) { /* Cortex-M0+ ROM */
 			if ((ap->dp->targetid & 0xfff) == JEP106_MANUFACTURER_RASPBERRY)
 				PROBE(rp_probe);
-			PROBE(lpc11xx_probe); /* LPC8 */
-		} else if (ap->ap_partno == 0x4c3)  { /* Cortex-M3 ROM */
+			PROBE(lpc11xx_probe);            /* LPC8 */
+		} else if (ap->ap_partno == 0x4c3) { /* Cortex-M3 ROM */
 			PROBE(lmi_probe);
 			PROBE(ch32f1_probe);
-			PROBE(stm32f1_probe); /* Care for other STM32F1 clones (?) */
-			PROBE(lpc15xx_probe); /* Thanks to JojoS for testing */
-			PROBE(lpc11xx_probe); /* LPC1343 */
-		} else if (ap->ap_partno == 0x471)  { /* Cortex-M0 ROM */
-			PROBE(lpc11xx_probe); /* LPC24C11 */
+			PROBE(stm32f1_probe);            /* Care for other STM32F1 clones (?) */
+			PROBE(lpc15xx_probe);            /* Thanks to JojoS for testing */
+			PROBE(lpc11xx_probe);            /* LPC1343 */
+		} else if (ap->ap_partno == 0x471) { /* Cortex-M0 ROM */
+			PROBE(lpc11xx_probe);            /* LPC24C11 */
 			PROBE(lpc43xx_probe);
 		} else if (ap->ap_partno == 0x4c4) { /* Cortex-M4 ROM */
 			PROBE(lmi_probe);
@@ -480,11 +479,11 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 			PROBE(lpc546xx_probe);
 
 			PROBE(lpc43xx_probe);
-			PROBE(kinetis_probe); /* Older K-series */
+			PROBE(kinetis_probe);            /* Older K-series */
 		} else if (ap->ap_partno == 0x4cb) { /* Cortex-M23 ROM */
-			PROBE(gd32f1_probe); /* GD32E23x uses GD32F1 peripherals */
+			PROBE(gd32f1_probe);             /* GD32E23x uses GD32F1 peripherals */
 		} else if (ap->ap_partno == 0x4c0) { /* Cortex-M0+ ROM */
-			PROBE(lpc11xx_probe); /* some of the LPC8xx series, like LPC802 */
+			PROBE(lpc11xx_probe);            /* some of the LPC8xx series, like LPC802 */
 		}
 		/* Info on PIDR of these parts wanted! */
 		PROBE(sam3x_probe);
@@ -515,7 +514,7 @@ bool cortexm_attach(target *t)
 	priv->hw_breakpoint_max = CORTEXM_MAX_BREAKPOINTS;
 	const uint32_t flash_break_cfg = target_mem_read32(t, CORTEXM_FPB_CTRL);
 	const uint32_t breakpoints = ((flash_break_cfg >> 4U) & 0xf);
-	if (breakpoints < priv->hw_breakpoint_max)	/* only look at NUM_COMP1 */
+	if (breakpoints < priv->hw_breakpoint_max) /* only look at NUM_COMP1 */
 		priv->hw_breakpoint_max = breakpoints;
 	priv->flash_patch_revision = flash_break_cfg >> 28U;
 
@@ -563,11 +562,11 @@ void cortexm_detach(target *t)
 	unsigned i;
 
 	/* Clear any stale breakpoints */
-	for(i = 0; i < priv->hw_breakpoint_max; i++)
+	for (i = 0; i < priv->hw_breakpoint_max; i++)
 		target_mem_write32(t, CORTEXM_FPB_COMP(i), 0);
 
 	/* Clear any stale watchpoints */
-	for(i = 0; i < priv->hw_watchpoint_max; i++)
+	for (i = 0; i < priv->hw_watchpoint_max; i++)
 		target_mem_write32(t, CORTEXM_DWT_FUNC(i), 0);
 
 	/* Restort DEMCR*/
@@ -577,53 +576,52 @@ void cortexm_detach(target *t)
 	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY);
 }
 
-enum { DB_DHCSR, DB_DCRSR, DB_DCRDR, DB_DEMCR };
+enum {
+	DB_DHCSR,
+	DB_DCRSR,
+	DB_DCRDR,
+	DB_DEMCR
+};
 
 static void cortexm_regs_read(target *t, void *data)
 {
 	uint32_t *regs = data;
 	ADIv5_AP_t *ap = cortexm_ap(t);
-	unsigned i;
+	size_t i;
 #if PC_HOSTED == 1
 	if ((ap->dp->ap_reg_read) && (ap->dp->ap_regs_read)) {
 		uint32_t base_regs[21];
 		ap->dp->ap_regs_read(ap, base_regs);
-		for(i = 0; i < sizeof(regnum_cortex_m) / 4; i++)
+		for (i = 0; i < sizeof(regnum_cortex_m) / 4; i++)
 			*regs++ = base_regs[regnum_cortex_m[i]];
 		if (t->target_options & TOPT_FLAVOUR_V7MF)
-			for(i = 0; i < sizeof(regnum_cortex_mf) / 4; i++)
+			for (i = 0; i < sizeof(regnum_cortex_mf) / 4; i++)
 				*regs++ = ap->dp->ap_reg_read(ap, regnum_cortex_mf[i]);
-	}
-#else
-	if (0) {}
+	} else
 #endif
-	else {
+	{
 		/* FIXME: Describe what's really going on here */
 		adiv5_ap_write(ap, ADIV5_AP_CSW, ap->csw | ADIV5_AP_CSW_SIZE_WORD);
 
 		/* Map the banked data registers (0x10-0x1c) to the
 		 * debug registers DHCSR, DCRSR, DCRDR and DEMCR respectively */
-		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_TAR,
-							CORTEXM_DHCSR);
+		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_TAR, CORTEXM_DHCSR);
 
 		/* Walk the regnum_cortex_m array, reading the registers it
 		 * calls out. */
 		adiv5_ap_write(ap, ADIV5_AP_DB(DB_DCRSR), regnum_cortex_m[0]);
-       /* Required to switch banks */
+		/* Required to switch banks */
 		*regs++ = adiv5_dp_read(ap->dp, ADIV5_AP_DB(DB_DCRDR));
-		for(i = 1; i < sizeof(regnum_cortex_m) / 4; i++) {
-		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR),
-			regnum_cortex_m[i]);
-		*regs++ = adiv5_dp_read(ap->dp, ADIV5_AP_DB(DB_DCRDR));
+		for (i = 1; i < sizeof(regnum_cortex_m) / 4; i++) {
+			adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR), regnum_cortex_m[i]);
+			*regs++ = adiv5_dp_read(ap->dp, ADIV5_AP_DB(DB_DCRDR));
 		}
 		if (t->target_options & TOPT_FLAVOUR_V7MF)
-			for(i = 0; i < sizeof(regnum_cortex_mf) / 4; i++) {
-				adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE,
-									ADIV5_AP_DB(DB_DCRSR),
-									regnum_cortex_mf[i]);
+			for (i = 0; i < sizeof(regnum_cortex_mf) / 4; i++) {
+				adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR), regnum_cortex_mf[i]);
 				*regs++ = adiv5_dp_read(ap->dp, ADIV5_AP_DB(DB_DCRDR));
 			}
-		}
+	}
 }
 
 static void cortexm_regs_write(target *t, const void *data)
@@ -637,49 +635,39 @@ static void cortexm_regs_write(target *t, const void *data)
 			regs++;
 		}
 		if (t->target_options & TOPT_FLAVOUR_V7MF)
-			for(size_t z = 0; z < sizeof(regnum_cortex_mf) / 4; z++) {
+			for (size_t z = 0; z < sizeof(regnum_cortex_mf) / 4; z++) {
 				ap->dp->ap_reg_write(ap, regnum_cortex_mf[z], *regs);
 				regs++;
 			}
-	}
-#else
-	if (0) {}
+	} else
 #endif
-	else {
-		unsigned i;
+	{
+		size_t i;
 
 		/* FIXME: Describe what's really going on here */
 		adiv5_ap_write(ap, ADIV5_AP_CSW, ap->csw | ADIV5_AP_CSW_SIZE_WORD);
 
 		/* Map the banked data registers (0x10-0x1c) to the
 		 * debug registers DHCSR, DCRSR, DCRDR and DEMCR respectively */
-		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_TAR,
-							CORTEXM_DHCSR);
+		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_TAR, CORTEXM_DHCSR);
 		/* Walk the regnum_cortex_m array, writing the registers it
 		 * calls out. */
 		adiv5_ap_write(ap, ADIV5_AP_DB(DB_DCRDR), *regs++);
-        /* Required to switch banks */
-		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR),
-							0x10000 | regnum_cortex_m[0]);
-		for(i = 1; i < sizeof(regnum_cortex_m) / 4; i++) {
-			adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE,
-								ADIV5_AP_DB(DB_DCRDR), *regs++);
-			adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR),
-								0x10000 | regnum_cortex_m[i]);
+		/* Required to switch banks */
+		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR), 0x10000 | regnum_cortex_m[0]);
+		for (i = 1; i < sizeof(regnum_cortex_m) / 4; i++) {
+			adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRDR), *regs++);
+			adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR), 0x10000 | regnum_cortex_m[i]);
 		}
 		if (t->target_options & TOPT_FLAVOUR_V7MF)
-			for(i = 0; i < sizeof(regnum_cortex_mf) / 4; i++) {
-				adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE,
-									ADIV5_AP_DB(DB_DCRDR), *regs++);
-				adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE,
-									ADIV5_AP_DB(DB_DCRSR),
-									0x10000 | regnum_cortex_mf[i]);
+			for (i = 0; i < sizeof(regnum_cortex_mf) / 4; i++) {
+				adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRDR), *regs++);
+				adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR), 0x10000 | regnum_cortex_mf[i]);
 			}
 	}
 }
 
-int cortexm_mem_write_sized(
-	target *t, target_addr dest, const void *src, size_t len, enum align align)
+int cortexm_mem_write_sized(target *t, target_addr dest, const void *src, size_t len, enum align align)
 {
 	cortexm_cache_clean(t, dest, len, true);
 	adiv5_mem_write_sized(cortexm_ap(t), dest, src, len, align);
@@ -688,12 +676,11 @@ int cortexm_mem_write_sized(
 
 static int dcrsr_regnum(target *t, unsigned reg)
 {
-	if (reg < sizeof(regnum_cortex_m) / 4) {
+	if (reg < sizeof(regnum_cortex_m) / 4U) {
 		return regnum_cortex_m[reg];
 	} else if ((t->target_options & TOPT_FLAVOUR_V7MF) &&
-	           (reg < (sizeof(regnum_cortex_m) +
-	                   sizeof(regnum_cortex_mf)) / 4)) {
-		return regnum_cortex_mf[reg - sizeof(regnum_cortex_m)/4];
+			   (reg < (sizeof(regnum_cortex_m) + sizeof(regnum_cortex_mf)) / 4)) {
+		return regnum_cortex_mf[reg - sizeof(regnum_cortex_m) / 4U];
 	} else {
 		return -1;
 	}
@@ -714,8 +701,7 @@ static ssize_t cortexm_reg_write(target *t, int reg, const void *data, size_t ma
 		return -1;
 	const uint32_t *r = data;
 	target_mem_write32(t, CORTEXM_DCRDR, *r);
-	target_mem_write32(t, CORTEXM_DCRSR, CORTEXM_DCRSR_REGWnR |
-	                                     dcrsr_regnum(t, reg));
+	target_mem_write32(t, CORTEXM_DCRSR, CORTEXM_DCRSR_REGWnR | dcrsr_regnum(t, reg));
 	return 4;
 }
 
@@ -737,7 +723,7 @@ static void cortexm_reset(target *t)
 {
 	/* Read DHCSR here to clear S_RESET_ST bit before reset */
 	target_mem_read32(t, CORTEXM_DHCSR);
-	platform_timeout to;
+	platform_timeout reset_timeout;
 	if ((t->target_options & CORTEXM_TOPT_INHIBIT_NRST) == 0) {
 		platform_nrst_set_val(true);
 		platform_nrst_set_val(false);
@@ -750,19 +736,19 @@ static void cortexm_reset(target *t)
 		/* No reset seen yet, maybe as nRST is not connected, or device has
          * CORTEXM_TOPT_INHIBIT_NRST set.
 		 * Trigger reset by AIRCR.*/
-		target_mem_write32(t, CORTEXM_AIRCR,
-						   CORTEXM_AIRCR_VECTKEY | CORTEXM_AIRCR_SYSRESETREQ);
+		target_mem_write32(t, CORTEXM_AIRCR, CORTEXM_AIRCR_VECTKEY | CORTEXM_AIRCR_SYSRESETREQ);
 	}
 	/* If target needs to do something extra (see Atmel SAM4L for example) */
 	if (t->extended_reset != NULL) {
 		t->extended_reset(t);
 	}
 	/* Wait for CORTEXM_DHCSR_S_RESET_ST to read 0, meaning reset released.*/
-	platform_timeout_set(&to, 1000);
+	platform_timeout_set(&reset_timeout, 1000);
 	while ((target_mem_read32(t, CORTEXM_DHCSR) & CORTEXM_DHCSR_S_RESET_ST) &&
-		   !platform_timeout_is_expired(&to));
+		   !platform_timeout_is_expired(&reset_timeout))
+		continue;
 #if defined(PLATFORM_HAS_DEBUG)
-	if (platform_timeout_is_expired(&to))
+	if (platform_timeout_is_expired(&reset_timeout))
 		DEBUG_WARN("Reset seem to be stuck low!\n");
 #endif
 	/* 10 ms delay to ensure that things such as the STM32 HSI clock
@@ -778,9 +764,7 @@ static void cortexm_halt_request(target *t)
 {
 	volatile struct exception e;
 	TRY_CATCH (e, EXCEPTION_TIMEOUT) {
-		target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY |
-		                                          CORTEXM_DHCSR_C_HALT |
-		                                          CORTEXM_DHCSR_C_DEBUGEN);
+		target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY | CORTEXM_DHCSR_C_HALT | CORTEXM_DHCSR_C_DEBUGEN);
 	}
 	if (e.type) {
 		tc_printf(t, "Timeout sending interrupt, is target in WFI?\n");
@@ -826,7 +810,7 @@ static enum target_halt_reason cortexm_halt_poll(target *t, target_addr *watch)
 		uint32_t pc = cortexm_pc_read(t);
 		uint16_t bkpt_instr;
 		bkpt_instr = target_mem_read16(t, pc);
-		if (bkpt_instr == 0xBEAB) {
+		if (bkpt_instr == 0xbeabU) {
 			if (cortexm_hostio_request(t)) {
 				return TARGET_HALT_REQUEST;
 			} else {
@@ -859,14 +843,14 @@ static void cortexm_halt_resume(target *t, bool step)
 		dhcsr |= CORTEXM_DHCSR_C_STEP | CORTEXM_DHCSR_C_MASKINTS;
 
 	/* Disable interrupts while single stepping... */
-	if(step != priv->stepping) {
+	if (step != priv->stepping) {
 		target_mem_write32(t, CORTEXM_DHCSR, dhcsr | CORTEXM_DHCSR_C_HALT);
 		priv->stepping = step;
 	}
 
 	if (priv->on_bkpt) {
 		uint32_t pc = cortexm_pc_read(t);
-		if ((target_mem_read16(t, pc) & 0xFF00) == 0xBE00)
+		if ((target_mem_read16(t, pc) & 0xff00U) == 0xbe00U)
 			cortexm_pc_write(t, pc + 2);
 	}
 
@@ -880,11 +864,11 @@ static int cortexm_fault_unwind(target *t)
 {
 	uint32_t hfsr = target_mem_read32(t, CORTEXM_HFSR);
 	uint32_t cfsr = target_mem_read32(t, CORTEXM_CFSR);
-	target_mem_write32(t, CORTEXM_HFSR, hfsr);/* write back to reset */
-	target_mem_write32(t, CORTEXM_CFSR, cfsr);/* write back to reset */
+	target_mem_write32(t, CORTEXM_HFSR, hfsr); /* write back to reset */
+	target_mem_write32(t, CORTEXM_CFSR, cfsr); /* write back to reset */
 	/* We check for FORCED in the HardFault Status Register or
 	 * for a configurable fault to avoid catching core resets */
-	if((hfsr & CORTEXM_HFSR_FORCED) || cfsr) {
+	if ((hfsr & CORTEXM_HFSR_FORCED) || cfsr) {
 		/* Unwind exception */
 		uint32_t regs[t->regs_size / 4];
 		uint32_t stack[8];
@@ -893,30 +877,30 @@ static int cortexm_fault_unwind(target *t)
 		target_regs_read(t, regs);
 		/* save retcode currently in lr */
 		retcode = regs[REG_LR];
-		bool spsel = retcode & (1<<2);
-		bool fpca = !(retcode & (1<<4));
+		bool spsel = retcode & (1U << 2U);
+		bool fpca = !(retcode & (1U << 4U));
 		/* Read stack for pre-exception registers */
 		uint32_t sp = spsel ? regs[REG_PSP] : regs[REG_MSP];
 		target_mem_read(t, stack, sp, sizeof(stack));
 		if (target_check_error(t))
 			return 0;
-		regs[REG_LR] = stack[5];	/* restore LR to pre-exception state */
-		regs[REG_PC] = stack[6];	/* restore PC to pre-exception state */
+		regs[REG_LR] = stack[5]; /* restore LR to pre-exception state */
+		regs[REG_PC] = stack[6]; /* restore PC to pre-exception state */
 
 		/* adjust stack to pop exception state */
-		framesize = fpca ? 0x68 : 0x20;	/* check for basic vs. extended frame */
-		if (stack[7] & (1<<9))				/* check for stack alignment fixup */
-			framesize += 4;
+		framesize = fpca ? 0x68U : 0x20U; /* check for basic vs. extended frame */
+		if (stack[7] & (1U << 9U))        /* check for stack alignment fixup */
+			framesize += 4U;
 
 		if (spsel) {
-			regs[REG_SPECIAL] |= 0x4000000;
+			regs[REG_SPECIAL] |= 0x4000000U;
 			regs[REG_SP] = regs[REG_PSP] += framesize;
 		} else {
 			regs[REG_SP] = regs[REG_MSP] += framesize;
 		}
 
 		if (fpca)
-			regs[REG_SPECIAL] |= 0x2000000;
+			regs[REG_SPECIAL] |= 0x2000000U;
 
 		/* FIXME: stack[7] contains xPSR when this is supported */
 		/* although, if we caught the exception it will be unchanged */
@@ -924,8 +908,7 @@ static int cortexm_fault_unwind(target *t)
 		/* Reset exception state to allow resuming from restored
 		 * state.
 		 */
-		target_mem_write32(t, CORTEXM_AIRCR,
-				CORTEXM_AIRCR_VECTKEY | CORTEXM_AIRCR_VECTCLRACTIVE);
+		target_mem_write32(t, CORTEXM_AIRCR, CORTEXM_AIRCR_VECTKEY | CORTEXM_AIRCR_VECTCLRACTIVE);
 
 		/* Write pre-exception registers back to core */
 		target_regs_write(t, regs);
@@ -935,10 +918,9 @@ static int cortexm_fault_unwind(target *t)
 	return 0;
 }
 
-int cortexm_run_stub(target *t, uint32_t loadaddr,
-                     uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3)
+int cortexm_run_stub(target *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3)
 {
-	uint32_t regs[t->regs_size / 4];
+	uint32_t regs[t->regs_size / 4U];
 
 	memset(regs, 0, sizeof(regs));
 	regs[0] = r0;
@@ -970,9 +952,8 @@ int cortexm_run_stub(target *t, uint32_t loadaddr,
 			DEBUG_WARN("Stub hangs\n");
 			uint32_t arm_regs[t->regs_size];
 			target_regs_read(t, arm_regs);
-			for (unsigned int i = 0; i < 20; i++) {
-				DEBUG_WARN("%2d: %08" PRIx32 ", %08" PRIx32 "\n",
-						   i, arm_regs_start[i], arm_regs[i]);
+			for (size_t i = 0; i < 20; i++) {
+				DEBUG_WARN("%2d: %08" PRIx32 ", %08" PRIx32 "\n", i, arm_regs_start[i], arm_regs[i]);
 			}
 #endif
 			return -3;
@@ -988,10 +969,10 @@ int cortexm_run_stub(target *t, uint32_t loadaddr,
 	}
 	uint32_t pc = cortexm_pc_read(t);
 	uint16_t bkpt_instr = target_mem_read16(t, pc);
-	if (bkpt_instr >> 8 != 0xbe)
+	if (bkpt_instr >> 8U != 0xbeU)
 		return -2;
 
-	return bkpt_instr & 0xff;
+	return bkpt_instr & 0xffU;
 }
 
 /* The following routines implement hardware breakpoints and watchpoints.
@@ -1034,18 +1015,18 @@ static uint32_t dwt_func(target *t, enum target_breakwatch type)
 static int cortexm_breakwatch_set(target *t, struct breakwatch *bw)
 {
 	struct cortexm_priv *priv = t->priv;
-	unsigned i;
+	size_t i;
 	uint32_t val = bw->addr;
 
 	switch (bw->type) {
 	case TARGET_BREAK_HARD:
 		if (priv->flash_patch_revision == 0) {
-			val &= 0x1FFFFFFC;
-			val |= (bw->addr & 2)?0x80000000:0x40000000;
+			val &= 0x1ffffffcU;
+			val |= (bw->addr & 2U) ? 0x80000000U : 0x40000000U;
 		}
-		val |= 1;
+		val |= 1U;
 
-		for(i = 0; i < priv->hw_breakpoint_max; i++)
+		for (i = 0; i < priv->hw_breakpoint_max; i++)
 			if (!priv->hw_breakpoint[i])
 				break;
 
@@ -1060,7 +1041,7 @@ static int cortexm_breakwatch_set(target *t, struct breakwatch *bw)
 	case TARGET_WATCH_WRITE:
 	case TARGET_WATCH_READ:
 	case TARGET_WATCH_ACCESS:
-		for(i = 0; i < priv->hw_watchpoint_max; i++)
+		for (i = 0; i < priv->hw_watchpoint_max; i++)
 			if (!priv->hw_watchpoint[i])
 				break;
 
@@ -1105,11 +1086,9 @@ static target_addr cortexm_check_watch(target *t)
 	struct cortexm_priv *priv = t->priv;
 	unsigned i;
 
-	for(i = 0; i < priv->hw_watchpoint_max; i++)
+	for (i = 0; i < priv->hw_watchpoint_max; i++)
 		/* if SET and MATCHED then break */
-		if(priv->hw_watchpoint[i] &&
-		   (target_mem_read32(t, CORTEXM_DWT_FUNC(i)) &
-					CORTEXM_DWT_FUNC_MATCHED))
+		if (priv->hw_watchpoint[i] && (target_mem_read32(t, CORTEXM_DWT_FUNC(i)) & CORTEXM_DWT_FUNC_MATCHED))
 			break;
 
 	if (i == priv->hw_watchpoint_max)
@@ -1121,17 +1100,16 @@ static target_addr cortexm_check_watch(target *t)
 static bool cortexm_vector_catch(target *t, int argc, char *argv[])
 {
 	struct cortexm_priv *priv = t->priv;
-	const char *vectors[] = {"reset", NULL, NULL, NULL, "mm", "nocp",
-				"chk", "stat", "bus", "int", "hard"};
+	static const char *vectors[] = {"reset", NULL, NULL, NULL, "mm", "nocp", "chk", "stat", "bus", "int", "hard"};
 	uint32_t tmp = 0;
 	unsigned i;
 
 	if (argc < 3) {
 		tc_printf(t, "usage: monitor vector_catch (enable|disable) "
-			     "(hard|int|bus|stat|chk|nocp|mm|reset)\n");
+					 "(hard|int|bus|stat|chk|nocp|mm|reset)\n");
 	} else {
 		for (int j = 0; j < argc; j++)
-			for (i = 0; i < sizeof(vectors) / sizeof(char*); i++) {
+			for (i = 0; i < sizeof(vectors) / sizeof(char *); i++) {
 				if (vectors[i] && !strcmp(vectors[i], argv[j]))
 					tmp |= 1 << i;
 			}
@@ -1149,7 +1127,7 @@ static bool cortexm_vector_catch(target *t, int argc, char *argv[])
 	}
 
 	tc_printf(t, "Catching vectors: ");
-	for (i = 0; i < sizeof(vectors) / sizeof(char*); i++) {
+	for (i = 0; i < sizeof(vectors) / sizeof(char *); i++) {
 		if (!vectors[i])
 			continue;
 		if (priv->demcr & (1 << i))
@@ -1161,7 +1139,7 @@ static bool cortexm_vector_catch(target *t, int argc, char *argv[])
 
 /* Windows defines this with some other meaning... */
 #ifdef SYS_OPEN
-#	undef SYS_OPEN
+#undef SYS_OPEN
 #endif
 
 /* Semihosting support */
@@ -1178,30 +1156,30 @@ static bool cortexm_vector_catch(target *t, int argc, char *argv[])
 
 /* ARM Semihosting syscall numbers, from "Semihosting for AArch32 and AArch64 Version 3.0" */
 
-#define SYS_CLOCK	0x10
-#define SYS_CLOSE	0x02
-#define SYS_ELAPSED	0x30
-#define SYS_ERRNO	0x13
-#define SYS_EXIT	0x18
-#define SYS_EXIT_EXTENDED	0x20
-#define SYS_FLEN	0x0C
-#define SYS_GET_CMDLINE	0x15
-#define SYS_HEAPINFO	0x16
-#define SYS_ISERROR	0x08
-#define SYS_ISTTY	0x09
-#define SYS_OPEN	0x01
-#define SYS_READ	0x06
-#define SYS_READC	0x07
-#define SYS_REMOVE	0x0E
-#define SYS_RENAME	0x0F
-#define SYS_SEEK	0x0A
-#define SYS_SYSTEM	0x12
-#define SYS_TICKFREQ	0x31
-#define SYS_TIME	0x11
-#define SYS_TMPNAM	0x0D
-#define SYS_WRITE	0x05
-#define SYS_WRITEC	0x03
-#define SYS_WRITE0	0x04
+#define SYS_CLOCK         0x10
+#define SYS_CLOSE         0x02
+#define SYS_ELAPSED       0x30
+#define SYS_ERRNO         0x13
+#define SYS_EXIT          0x18
+#define SYS_EXIT_EXTENDED 0x20
+#define SYS_FLEN          0x0C
+#define SYS_GET_CMDLINE   0x15
+#define SYS_HEAPINFO      0x16
+#define SYS_ISERROR       0x08
+#define SYS_ISTTY         0x09
+#define SYS_OPEN          0x01
+#define SYS_READ          0x06
+#define SYS_READC         0x07
+#define SYS_REMOVE        0x0E
+#define SYS_RENAME        0x0F
+#define SYS_SEEK          0x0A
+#define SYS_SYSTEM        0x12
+#define SYS_TICKFREQ      0x31
+#define SYS_TIME          0x11
+#define SYS_TMPNAM        0x0D
+#define SYS_WRITE         0x05
+#define SYS_WRITEC        0x03
+#define SYS_WRITE0        0x04
 
 #ifdef PLATFORM_HAS_USBUART
 static bool cortexm_redirect_stdout(target *t, int argc, const char **argv)
@@ -1222,16 +1200,18 @@ static void probe_mem_read(target *t __attribute__((unused)), void *probe_dest, 
 	uint8_t *src = (uint8_t *)target_src;
 
 	DEBUG_INFO("probe_mem_read\n");
-	while (len--) *dst++=*src++;
+
+	memcpy(dst, src, len);
 }
 
-static void probe_mem_write(target *t __attribute__((unused)), target_addr target_dest, const void *probe_src, size_t len)
+static void probe_mem_write(
+	target *t __attribute__((unused)), target_addr target_dest, const void *probe_src, size_t len)
 {
 	uint8_t *dst = (uint8_t *)target_dest;
 	uint8_t *src = (uint8_t *)probe_src;
 
 	DEBUG_INFO("probe_mem_write\n");
-	while (len--) *dst++=*src++;
+	memcpy(dst, src, len);
 }
 #endif
 
@@ -1243,31 +1223,33 @@ static int cortexm_hostio_request(target *t)
 	t->tc->interrupted = false;
 	target_regs_read(t, arm_regs);
 	uint32_t syscall = arm_regs[0];
-	if (syscall != SYS_EXIT) target_mem_read(t, params, arm_regs[1], sizeof(params));
+	if (syscall != SYS_EXIT)
+		target_mem_read(t, params, arm_regs[1], sizeof(params));
 	int32_t ret = 0;
 
-	DEBUG_INFO("syscall 0"PRIx32"%"PRIx32" (%"PRIx32" %"PRIx32" %"PRIx32" %"PRIx32")\n",
-              syscall, params[0], params[1], params[2], params[3]);
+	DEBUG_INFO("syscall 0" PRIx32 "%" PRIx32 " (%" PRIx32 " %" PRIx32 " %" PRIx32 " %" PRIx32 ")\n", syscall, params[0],
+		params[1], params[2], params[3]);
 	switch (syscall) {
 #if PC_HOSTED == 1
 
-	/* code that runs in pc-hosted process. use linux system calls. */
+		/* code that runs in pc-hosted process. use linux system calls. */
 
-	case SYS_OPEN:{	/* open */
-		target_addr fnam_taddr =  params[0];
+	case SYS_OPEN: { /* open */
+		target_addr fnam_taddr = params[0];
 		uint32_t fnam_len = params[2];
 		ret = -1;
-		if ((fnam_taddr == TARGET_NULL) || (fnam_len == 0)) break;
+		if (fnam_taddr == TARGET_NULL || fnam_len == 0)
+			break;
 
 		/* Translate stupid fopen modes to open flags.
 		 * See DUI0471C, Table 8-3 */
-		const uint32_t flags[] = {
-			O_RDONLY,	/* r, rb */
-			O_RDWR,		/* r+, r+b */
-			O_WRONLY | O_CREAT | O_TRUNC,/*w*/
-			O_RDWR | O_CREAT | O_TRUNC,/*w+*/
-			O_WRONLY | O_CREAT | O_APPEND,/*a*/
-			O_RDWR | O_CREAT | O_APPEND,/*a+*/
+		static const uint32_t flags[] = {
+			O_RDONLY,                      /* r, rb */
+			O_RDWR,                        /* r+, r+b */
+			O_WRONLY | O_CREAT | O_TRUNC,  /*w*/
+			O_RDWR | O_CREAT | O_TRUNC,    /*w+*/
+			O_WRONLY | O_CREAT | O_APPEND, /*a*/
+			O_RDWR | O_CREAT | O_APPEND,   /*a+*/
 		};
 		uint32_t pflag = flags[params[1] >> 1];
 		char filename[4];
@@ -1286,18 +1268,22 @@ static int cortexm_hostio_request(target *t)
 		}
 
 		char *fnam = malloc(fnam_len + 1);
-		if (fnam == NULL) break;
+		if (fnam == NULL)
+			break;
 		target_mem_read(t, fnam, fnam_taddr, fnam_len + 1);
-		if (target_check_error(t)) {free(fnam); break;}
-		fnam[fnam_len]='\0';
+		if (target_check_error(t)) {
+			free(fnam);
+			break;
+		}
+		fnam[fnam_len] = '\0';
 		ret = open(fnam, pflag, 0644);
 		free(fnam);
 		if (ret != -1)
 			ret++;
 		break;
-		}
+	}
 
-	case SYS_CLOSE:	/* close */
+	case SYS_CLOSE: /* close */
 		ret = close(params[0] - 1);
 		break;
 
@@ -1305,154 +1291,205 @@ static int cortexm_hostio_request(target *t)
 		ret = -1;
 		target_addr buf_taddr = params[1];
 		uint32_t buf_len = params[2];
-		if (buf_taddr == TARGET_NULL) break;
-		if (buf_len == 0) {ret = 0; break;}
+		if (buf_taddr == TARGET_NULL)
+			break;
+		if (buf_len == 0) {
+			ret = 0;
+			break;
+		}
 		uint8_t *buf = malloc(buf_len);
-		if (buf == NULL) break;
+		if (buf == NULL)
+			break;
 		ssize_t rc = read(params[0] - 1, buf, buf_len);
 		if (rc >= 0)
 			rc = buf_len - rc;
 		target_mem_write(t, buf_taddr, buf, buf_len);
 		free(buf);
-		if (target_check_error(t)) break;
+		if (target_check_error(t))
+			break;
 		ret = rc;
 		break;
-		}
+	}
 
-	case SYS_WRITE:	{ /* write */
+	case SYS_WRITE: { /* write */
 		ret = -1;
 		target_addr buf_taddr = params[1];
 		uint32_t buf_len = params[2];
-		if (buf_taddr == TARGET_NULL) break;
-		if (buf_len == 0) {ret = 0; break;}
+		if (buf_taddr == TARGET_NULL)
+			break;
+		if (buf_len == 0) {
+			ret = 0;
+			break;
+		}
 		uint8_t *buf = malloc(buf_len);
-		if (buf == NULL) break;
+		if (buf == NULL)
+			break;
 		target_mem_read(t, buf, buf_taddr, buf_len);
-		if (target_check_error(t)) {free(buf); break;}
+		if (target_check_error(t)) {
+			free(buf);
+			break;
+		}
 		ret = write(params[0] - 1, buf, buf_len);
 		free(buf);
 		if (ret >= 0)
 			ret = buf_len - ret;
 		break;
-		}
+	}
 
 	case SYS_WRITEC: { /* writec */
 		ret = -1;
 		uint8_t ch;
 		target_addr ch_taddr = arm_regs[1];
-		if (ch_taddr == TARGET_NULL) break;
+		if (ch_taddr == TARGET_NULL)
+			break;
 		ch = target_mem_read8(t, ch_taddr);
-		if (target_check_error(t)) break;
+		if (target_check_error(t))
+			break;
 		fputc(ch, stderr);
 		ret = 0;
 		break;
-		}
+	}
 
-	case SYS_WRITE0:{ /* write0 */
+	case SYS_WRITE0: { /* write0 */
 		ret = -1;
 		uint8_t ch;
 		target_addr str = arm_regs[1];
-		if (str == TARGET_NULL) break;
+		if (str == TARGET_NULL)
+			break;
 		while ((ch = target_mem_read8(t, str++)) != '\0') {
-			if (target_check_error(t)) break;
+			if (target_check_error(t))
+				break;
 			fputc(ch, stderr);
-			}
+		}
 		ret = 0;
 		break;
-		}
+	}
 
-	case SYS_ISTTY:	/* isatty */
+	case SYS_ISTTY: /* isatty */
 		ret = isatty(params[0] - 1);
 		break;
 
-	case SYS_SEEK:{	/* lseek */
+	case SYS_SEEK: { /* lseek */
 		off_t pos = params[1];
-		if (lseek(params[0] - 1, pos, SEEK_SET) == (off_t)pos) ret = 0;
-		else ret = -1;
+		if (lseek(params[0] - 1, pos, SEEK_SET) == (off_t)pos)
+			ret = 0;
+		else
+			ret = -1;
 		break;
-		}
+	}
 
 	case SYS_RENAME: { /* rename */
 		ret = -1;
 		target_addr fnam1_taddr = params[0];
 		uint32_t fnam1_len = params[1];
-		if (fnam1_taddr == TARGET_NULL) break;
-		if (fnam1_len == 0) break;
+		if (fnam1_taddr == TARGET_NULL)
+			break;
+		if (fnam1_len == 0)
+			break;
 		target_addr fnam2_taddr = params[2];
 		uint32_t fnam2_len = params[3];
-		if (fnam2_taddr == TARGET_NULL) break;
-		if (fnam2_len == 0) break;
+		if (fnam2_taddr == TARGET_NULL)
+			break;
+		if (fnam2_len == 0)
+			break;
 		char *fnam1 = malloc(fnam1_len + 1);
-		if (fnam1 == NULL) break;
+		if (fnam1 == NULL)
+			break;
 		target_mem_read(t, fnam1, fnam1_taddr, fnam1_len + 1);
-		if (target_check_error(t)) {free(fnam1); break;}
-		fnam1[fnam1_len]='\0';
+		if (target_check_error(t)) {
+			free(fnam1);
+			break;
+		}
+		fnam1[fnam1_len] = '\0';
 		char *fnam2 = malloc(fnam2_len + 1);
-		if (fnam2 == NULL) {free(fnam1); break;}
+		if (fnam2 == NULL) {
+			free(fnam1);
+			break;
+		}
 		target_mem_read(t, fnam2, fnam2_taddr, fnam2_len + 1);
-		if (target_check_error(t)) {free(fnam1); free(fnam2); break;}
-		fnam2[fnam2_len]='\0';
+		if (target_check_error(t)) {
+			free(fnam1);
+			free(fnam2);
+			break;
+		}
+		fnam2[fnam2_len] = '\0';
 		ret = rename(fnam1, fnam2);
 		free(fnam1);
 		free(fnam2);
 		break;
-		}
+	}
 
 	case SYS_REMOVE: { /* unlink */
 		ret = -1;
 		target_addr fnam_taddr = params[0];
-		if (fnam_taddr == TARGET_NULL) break;
+		if (fnam_taddr == TARGET_NULL)
+			break;
 		uint32_t fnam_len = params[1];
-		if (fnam_len == 0) break;
+		if (fnam_len == 0)
+			break;
 		char *fnam = malloc(fnam_len + 1);
-		if (fnam == NULL) break;
+		if (fnam == NULL)
+			break;
 		target_mem_read(t, fnam, fnam_taddr, fnam_len + 1);
-		if (target_check_error(t)) {free(fnam); break;}
-		fnam[fnam_len]='\0';
+		if (target_check_error(t)) {
+			free(fnam);
+			break;
+		}
+		fnam[fnam_len] = '\0';
 		ret = remove(fnam);
 		free(fnam);
 		break;
-		}
+	}
 
 	case SYS_SYSTEM: { /* system */
 		ret = -1;
 		target_addr cmd_taddr = params[0];
-		if (cmd_taddr == TARGET_NULL) break;
+		if (cmd_taddr == TARGET_NULL)
+			break;
 		uint32_t cmd_len = params[1];
-		if (cmd_len == 0) break;
+		if (cmd_len == 0)
+			break;
 		char *cmd = malloc(cmd_len + 1);
-		if (cmd == NULL) break;
+		if (cmd == NULL)
+			break;
 		target_mem_read(t, cmd, cmd_taddr, cmd_len + 1);
-		if (target_check_error(t)) {free(cmd); break;}
-		cmd[cmd_len]='\0';
+		if (target_check_error(t)) {
+			free(cmd);
+			break;
+		}
+		cmd[cmd_len] = '\0';
 		ret = system(cmd);
 		free(cmd);
 		break;
-		}
+	}
 
 	case SYS_FLEN: { /* file length */
 		ret = -1;
 		struct stat stat_buf;
-		if (fstat(params[0]-1, &stat_buf) != 0) break;
-		if (stat_buf.st_size > INT32_MAX) break;
+		if (fstat(params[0] - 1, &stat_buf) != 0)
+			break;
+		if (stat_buf.st_size > INT32_MAX)
+			break;
 		ret = stat_buf.st_size;
 		break;
-		}
+	}
 
 	case SYS_CLOCK: { /* clock */
 		/* can't use clock() because that would give cpu time of pc-hosted process */
 		ret = -1;
 		struct timeval timeval_buf;
-		if(gettimeofday(&timeval_buf, NULL) != 0) break;
+		if (gettimeofday(&timeval_buf, NULL) != 0)
+			break;
 		uint32_t sec = timeval_buf.tv_sec;
 		uint64_t usec = timeval_buf.tv_usec;
-		if (time0_sec > sec) time0_sec = sec;
+		if (time0_sec > sec)
+			time0_sec = sec;
 		sec -= time0_sec;
-		uint64_t csec64 = (sec * 1000000ull + usec)/10000ull;
+		uint64_t csec64 = (sec * UINT64_C(1000000) + usec) / UINT64_C(10000);
 		uint32_t csec = csec64 & 0x7fffffff;
 		ret = csec;
 		break;
-		}
+	}
 
 	case SYS_TIME: /* time */
 		ret = time(NULL);
@@ -1468,18 +1505,18 @@ static int cortexm_hostio_request(target *t)
 
 #else
 
-	/* code that runs in probe. use gdb fileio calls. */
+		/* code that runs in probe. use gdb fileio calls. */
 
-	case SYS_OPEN:{	/* open */
+	case SYS_OPEN: { /* open */
 		/* Translate stupid fopen modes to open flags.
 		 * See DUI0471C, Table 8-3 */
-		const uint32_t flags[] = {
-			TARGET_O_RDONLY,	/* r, rb */
-			TARGET_O_RDWR,		/* r+, r+b */
-			TARGET_O_WRONLY | TARGET_O_CREAT | TARGET_O_TRUNC,/*w*/
-			TARGET_O_RDWR | TARGET_O_CREAT | TARGET_O_TRUNC,/*w+*/
-			TARGET_O_WRONLY | TARGET_O_CREAT | TARGET_O_APPEND,/*a*/
-			TARGET_O_RDWR | TARGET_O_CREAT | TARGET_O_APPEND,/*a+*/
+		static const uint32_t flags[] = {
+			TARGET_O_RDONLY,                                    /* r, rb */
+			TARGET_O_RDWR,                                      /* r+, r+b */
+			TARGET_O_WRONLY | TARGET_O_CREAT | TARGET_O_TRUNC,  /*w*/
+			TARGET_O_RDWR | TARGET_O_CREAT | TARGET_O_TRUNC,    /*w+*/
+			TARGET_O_WRONLY | TARGET_O_CREAT | TARGET_O_APPEND, /*a*/
+			TARGET_O_RDWR | TARGET_O_CREAT | TARGET_O_APPEND,   /*a+*/
 		};
 		uint32_t pflag = flags[params[1] >> 1];
 		char filename[4];
@@ -1501,17 +1538,17 @@ static int cortexm_hostio_request(target *t)
 		if (ret != -1)
 			ret++;
 		break;
-		}
+	}
 
-	case SYS_CLOSE:	/* close */
+	case SYS_CLOSE: /* close */
 		ret = tc_close(t, params[0] - 1);
 		break;
-	case SYS_READ:	/* read */
+	case SYS_READ: /* read */
 		ret = tc_read(t, params[0] - 1, params[1], params[2]);
 		if (ret >= 0)
 			ret = params[2] - ret;
 		break;
-	case SYS_WRITE:	/* write */
+	case SYS_WRITE: /* write */
 		ret = tc_write(t, params[0] - 1, params[1], params[2]);
 		if (ret >= 0)
 			ret = params[2] - ret;
@@ -1519,65 +1556,70 @@ static int cortexm_hostio_request(target *t)
 	case SYS_WRITEC: /* writec */
 		ret = tc_write(t, STDERR_FILENO, arm_regs[1], 1);
 		break;
-	case SYS_WRITE0:{ /* write0 */
+	case SYS_WRITE0: { /* write0 */
 		ret = -1;
 		target_addr str_begin = arm_regs[1];
 		target_addr str_end = str_begin;
 		while (target_mem_read8(t, str_end) != 0) {
-			if (target_check_error(t)) break;
+			if (target_check_error(t))
+				break;
 			str_end++;
-			}
+		}
 		int len = str_end - str_begin;
 		if (len != 0) {
 			int rc = tc_write(t, STDERR_FILENO, str_begin, len);
-			if (rc != len) break;
+			if (rc != len)
+				break;
 		}
 		ret = 0;
 		break;
-		}
-	case SYS_ISTTY:	/* isatty */
+	}
+	case SYS_ISTTY: /* isatty */
 		ret = tc_isatty(t, params[0] - 1);
 		break;
-	case SYS_SEEK:	/* lseek */
-		if (tc_lseek(t, params[0] - 1, params[1], TARGET_SEEK_SET) == (long)params[1]) ret = 0;
-		else ret = -1;
+	case SYS_SEEK: /* lseek */
+		if (tc_lseek(t, params[0] - 1, params[1], TARGET_SEEK_SET) == (long)params[1])
+			ret = 0;
+		else
+			ret = -1;
 		break;
-	case SYS_RENAME:/* rename */
-		ret = tc_rename(t, params[0], params[1] + 1,
-				params[2], params[3] + 1);
+	case SYS_RENAME: /* rename */
+		ret = tc_rename(t, params[0], params[1] + 1, params[2], params[3] + 1);
 		break;
-	case SYS_REMOVE:/* unlink */
+	case SYS_REMOVE: /* unlink */
 		ret = tc_unlink(t, params[0], params[1] + 1);
 		break;
-	case SYS_SYSTEM:/* system */
+	case SYS_SYSTEM: /* system */
 		/* before use first enable system calls with the following gdb command: 'set remote system-call-allowed 1' */
 		ret = tc_system(t, params[0], params[1] + 1);
 		break;
 
-	case SYS_FLEN:
-		 {	/* file length */
-			 ret = -1;
-			 uint32_t fio_stat[16]; /* same size as fio_stat in gdb/include/gdb/fileio.h */
-			 //DEBUG("SYS_FLEN fio_stat addr %p\n", fio_stat);
-			 void (*saved_mem_read)(target *t, void *dest, target_addr src, size_t len);
-			 void (*saved_mem_write)(target *t, target_addr dest, const void *src, size_t len);
-			 saved_mem_read = t->mem_read;
-			 saved_mem_write = t->mem_write;
-			 t->mem_read = probe_mem_read;
-			 t->mem_write = probe_mem_write;
-			 int rc = tc_fstat(t, params[0] - 1, (target_addr)fio_stat); /* write fstat() result in fio_stat[] */
-			 t->mem_read = saved_mem_read;
-			 t->mem_write = saved_mem_write;
-			 if (rc) break; /* tc_fstat() failed */
-			 uint32_t fst_size_msw = fio_stat[7]; /* most significant 32 bits of fst_size in fio_stat */
-			 uint32_t fst_size_lsw = fio_stat[8]; /* least significant 32 bits of fst_size in fio_stat */
-			 if (fst_size_msw != 0) break; /* file size too large for int32_t return type */
-			 ret = __builtin_bswap32(fst_size_lsw); /* convert from bigendian to target order */
-			 if (ret < 0) ret = -1; /* file size too large for int32_t return type */
-			 break;
-		 }
+	case SYS_FLEN: { /* file length */
+		ret = -1;
+		uint32_t fio_stat[16]; /* same size as fio_stat in gdb/include/gdb/fileio.h */
+		//DEBUG("SYS_FLEN fio_stat addr %p\n", fio_stat);
+		void (*saved_mem_read)(target * t, void *dest, target_addr src, size_t len);
+		void (*saved_mem_write)(target * t, target_addr dest, const void *src, size_t len);
+		saved_mem_read = t->mem_read;
+		saved_mem_write = t->mem_write;
+		t->mem_read = probe_mem_read;
+		t->mem_write = probe_mem_write;
+		int rc = tc_fstat(t, params[0] - 1, (target_addr)fio_stat); /* write fstat() result in fio_stat[] */
+		t->mem_read = saved_mem_read;
+		t->mem_write = saved_mem_write;
+		if (rc)
+			break;                           /* tc_fstat() failed */
+		uint32_t fst_size_msw = fio_stat[7]; /* most significant 32 bits of fst_size in fio_stat */
+		uint32_t fst_size_lsw = fio_stat[8]; /* least significant 32 bits of fst_size in fio_stat */
+		if (fst_size_msw != 0)
+			break;                             /* file size too large for int32_t return type */
+		ret = __builtin_bswap32(fst_size_lsw); /* convert from bigendian to target order */
+		if (ret < 0)
+			ret = -1; /* file size too large for int32_t return type */
+		break;
+	}
 
-	case SYS_CLOCK: /* clock */
+	case SYS_CLOCK:  /* clock */
 	case SYS_TIME: { /* time */
 		/* use same code for SYS_CLOCK and SYS_TIME, more compact */
 		ret = -1;
@@ -1586,46 +1628,51 @@ static int cortexm_hostio_request(target *t)
 			uint64_t ftv_usec;
 		} fio_timeval;
 		//DEBUG("SYS_TIME fio_timeval addr %p\n", &fio_timeval);
-		void (*saved_mem_read)(target *t, void *dest, target_addr src, size_t len);
-		void (*saved_mem_write)(target *t, target_addr dest, const void *src, size_t len);
+		void (*saved_mem_read)(target * t, void *dest, target_addr src, size_t len);
+		void (*saved_mem_write)(target * t, target_addr dest, const void *src, size_t len);
 		saved_mem_read = t->mem_read;
 		saved_mem_write = t->mem_write;
 		t->mem_read = probe_mem_read;
 		t->mem_write = probe_mem_write;
-		int rc = tc_gettimeofday(t, (target_addr) &fio_timeval, (target_addr) NULL); /* write gettimeofday() result in fio_timeval[] */
+		int rc = tc_gettimeofday(
+			t, (target_addr)&fio_timeval, (target_addr)NULL); /* write gettimeofday() result in fio_timeval[] */
 		t->mem_read = saved_mem_read;
 		t->mem_write = saved_mem_write;
-		if (rc) break; /* tc_gettimeofday() failed */
+		if (rc)
+			break;                                             /* tc_gettimeofday() failed */
 		uint32_t sec = __builtin_bswap32(fio_timeval.ftv_sec); /* convert from bigendian to target order */
 		uint64_t usec = __builtin_bswap64(fio_timeval.ftv_usec);
 		if (syscall == SYS_TIME) { /* SYS_TIME: time in seconds */
 			ret = sec;
 		} else { /* SYS_CLOCK: time in hundredths of seconds */
-			if (time0_sec > sec) time0_sec = sec; /* set sys_clock time origin */
+			if (time0_sec > sec)
+				time0_sec = sec; /* set sys_clock time origin */
 			sec -= time0_sec;
-			uint64_t csec64 = (sec * 1000000ull + usec)/10000ull;
+			uint64_t csec64 = (sec * UINT64_C(1000000) + usec) / UINT64_C(10000);
 			uint32_t csec = csec64 & 0x7fffffff;
 			ret = csec;
 		}
 		break;
-		}
+	}
 
 	case SYS_READC: { /* readc */
-		uint8_t ch='?';
+		uint8_t ch = '?';
 		//DEBUG("SYS_READC ch addr %p\n", &ch);
-		void (*saved_mem_read)(target *t, void *dest, target_addr src, size_t len);
-		void (*saved_mem_write)(target *t, target_addr dest, const void *src, size_t len);
+		void (*saved_mem_read)(target * t, void *dest, target_addr src, size_t len);
+		void (*saved_mem_write)(target * t, target_addr dest, const void *src, size_t len);
 		saved_mem_read = t->mem_read;
 		saved_mem_write = t->mem_write;
 		t->mem_read = probe_mem_read;
 		t->mem_write = probe_mem_write;
-		int rc = tc_read(t, STDIN_FILENO, (target_addr) &ch, 1); /* read a character in ch */
+		int rc = tc_read(t, STDIN_FILENO, (target_addr)&ch, 1); /* read a character in ch */
 		t->mem_read = saved_mem_read;
 		t->mem_write = saved_mem_write;
-		if (rc == 1) ret = ch;
-		else ret = -1;
+		if (rc == 1)
+			ret = ch;
+		else
+			ret = -1;
 		break;
-		}
+	}
 
 	case SYS_ERRNO: /* Return last errno from GDB */
 		ret = t->tc->errno_;
@@ -1637,7 +1684,7 @@ static int cortexm_hostio_request(target *t)
 		target_halt_resume(t, 1);
 		break;
 
-	case SYS_EXIT_EXTENDED: /* _exit() */
+	case SYS_EXIT_EXTENDED:                                      /* _exit() */
 		tc_printf(t, "_exit(0x%x%08x)\n", params[1], params[0]); /* exit() with 64bit exit value */
 		target_halt_resume(t, 1);
 		break;
@@ -1647,43 +1694,31 @@ static int cortexm_hostio_request(target *t)
 		ret = -1;
 		target_addr buf_ptr = params[0];
 		target_addr buf_len = params[1];
-		if (strlen(t->cmdline)+1 > buf_len) break;
-		if(target_mem_write(t, buf_ptr, t->cmdline, strlen(t->cmdline)+1)) break;
+		if (strlen(t->cmdline) + 1 > buf_len)
+			break;
+		if (target_mem_write(t, buf_ptr, t->cmdline, strlen(t->cmdline) + 1))
+			break;
 		retval[0] = buf_ptr;
-		retval[1] = strlen(t->cmdline)+1;
-		if(target_mem_write(t, arm_regs[1], retval, sizeof(retval))) break;
+		retval[1] = strlen(t->cmdline) + 1;
+		if (target_mem_write(t, arm_regs[1], retval, sizeof(retval)))
+			break;
 		ret = 0;
 		break;
-		}
+	}
 
 	case SYS_ISERROR: { /* iserror */
 		int errorNo = params[0];
-		ret = (errorNo == TARGET_EPERM) ||
-			  (errorNo == TARGET_ENOENT) ||
-			  (errorNo == TARGET_EINTR) ||
-			  (errorNo == TARGET_EIO) ||
-			  (errorNo == TARGET_EBADF) ||
-			  (errorNo == TARGET_EACCES) ||
-			  (errorNo == TARGET_EFAULT) ||
-			  (errorNo == TARGET_EBUSY) ||
-			  (errorNo == TARGET_EEXIST) ||
-			  (errorNo == TARGET_ENODEV) ||
-			  (errorNo == TARGET_ENOTDIR) ||
-			  (errorNo == TARGET_EISDIR) ||
-			  (errorNo == TARGET_EINVAL) ||
-			  (errorNo == TARGET_ENFILE) ||
-			  (errorNo == TARGET_EMFILE) ||
-			  (errorNo == TARGET_EFBIG) ||
-			  (errorNo == TARGET_ENOSPC) ||
-			  (errorNo == TARGET_ESPIPE) ||
-			  (errorNo == TARGET_EROFS) ||
-			  (errorNo == TARGET_ENOSYS) ||
-			  (errorNo == TARGET_ENAMETOOLONG) ||
-			  (errorNo == TARGET_EUNKNOWN);
+		ret = errorNo == TARGET_EPERM || errorNo == TARGET_ENOENT || errorNo == TARGET_EINTR || errorNo == TARGET_EIO ||
+		      errorNo == TARGET_EBADF || errorNo == TARGET_EACCES || errorNo == TARGET_EFAULT ||
+		      errorNo == TARGET_EBUSY || errorNo == TARGET_EEXIST || errorNo == TARGET_ENODEV ||
+		      errorNo == TARGET_ENOTDIR || errorNo == TARGET_EISDIR || errorNo == TARGET_EINVAL ||
+		      errorNo == TARGET_ENFILE || errorNo == TARGET_EMFILE || errorNo == TARGET_EFBIG ||
+		      errorNo == TARGET_ENOSPC || errorNo == TARGET_ESPIPE || errorNo == TARGET_EROFS ||
+		      errorNo == TARGET_ENOSYS || errorNo == TARGET_ENAMETOOLONG || errorNo == TARGET_EUNKNOWN;
 		break;
-		}
+	}
 
-	case SYS_HEAPINFO: /* heapinfo */
+	case SYS_HEAPINFO:                                                       /* heapinfo */
 		target_mem_write(t, arm_regs[1], &t->heapinfo, sizeof(t->heapinfo)); /* See newlib/libc/sys/arm/crt0.S */
 		break;
 
@@ -1692,25 +1727,29 @@ static int cortexm_hostio_request(target *t)
 		target_addr buf_ptr = params[0];
 		int target_id = params[1];
 		int buf_size = params[2];
-		char fnam[]="tempXX.tmp";
+		char fnam[] = "tempXX.tmp";
 		ret = -1;
-		if (buf_ptr == 0) break;
-		if (buf_size <= 0) break;
-		if ((target_id < 0) || (target_id > 255)) break; /* target id out of range */
-		fnam[5]='A'+(target_id&0xF); /* create filename */
-		fnam[4]='A'+(target_id>>4&0xF);
-		if (strlen(fnam)+1>(uint32_t)buf_size) break; /* target buffer too small */
-		if(target_mem_write(t, buf_ptr, fnam, strlen(fnam)+1)) break; /* copy filename to target */
+		if (buf_ptr == 0)
+			break;
+		if (buf_size <= 0)
+			break;
+		if ((target_id < 0) || (target_id > 255))
+			break;                         /* target id out of range */
+		fnam[5] = 'A' + (target_id & 0xF); /* create filename */
+		fnam[4] = 'A' + (target_id >> 4 & 0xF);
+		if (strlen(fnam) + 1 > (uint32_t)buf_size)
+			break; /* target buffer too small */
+		if (target_mem_write(t, buf_ptr, fnam, strlen(fnam) + 1))
+			break; /* copy filename to target */
 		ret = 0;
 		break;
-		}
+	}
 
 	// not implemented yet:
-	case SYS_ELAPSED: /* elapsed */
+	case SYS_ELAPSED:  /* elapsed */
 	case SYS_TICKFREQ: /* tickfreq */
 		ret = -1;
 		break;
-
 	}
 
 	arm_regs[0] = ret;

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -24,174 +24,172 @@
 
 extern unsigned cortexm_wait_timeout;
 /* Private peripheral bus base address */
-#define CORTEXM_PPB_BASE	0xE0000000
+#define CORTEXM_PPB_BASE 0xe0000000U
 
-#define CORTEXM_SCS_BASE	(CORTEXM_PPB_BASE + 0xE000)
+#define CORTEXM_SCS_BASE (CORTEXM_PPB_BASE + 0xe000U)
 
-#define CORTEXM_CPUID		(CORTEXM_SCS_BASE + 0xD00)
-#define CORTEXM_AIRCR		(CORTEXM_SCS_BASE + 0xD0C)
-#define CORTEXM_CFSR		(CORTEXM_SCS_BASE + 0xD28)
-#define CORTEXM_HFSR		(CORTEXM_SCS_BASE + 0xD2C)
-#define CORTEXM_DFSR		(CORTEXM_SCS_BASE + 0xD30)
-#define CORTEXM_CPACR		(CORTEXM_SCS_BASE + 0xD88)
-#define CORTEXM_DHCSR		(CORTEXM_SCS_BASE + 0xDF0)
-#define CORTEXM_DCRSR		(CORTEXM_SCS_BASE + 0xDF4)
-#define CORTEXM_DCRDR		(CORTEXM_SCS_BASE + 0xDF8)
-#define CORTEXM_DEMCR		(CORTEXM_SCS_BASE + 0xDFC)
+#define CORTEXM_CPUID (CORTEXM_SCS_BASE + 0xd00U)
+#define CORTEXM_AIRCR (CORTEXM_SCS_BASE + 0xd0cU)
+#define CORTEXM_CFSR  (CORTEXM_SCS_BASE + 0xd28U)
+#define CORTEXM_HFSR  (CORTEXM_SCS_BASE + 0xd2cU)
+#define CORTEXM_DFSR  (CORTEXM_SCS_BASE + 0xd30U)
+#define CORTEXM_CPACR (CORTEXM_SCS_BASE + 0xd88U)
+#define CORTEXM_DHCSR (CORTEXM_SCS_BASE + 0xdf0U)
+#define CORTEXM_DCRSR (CORTEXM_SCS_BASE + 0xdf4U)
+#define CORTEXM_DCRDR (CORTEXM_SCS_BASE + 0xdf8U)
+#define CORTEXM_DEMCR (CORTEXM_SCS_BASE + 0xdfcU)
 
 /* Cache identification */
-#define CORTEXM_CLIDR		(CORTEXM_SCS_BASE + 0xD78)
-#define CORTEXM_CTR		(CORTEXM_SCS_BASE + 0xD7C)
-#define CORTEXM_CCSIDR		(CORTEXM_SCS_BASE + 0xD80)
-#define CORTEXM_CSSELR		(CORTEXM_SCS_BASE + 0xD84)
+#define CORTEXM_CLIDR  (CORTEXM_SCS_BASE + 0xd78U)
+#define CORTEXM_CTR    (CORTEXM_SCS_BASE + 0xd7cU)
+#define CORTEXM_CCSIDR (CORTEXM_SCS_BASE + 0xd80U)
+#define CORTEXM_CSSELR (CORTEXM_SCS_BASE + 0xd84U)
 
 /* Cache maintenance operations */
-#define CORTEXM_ICIALLU		(CORTEXM_SCS_BASE + 0xF50)
-#define CORTEXM_DCCMVAC		(CORTEXM_SCS_BASE + 0xF68)
-#define CORTEXM_DCCIMVAC	(CORTEXM_SCS_BASE + 0xF70)
+#define CORTEXM_ICIALLU  (CORTEXM_SCS_BASE + 0xf50U)
+#define CORTEXM_DCCMVAC  (CORTEXM_SCS_BASE + 0xf68U)
+#define CORTEXM_DCCIMVAC (CORTEXM_SCS_BASE + 0xf70U)
 
-#define CORTEXM_FPB_BASE	(CORTEXM_PPB_BASE + 0x2000)
+#define CORTEXM_FPB_BASE (CORTEXM_PPB_BASE + 0x2000U)
 
 /* ARM Literature uses FP_*, we use CORTEXM_FPB_* consistently */
-#define CORTEXM_FPB_CTRL	(CORTEXM_FPB_BASE + 0x000)
-#define CORTEXM_FPB_REMAP	(CORTEXM_FPB_BASE + 0x004)
-#define CORTEXM_FPB_COMP(i)	(CORTEXM_FPB_BASE + 0x008 + (4*(i)))
+#define CORTEXM_FPB_CTRL    (CORTEXM_FPB_BASE + 0x000U)
+#define CORTEXM_FPB_REMAP   (CORTEXM_FPB_BASE + 0x004U)
+#define CORTEXM_FPB_COMP(i) (CORTEXM_FPB_BASE + 0x008U + (4U * (i)))
 
-#define CORTEXM_DWT_BASE	(CORTEXM_PPB_BASE + 0x1000)
+#define CORTEXM_DWT_BASE (CORTEXM_PPB_BASE + 0x1000U)
 
-#define CORTEXM_DWT_CTRL	(CORTEXM_DWT_BASE + 0x000)
-#define CORTEXM_DWT_COMP(i)	(CORTEXM_DWT_BASE + 0x020 + (0x10*(i)))
-#define CORTEXM_DWT_MASK(i)	(CORTEXM_DWT_BASE + 0x024 + (0x10*(i)))
-#define CORTEXM_DWT_FUNC(i)	(CORTEXM_DWT_BASE + 0x028 + (0x10*(i)))
+#define CORTEXM_DWT_CTRL    (CORTEXM_DWT_BASE + 0x000U)
+#define CORTEXM_DWT_COMP(i) (CORTEXM_DWT_BASE + 0x020U + (0x10U * (i)))
+#define CORTEXM_DWT_MASK(i) (CORTEXM_DWT_BASE + 0x024U + (0x10U * (i)))
+#define CORTEXM_DWT_FUNC(i) (CORTEXM_DWT_BASE + 0x028U + (0x10U * (i)))
 
 /* Application Interrupt and Reset Control Register (AIRCR) */
-#define CORTEXM_AIRCR_VECTKEY		(0x05FA << 16)
+#define CORTEXM_AIRCR_VECTKEY (0x05faU << 16U)
 /* Bits 31:16 - Read as VECTKETSTAT, 0xFA05 */
-#define CORTEXM_AIRCR_ENDIANESS		(1 << 15)
+#define CORTEXM_AIRCR_ENDIANESS (1U << 15U)
 /* Bits 15:11 - Unused, reserved */
-#define CORTEXM_AIRCR_PRIGROUP		(7 << 8)
+#define CORTEXM_AIRCR_PRIGROUP (7U << 8U)
 /* Bits 7:3 - Unused, reserved */
-#define CORTEXM_AIRCR_SYSRESETREQ	(1 << 2)
-#define CORTEXM_AIRCR_VECTCLRACTIVE	(1 << 1)
-#define CORTEXM_AIRCR_VECTRESET		(1 << 0)
+#define CORTEXM_AIRCR_SYSRESETREQ   (1U << 2U)
+#define CORTEXM_AIRCR_VECTCLRACTIVE (1U << 1U)
+#define CORTEXM_AIRCR_VECTRESET     (1U << 0U)
 
 /* HardFault Status Register (HFSR) */
-#define CORTEXM_HFSR_DEBUGEVT		(1 << 31)
-#define CORTEXM_HFSR_FORCED		(1 << 30)
+#define CORTEXM_HFSR_DEBUGEVT (1U << 31U)
+#define CORTEXM_HFSR_FORCED   (1U << 30U)
 /* Bits 29:2 - Not specified */
-#define CORTEXM_HFSR_VECTTBL		(1 << 1)
+#define CORTEXM_HFSR_VECTTBL (1U << 1U)
 /* Bits 0 - Reserved */
 
 /* Debug Fault Status Register (DFSR) */
 /* Bits 31:5 - Reserved */
-#define CORTEXM_DFSR_RESETALL		0x1F
-#define CORTEXM_DFSR_EXTERNAL		(1 << 4)
-#define CORTEXM_DFSR_VCATCH		(1 << 3)
-#define CORTEXM_DFSR_DWTTRAP		(1 << 2)
-#define CORTEXM_DFSR_BKPT		(1 << 1)
-#define CORTEXM_DFSR_HALTED		(1 << 0)
+#define CORTEXM_DFSR_RESETALL 0x1fU
+#define CORTEXM_DFSR_EXTERNAL (1U << 4U)
+#define CORTEXM_DFSR_VCATCH   (1U << 3U)
+#define CORTEXM_DFSR_DWTTRAP  (1U << 2U)
+#define CORTEXM_DFSR_BKPT     (1U << 1U)
+#define CORTEXM_DFSR_HALTED   (1U << 0U)
 
 /* Debug Halting Control and Status Register (DHCSR) */
 /* This key must be written to bits 31:16 for write to take effect */
-#define CORTEXM_DHCSR_DBGKEY		0xA05F0000
+#define CORTEXM_DHCSR_DBGKEY 0xa05f0000U
 /* Bits 31:26 - Reserved */
-#define CORTEXM_DHCSR_S_RESET_ST	(1 << 25)
-#define CORTEXM_DHCSR_S_RETIRE_ST	(1 << 24)
+#define CORTEXM_DHCSR_S_RESET_ST  (1U << 25U)
+#define CORTEXM_DHCSR_S_RETIRE_ST (1U << 24U)
 /* Bits 23:20 - Reserved */
-#define CORTEXM_DHCSR_S_LOCKUP		(1 << 19)
-#define CORTEXM_DHCSR_S_SLEEP		(1 << 18)
-#define CORTEXM_DHCSR_S_HALT		(1 << 17)
-#define CORTEXM_DHCSR_S_REGRDY		(1 << 16)
+#define CORTEXM_DHCSR_S_LOCKUP (1U << 19U)
+#define CORTEXM_DHCSR_S_SLEEP  (1U << 18U)
+#define CORTEXM_DHCSR_S_HALT   (1U << 17U)
+#define CORTEXM_DHCSR_S_REGRDY (1U << 16U)
 /* Bits 15:6 - Reserved */
-#define CORTEXM_DHCSR_C_SNAPSTALL	(1 << 5)	/* v7m only */
+#define CORTEXM_DHCSR_C_SNAPSTALL (1U << 5U) /* v7m only */
 /* Bit 4 - Reserved */
-#define CORTEXM_DHCSR_C_MASKINTS	(1 << 3)
-#define CORTEXM_DHCSR_C_STEP		(1 << 2)
-#define CORTEXM_DHCSR_C_HALT		(1 << 1)
-#define CORTEXM_DHCSR_C_DEBUGEN		(1 << 0)
+#define CORTEXM_DHCSR_C_MASKINTS (1U << 3U)
+#define CORTEXM_DHCSR_C_STEP     (1U << 2U)
+#define CORTEXM_DHCSR_C_HALT     (1U << 1U)
+#define CORTEXM_DHCSR_C_DEBUGEN  (1U << 0U)
 
 /* Debug Core Register Selector Register (DCRSR) */
-#define CORTEXM_DCRSR_REGWnR		0x00010000
-#define CORTEXM_DCRSR_REGSEL_MASK	0x0000001F
-#define CORTEXM_DCRSR_REGSEL_XPSR	0x00000010
-#define CORTEXM_DCRSR_REGSEL_MSP	0x00000011
-#define CORTEXM_DCRSR_REGSEL_PSP	0x00000012
+#define CORTEXM_DCRSR_REGWnR      0x00010000
+#define CORTEXM_DCRSR_REGSEL_MASK 0x0000001f
+#define CORTEXM_DCRSR_REGSEL_XPSR 0x00000010
+#define CORTEXM_DCRSR_REGSEL_MSP  0x00000011
+#define CORTEXM_DCRSR_REGSEL_PSP  0x00000012
 
 /* Debug Exception and Monitor Control Register (DEMCR) */
 /* Bits 31:25 - Reserved */
-#define CORTEXM_DEMCR_TRCENA		(1 << 24)
+#define CORTEXM_DEMCR_TRCENA (1U << 24U)
 /* Bits 23:20 - Reserved */
-#define CORTEXM_DEMCR_MON_REQ		(1 << 19)	/* v7m only */
-#define CORTEXM_DEMCR_MON_STEP		(1 << 18)	/* v7m only */
-#define CORTEXM_DEMCR_VC_MON_PEND	(1 << 17)	/* v7m only */
-#define CORTEXM_DEMCR_VC_MON_EN		(1 << 16)	/* v7m only */
+#define CORTEXM_DEMCR_MON_REQ     (1U << 19U) /* v7m only */
+#define CORTEXM_DEMCR_MON_STEP    (1U << 18U) /* v7m only */
+#define CORTEXM_DEMCR_VC_MON_PEND (1U << 17U) /* v7m only */
+#define CORTEXM_DEMCR_VC_MON_EN   (1U << 16U) /* v7m only */
 /* Bits 15:11 - Reserved */
-#define CORTEXM_DEMCR_VC_HARDERR	(1 << 10)
-#define CORTEXM_DEMCR_VC_INTERR		(1 << 9)	/* v7m only */
-#define CORTEXM_DEMCR_VC_BUSERR		(1 << 8)	/* v7m only */
-#define CORTEXM_DEMCR_VC_STATERR	(1 << 7)	/* v7m only */
-#define CORTEXM_DEMCR_VC_CHKERR		(1 << 6)	/* v7m only */
-#define CORTEXM_DEMCR_VC_NOCPERR	(1 << 5)	/* v7m only */
-#define CORTEXM_DEMCR_VC_MMERR		(1 << 4)	/* v7m only */
+#define CORTEXM_DEMCR_VC_HARDERR (1U << 10U)
+#define CORTEXM_DEMCR_VC_INTERR  (1U << 9U) /* v7m only */
+#define CORTEXM_DEMCR_VC_BUSERR  (1U << 8U) /* v7m only */
+#define CORTEXM_DEMCR_VC_STATERR (1U << 7U) /* v7m only */
+#define CORTEXM_DEMCR_VC_CHKERR  (1U << 6U) /* v7m only */
+#define CORTEXM_DEMCR_VC_NOCPERR (1U << 5U) /* v7m only */
+#define CORTEXM_DEMCR_VC_MMERR   (1U << 4U) /* v7m only */
 /* Bits 3:1 - Reserved */
-#define CORTEXM_DEMCR_VC_CORERESET	(1 << 0)
+#define CORTEXM_DEMCR_VC_CORERESET (1U << 0U)
 
 /* Flash Patch and Breakpoint Control Register (FP_CTRL) */
 /* Bits 32:15 - Reserved */
-/* Bits 14:12 - NUM_CODE2 */	/* v7m only */
-/* Bits 11:8 - NUM_LIT */	/* v7m only */
+/* Bits 14:12 - NUM_CODE2 */ /* v7m only */
+/* Bits 11:8 - NUM_LIT */    /* v7m only */
 /* Bits 7:4 - NUM_CODE1 */
 /* Bits 3:2 - Unspecified */
-#define CORTEXM_FPB_CTRL_KEY		(1 << 1)
-#define CORTEXM_FPB_CTRL_ENABLE		(1 << 0)
+#define CORTEXM_FPB_CTRL_KEY    (1U << 1U)
+#define CORTEXM_FPB_CTRL_ENABLE (1U << 0U)
 
 /* Data Watchpoint and Trace Mask Register (DWT_MASKx)
 *  The value here is the number of address bits we mask out */
-#define CORTEXM_DWT_MASK_BYTE		(0)
-#define CORTEXM_DWT_MASK_HALFWORD	(1)
-#define CORTEXM_DWT_MASK_WORD		(2)
-#define CORTEXM_DWT_MASK_DWORD		(3)
+#define CORTEXM_DWT_MASK_BYTE     (0U)
+#define CORTEXM_DWT_MASK_HALFWORD (1U)
+#define CORTEXM_DWT_MASK_WORD     (2U)
+#define CORTEXM_DWT_MASK_DWORD    (3U)
 
 /* Data Watchpoint and Trace Function Register (DWT_FUNCTIONx) */
-#define CORTEXM_DWT_FUNC_MATCHED	(1 << 24)
-#define CORTEXM_DWT_FUNC_DATAVSIZE_WORD	(2 << 10)	/* v7m only */
-#define CORTEXM_DWT_FUNC_FUNC_READ	(5 << 0)
-#define CORTEXM_DWT_FUNC_FUNC_WRITE	(6 << 0)
-#define CORTEXM_DWT_FUNC_FUNC_ACCESS	(7 << 0)
+#define CORTEXM_DWT_FUNC_MATCHED        (1U << 24U)
+#define CORTEXM_DWT_FUNC_DATAVSIZE_WORD (2U << 10U) /* v7m only */
+#define CORTEXM_DWT_FUNC_FUNC_READ      (5U << 0U)
+#define CORTEXM_DWT_FUNC_FUNC_WRITE     (6U << 0U)
+#define CORTEXM_DWT_FUNC_FUNC_ACCESS    (7U << 0U)
 
-#define REG_SP		13
-#define REG_LR		14
-#define REG_PC		15
-#define REG_XPSR	16
-#define REG_MSP		17
-#define REG_PSP		18
-#define REG_SPECIAL	19
+#define REG_SP      13U
+#define REG_LR      14U
+#define REG_PC      15U
+#define REG_XPSR    16U
+#define REG_MSP     17U
+#define REG_PSP     18U
+#define REG_SPECIAL 19U
 
-#define ARM_THUMB_BREAKPOINT 0xBE00
-#define CORTEXM_XPSR_THUMB (1 << 24)
+#define ARM_THUMB_BREAKPOINT 0xbe00U
+#define CORTEXM_XPSR_THUMB   (1U << 24U)
 
-#define	CORTEXM_TOPT_INHIBIT_NRST (1 << 2)
+#define CORTEXM_TOPT_INHIBIT_NRST (1U << 2U)
 
 enum cortexm_types {
-	CORTEX_M0  = 0xc200,
+	CORTEX_M0 = 0xc200,
 	CORTEX_M0P = 0xc600,
-	CORTEX_M3  = 0xc230,
-	CORTEX_M4  = 0xc240,
-	CORTEX_M7  = 0xc270,
+	CORTEX_M3 = 0xc230,
+	CORTEX_M4 = 0xc240,
+	CORTEX_M7 = 0xc270,
 	CORTEX_M23 = 0xd200,
 	CORTEX_M33 = 0xd210,
 };
-#define CPUID_PARTNO_MASK 0xfff0
-#define CPUID_REVISION_MASK 0x00f00000
-#define CPUID_PATCH_MASK 0xf
+#define CPUID_PARTNO_MASK   0xfff0U
+#define CPUID_REVISION_MASK 0x00f00000U
+#define CPUID_PATCH_MASK    0xfU
 
 ADIv5_AP_t *cortexm_ap(target *t);
 
 bool cortexm_attach(target *t);
 void cortexm_detach(target *t);
-int cortexm_run_stub(target *t, uint32_t loadaddr,
-                     uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3);
-int cortexm_mem_write_sized(
-	target *t, target_addr dest, const void *src, size_t len, enum align align);
+int cortexm_run_stub(target *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3);
+int cortexm_mem_write_sized(target *t, target_addr dest, const void *src, size_t len, enum align align);
 
 #endif

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -540,7 +540,7 @@ bool efm32_probe(target *t)
 
 	/* Read the IDCODE register from the SW-DP */
 	ADIv5_AP_t *ap = cortexm_ap(t);
-	uint32_t ap_idcode = ap->dp->idcode;
+	uint32_t ap_idcode = ap->dp->debug_port_id;
 
 	/* Check the idcode. See AN0062 Section 2.2 */
 	if (ap_idcode == 0x2BA01477) {

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -536,23 +536,9 @@ struct efm32_priv_s {
 
 bool efm32_probe(target *t)
 {
-	uint8_t di_version = 1;
-
-	/* Read the IDCODE register from the SW-DP */
-	ADIv5_AP_t *ap = cortexm_ap(t);
-	uint32_t ap_idcode = ap->dp->debug_port_id;
-
-	/* Check the idcode. See AN0062 Section 2.2 */
-	if (ap_idcode == 0x2BA01477) {
-		/* Cortex M3, Cortex M4 */
-	} else if (ap_idcode == 0x0BC11477) {
-		/* Cortex M0+ */
-	} else {
-		return false;
-	}
-
 	/* Check if the OUI in the EUI is silabs or energymicro.
 	 * Use this to identify the Device Identification (DI) version */
+	uint8_t di_version = 1;
 	uint64_t oui24 = ((efm32_v1_read_eui64(t) >> 40) & 0xFFFFFF);
 	if (oui24 == EFM32_V1_DI_EUI_SILABS) {
 		/* Device Identification (DI) version 1 */

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -33,8 +33,6 @@
 #define IAP_RAM_BASE				0x10000000
 
 #define MEMMAP						0x400FC040
-#define LPC17xx_JTAG_IDCODE			0x4BA00477
-#define LPC17xx_SWDP_IDCODE			0x2BA01477
 #define FLASH_NUM_SECTOR			30
 
 struct flash_param {
@@ -64,15 +62,6 @@ static void lpc17xx_add_flash(target *t, uint32_t addr, size_t len, size_t erase
 bool
 lpc17xx_probe(target *t)
 {
-	/* Read the IDCODE register from the SW-DP */
-	ADIv5_AP_t *ap = cortexm_ap(t);
-	uint32_t ap_idcode = ap->dp->debug_port_id;
-
-	if (ap_idcode == LPC17xx_JTAG_IDCODE || ap_idcode == LPC17xx_SWDP_IDCODE) {
-		/* LPC176x/5x family. See UM10360.pdf 33.7 JTAG TAP Identification*/
-	} else
-		return false;
-
 	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M3)  {
 		/*
 		 * Now that we're sure it's a Cortex-M3, we need to halt the

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -66,7 +66,7 @@ lpc17xx_probe(target *t)
 {
 	/* Read the IDCODE register from the SW-DP */
 	ADIv5_AP_t *ap = cortexm_ap(t);
-	uint32_t ap_idcode = ap->dp->idcode;
+	uint32_t ap_idcode = ap->dp->debug_port_id;
 
 	if (ap_idcode == LPC17xx_JTAG_IDCODE || ap_idcode == LPC17xx_SWDP_IDCODE) {
 		/* LPC176x/5x family. See UM10360.pdf 33.7 JTAG TAP Identification*/

--- a/src/target/semihosting.h
+++ b/src/target/semihosting.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022  Black Sphere Technologies Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __SEMIHOSTING_H
+#define __SEMIHOSTING_H
+
+/* Semihosting support */
+
+/*
+ * If the target wants to read the special filename ":semihosting-features"
+ * to know what semihosting features are supported, it's easiest to create
+ * that file on the host in the directory where gdb runs,
+ * or, if using pc-hosted, where blackmagic_hosted runs.
+ *
+ * $ echo -e 'SHFB\x03' > ":semihosting-features"
+ * $ chmod 0444 ":semihosting-features"
+ */
+
+/* ARM Semihosting syscall numbers, from "Semihosting for AArch32 and AArch64 Version 3.0" */
+
+#define SEMIHOSTING_SYS_CLOCK         0x10U
+#define SEMIHOSTING_SYS_CLOSE         0x02U
+#define SEMIHOSTING_SYS_ELAPSED       0x30U
+#define SEMIHOSTING_SYS_ERRNO         0x13U
+#define SEMIHOSTING_SYS_EXIT          0x18U
+#define SEMIHOSTING_SYS_EXIT_EXTENDED 0x20U
+#define SEMIHOSTING_SYS_FLEN          0x0cU
+#define SEMIHOSTING_SYS_GET_CMDLINE   0x15U
+#define SEMIHOSTING_SYS_HEAPINFO      0x16U
+#define SEMIHOSTING_SYS_ISERROR       0x08U
+#define SEMIHOSTING_SYS_ISTTY         0x09U
+#define SEMIHOSTING_SYS_OPEN          0x01U
+#define SEMIHOSTING_SYS_READ          0x06U
+#define SEMIHOSTING_SYS_READC         0x07U
+#define SEMIHOSTING_SYS_REMOVE        0x0eU
+#define SEMIHOSTING_SYS_RENAME        0x0fU
+#define SEMIHOSTING_SYS_SEEK          0x0aU
+#define SEMIHOSTING_SYS_SYSTEM        0x12U
+#define SEMIHOSTING_SYS_TICKFREQ      0x31U
+#define SEMIHOSTING_SYS_TIME          0x11U
+#define SEMIHOSTING_SYS_TMPNAM        0x0dU
+#define SEMIHOSTING_SYS_WRITE         0x05U
+#define SEMIHOSTING_SYS_WRITEC        0x03U
+#define SEMIHOSTING_SYS_WRITE0        0x04U
+
+#endif /* __SEMIHOSTING_H */

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -515,7 +515,7 @@ bool stm32l4_probe(target *t)
 		idcode = (ap->dp->targetid >> 16) & 0xfff;
 	} else {
 		uint32_t idcode_reg = STM32L4_DBGMCU_IDCODE_PHYS;
-		if (ap->dp->idcode == 0x0Be12477)
+		if (ap->dp->debug_port_id == 0x0Be12477)
 			idcode_reg = STM32L5_DBGMCU_IDCODE_PHYS;
 		idcode = target_mem_read32(t, idcode_reg) & 0xfff;
 		DEBUG_INFO("Idcode %08" PRIx32 "\n", idcode);


### PR DESCRIPTION
a second round of cleanup on adi code, this fixes the misleading idcode naming, we were actually reading the DP DPIDR register, it also fixes the JEP106 code for raspberry, and the handling of designer code in a couple registers (the reason for the wrong jep code)