### PR TITLE
misc: Switched the descripton and checklist blocks around so the template has better flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,5 @@
 <!-- Filling this template is mandatory -->
 
-## Your checklist for this pull request
-
-* [ ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
-* [ ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
-* [ ] It builds for hardware native (`make PROBE_HOST=native`)
-* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
-* [ ] I've tested it to the best of my ability
-* [ ] My commit messages provide a useful short description of what the commits do
-
 ## Detailed description
 
 <!--
@@ -19,6 +10,15 @@ Explain the **details** for making this change.
 Please provide enough information so that others can review your pull request.
 Information embedded in the description part of the commits doesn't count.
 -->
+
+## Your checklist for this pull request
+
+* [ ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
+* [ ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
+* [ ] It builds for hardware native (`make PROBE_HOST=native`)
+* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
+* [ ] I've tested it to the best of my ability
+* [ ] My commit messages provide a useful short description of what the commits do
 
 ## Closing issues
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

The description block in the PR template comming after the checklist turns out to be bad for ergonomics, so as requested by Esden, this PR switches the two so the order of blocks is now description, checklist, closing issues.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
