### PR TITLE
Fix: ADIv5 format string

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -753,7 +753,7 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 
 		dp->target_partno = (targetid & ADIV5_DP_TARGETID_TPARTNO_MASK) >> ADIV5_DP_TARGETID_TPARTNO_OFFSET;
 
-		DEBUG_INFO("TARGETID 0x%08" PRIx32 " designer 0x%" PRIx32 " partno 0x%" PRIx32 "\n", targetid,
+		DEBUG_INFO("TARGETID 0x%08" PRIx32 " designer 0x%x partno 0x%x\n", targetid,
 			dp->target_designer_code, dp->target_partno);
 
 		dp->targetsel = dp->instance << ADIV5_DP_TARGETSEL_TINSTANCE_OFFSET |

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -95,7 +95,7 @@ uint32_t fw_adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW, uint16_t addr, 
 		dp->fault = 1;
 		return 0;
 	}
-	if ((ack != JTAGDP_ACK_OK))
+	if  (ack != JTAGDP_ACK_OK)
 		raise_exception(EXCEPTION_ERROR, "JTAG-DP invalid ACK");
 
 	return (uint32_t)(response >> 3);


### PR DESCRIPTION
This PR addresses a couple of small defects found while working on #1161.

The one in adiv5_jtagdp.c is purely cosmetic. The one in adiv5.c prevents ENABLE_DEBUG=1 builds from succeeding due to the format string mismatching the arguments provided