### PR TITLE
blackboard dfu stuff

### DIFF
--- a/src/platforms/common/cdcacm.c
+++ b/src/platforms/common/cdcacm.c
@@ -419,7 +419,8 @@ static const char *usb_strings[] = {
 	serial_no,
 	"Black Magic GDB Server",
 	"Black Magic UART Port",
-	"Black Magic DFU",
+	/* Required, the line for stm32f1s is "@Internal Flash   /0x08000000/8*001Ka,56*001Kg" maybe use an if statement? */
+	"@Internal Flash   /0x08000000/04*016Kg,01*064Kg,03*128Kg",
 #if defined(PLATFORM_HAS_TRACESWO)
 	"Black Magic Trace Capture",
 #endif


### PR DESCRIPTION
Hello, sum simple fixes for blackboard dfu, Fixed the button on A0 its actually active low but without an active pullup would sometimes work the otherway and bounce around. The blackboardv2 can now switch into dfu flash and come back all via dfu-util without any user intervention. Use dfu-util v0.11 and dfu-util -a 0 --dfuse-address 0x08000000:leave -R -D blackmagic.bin . The only thing that may not fly is the usb string for the interface which is needed, but diff depending on stm32 part number. Also i see no adc for target, is this intentional or just hasnt been gotten to yet?