### PR TITLE
target/stm32h7: fix ids

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -146,9 +146,9 @@ enum stm32h7_regs {
 #define FLASH_SECTOR_SIZE 	0x20000
 #define BANK2_START         0x08100000
 enum ID_STM32H7 {
-	ID_STM32H74x  = 0x450,      /* RM0433, RM0399 */
-	ID_STM32H7Bx  = 0x480,      /* RM0455 */
-	ID_STM32H72x  = 0x483,      /* RM0468 */
+	ID_STM32H74x  = 0x4500,      /* RM0433, RM0399 */
+	ID_STM32H7Bx  = 0x4800,      /* RM0455 */
+	ID_STM32H72x  = 0x4830,      /* RM0468 */
 };
 
 struct stm32h7_flash {


### PR DESCRIPTION
this is a naive attempt at fixing #1159, following the assumptions I made there

Other targets that were probably affected by the same problem:
stm32f4
stm32g0
stm32lx

Signed-off-by: Rafael Silva <perigoso@riseup.net>