### PR TITLE
hosted/jlink: fix bad line reset cmd building

### DIFF
--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -56,9 +56,7 @@ static int line_reset(bmp_info_t *info)
 	/* write 19 Bytes.*/
 	cmd[2] = 19 * 8;
 	uint8_t *direction = cmd + 4;
-	memset(direction, 0, 5);
 	memset(direction + 5, 0xffU, 9);
-	memset(direction + 14, 0xffU, 4);
 	direction[18] = 0xe0;
 	uint8_t *data = direction + 19;
 	memset(data + 5, 0xffU, 7);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

Fixes an error made while cleaning up code in #1169

Extra bits are being set to 1 that were not before, due to an erroneous memset

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
