### PR TITLE
target/cortexm: print t->part_id not ap->partno in unknown device warning

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -498,9 +498,9 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		break;
 	}
 #if PC_HOSTED == 0
-	gdb_outf("Please report unknown device with Designer %x Part ID %x\n", ap->designer_code, ap->partno);
+	gdb_outf("Please report unknown device with Designer 0x%x Part ID 0x%x\n", t->designer_code, t->part_id);
 #else
-	DEBUG_WARN("Please report unknown device with Designer %x Part ID %x\n", ap->designer_code, ap->partno);
+	DEBUG_WARN("Please report unknown device with Designer 0x%x Part ID 0x%x\n", t->designer_code, t->part_id);
 #endif
 #undef PROBE
 	return true;


### PR DESCRIPTION
this is the id used to probe, which may or may not be the same as the one on the ap

fixup related to #1159 