### PR TITLE
Correct BMDA build error for BMP only

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -43,7 +43,11 @@
 #include "traceswo.h"
 #endif
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <malloc.h>
+#else
 #include <alloca.h>
+#endif
 
 static bool cmd_version(target *t, int argc, const char **argv);
 static bool cmd_help(target *t, int argc, const char **argv);

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -39,7 +39,11 @@
 #include "rtt.h"
 #endif
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <malloc.h>
+#else
 #include <alloca.h>
+#endif
 
 enum gdb_signal {
 	GDB_SIGINT = 2,


### PR DESCRIPTION
Windows does not have alloca.h, conditionally use malloc.h on Windows