### PR TITLE
Feature: SFDP support for SPI Flash

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,7 @@ SRC =			\
 	sam4l.c		\
 	samd.c		\
 	samx5x.c	\
+	sfdp.c      \
 	stm32f1.c	\
 	ch32f1.c	\
 	stm32f4.c	\

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -157,6 +157,14 @@ static bool rp_mass_erase(target *t);
 static void rp_spi_read_sfdp(target *const t, const uint32_t address, void *const buffer, const size_t length)
 {
 	rp_spi_read(t, SPI_FLASH_CMD_READ_SFDP, address, buffer, length);
+#if ENABLE_DEBUG
+	DEBUG_INFO("%" PRIu32 " byte SFDP read at 0x%" PRIx32 ":\n", (uint32_t)length, address);
+	const uint8_t *const data = buffer;
+	for (size_t i = 0; i < length; i += 8U) {
+		DEBUG_INFO("\t%02x %02x %02x %02x %02x %02x %02x %02x\n", data[i + 0], data[i + 1], data[i + 2], data[i + 3],
+			data[i + 4], data[i + 5], data[i + 6], data[i + 7]);
+	}
+#endif
 }
 
 static void rp_add_flash(target *t, uint32_t addr, size_t length)

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -42,15 +42,17 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
-#define RP_ID              "Raspberry RP2040"
-#define RP_MAX_TABLE_SIZE  0x80
-#define BOOTROM_MAGIC      ('M' | ('u' << 8) | (0x01 << 16))
-#define BOOTROM_MAGIC_ADDR 0x00000010
-#define XIP_FLASH_START    0x10000000
-#define SRAM_START         0x20000000
-#define SRAM_SIZE          0x42000
-#define SSI_DR0_ADDR       0x18000060
-#define QSPI_CTRL_ADDR     0x4001800c
+#define RP_ID                 "Raspberry RP2040"
+#define RP_MAX_TABLE_SIZE     0x80U
+#define BOOTROM_MAGIC_ADDR    0x00000010U
+#define BOOTROM_MAGIC         ('M' | ('u' << 8) | (0x01 << 16))
+#define BOOTROM_MAGIC_MASK    0x00ffffffU
+#define BOOTROM_VERSION_SHIFT 24U
+#define XIP_FLASH_START       0x10000000U
+#define SRAM_START            0x20000000U
+#define SRAM_SIZE             0x42000U
+#define SSI_DR0_ADDR          0x18000060U
+#define QSPI_CTRL_ADDR        0x4001800cU
 
 #define FLASHSIZE_4K_SECTOR      (4U * 1024U)
 #define FLASHSIZE_32K_BLOCK      (32U * 1024U)
@@ -127,14 +129,16 @@ bool rp_probe(target *t)
 {
 	/* Check bootrom magic*/
 	uint32_t boot_magic = target_mem_read32(t, BOOTROM_MAGIC_ADDR);
-	if ((boot_magic & 0x00ffffff) != BOOTROM_MAGIC) {
+	if ((boot_magic & BOOTROM_MAGIC_MASK) != BOOTROM_MAGIC) {
 		DEBUG_WARN("Wrong Bootmagic %08" PRIx32 " found!\n", boot_magic);
 		return false;
 	}
+
 #if defined(ENABLE_DEBUG)
-	if ((boot_magic >> 24) == 1)
+	if ((boot_magic >> BOOTROM_VERSION_SHIFT) == 1)
 		DEBUG_WARN("Old Bootrom Version 1!\n");
 #endif
+
 	struct rp_priv_s *priv_storage = calloc(1, sizeof(struct rp_priv_s));
 	if (!priv_storage) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -149,8 +149,8 @@ const struct command_s rp_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static int rp_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int rp_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+static int rp_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int rp_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 
 static bool rp_read_rom_func_table(target *t);
 static bool rp_attach(target *t);
@@ -389,7 +389,7 @@ static void rp_flash_resume(target *t)
  * chip erase           5000/25000 ms
  * page programm           0.4/  3 ms
  */
-static int rp_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int rp_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	DEBUG_INFO("Erase addr 0x%08" PRIx32 " len 0x%" PRIx32 "\n", addr, (uint32_t)len);
 	target *t = f->t;
@@ -454,7 +454,7 @@ static int rp_flash_erase(struct target_flash *f, target_addr addr, size_t len)
 	return ret;
 }
 
-static int rp_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len)
+static int rp_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	DEBUG_INFO("RP Write 0x%08" PRIx32 " len 0x%" PRIx32 "\n", dest, (uint32_t)len);
 	target *t = f->t;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -54,6 +54,7 @@
 #define SSI_DR0_ADDR          0x18000060U
 #define QSPI_CTRL_ADDR        0x4001800cU
 
