### PR TITLE
Fix: ADIv5 early AP accesses trigger aborts, corrupting DP writes

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -423,6 +423,9 @@ static void dap_mem_write_sized( ADIv5_AP_t *ap, uint32_t dest, const void *src,
 			src       += transfersize;
 		}
 	}
+
+	/* Make sure this write is complete by doing a dummy read */
+	adiv5_dp_read(ap->dp, ADIV5_DP_RDBUFF);
 	DEBUG_WIRE("memwrite done\n");
 }
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -996,6 +996,8 @@ void firmware_mem_write_sized(ADIv5_AP_t *ap, uint32_t dest, const void *src, si
 			adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_TAR, dest);
 		}
 	}
+	/* Make sure this write is complete by doing a dummy read */
+	adiv5_dp_read(ap->dp, ADIV5_DP_RDBUFF);
 }
 
 void firmware_ap_write(ADIv5_AP_t *ap, uint16_t addr, uint32_t value)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Due to the excellent work by @mubes on ORBTrace and the CMSIS-DAP interface it features that BMDA can use, it was found that BMP was, after doing a Debug Port (DP) write, under certain conditions then immediately following it with an Access Port (AP) access that fires an abort. This flushes the queue on the DP and causes data corruption that's especially noticeable when trying to Flash a part.

To trigger this bug requires crossing a threshold access speed, and should be possible on native hardware, albeit very difficult. ARM's own advice is to perform a read on the DP or a safe register on the AP, triggering a wait state till the write completes. This makes accesses safe by functioning as a barrier.

This PR implements the DP read version of the fix which provides the least slowdown (a 53KB/s Flash slows down down to 52KB/s with this patch vs down to 51KB/s when using the AP version of the fix).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1117
