### PR TITLE
Fix: rp2040 code cleanup

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -385,7 +385,7 @@ static void rp_add_flash(target *t, uint32_t addr, size_t length)
 	target_add_flash(t, f);
 }
 
-void rp_ssel_active(target *t, bool active)
+static void rp_ssel_active(target *t, bool active)
 {
 	const uint32_t qspi_ctrl_outover_low = 2UL << 8;
 	const uint32_t qspi_ctrl_outover_high = 3UL << 8;
@@ -395,7 +395,7 @@ void rp_ssel_active(target *t, bool active)
 	target_mem_write32(t, QSPI_CTRL_ADDR, val);
 }
 
-uint32_t rp_read_flash_chip(target *t, uint32_t cmd)
+static uint32_t rp_read_flash_chip(target *t, uint32_t cmd)
 {
 	uint32_t value = 0;
 
@@ -417,7 +417,7 @@ uint32_t rp_read_flash_chip(target *t, uint32_t cmd)
 	return value;
 }
 
-uint32_t rp_get_flash_length(target *t)
+static uint32_t rp_get_flash_length(target *t)
 {
 	uint32_t size = MAX_FLASH;
 	uint32_t bootsec[16];

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -486,11 +486,6 @@ static bool rp_attach(target *t)
 	return true;
 }
 