+#define BOOTROM_FUNC_TABLE_ADDR  0x00000014U
 #define FLASHSIZE_4K_SECTOR      (4U * 1024U)
 #define FLASHSIZE_32K_BLOCK      (32U * 1024U)
 #define FLASHSIZE_64K_BLOCK      (64U * 1024U)
@@ -161,7 +162,8 @@ static bool rp_attach(target *t)
 
 	struct rp_priv_s *ps = (struct rp_priv_s*)t->target_storage;
 	uint16_t table[RP_MAX_TABLE_SIZE];
-	uint16_t table_offset = target_mem_read32( t, BOOTROM_MAGIC_ADDR + 4);
+	/* We have to do a 32-bit read here but the pointer contained is only 16-bit. */
+	uint16_t table_offset = target_mem_read32(t, BOOTROM_FUNC_TABLE_ADDR) & 0x0000ffffU;
 	if (target_mem_read(t, table, table_offset, RP_MAX_TABLE_SIZE) ||
 		rp_fill_table(ps, table, RP_MAX_TABLE_SIZE))
 		return false;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -55,6 +55,7 @@
 #define QSPI_CTRL_ADDR        0x4001800cU
 
 #define BOOTROM_FUNC_TABLE_ADDR  0x00000014U
+#define BOOTROM_FUNC_TABLE_TAG(x, y) ((uint8_t)(x) | ((uint8_t)(y) << 8U))
 #define FLASHSIZE_4K_SECTOR      (4U * 1024U)
 #define FLASHSIZE_32K_BLOCK      (32U * 1024U)
 #define FLASHSIZE_64K_BLOCK      (64U * 1024U)
