### PR TITLE
Fix jlink vid-pid

### DIFF
--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -185,8 +185,11 @@ int jlink_init(bmp_info_t *info)
 		if ((desc.idProduct != USB_PID_SEGGER_0101) &&
 			(desc.idProduct != USB_PID_SEGGER_0105) &&
 			(desc.idProduct != USB_PID_SEGGER_1015) &&
-			(desc.idProduct != USB_PID_SEGGER_1020))
-			continue;
+			(desc.idProduct != USB_PID_SEGGER_1020)) {
+				DEBUG_WARN("Ignored device with product id 0x%04x, please report if this is a valid J-Link probe\n",
+				desc.idProduct);
+				continue;
+		}
 		int res = libusb_open(dev, &jl->ul_libusb_device_handle);
 		if (res != LIBUSB_SUCCESS)
 			continue;

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -33,12 +33,12 @@
 #include "cli.h"
 #include "jlink.h"
 
-#define USB_PID_SEGGER       0x1366
+#define USB_VID_SEGGER       0x1366
 
 /* Only two devices PIDS tested so long */
-#define USB_VID_SEGGER_0101  0x0101
-#define USB_VID_SEGGER_0105  0x0105
-#define USB_VID_SEGGER_1020  0x1020
+#define USB_PID_SEGGER_0101  0x0101
+#define USB_PID_SEGGER_0105  0x0105
+#define USB_PID_SEGGER_1020  0x1020
 
 static uint32_t emu_caps;
 static uint32_t emu_speed_kHz;
@@ -180,11 +180,11 @@ int jlink_init(bmp_info_t *info)
             DEBUG_WARN( "libusb_get_device_descriptor() failed");
 			goto error;;
 		}
-		if (desc.idVendor !=  USB_PID_SEGGER)
+		if (desc.idVendor !=  USB_VID_SEGGER)
 			continue;
-		if ((desc.idProduct != USB_VID_SEGGER_0101) &&
-			(desc.idProduct != USB_VID_SEGGER_0105) &&
-			(desc.idProduct != USB_VID_SEGGER_1020))
+		if ((desc.idProduct != USB_PID_SEGGER_0101) &&
+			(desc.idProduct != USB_PID_SEGGER_0105) &&
+			(desc.idProduct != USB_PID_SEGGER_1020))
 			continue;
 		int res = libusb_open(dev, &jl->ul_libusb_device_handle);
 		if (res != LIBUSB_SUCCESS)

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -35,9 +35,9 @@
 
 #define USB_VID_SEGGER       0x1366
 
-/* Only two devices PIDS tested so long */
 #define USB_PID_SEGGER_0101  0x0101
 #define USB_PID_SEGGER_0105  0x0105
+#define USB_PID_SEGGER_1015  0x1015
 #define USB_PID_SEGGER_1020  0x1020
 
 static uint32_t emu_caps;
@@ -184,6 +184,7 @@ int jlink_init(bmp_info_t *info)
 			continue;
 		if ((desc.idProduct != USB_PID_SEGGER_0101) &&
 			(desc.idProduct != USB_PID_SEGGER_0105) &&
+			(desc.idProduct != USB_PID_SEGGER_1015) &&
 			(desc.idProduct != USB_PID_SEGGER_1020))
 			continue;
 		int res = libusb_open(dev, &jl->ul_libusb_device_handle);


### PR DESCRIPTION
Adds PID 0x1015 to the list of valid J-Link probes ( Closes #1154 )
Fixes the PID-VID transposition error
Adds Warning when ignoring unknown PIDs sp that the user knows what happened