-static void rp_detach(target *t)
-{
-	cortexm_detach(t);
-}
-
 bool rp_probe(target *t)
 {
 	/* Check bootrom magic*/
@@ -514,7 +509,6 @@ bool rp_probe(target *t)
 	t->driver = RP_ID;
 	t->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 	t->attach = rp_attach;
-	t->detach = rp_detach;
 	target_add_commands(t, rp_cmd_list, RP_ID);
 	return true;
 }

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -514,9 +514,9 @@ static bool rp_cmd_reset_usb_boot(target *t, int argc, const char **argv)
 {
 	struct rp_priv_s *ps = (struct rp_priv_s *)t->target_storage;
 	if (argc > 2) {
-		ps->regs[1] = atoi(argv[2]);
+		ps->regs[1] = strtoul(argv[2], NULL, 0);
 	} else if (argc < 3) {
-		ps->regs[0] = atoi(argv[1]);
+		ps->regs[0] = strtoul(argv[1], NULL, 0);
 	} else {
 		ps->regs[0] = 0;
 		ps->regs[1] = 0;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -467,9 +467,9 @@ static uint32_t rp_get_flash_length(target *t)
 		uint32_t mirrorsec[16];
 		while (size > FLASHSIZE_4K_SECTOR) {
 			target_mem_read(t, mirrorsec, XIP_FLASH_START + size, sizeof(bootsec));
-			if (memcmp(bootsec, mirrorsec, sizeof(bootsec)))
-				return size << 1;
-			size >>= 1;
+			if (memcmp(bootsec, mirrorsec, sizeof(bootsec)) != 0)
+				return size << 1U;
+			size >>= 1U;
 		}
 	}
 

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -380,46 +380,11 @@ static int rp_flash_write(struct target_flash *f, target_addr dest, const void *
 	return ret;
 }
 
-static bool rp_cmd_reset_usb_boot(target *t, int argc, const char **argv)
-{
-	struct rp_priv_s *ps = (struct rp_priv_s *)t->target_storage;
-	if (argc > 2) {
-		ps->regs[1] = atoi(argv[2]);
-	} else if (argc < 3) {
-		ps->regs[0] = atoi(argv[1]);
-	} else {
-		ps->regs[0] = 0;
-		ps->regs[1] = 0;
-	}
-	rp_rom_call(t, ps->regs, ps->reset_usb_boot, 0);
-	return true;
-}
-
 static bool rp_mass_erase(target *t)
 {
 	struct rp_priv_s *ps = (struct rp_priv_s *)t->target_storage;
 	ps->is_monitor = true;
 	const bool result = rp_flash_erase(t->flash, t->flash->start, t->flash->length) == 0;
-	ps->is_monitor = false;
-	return result;
-}
-
-static bool rp_cmd_erase_sector(target *t, int argc, const char **argv)
-{
-	uint32_t start = t->flash->start;
-	uint32_t length;
-
-	if (argc == 3) {
-		start = strtoul(argv[1], NULL, 0);
-		length = strtoul(argv[2], NULL, 0);
-	} else if (argc == 2)
-		length = strtoul(argv[1], NULL, 0);
-	else
-		return -1;
-
-	struct rp_priv_s *ps = (struct rp_priv_s *)t->target_storage;
-	ps->is_monitor = true;
-	const bool result = rp_flash_erase(t->flash, start, length) == 0;
 	ps->is_monitor = false;
 	return result;
 }
@@ -522,6 +487,41 @@ static bool rp_attach(target *t)
 	rp_add_flash(t, XIP_FLASH_START, size);
 	target_add_ram(t, SRAM_START, SRAM_SIZE);
 
+	return true;
+}
+
+static bool rp_cmd_erase_sector(target *t, int argc, const char **argv)
+{
+	uint32_t start = t->flash->start;
+	uint32_t length;
+
+	if (argc == 3) {
+		start = strtoul(argv[1], NULL, 0);
+		length = strtoul(argv[2], NULL, 0);
+	} else if (argc == 2)
+		length = strtoul(argv[1], NULL, 0);
+	else
+		return -1;
+
+	struct rp_priv_s *ps = (struct rp_priv_s *)t->target_storage;
+	ps->is_monitor = true;
+	const bool result = rp_flash_erase(t->flash, start, length) == 0;
+	ps->is_monitor = false;
+	return result;
+}
+
+static bool rp_cmd_reset_usb_boot(target *t, int argc, const char **argv)
+{
+	struct rp_priv_s *ps = (struct rp_priv_s *)t->target_storage;
+	if (argc > 2) {
+		ps->regs[1] = atoi(argv[2]);
+	} else if (argc < 3) {
+		ps->regs[0] = atoi(argv[1]);
+	} else {
+		ps->regs[0] = 0;
+		ps->regs[1] = 0;
+	}
+	rp_rom_call(t, ps->regs, ps->reset_usb_boot, 0);
 	return true;
 }
 

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -100,7 +100,7 @@ const struct command_s rp_cmd_list[] = {
 static int rp_flash_erase(struct target_flash *f, target_addr addr, size_t len);
 static int rp_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
 
-static bool rp2040_fill_table(struct rp_priv_s *priv, uint16_t *table, int max);
+static bool rp_fill_table(struct rp_priv_s *priv, uint16_t *table, int max);
 static bool rp_attach(target *t);
 static uint32_t rp_get_flash_length(target *t);
 static bool rp_mass_erase(target *t);
@@ -159,7 +159,7 @@ static bool rp_attach(target *t)
 	uint16_t table[RP_MAX_TABLE_SIZE];
 	uint16_t table_offset = target_mem_read32( t, BOOTROM_MAGIC_ADDR + 4);
 	if (target_mem_read(t, table, table_offset, RP_MAX_TABLE_SIZE) ||
-		rp2040_fill_table(ps, table, RP_MAX_TABLE_SIZE))
+		rp_fill_table(ps, table, RP_MAX_TABLE_SIZE))
 		return false;
 
 	/* Free previously loaded memory map */
@@ -174,7 +174,7 @@ static bool rp_attach(target *t)
 	return true;
 }
 
-static bool rp2040_fill_table(struct rp_priv_s *priv, uint16_t *table, int max)
+static bool rp_fill_table(struct rp_priv_s *priv, uint16_t *table, int max)
 {
 	uint16_t tag = *table++;
 	int check = 0;


### PR DESCRIPTION
In this PR we re-order and clean up the RP2040 support code to make it easier to read and ordered/structured more like other existing targets.

This does include some clang-tidy warnings fixes and reduces code size by a few bytes, but is otherwise purely reorganisation and renaming work.

Tested working against our RP2040.