@@ -189,31 +190,31 @@ static bool rp_fill_table(struct rp_priv_s *priv, uint16_t *table, int max)
 		check++;
 		max -= 2;
 		switch (tag) {
-		case ('D' | ('T' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('D', 'T'):
 			priv->rom_debug_trampoline_begin = data;
 			break;
-		case ('D' | ('E' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('D', 'E'):
 			priv->rom_debug_trampoline_end = data;
 			break;
-		case ('I' | ('F' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('I', 'F'):
 			priv->rom_connect_internal_flash = data;
 			break;
-		case ('C' | ('X' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('C', 'X'):
 			priv->rom_flash_enter_xip = data;
 			break;
-		case ('E' | ('X' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('E', 'X'):
 			priv->rom_flash_exit_xip = data;
 			break;
-		case ('R' | ('E' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('R', 'E'):
 			priv->rom_flash_range_erase = data;
 			break;
-		case ('R' | ('P' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('R', 'P'):
 			priv->rom_flash_range_program = data;
 			break;
-		case ('F' | ('C' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('F', 'C'):
 			priv->rom_flash_flush_cache = data;
 			break;
-		case ('U' | ('B' << 8)):
+		case BOOTROM_FUNC_TABLE_TAG('U', 'B'):
 			priv->rom_reset_usb_boot = data;
 			break;
 		default:

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -383,11 +383,12 @@ static void rp_flash_resume(target *t)
 	}
 }
 
-/* FLASHCMD_SECTOR_ERASE  45/  400 ms
- * 32k block erase       120/ 1600 ms
- * 64k block erase       150/ 2000 ms
- * chip erase           5000/25000 ms
- * page programm           0.4/  3 ms
+/*
+ * 4k sector erase    45/  400 ms
+ * 32k block erase   120/ 1600 ms
+ * 64k block erase   150/ 2000 ms
+ * chip erase       5000/25000 ms
+ * page programm       0.4/  3 ms
  */
 static int rp_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
@@ -397,13 +398,13 @@ static int rp_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 		DEBUG_WARN("Unaligned erase\n");
 		return -1;
 	}
-	if ((addr < t->flash->start) || (addr >= t->flash->start + t->flash->length)) {
+	if ((addr < f->start) || (addr >= f->start + f->length)) {
 		DEBUG_WARN("Address is invalid\n");
 		return -1;
 	}
-	addr -= t->flash->start;
+	addr -= f->start;
 	len = ALIGN(len, FLASHSIZE_4K_SECTOR);
-	len = MIN(len, t->flash->length - addr);
+	len = MIN(len, f->length - addr);
 	rp_priv_s *ps = (rp_priv_s *)t->target_storage;
 	const bool full_erase = addr == f->start && len == f->length;
 	platform_timeout timeout;
@@ -462,7 +463,7 @@ static int rp_flash_write(target_flash_s *f, target_addr dest, const void *src, 
 		DEBUG_WARN("Unaligned write\n");
 		return -1;
 	}
-	dest -= t->flash->start;
+	dest -= f->start;
 	rp_priv_s *ps = (rp_priv_s *)t->target_storage;
 	/* Write payload to target ram */
 	rp_flash_prepare(t);

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -164,14 +164,6 @@ static bool rp_mass_erase(target *t);
 static void rp_spi_read_sfdp(target *const t, const uint32_t address, void *const buffer, const size_t length)
 {
 	rp_spi_read(t, SPI_FLASH_CMD_READ_SFDP, address, buffer, length);
-#if ENABLE_DEBUG
-	DEBUG_INFO("%" PRIu32 " byte SFDP read at 0x%" PRIx32 ":\n", (uint32_t)length, address);
-	const uint8_t *const data = buffer;
-	for (size_t i = 0; i < length; i += 8U) {
-		DEBUG_INFO("\t%02x %02x %02x %02x %02x %02x %02x %02x\n", data[i + 0], data[i + 1], data[i + 2], data[i + 3],
-			data[i + 4], data[i + 5], data[i + 6], data[i + 7]);
-	}
-#endif
 }
 
 static void rp_add_flash(target *t)

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -250,41 +250,41 @@ static bool rp_read_rom_func_table(target *const t)
 	size_t check = 0;
 	for (size_t i = 0; i < RP_MAX_TABLE_SIZE; i += 2) {
 		const uint16_t tag = table[i];
-		const uint16_t data = table[i + 1];
+		const uint16_t addr = table[i + 1];
 		switch (tag) {
 		case BOOTROM_FUNC_TABLE_TAG('D', 'T'):
-			priv->rom_debug_trampoline_begin = data;
+			priv->rom_debug_trampoline_begin = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('D', 'E'):
-			priv->rom_debug_trampoline_end = data;
+			priv->rom_debug_trampoline_end = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('I', 'F'):
-			priv->rom_connect_internal_flash = data;
+			priv->rom_connect_internal_flash = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('C', 'X'):
-			priv->rom_flash_enter_xip = data;
+			priv->rom_flash_enter_xip = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('E', 'X'):
-			priv->rom_flash_exit_xip = data;
+			priv->rom_flash_exit_xip = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('R', 'E'):
-			priv->rom_flash_range_erase = data;
+			priv->rom_flash_range_erase = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('R', 'P'):
-			priv->rom_flash_range_program = data;
+			priv->rom_flash_range_program = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('F', 'C'):
-			priv->rom_flash_flush_cache = data;
+			priv->rom_flash_flush_cache = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('U', 'B'):
-			priv->rom_reset_usb_boot = data;
+			priv->rom_reset_usb_boot = addr;
 			break;
 		default:
 			continue;
 		}
 		++check;
 	}
-	DEBUG_TARGET("connect %04x debug_trampoline %04x end %04x\n", priv->rom_connect_internal_flash,
+	DEBUG_TARGET("RP ROM routines connect %04x debug_trampoline %04x end %04x\n", priv->rom_connect_internal_flash,
 		priv->rom_debug_trampoline_begin, priv->rom_debug_trampoline_end);
 	return check == 9;
 }

--- a/src/target/sfdp.c
+++ b/src/target/sfdp.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include "sfdp_internal.h"
+
+#ifdef MIN
+#undef MIN
+#endif
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+static inline size_t sfdp_memory_density_to_capacity_bits(const uint8_t *const density)
+{
+	if (SFDP_DENSITY_IS_EXPONENTIAL(density))
+		return 1U << SFDP_DENSITY_VALUE(density);
+	else /* NOLINT(readability-else-after-return) */
+		return SFDP_DENSITY_VALUE(density) + 1U;
+}
+
+static spi_parameters_s sfdp_read_basic_parameter_table(target *const t, const uint32_t address, const size_t length,
+	const read_sfdp_func sfdp_read)
+{
+	sfdp_basic_parameter_table_s parameter_table;
+	const size_t table_length = MIN(sizeof(sfdp_basic_parameter_table_s), length);
+	sfdp_read(t, address, &parameter_table, table_length);
+
+	spi_parameters_s result;
+	result.capacity = sfdp_memory_density_to_capacity_bits(parameter_table.memory_density) >> 3U;
+	for (size_t i = 0; i < SFDP_ERASE_TYPES; ++i) {
+		erase_parameters_s *erase_type = &parameter_table.erase_types[i];
+		if (erase_type->opcode == parameter_table.sector_erase_opcode) {
+			result.sector_erase_opcode = erase_type->opcode;
+			result.sector_size = SFDP_ERASE_SIZE(erase_type);
+			break;
+		}
+	}
+	result.page_size = SFDP_PAGE_SIZE(parameter_table);
+	return result;
+}
+
+bool sfdp_read_parameters(target *const t, spi_parameters_s *params, const read_sfdp_func sfdp_read)
+{
+	sfdp_header_s header;
+	sfdp_read(t, SFDP_HEADER_ADDRESS, &header, sizeof(header));
+	if (memcmp(header.magic, SFDP_MAGIC, 4) != 0)
+		return false;
+
+	for (size_t i = 0; i <= header.parameter_headers_count; ++i) {
+		sfdp_parameter_table_header_s table_header;
+		sfdp_read(t, SFDP_TABLE_HEADER_ADDRESS + (sizeof(table_header) * i), &table_header, sizeof(table_header));
+		const uint16_t jedec_parameter_id = SFDP_JEDEC_PARAMETER_ID(table_header);
+		if (jedec_parameter_id == SFDP_BASIC_SPI_PARAMETER_TABLE) {
+			const uint32_t table_address = SFDP_TABLE_ADDRESS(table_header);
+			const uint16_t table_length = table_header.table_length_in_u32s * 4U;
+			*params = sfdp_read_basic_parameter_table(t, table_address, table_length, sfdp_read);
+			return true;
+		}
+	}
+	return false;
+}

--- a/src/target/sfdp.h
+++ b/src/target/sfdp.h
@@ -40,6 +40,12 @@
 
 #include "target.h"
 
+typedef struct spi_flash_id {
+	uint8_t manufacturer;
+	uint8_t type;
+	uint8_t capacity;
+} spi_flash_id_s;
+
 typedef struct spi_parameters {
 	uint32_t page_size;
 	uint32_t sector_size;

--- a/src/target/sfdp.h
+++ b/src/target/sfdp.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SFDP_H
+#define SFDP_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#include "target.h"
+
+typedef struct spi_parameters {
+	uint32_t page_size;
+	uint32_t sector_size;
+	size_t capacity;
+	uint8_t sector_erase_opcode;
+} spi_parameters_s;
+
+typedef void (*read_sfdp_func)(target *t, uint32_t address, void *buffer, size_t length);
+
+bool sfdp_read_parameters(target *t, spi_parameters_s *params, read_sfdp_func sfdp_read);
+
+#endif /*SFDP_H*/

--- a/src/target/sfdp_internal.h
+++ b/src/target/sfdp_internal.h
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SFDP_INTERNAL_H
+#define SFDP_INTERNAL_H
+
+#include "sfdp.h"
+
+#define SFDP_HEADER_ADDRESS       0U
+#define SFDP_TABLE_HEADER_ADDRESS sizeof(sfdp_header_s)
+
+#define SFDP_MAGIC                     "SFDP"
+#define SFDP_BASIC_SPI_PARAMETER_TABLE 0xFF00U
+
+#define SFDP_ACCESS_PROTOCOL_LEGACY_JESD216B 0xFFU
+
+#define SFDP_JEDEC_PARAMETER_ID(header) (((header).jedec_parameter_id_high << 8U) | (header).jedec_parameter_id_low)
+#define SFDP_TABLE_ADDRESS(header) \
+	(((header).table_address[2] << 16U) | ((header).table_address[1] << 8U) | (header).table_address[0])
+
+typedef struct sfdp_header {
+	char magic[4];
+	uint8_t version_minor;
+	uint8_t version_major;
+	uint8_t parameter_headers_count;
+	uint8_t access_protocol;
+} sfdp_header_s;
+
+typedef struct sfdp_parameter_table_header {
+	uint8_t jedec_parameter_id_low;
+	uint8_t version_minor;
+	uint8_t version_major;
+	uint8_t table_length_in_u32s;
+	uint8_t table_address[3];
+	uint8_t jedec_parameter_id_high;
+} sfdp_parameter_table_header_s;
+
+#endif /*SFDP_INTERNAL_H*/

--- a/src/target/sfdp_internal.h
+++ b/src/target/sfdp_internal.h
@@ -48,6 +48,15 @@
 #define SFDP_TABLE_ADDRESS(header) \
 	(((header).table_address[2] << 16U) | ((header).table_address[1] << 8U) | (header).table_address[0])
 
+#define SFDP_DENSITY_IS_EXPONENTIAL(density) ((density)[3] & 0x80U)
+#define SFDP_DENSITY_VALUE(density) \
+	((((density)[3] & 0x7FU) << 24U) | ((density)[2] << 16U) | ((density)[1] << 8U) | (density)[0])
+
+#define SFDP_ERASE_TYPES            4U
+#define SFDP_ERASE_SIZE(erase_type) (1U << ((erase_type)->erase_size_exponent))
+#define SFDP_PAGE_SIZE(parameter_table) \
+	(1U << ((parameter_table).programming_and_chip_erase_timing.programming_timing_ratio_and_page_size >> 4U))
+
 typedef struct sfdp_header {
 	char magic[4];
 	uint8_t version_minor;
@@ -64,5 +73,51 @@ typedef struct sfdp_parameter_table_header {
 	uint8_t table_address[3];
 	uint8_t jedec_parameter_id_high;
 } sfdp_parameter_table_header_s;
+
+typedef struct timings_and_opcode {
+	uint8_t timings;
+	uint8_t opcode;
+} timings_and_opcode_s;
+
+typedef struct erase_parameters {
+	uint8_t erase_size_exponent;
+	uint8_t opcode;
+} erase_parameters_s;
+
+typedef struct programming_and_chip_erase_timing {
+	uint8_t programming_timing_ratio_and_page_size;
+	uint8_t erase_timings[3];
+} programming_and_chip_erase_timing_s;
+
+typedef struct sfdp_basic_parameter_table {
+	uint8_t value1;
+	uint8_t sector_erase_opcode;
+	uint8_t value2;
+	uint8_t reserved1;
+	uint8_t memory_density[4];
+	timings_and_opcode_s fast_quad_io;
+	timings_and_opcode_s fast_quad_output;
+	timings_and_opcode_s fast_dual_output;
+	timings_and_opcode_s fast_dual_io;
+	uint8_t fast_support_flags;
+	uint8_t reserved2[5];
+	timings_and_opcode_s fast_dual_dpi;
+	uint8_t reserved3[2];
+	timings_and_opcode_s fast_quad_qpi;
+	erase_parameters_s erase_types[SFDP_ERASE_TYPES];
+	uint32_t erase_timing;
+	programming_and_chip_erase_timing_s programming_and_chip_erase_timing;
+	uint8_t operational_prohibitions;
+	uint8_t suspend_latency_specs[3];
+	uint8_t program_resume_opcode;
+	uint8_t program_suspend_opcode;
+	uint8_t resume_opcode;
+	uint8_t suspend_opcode;
+	uint8_t status_register_polling_flags;
+	uint8_t deep_powerdown[3];
+	uint8_t dual_and_quad_mode[3];
+	uint8_t reserved4;
+	uint32_t status_and_addressing_mode;
+} sfdp_basic_parameter_table_s;
 
 #endif /*SFDP_INTERNAL_H*/

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -32,11 +32,13 @@ struct target_ram {
 	struct target_ram *next;
 };
 
-struct target_flash;
-typedef int (*flash_erase_func)(struct target_flash *f, target_addr addr, size_t len);
-typedef int (*flash_write_func)(struct target_flash *f, target_addr dest,
+typedef struct target_flash target_flash_s;
+
+typedef int (*flash_erase_func)(target_flash_s *f, target_addr addr, size_t len);
+typedef int (*flash_write_func)(target_flash_s *f, target_addr dest,
                                 const void *src, size_t len);
-typedef int (*flash_done_func)(struct target_flash *f);
+typedef int (*flash_done_func)(target_flash_s *f);
+
 struct target_flash {
 	target_addr start;
 	size_t length;


### PR DESCRIPTION
This PR is dual-purpose. It adds support for parsing SFDP tables from SPI Flash both for Flashless microcontrollers that use externally connected SPI Flash, and as the first step in providing support in BMP for directly accessing and modifying the contents of SPI Flash chips.

We have partially converted the RP2040 support code to use the new SFDP readout support and showcase the API, however it's recognised we should do more to identify the different erase page sizes and extract their instructions + the chip erase instruction as all this information is available in the SFDP data. These extra pieces of information will be extracted in later PRs and put to use.

Tested on our RP2040.