### PR TITLE
Supports for BlackPill AT32F403A

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -481,6 +481,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 
 			PROBE(lpc43xx_probe);
 			PROBE(kinetis_probe); /* Older K-series */
+			PROBE(at32fxx_probe);
 		} else if (ap->ap_partno == 0x4cb) { /* Cortex-M23 ROM */
 			PROBE(gd32f1_probe); /* GD32E23x uses GD32F1 peripherals */
 		} else if (ap->ap_partno == 0x4c0) { /* Cortex-M0+ ROM */

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -154,6 +154,90 @@ bool gd32f1_probe(target *t)
 }
 
 /**
+	\brief identify at32fxx chips (Cortex-M4)
+*/
+bool at32fxx_probe(target *t)
+{
+	// Artery clones uses Cortex M4 cores
+	if ((t->cpuid & CPUID_PARTNO_MASK) != CORTEX_M4)
+		return false;
+	// Artery chips use the complete idcode word for identification ()
+	const uint32_t idcode = target_mem_read32(t, DBGMCU_IDCODE);
+	// AT32F415 Series?
+	if ((idcode & 0xfffff000U) == 0x70030000) {
+		switch(idcode &0x00000FFF) {
+			case 0x0240:	// LQFP64_10x10
+			case 0x0241:	// LQFP48_7x7
+			case 0x0242:	// QFN32_4x4
+			case 0x0243:	// LQFP64_7x7
+			case 0x024c:	// QFN48_6x6
+				// Flash: 256 KB / 2KB per block
+				stm32f1_add_flash(t, 0x08000000, 256 * 1024, 2 * 1024);
+				break;
+			case 0x01c4:	// LQFP64_10x10
+			case 0x01c5:	// LQFP48_7x7
+			case 0x01c6:	// QFN32_4x4
+			case 0x01c7:	// LQFP64_7x7
+			case 0x01cd:	// QFN48_6x6
+				// Flash: 128 KB / 2KB per block
+				stm32f1_add_flash(t, 0x08000000, 128 * 1024, 2 * 1024);
+				break;
+			case 0x0108:	// LQFP64_10x10
+			case 0x0109:	// LQFP48_7x7
+			case 0x010a:	// QFN32_4x4
+				// Flash: 64 KB / 2KB per block
+				stm32f1_add_flash(t, 0x08000000, 64 * 1024, 2 * 1024);
+				break;
+			// Unknown/undocumented
+			default:
+				return false;
+		}
+		// All parts have 32KB SRAM
+		target_add_ram(t, 0x20000000, 32 * 1024);
+		t->driver = "AT32F415";
+	}
+	// AT32F403A/407 Series?
+	else if ((idcode & 0xfffff000U) == 0x70050000) {
+		// Current driver supports only *default* memory layout (256 KB Flash / 96 KB SRAM)
+		// (*) Support for external Flash for 512KB and 1024KB parts requires specific flash code (not implement)
+		switch(idcode &0x00000FFF) {
+			case 0x0240:	// AT32F403AVCT7 256KB / LQFP100
+			case 0x0241:	// AT32F403ARCT7 256KB / LQFP64
+			case 0x0242:	// AT32F403ACCT7 256KB / LQFP48
+			case 0x0243:	// AT32F403ACCU7 256KB / QFN48
+			case 0x0249:	// AT32F407VCT7 256KB / LQFP100
+			case 0x024a:	// AT32F407RCT7 256KB / LQFP64
+			case 0x0254:	// AT32F407AVCT7 256KB / LQFP100
+			case 0x02cd:	// AT32F403AVET7 512KB / LQFP100 (*)
+			case 0x02ce:	// AT32F403ARET7 512KB / LQFP64 (*)
+			case 0x02cf:	// AT32F403ACET7 512KB / LQFP48 (*)
+			case 0x02d0:	// AT32F403ACEU7 512KB / QFN48 (*)
+			case 0x02d1:	// AT32F407VET7 512KB / LQFP100 (*)
+			case 0x02d2:	// AT32F407RET7 512KB / LQFP64 (*)
+			case 0x0344:	// AT32F403AVGT7 1024KB / LQFP100 (*)
+			case 0x0345:	// AT32F403ARGT7 1024KB / LQFP64 (*)
+			case 0x0346:	// AT32F403ACGT7 1024KB / LQFP48 (*)
+			case 0x0347:	// AT32F403ACGU7 1024KB / QFN48 (found on BlackPill+ WeAct Studio) (*)
+			case 0x034b:	// AT32F407VGT7 1024KB / LQFP100 (*)
+			case 0x034c:	// AT32F407VGT7 1024KB / LQFP64 (*)
+			case 0x0353:	// AT32F407AVGT7 1024KB / LQFP100 (*)
+				// Flash: 256 KB / 2KB per block
+				stm32f1_add_flash(t, 0x08000000, 256 * 1024, 2 * 1024);
+				break;
+			// Unknown/undocumented
+			default:
+				return false;
+		}
+		// All parts have 96KB SRAM
+		target_add_ram(t, 0x20000000, 96 * 1024);
+		t->driver = "AT32F403A/407";
+	}
+	else
+		return false;
+	return true;
+}
+
+/**
     \brief identify the stm32f1 chip
 */
 bool stm32f1_probe(target *t)

--- a/src/target/target_probe.h
+++ b/src/target/target_probe.h
@@ -37,6 +37,7 @@ bool efm32_aap_probe(ADIv5_AP_t *ap);
 bool rp_rescue_probe(ADIv5_AP_t *ap);
 
 bool ch32f1_probe(target *t); // will catch all the clones
+bool at32fxx_probe(target *t); // STM32 clones from Artery
 bool gd32f1_probe(target *t);
 bool stm32f1_probe(target *t);
 bool stm32f4_probe(target *t);


### PR DESCRIPTION
While Chip crisis is ongoing one more common alternative developed by WeActStudio, the [BlackPill AT32F403A](https://github.com/WeActStudio/WeActStudio.BlackPill).
This PR adds support for the entire family of chips. This family may offer an _external Flash_, which requires custom flash code to be used. With this PR the interface common to STM32F103 allows for 256KB usage, which is quite a good start.
Tested with the referred board.