### PR TITLE
Fix: ch32f1 cleanup

### DIFF
--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -129,7 +129,7 @@ static void ch32f1_add_flash(target *t, uint32_t addr, size_t length, size_t era
   \fn ch32f1_flash_unlock
   \brief unlock ch32f103 in fast mode
 */
-static int ch32f1_flash_unlock(target *t)
+static bool ch32f1_flash_unlock(target *t)
 {
 	DEBUG_INFO("CH32: flash unlock \n");
 
@@ -141,9 +141,9 @@ static int ch32f1_flash_unlock(target *t)
 	uint32_t cr = target_mem_read32(t, FLASH_CR);
 	if (cr & FLASH_CR_FLOCK_CH32) {
 		DEBUG_WARN("Fast unlock failed, cr: 0x%08" PRIx32 "\n", cr);
-		return -1;
+		return true;
 	}
-	return 0;
+	return false;
 }
 
 static int ch32f1_flash_lock(target *t)

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -146,17 +146,17 @@ static bool ch32f1_flash_unlock(target *t)
 	return false;
 }
 
-static int ch32f1_flash_lock(target *t)
+static bool ch32f1_flash_lock(target *t)
 {
 	DEBUG_INFO("CH32: flash lock \n");
 	SET_CR(FLASH_CR_LOCK);
-	uint32_t cr = target_mem_read32(t, FLASH_CR);
+	const uint32_t cr = target_mem_read32(t, FLASH_CR);
 	// FLASH_CR_FLOCK_CH32 bit does not exists on *regular* clones and defaults to '0' (see PM0075 for STM32F1xx)
-	if ((cr & FLASH_CR_FLOCK_CH32) == 0) {
+	if (!(cr & FLASH_CR_FLOCK_CH32)) {
 		DEBUG_WARN("Fast lock failed, cr: 0x%08" PRIx32 "\n", cr);
-		return -1;
+		return true;
 	}
-	return 0;
+	return false;
 }
 
 /**

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -276,7 +276,7 @@ static int ch32f1_upload(target *t, uint32_t dest, const void *src, uint32_t off
 	\fn ch32f1_buffer_clear
 	\brief clear the write buffer
 */
-int ch32f1_buffer_clear(target *t)
+static int ch32f1_buffer_clear(target *t)
 {
 	volatile uint32_t sr;
 	SET_CR(FLASH_CR_FTPG_CH32); // Fast page program 4-


### PR DESCRIPTION
This PR cleans up some type abuse and missing `static` in the CH32F1 code.

The cleanup was prompted by #1148 which fixes a bug in how CH32F1 parts are probed for vs other clones.