### PR TITLE
native: Enable uart on HW >=V3 when debugging.

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -225,9 +225,11 @@ void platform_init(void)
 	platform_timing_init();
 	cdcacm_init();
 
-	/* On mini hardware, UART and SWD share connector pins.
+	/* On hardware version 1 and 2, UART and SWD share connector pins.
 	 * Don't enable UART if we're being debugged. */
-	if ((platform_hwversion() == 0) || !(SCS_DEMCR & SCS_DEMCR_TRCENA))
+	if (platform_hwversion() == 0 ||
+	    platform_hwversion() >= 3 ||
+	    !(SCS_DEMCR & SCS_DEMCR_TRCENA))
 		usbuart_init();
 
 	setup_vbus_irq();


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Detailed description

We were disabling the UART on all Hardware V1 and newer, as V1 and V2
had the SWD pins connected to the UART pins. Since V3 this is not the
case any more so we can keep the UART enabled when an SWD debugger is
connected to the BMP.

## Closing issues

Closes #1103 
