### PR TITLE
fix: Add nop instruction for timing purpose

### DIFF
--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -108,6 +108,7 @@ static void jtagtap_tms_seq_no_delay(uint32_t tms_states, size_t ticks)
 		gpio_set_val(TMS_PORT, TMS_PIN, state);
 		gpio_set(TCK_PORT, TCK_PIN);
 		tms_states >>= 1;
+		__asm__("nop");
 		ticks--;
 		gpio_clear(TCK_PORT, TCK_PIN);
 	}


### PR DESCRIPTION
Adding a nop instruction in the no_delay TMS sequence routine fixes timing on the f4discovery platform