### PR TITLE
misc: change old wiki links to point to website instead

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -1,1 +1,1 @@
-See https://github.com/blackmagic-debug/blackmagic/wiki/Hacking
+See https://black-magic.org/hacking/hacking.html

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ standard USB interface. The user is able to control exactly what happens
 using the GNU source level debugging software, GDB.
 Serial Wire Output (SWO) allows the target to write tracing and logging to the host
 without using usb or serial port. Decoding SWO in the probe itself
-makes [SWO viewing as simple as connecting to a serial port](https://github.com/blackmagic-debug/blackmagic/wiki/Serial-Wire-Output).
+makes [SWO viewing as simple as connecting to a serial port](https://black-magic.org/usage/swo.html).
 
 ## Resources
 
-* [Documentation](https://github.com/blackmagic-debug/blackmagic/wiki)
+* [Official website](https://black-magic.org/index.html)
 * [Binary builds](http://builds.blacksphere.co.nz/blackmagic)
 
 ## Toolchain specific remarks

--- a/UsingRTT.md
+++ b/UsingRTT.md
@@ -143,7 +143,7 @@ Setting an identifier string is optional. RTT gives the same output at the same 
 
 ## Operating systems
 
-[Configuration](https://github.com/blacksphere/blackmagic/wiki/Getting-Started) instructions for windows, linux and macos.
+[Configuration](https://black-magic.org/getting-started.html) instructions for windows, linux and macos.
 
 ### Windows
 


### PR DESCRIPTION
## Detailed description

The [GitHub wiki](https://github.com/blackmagic-debug/blackmagic/wiki) has been deprecated in favor of the [official website](https://black-magic.org/), yet some links to the wiki remained in the repo. This PR points them to the website instead.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* N/A It builds for hardware native (`make PROBE_HOST=native`)
* N/A It builds as BMDA (`make PROBE_HOST=hosted`)
* N/A I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
