### PR TITLE
Rework/cleanup TARGETID handling

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -359,8 +359,8 @@ static void display_target(int i, target *t, void *context)
 	const char attached = target_attached(t) ? '*' : ' ';
 	const char *const core_name = target_core_name(t);
 	if (!strcmp(target_driver_name(t), "ARM Cortex-M"))
-		gdb_outf("***%2d %c Unknown %s Designer 0x%03x Partno 0x%03x %s\n", i, attached, target_driver_name(t),
-			target_designer(t), target_idcode(t), core_name ? core_name : "");
+		gdb_outf("***%2d %c Unknown %s Designer 0x%x Part ID 0x%x %s\n", i, attached, target_driver_name(t),
+			target_designer(t), target_part_id(t), core_name ? core_name : "");
 	else
 		gdb_outf("%2d   %c  %s %s\n", i, attached, target_driver_name(t), core_name ? core_name : "");
 }

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -52,7 +52,7 @@ bool target_attached(target *t);
 const char *target_driver_name(target *t);
 const char *target_core_name(target *t);
 unsigned int target_designer(target *t);
-unsigned int target_idcode(target *t);
+unsigned int target_part_id(target *t);
 
 /* Memory access functions */
 bool target_mem_map(target *t, char *buf, size_t len);

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -391,11 +391,11 @@ static void display_target(int i, target *t, void *context)
 {
 	(void)context;
 	if (!strcmp(target_driver_name(t), "ARM Cortex-M")) {
-		DEBUG_INFO("***%2d%sUnknown %s Designer %3x Partno %3x %s\n",
+		DEBUG_INFO("***%2d%sUnknown %s Designer %x Part ID %x %s\n",
 			  i, target_attached(t)?" * ":" ",
 			  target_driver_name(t),
 			  target_designer(t),
-			  target_idcode(t),
+			  target_part_id(t),
 			  (target_core_name(t)) ? target_core_name(t): "");
 	} else {
 		DEBUG_INFO("*** %2d   %c  %s %s\n", i, target_attached(t)?'*':' ',

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1078,17 +1078,20 @@ int stlink_enter_debug_swd(bmp_info_t *info, ADIv5_DP_t *dp)
 	if (stlink_usb_error_check(data, true))
 		exit( -1);
 	dp->debug_port_id = stlink_read_coreid();
+	dp->version = (dp->debug_port_id & ADIV5_DP_DPIDR_VERSION_MASK) >> ADIV5_DP_DPIDR_VERSION_OFFSET;
+
 	dp->dp_read = stlink_dp_read;
 	dp->error = stlink_dp_error;
 	dp->low_access = stlink_dp_low_access;
 	dp->abort = stlink_dp_abort;
 
 	stlink_dp_error(dp);
-	if ((dp->debug_port_id & ADIV5_DP_DPIDR_VERSION_MASK) == ADIV5_DP_DPIDR_VERSION_DPv2) {
-		adiv5_dp_write(dp, ADIV5_DP_SELECT, 2);
-		dp->targetid = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
+
+	if (dp->version >= 2) {
+		/* READ TARGETID, only available on DPv2 or later */
+		adiv5_dp_write(dp, ADIV5_DP_SELECT, 2); /* TARGETID is on bank 2 */
+		dp->target_id = adiv5_dp_read(dp, ADIV5_DP_TARGETID);
 		adiv5_dp_write(dp, ADIV5_DP_SELECT, 0);
-		DEBUG_INFO("TARGETID 0x%08" PRIx32 "\n", dp->targetid);
 	}
 	return 0;
 }

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -510,9 +510,9 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, const size_t re
 	if (cid_class == cidc_romtab) {
 		if (recursion == 0) {
 			ap->designer_code = designer_code;
-			ap->ap_partno = part_number;
+			ap->partno = part_number;
 
-			if (ap->designer_code == JEP106_MANUFACTURER_ATMEL && ap->ap_partno == 0xcd0) {
+			if (ap->designer_code == JEP106_MANUFACTURER_ATMEL && ap->partno == 0xcd0) {
 				uint32_t ctrlstat = adiv5_mem_read32(ap, SAMX5X_DSU_CTRLSTAT);
 				if (ctrlstat & SAMX5X_STATUSB_PROT) {
 					/* A protected SAMx5x device is found.

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -41,7 +41,7 @@
 #define ADIV5_DP_DPIDR     ADIV5_DP_REG(0x0U)
 #define ADIV5_DP_ABORT     ADIV5_DP_REG(0x0U)
 #define ADIV5_DP_CTRLSTAT  ADIV5_DP_REG(0x4U)
-#define ADIV5_DP_TARGETID  (ADIV5_DP_BANK2 | ADIV5_DP_REG(0x4U))
+#define ADIV5_DP_TARGETID  ADIV5_DP_REG(0x4U) /* ADIV5_DP_BANK2 */
 #define ADIV5_DP_SELECT    ADIV5_DP_REG(0x8U)
 #define ADIV5_DP_RDBUFF    ADIV5_DP_REG(0xCU)
 #define ADIV5_DP_TARGETSEL ADIV5_DP_REG(0xCU)
@@ -68,7 +68,7 @@
 #define ADIV5_DP_TARGETID_TDESIGNER_OFFSET 1U
 #define ADIV5_DP_TARGETID_TDESIGNER_MASK   (0x7ffU << ADIV5_DP_TARGETID_TDESIGNER_OFFSET)
 
-/* DP DPIDR/TARGETID DESIGNER */
+/* DP DPIDR/TARGETID/IDCODE DESIGNER */
 /* Bits 10:7 - JEP-106 Continuation code */
 /* Bits 6:0 - JEP-106 Identity code */
 #define ADIV5_DP_DESIGNER_JEP106_CONT_OFFSET 7U
@@ -146,6 +146,14 @@
 #define ADIV5_ROM_ROMENTRY_PRESENT (1U << 0U)
 #define ADIV5_ROM_ROMENTRY_OFFSET  (0xFFFFF000U)
 
+/* JTAG TAP IDCODE */
+#define JTAG_IDCODE_VERSION_OFFSET  28U
+#define JTAG_IDCODE_VERSION_MASK    (0xfU << JTAG_IDCODE_VERSION_OFFSET)
+#define JTAG_IDCODE_PARTNO_OFFSET   12U
+#define JTAG_IDCODE_PARTNO_MASK     (0xffffU << JTAG_IDCODE_PARTNO_OFFSET)
+#define JTAG_IDCODE_DESIGNER_OFFSET 1U
+#define JTAG_IDCODE_DESIGNER_MASK   (0x7ffU << JTAG_IDCODE_DESIGNER_OFFSET)
+
 /* Constants to make RnW parameters more clear in code */
 #define ADIV5_LOW_WRITE 0
 #define ADIV5_LOW_READ  1
@@ -220,11 +228,7 @@ typedef struct ADIv5_DP_s {
 	int refcnt;
 
 	uint32_t debug_port_id;
-
-	uint16_t designer_code;
-	uint16_t partno;
-
-	uint32_t targetid; /* Contains IDCODE for DPv2 devices.*/
+	uint32_t target_id; /* present on DPv2 or later */
 
 	void (*seq_out)(uint32_t tms_states, size_t clock_cycles);
 	void (*seq_out_parity)(uint32_t tms_states, size_t clock_cycles);
@@ -254,6 +258,15 @@ typedef struct ADIv5_DP_s {
 	void (*mem_write_sized)(ADIv5_AP_t *ap, uint32_t dest, const void *src, size_t len, enum align align);
 	uint8_t dp_jd_index;
 	uint8_t fault;
+
+	uint8_t version;
+
+	uint8_t revision;
+	bool mindp;
+
+	/* DP designer (not implementer!) and partno */
+	uint16_t designer_code;
+	uint16_t partno;
 } ADIv5_DP_t;
 
 struct ADIv5_AP_s {

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -267,8 +267,10 @@ struct ADIv5_AP_s {
 	uint32_t csw;
 	uint32_t ap_cortexm_demcr; /* Copy of demcr when starting */
 	uint32_t ap_storage;       /* E.g to hold STM32F7 initial DBGMCU_CR value.*/
+
+	/* AP designer and partno */
 	uint16_t designer_code;
-	uint16_t ap_partno;
+	uint16_t partno;
 };
 
 unsigned int make_packet_request(uint8_t RnW, uint16_t addr);

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -48,11 +48,7 @@ void adiv5_jtag_dp_handler(uint8_t jd_index)
 	}
 
 	dp->dp_jd_index = jd_index;
-	/* From the ADI spec :
-	 * The architecture does not require that the TAP IDCODE
-	 * register value and the DPIDR (ADIv5) value are the same
-	 * should read DPIDR here
-	 */
+	/* JTAG routine passes IDCODE to port ID and version = 0 */
 	dp->debug_port_id = jtag_devs[jd_index].jd_idcode;
 	if ((PC_HOSTED == 0 ) || (!platform_jtag_dp_init(dp))) {
 		dp->dp_read = fw_adiv5_jtagdp_read;

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -167,8 +167,8 @@ bool ch32f1_probe(target *t)
 {
 	if ((t->cpuid & CPUID_PARTNO_MASK) != CORTEX_M3)
 		return false;
-	const uint32_t idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0x00000fffU;
-	if (idcode != 0x410) // only ch32f103
+	const uint32_t device_id = target_mem_read32(t, DBGMCU_IDCODE) & 0x00000fffU;
+	if (device_id != 0x410) // only ch32f103
 		return false;
 
 	// try to flock (if this fails it is not a CH32 chip)
@@ -178,7 +178,7 @@ bool ch32f1_probe(target *t)
 	if (ch32f1_flash_unlock(t))
 		return false;
 
-	t->idcode = idcode;
+	t->part_id = device_id;
 	uint32_t signature = target_mem_read32(t, FLASHSIZE);
 	uint32_t flashSize = signature & 0xFFFF;
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -284,7 +284,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 
 	adiv5_ap_ref(ap);
 	t->designer_code = ap->designer_code;
-	t->idcode = ap->ap_partno;
+	t->part_id = ap->ap_partno;
 	struct cortexm_priv *priv = calloc(1, sizeof(*priv));
 	if (!priv) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -74,8 +74,6 @@ static void lpc11xx_add_flash(target *t, const uint32_t addr, const size_t len, 
 
 bool lpc11xx_probe(target *t)
 {
-	uint32_t idcode;
-
 	/* read the device ID register */
 	/* For LPC11xx & LPC11Cxx see UM10398 Rev. 12.4 Chapter 26.5.11 Table 387
 	 * For LPC11Uxx see UM10462 Rev. 5.5 Chapter 20.13.11 Table 377
@@ -85,8 +83,9 @@ bool lpc11xx_probe(target *t)
 	 *   2) the LPC11U3x series, see UM10462 Rev.5.5 Chapter 3.1
 	 * But see the comment for the LPC8xx series below.
 	 */
-	idcode = target_mem_read32(t, LPC11XX_DEVICE_ID);
-	switch (idcode) {
+	uint32_t device_id = target_mem_read32(t, LPC11XX_DEVICE_ID);
+
+	switch (device_id) {
 	case 0x0A07102B: /* LPC1110 - 4K Flash 1K SRAM */
 	case 0x1A07102B: /* LPC1110 - 4K Flash 1K SRAM */
 	case 0x0A16D02B: /* LPC1111/002 - 8K Flash 2K SRAM */
@@ -159,8 +158,8 @@ bool lpc11xx_probe(target *t)
 		target_add_commands(t, lpc11xx_cmd_list, "LPC8N04");
 		return true;
 	}
-	if ((t->designer_code != JEP106_MANUFACTURER_SPECULAR) && idcode) {
-		DEBUG_INFO("LPC11xx: Unknown IDCODE 0x%08" PRIx32 "\n", idcode);
+	if ((t->designer_code != JEP106_MANUFACTURER_SPECULAR) && device_id) {
+		DEBUG_INFO("LPC11xx: Unknown Device ID 0x%08" PRIx32 "\n", device_id);
 	}
 	/* For LPC802, see UM11045 Rev. 1.4 Chapter 6.6.29 Table 84
 	 * For LPC804, see UM11065 Rev. 1.0 Chapter 6.6.31 Table 87
@@ -173,8 +172,8 @@ bool lpc11xx_probe(target *t)
 	 * for the LPC8xx series is also valid for the LPC11xx "XL" and the
 	 * LPC11U3x variants.
 	 */
-	idcode = target_mem_read32(t, LPC8XX_DEVICE_ID);
-	switch (idcode) {
+	device_id = target_mem_read32(t, LPC8XX_DEVICE_ID);
+	switch (device_id) {
 	case 0x00008021: /* LPC802M001JDH20 - 16K Flash 2K SRAM */
 	case 0x00008022: /* LPC802M011JDH20 */
 	case 0x00008023: /* LPC802M001JDH16 */
@@ -273,8 +272,8 @@ bool lpc11xx_probe(target *t)
 		target_add_commands(t, lpc11xx_cmd_list, "LPC11xx-XL");
 		return true;
 	}
-	if (idcode) {
-		DEBUG_INFO("LPC8xx: Unknown IDCODE 0x%08" PRIx32 "\n", idcode);
+	if (device_id) {
+		DEBUG_INFO("LPC8xx: Unknown Device ID 0x%08" PRIx32 "\n", device_id);
 	}
 
 	return false;

--- a/src/target/lpc15xx.c
+++ b/src/target/lpc15xx.c
@@ -69,12 +69,12 @@ static void lpc15xx_add_flash(target *t, uint32_t addr, size_t len, size_t erase
 bool
 lpc15xx_probe(target *t)
 {
-	uint32_t idcode;
 	uint32_t ram_size = 0;
 
 	/* read the device ID register */
-	idcode = target_mem_read32(t, LPC15XX_DEVICE_ID);
-	switch (idcode) {
+	const uint32_t device_id = target_mem_read32(t, LPC15XX_DEVICE_ID);
+
+	switch (device_id) {
 	case 0x00001549:
 	case 0x00001519:
 		ram_size = 0x9000;
@@ -88,6 +88,7 @@ lpc15xx_probe(target *t)
 		ram_size = 0x3000;
 		break;
 	}
+
 	if (ram_size) {
 		t->driver = "LPC15xx";
 		target_add_ram(t, 0x02000000, ram_size);

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -206,7 +206,7 @@ bool stm32g0_probe(target *t)
 
 	target_mem_map_free(t);
 
-	switch (t->idcode) {
+	switch (t->part_id) {
 	case STM32G03_4:
 		/* SRAM 8 kiB, Flash up to 64 kiB */
 		ram_size = (uint32_t)RAM_SIZE_G03_4;
@@ -354,7 +354,7 @@ static int stm32g0_flash_erase(struct target_flash *f, target_addr addr, size_t 
 		goto exit_cleanup;
 
 	nb_pages_to_erase = (uint16_t)((len - 1U) / f->blocksize) + 1U;
-	if (t->idcode == STM32G0B_C) // Dual-bank devices
+	if (t->part_id == STM32G0B_C) // Dual-bank devices
 		bank1_end_page_nb = ((f->length / 2U) - 1U) / f->blocksize;
 	page_nb = (uint16_t)((addr - f->start) / f->blocksize);
 

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -224,8 +224,7 @@ static void stm32h7_detach(target *t)
 
 bool stm32h7_probe(target *t)
 {
-	uint32_t idcode = t->idcode;
-	if (idcode == ID_STM32H74x || idcode == ID_STM32H7Bx || idcode == ID_STM32H72x) {
+	if (t->part_id == ID_STM32H74x || t->part_id == ID_STM32H7Bx || t->part_id == ID_STM32H72x) {
 		t->mass_erase = stm32h7_mass_erase;
 		t->driver = stm32h7_driver_str;
 		t->attach = stm32h7_attach;
@@ -406,7 +405,7 @@ static bool stm32h7_uid(target *t, int argc, const char **argv)
 	(void)argv;
 
 	uint32_t uid = 0x1ff1e800;
-	if (t->idcode == ID_STM32H7Bx) {
+	if (t->part_id == ID_STM32H7Bx) {
 		uid = 0x08fff800;  /* 7B3/7A3/7B0 */
 	}
 

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -165,7 +165,7 @@ enum stm32l_idcode_e {
 
 static bool stm32lx_is_stm32l1(target *t)
 {
-	switch (t->idcode) {
+	switch (t->part_id) {
 	case 0x457: /* STM32L0xx Cat1 */
 	case 0x425: /* STM32L0xx Cat2 */
 	case 0x417: /* STM32L0xx Cat3 */
@@ -178,7 +178,7 @@ static bool stm32lx_is_stm32l1(target *t)
 
 static uint32_t stm32lx_nvm_eeprom_size(target *t)
 {
-	switch (t->idcode) {
+	switch (t->part_id) {
 	case 0x457: /* STM32L0xx Cat1 */
 		return STM32L0_NVM_EEPROM_CAT1_SIZE;
 	case 0x425: /* STM32L0xx Cat2 */
@@ -194,7 +194,7 @@ static uint32_t stm32lx_nvm_eeprom_size(target *t)
 
 static uint32_t stm32lx_nvm_phys(target *t)
 {
-	switch (t->idcode) {
+	switch (t->part_id) {
 	case 0x457: /* STM32L0xx Cat1 */
 	case 0x425: /* STM32L0xx Cat2 */
 	case 0x417: /* STM32L0xx Cat3 */
@@ -207,7 +207,7 @@ static uint32_t stm32lx_nvm_phys(target *t)
 
 static uint32_t stm32lx_nvm_option_size(target *t)
 {
-	switch (t->idcode) {
+	switch (t->part_id) {
 	case 0x457: /* STM32L0xx Cat1 */
 	case 0x425: /* STM32L0xx Cat2 */
 	case 0x417: /* STM32L0xx Cat3 */
@@ -256,7 +256,7 @@ static void stm32l_add_eeprom(target *t, uint32_t addr, size_t length)
     STM32L0xx parts as well as the STM32L1xx's. */
 bool stm32l0_probe(target *t)
 {
-	switch (t->idcode) {
+	switch (t->part_id) {
 	case 0x416: /* CAT. 1 device */
 	case 0x429: /* CAT. 2 device */
 	case 0x427: /* CAT. 3 device */

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -214,7 +214,7 @@ struct stm32l4_info {
 	uint16_t sram1; /* Normal SRAM mapped at 0x20000000*/
 	uint16_t sram2; /* SRAM at 0x10000000, mapped after sram1 (not L47) */
 	uint16_t sram3; /* SRAM mapped after SRAM1 and SRAM2 */
-	enum ID_STM32L4 idcode;
+	enum ID_STM32L4 device_id;
 	enum FAM_STM32L4 family;
 	uint8_t flags;          /* Only DUAL_BANK is evaluated for now.*/
 	const uint32_t *flash_regs_map;
@@ -222,7 +222,7 @@ struct stm32l4_info {
 
 static struct stm32l4_info const L4info[] = {
 	{
-		.idcode = ID_STM32L41,
+		.device_id = ID_STM32L41,
 		.family = FAM_STM32L4xx,
 		.designator = "STM32L41x",
 		.sram1 = 32,
@@ -231,7 +231,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32L43,
+		.device_id = ID_STM32L43,
 		.family = FAM_STM32L4xx,
 		.designator = "STM32L43x",
 		.sram1 = 48,
@@ -240,7 +240,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32L45,
+		.device_id = ID_STM32L45,
 		.family = FAM_STM32L4xx,
 		.designator = "STM32L45x",
 		.sram1 = 128,
@@ -249,7 +249,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32L47,
+		.device_id = ID_STM32L47,
 		.family = FAM_STM32L4xx,
 		.designator = "STM32L47x",
 		.sram1 = 96,
@@ -258,7 +258,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32L49,
+		.device_id = ID_STM32L49,
 		.family = FAM_STM32L4xx,
 		.designator = "STM32L49x",
 		.sram1 = 256,
@@ -267,7 +267,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32L4R,
+		.device_id = ID_STM32L4R,
 		.family = FAM_STM32L4Rx,
 		.designator = "STM32L4Rx",
 		.sram1 = 192,
@@ -277,7 +277,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32G43,
+		.device_id = ID_STM32G43,
 		.family = FAM_STM32G4xx,
 		.designator = "STM32G43",
 		.sram1 = 22,
@@ -285,7 +285,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32G47,
+		.device_id = ID_STM32G47,
 		.family = FAM_STM32G4xx,
 		.designator = "STM32G47",
 		.sram1 = 96, /* SRAM1 and SRAM2 are mapped continuous */
@@ -294,7 +294,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32G49,
+		.device_id = ID_STM32G49,
 		.family = FAM_STM32G4xx,
 		.designator = "STM32G49",
 		.sram1 = 96, /* SRAM1 and SRAM2 are mapped continuously */
@@ -303,7 +303,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l4_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32L55,
+		.device_id = ID_STM32L55,
 		.family = FAM_STM32L55x,
 		.designator = "STM32L55",
 		.sram1 = 192, /* SRAM1 and SRAM2 are mapped continuous */
@@ -312,7 +312,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32l5_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32WLXX,
+		.device_id = ID_STM32WLXX,
 		.family = FAM_STM32WLxx,
 		.designator = "STM32WLxx",
 		.sram1 = 32,
@@ -321,7 +321,7 @@ static struct stm32l4_info const L4info[] = {
 		.flash_regs_map = stm32wl_flash_regs_map,
 	},
 	{
-		.idcode = ID_STM32WBXX,
+		.device_id = ID_STM32WBXX,
 		.family = FAM_STM32WBxx,
 		.designator = "STM32WBxx",
 		.sram1 = 192,
@@ -331,35 +331,35 @@ static struct stm32l4_info const L4info[] = {
 	},
 	{
 		/* Terminator */
-		.idcode = 0,
+		.device_id = 0,
 	},
 };
 
 /* Retrieve chip basic information, just add to the vector to extend */
-static struct stm32l4_info const * stm32l4_get_chip_info(uint32_t idcode) {
+static struct stm32l4_info const * stm32l4_get_chip_info(uint32_t device_id) {
 	struct stm32l4_info const *p = L4info;
-	while (p->idcode && (p->idcode != idcode))
+	while (p->device_id && (p->device_id != device_id))
 		p++;
 	return p;
 }
 
 static uint32_t stm32l4_flash_read16(target *t, enum stm32l4_flash_regs reg)
 {
-	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->idcode);
+	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->part_id);
 	uint32_t addr = chip->flash_regs_map[reg];
 	return target_mem_read16(t, addr);
 }
 
 static uint32_t stm32l4_flash_read32(target *t, enum stm32l4_flash_regs reg)
 {
-	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->idcode);
+	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->part_id);
 	uint32_t addr = chip->flash_regs_map[reg];
 	return target_mem_read32(t, addr);
 }
 
 static void stm32l4_flash_write32(target *t, enum stm32l4_flash_regs reg, uint32_t value)
 {
-	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->idcode);
+	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->part_id);
 	uint32_t addr = chip->flash_regs_map[reg];
 	target_mem_write32(t, addr, value);
 }
@@ -403,7 +403,7 @@ static bool stm32l4_attach(target *t)
 		return false;
 
 	/* Retrive chip information, no need to check return */
-	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->idcode);
+	struct stm32l4_info const *chip = stm32l4_get_chip_info(t->part_id);
 
 	uint32_t idcodereg;
 	switch(chip->family) {
@@ -432,7 +432,7 @@ static bool stm32l4_attach(target *t)
 	else
 		target_add_ram(t, 0x10000000, chip->sram2 << 10);
 	/* All L4 beside L47 alias SRAM2 after SRAM1.*/
-	uint32_t ramsize = (t->idcode == ID_STM32L47)?
+	uint32_t ramsize = (t->part_id == ID_STM32L47)?
 		chip->sram1 : (chip->sram1 + chip->sram2 + chip->sram3);
 	target_add_ram(t, 0x20000000, ramsize << 10);
 
@@ -461,11 +461,11 @@ static bool stm32l4_attach(target *t)
 		// Cat 2 is always 128k with 2k pages, single bank
 		// Cat 3 is dual bank with an option bit to choose single 512k bank with 4k pages or dual bank as 2x256k with 2k pages
 		// Cat 4 is single bank with up to 512k, 2k pages
-		if (chip->idcode == ID_STM32G43) {
+		if (chip->device_id == ID_STM32G43) {
 			uint32_t banksize = size << 10;
 			stm32l4_add_flash(t, 0x08000000, banksize, 0x0800, -1);
 		}
-		else if (chip->idcode == ID_STM32G49) {
+		else if (chip->device_id == ID_STM32G49) {
 			// Announce maximum possible flash size on this chip
 			stm32l4_add_flash(t, 0x08000000, FLASH_SIZE_MAX_G4_CAT4, 0x0800, -1);
 		}
@@ -510,29 +510,30 @@ static void stm32l4_detach(target *t)
 bool stm32l4_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
-	uint32_t idcode;
-	if (ap->dp->targetid > 1) { /* STM32L552 has in valid TARGETID 1 */
-		idcode = (ap->dp->targetid >> 16) & 0xfff;
+	uint32_t device_id;
+	if (ap->dp->targetid > 1) { /* STM32L552 has invalid TARGETID 1 */
+		/* todo: cleanup, this does not look correct, nothing in TARGETID register has offset 16 */
+		device_id = (ap->dp->targetid >> 16) & 0xfff;
 	} else {
 		uint32_t idcode_reg = STM32L4_DBGMCU_IDCODE_PHYS;
 		if (ap->dp->debug_port_id == 0x0Be12477)
 			idcode_reg = STM32L5_DBGMCU_IDCODE_PHYS;
-		idcode = target_mem_read32(t, idcode_reg) & 0xfff;
-		DEBUG_INFO("Idcode %08" PRIx32 "\n", idcode);
+		device_id = target_mem_read32(t, idcode_reg) & 0xfff;
+		DEBUG_INFO("Idcode %08" PRIx32 "\n", device_id);
 	}
 
-	struct stm32l4_info const *chip = stm32l4_get_chip_info(idcode);
+	struct stm32l4_info const *chip = stm32l4_get_chip_info(device_id);
 
-	if( !chip->idcode )	/* Not found */
+	if( !chip->device_id )	/* Not found */
 		return false;
 
 	t->driver = chip->designator;
-	switch (idcode) {
+	switch (device_id) {
 		case ID_STM32WLXX:
 		case ID_STM32WBXX:
 			if ((stm32l4_flash_read32(t, FLASH_OPTR)) &	FLASH_OPTR_ESE) {
 				DEBUG_WARN("STM32W security enabled\n");
-				t->driver = (idcode == ID_STM32WLXX) ?
+				t->driver = (device_id == ID_STM32WLXX) ?
 					"STM32WLxx(secure)" : "STM32WBxx(secure)";
 			}
 			if (ap->apsel == 0) {
@@ -734,15 +735,15 @@ static bool stm32l4_option_write(
 
 static bool stm32l4_cmd_option(target *t, int argc, char *argv[])
 {
-	if (t->idcode == ID_STM32L55) {
+	if (t->part_id == ID_STM32L55) {
 		tc_printf(t, "STM32L5 options not implemented!\n");
 		return false;
 	}
-	if (t->idcode == ID_STM32WBXX) {
+	if (t->part_id == ID_STM32WBXX) {
 		tc_printf(t, "STM32WBxx options not implemented!\n");
 		return false;
 	}
-	if (t->idcode == ID_STM32WLXX) {
+	if (t->part_id == ID_STM32WLXX) {
 		tc_printf(t, "STM32WLxx options not implemented!\n");
 		return false;
 	}
@@ -766,20 +767,20 @@ static bool stm32l4_cmd_option(target *t, int argc, char *argv[])
 	bool res = false;
 	uint32_t fpec_base = L4_FPEC_BASE;
 	const uint8_t *i2offset = l4_i2offset;
-	if (t->idcode == ID_STM32L43) {/* L43x */
+	if (t->part_id == ID_STM32L43) {/* L43x */
 		len = 5;
-	} else if (t->idcode == ID_STM32G47) {/* G47 */
+	} else if (t->part_id == ID_STM32G47) {/* G47 */
 		i2offset = g4_i2offset;
 		len = 11;
 		for (int i = 0; i < len; i++)
 			values[i] = g4_values[i];
-	} else if ((t->idcode == ID_STM32G43) || (t->idcode == ID_STM32G49)) {
+	} else if ((t->part_id == ID_STM32G43) || (t->part_id == ID_STM32G49)) {
 		/* G4 cat 2 and 4 (single bank) */
 		i2offset = g4_i2offset;
 		len = 6;
 		for (int i = 0; i < len; i++)
 			values[i] = g4_values[i];
-	} else if (t->idcode == ID_STM32WLXX) {/* WLxx */
+	} else if (t->part_id == ID_STM32WLXX) {/* WLxx */
 		len = 7;
 		i2offset = wl_i2offset;
 		fpec_base = WL_FPEC_BASE;

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -511,14 +511,14 @@ bool stm32l4_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
 	uint32_t device_id;
-	if (ap->dp->targetid > 1) { /* STM32L552 has invalid TARGETID 1 */
-		/* todo: cleanup, this does not look correct, nothing in TARGETID register has offset 16 */
-		device_id = (ap->dp->targetid >> 16) & 0xfff;
+	if (ap->dp->version >= 2 && ap->dp->target_id > 1) { /* STM32L552 has invalid TARGETID 1 */
+		/* FIXME: this does not look correct, nothing in TARGETID register has offset 16 */
+		device_id = (ap->dp->target_id >> 16U) & 0xfffU;
 	} else {
 		uint32_t idcode_reg = STM32L4_DBGMCU_IDCODE_PHYS;
-		if (ap->dp->debug_port_id == 0x0Be12477)
+		if (ap->dp->debug_port_id == 0x0be12477U)
 			idcode_reg = STM32L5_DBGMCU_IDCODE_PHYS;
-		device_id = target_mem_read32(t, idcode_reg) & 0xfff;
+		device_id = target_mem_read32(t, idcode_reg) & 0xfffU;
 		DEBUG_INFO("Idcode %08" PRIx32 "\n", device_id);
 	}
 

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -589,9 +589,9 @@ unsigned int target_designer(target *t)
 	return t->designer_code;
 }
 
-unsigned int target_idcode(target *t)
+unsigned int target_part_id(target *t)
 {
-	return t->idcode;
+	return t->part_id;
 }
 
 uint32_t target_mem_read32(target *t, uint32_t addr)

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -117,9 +117,6 @@ struct target_s {
 	/* target-defined options */
 	unsigned target_options;
 
-	uint16_t designer_code;
-	uint16_t part_id;
-
 	void *target_storage;
 	union {
 		bool unsafe_enabled;
@@ -144,6 +141,13 @@ struct target_s {
 
 	void *priv;
 	void (*priv_free)(void *);
+
+	/* Target designer and id / partno */
+	uint16_t designer_code;
+	/* targetid partno if available (>= DPv2)
+	 * fallback to ap partno
+	 */
+	uint16_t part_id;
 };
 
 void target_print_progress(platform_timeout *timeout);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -116,8 +116,10 @@ struct target_s {
 
 	/* target-defined options */
 	unsigned target_options;
+
 	uint16_t designer_code;
-	uint16_t idcode;
+	uint16_t part_id;
+
 	void *target_storage;
 	union {
 		bool unsafe_enabled;


### PR DESCRIPTION
built on top of #1143 mind the extra commits

This tries to improve readabilty and correctness in the initialization of the dp and the reading and usage of targetid

This needs some more thorough testing, but so far it looks good, on some embedded jlink targets target id is now being read where it was not before

changed the logic in the target probe "selection" including the change mentioned on discord

~~note: i think we can, and should, safely move the target id reading inside the dp_init method, but I'll leave that for a future cleanup~~