### PR TITLE
Feature: high-z TCK/SWCLK when idle

### DIFF
--- a/COPYING-MIT
+++ b/COPYING-MIT
@@ -1,0 +1,21 @@
+ MIT License
+
+ Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/src/command.c
+++ b/src/command.c
@@ -224,6 +224,7 @@ static bool cmd_jtag_scan(target *t, int argc, const char **argv)
 	}
 
 	if (devs == 0) {
+		platform_target_clk_output_enable(false);
 		platform_nrst_set_val(false);
 		gdb_out("JTAG device scan failed!\n");
 		return false;
@@ -319,6 +320,7 @@ bool cmd_auto_scan(target *t, int argc, const char **argv)
 		break;
 	}
 	if (devs == 0) {
+		platform_target_clk_output_enable(false);
 		platform_nrst_set_val(false);
 		gdb_out("auto scan failed!\n");
 		return false;

--- a/src/command.c
+++ b/src/command.c
@@ -231,6 +231,7 @@ static bool cmd_jtag_scan(target *t, int argc, const char **argv)
 	}
 
 	cmd_targets(NULL, 0, NULL);
+	platform_target_clk_output_enable(false);
 	morse(NULL, false);
 	return true;
 }
@@ -273,6 +274,7 @@ bool cmd_swdp_scan(target *t, int argc, const char **argv)
 	}
 
 	cmd_targets(NULL, 0, NULL);
+	platform_target_clk_output_enable(false);
 	morse(NULL, false);
 	return true;
 }
@@ -308,6 +310,7 @@ bool cmd_auto_scan(target *t, int argc, const char **argv)
 		if (devs > 0)
 			break;
 
+		platform_target_clk_output_enable(false);
 		platform_nrst_set_val(false);
 		gdb_out("SW-DP scan failed!\n");
 		return false;
@@ -328,6 +331,7 @@ bool cmd_auto_scan(target *t, int argc, const char **argv)
 	}
 
 	cmd_targets(NULL, 0, NULL);
+	platform_target_clk_output_enable(false);
 	morse(NULL, false);
 	return true;
 }

--- a/src/command.c
+++ b/src/command.c
@@ -310,10 +310,7 @@ bool cmd_auto_scan(target *t, int argc, const char **argv)
 		if (devs > 0)
 			break;
 
-		platform_target_clk_output_enable(false);
-		platform_nrst_set_val(false);
-		gdb_out("SW-DP scan failed!\n");
-		return false;
+		gdb_out("SW-DP scan found no devices.\n");
 	}
 	switch (e.type) {
 	case EXCEPTION_TIMEOUT:
@@ -323,6 +320,7 @@ bool cmd_auto_scan(target *t, int argc, const char **argv)
 		gdb_outf("Exception: %s\n", e.msg);
 		break;
 	}
+
 	if (devs == 0) {
 		platform_target_clk_output_enable(false);
 		platform_nrst_set_val(false);

--- a/src/command.c
+++ b/src/command.c
@@ -266,6 +266,7 @@ bool cmd_swdp_scan(target *t, int argc, const char **argv)
 	}
 
 	if (devs == 0) {
+		platform_target_clk_output_enable(false);
 		platform_nrst_set_val(false);
 		gdb_out("SW-DP scan failed!\n");
 		return false;

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -313,12 +313,11 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 
 		case 'r':	/* Reset the target system */
 		case 'R':	/* Restart the target program */
-			if(cur_target)
+			if (cur_target)
 				target_reset(cur_target);
-			else if(last_target) {
-				cur_target = target_attach(last_target,
-						           &gdb_controller);
-				if(cur_target)
+			else if (last_target) {
+				cur_target = target_attach(last_target, &gdb_controller);
+				if (cur_target)
 					morse(NULL, false);
 				target_reset(cur_target);
 			}

--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -50,4 +50,6 @@ void platform_request_boot(void);
 void platform_max_frequency_set(uint32_t frequency);
 uint32_t platform_max_frequency_get(void);
 
+void platform_target_clk_output_enable(bool enable);
+
 #endif

--- a/src/platforms/96b_carbon/platform.c
+++ b/src/platforms/96b_carbon/platform.c
@@ -101,3 +101,8 @@ void platform_request_boot(void)
 	SYSCFG_MEMRM &= ~3;
 	SYSCFG_MEMRM |=  1;
 }
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/blackpillv2/platform.c
+++ b/src/platforms/blackpillv2/platform.c
@@ -142,3 +142,8 @@ void platform_target_set_power(const bool power)
 	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, !power);
 }
 #endif
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -37,6 +37,7 @@ static void jtagtap_cycle(bool tms, bool tdi, size_t clock_cycles);
 
 int jtagtap_init()
 {
+	platform_target_clk_output_enable(true);
 	TMS_SET_MODE();
 
 	jtag_proc.jtagtap_reset = jtagtap_reset;

--- a/src/platforms/f072/platform.c
+++ b/src/platforms/f072/platform.c
@@ -110,3 +110,8 @@ void platform_request_boot(void)
 	magic[1] = BOOTMAGIC1;
 	scb_reset_system();
 }
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/f3/platform.c
+++ b/src/platforms/f3/platform.c
@@ -115,3 +115,8 @@ void platform_request_boot(void)
 	magic[1] = BOOTMAGIC1;
 	scb_reset_system();
 }
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -137,3 +137,8 @@ void platform_target_set_power(const bool power)
 	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, !power);
 }
 #endif
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -180,6 +180,17 @@ const char *remote_target_voltage(void)
 	return (char *)&construct[1];
 }
 
+void remote_target_clk_output_enable(const bool enable)
+{
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_TARGET_CLK_OE_STR, enable ? '1' : '0');
+	platform_buffer_write((uint8_t *)buffer, length);
+
+	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
+		DEBUG_WARN("remote_target_clk_output_enable failed, error %s\n", length ? buffer + 1 : "unknown");
+}
+
 static uint32_t remote_adiv5_dp_read(ADIv5_DP_t *dp, uint16_t addr)
 {
 	(void)dp;

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -16,8 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
-#if !defined(__BMP_REMOTE_H_)
-#define      __BMP_REMOTE_H_
+#ifndef __BMP_REMOTE_H_
+#define __BMP_REMOTE_H_
+
 #include "jtagtap.h"
 #include "adiv5.h"
 #include "target.h"
@@ -33,13 +34,14 @@ int remote_swdptap_init(ADIv5_DP_t *dp);
 int remote_jtagtap_init(jtag_proc_t *jtag_proc);
 bool remote_target_get_power(void);
 const char *remote_target_voltage(void);
-bool remote_target_set_power(const bool power);
+bool remote_target_set_power(bool power);
 void remote_nrst_set_val(bool assert);
 bool remote_nrst_get_val(void);
 void remote_max_frequency_set(uint32_t freq);
 uint32_t remote_max_frequency_get(void);
-const char *platform_target_voltage(void);
+void remote_target_clk_output_enable(bool enable);
+
 void remote_adiv5_dp_defaults(ADIv5_DP_t *dp);
 void remote_add_jtag_dev(uint32_t i, const jtag_dev_t *jtag_dev);
-#define __BMP_REMOTE_H_
-#endif
+
+#endif /*__BMP_REMOTE_H_*/

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -483,6 +483,18 @@ void platform_buffer_flush(void)
 	}
 }
 
+void platform_target_clk_output_enable(const bool enable)
+{
+	switch (info.bmp_type) {
+	case BMP_TYPE_BMP:
+		remote_target_clk_output_enable(enable);
+		break;
+
+	default:
+		break;
+	}
+}
+
 static void ap_decode_access(uint16_t addr, uint8_t RnW)
 {
 	if (RnW)

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -50,11 +50,10 @@ static inline unsigned int bool_to_int(const bool value)
 
 int remote_jtagtap_init(jtag_proc_t *jtag_proc)
 {
-	char buffer[REMOTE_MAX_MSG_SIZE];
-	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_JTAG_INIT_STR);
-	platform_buffer_write((uint8_t *)buffer, length);
+	platform_buffer_write((uint8_t *)REMOTE_JTAG_INIT_STR, sizeof(REMOTE_JTAG_INIT_STR));
 
-	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
 	if ((!length) || (buffer[0] == REMOTE_RESP_ERR)) {
 		DEBUG_WARN("jtagtap_init failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);

--- a/src/platforms/hydrabus/platform.c
+++ b/src/platforms/hydrabus/platform.c
@@ -105,3 +105,8 @@ void platform_request_boot(void)
 	SYSCFG_MEMRM &= ~3;
 	SYSCFG_MEMRM |=  1;
 }
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -141,3 +141,8 @@ uint32_t platform_max_frequency_get(void)
 {
 	return 0;
 }
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -340,8 +340,16 @@ void platform_request_boot(void)
 
 void platform_target_clk_output_enable(bool enable)
 {
-	if (platform_hwversion() >= 6)
+	if (platform_hwversion() >= 6) {
+		/* If we're switching to tristate mode, first convert the processor pin to an input */
+		if (!enable)
+			gpio_set_mode(TCK_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, TCK_PIN);
+		/* Reconfigure the logic levelt translator */
 		gpio_set_val(TCK_DIR_PORT, TCK_DIR_PIN, enable);
+		/* If we're switching back out of tristate mode, we're now safe to make the processor pin an output again */
+		if (enable)
+			gpio_set_mode(TCK_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TCK_PIN);
+	}
 }
 
 void exti15_10_isr(void)

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -156,17 +156,11 @@ void platform_init(void)
 
 	/* Setup GPIO ports */
 	gpio_clear(USB_PU_PORT, USB_PU_PIN);
-	gpio_set_mode(USB_PU_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT,
-			USB_PU_PIN);
+	gpio_set_mode(USB_PU_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, USB_PU_PIN);
 
-	gpio_set_mode(JTAG_PORT, GPIO_MODE_OUTPUT_50_MHZ,
-			GPIO_CNF_OUTPUT_PUSHPULL,
-			TMS_DIR_PIN | TMS_PIN | TCK_PIN | TDI_PIN);
-	gpio_set_mode(JTAG_PORT, GPIO_MODE_OUTPUT_50_MHZ,
-			GPIO_CNF_OUTPUT_PUSHPULL,
-			TMS_DIR_PIN | TCK_PIN | TDI_PIN);
-	gpio_set_mode(JTAG_PORT, GPIO_MODE_OUTPUT_50_MHZ,
-			GPIO_CNF_INPUT_FLOAT, TMS_PIN);
+	gpio_set_mode(JTAG_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TMS_DIR_PIN | TCK_PIN | TDI_PIN);
+	gpio_set_mode(JTAG_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_INPUT_FLOAT, TMS_PIN);
+
 	/* This needs some fixing... */
 	/* Toggle required to sort out line drivers... */
 	gpio_port_write(GPIOA, 0x8102);
@@ -181,9 +175,7 @@ void platform_init(void)
 		gpio_clear(TCK_DIR_PORT, TCK_DIR_PIN);
 	}
 
-	gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ,
-			GPIO_CNF_OUTPUT_PUSHPULL,
-			LED_UART | LED_IDLE_RUN | LED_ERROR);
+	gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, LED_UART | LED_IDLE_RUN | LED_ERROR);
 
 	/* Enable nRST output. Original uses a NPN to pull down, so setting the
 	 * output HIGH asserts. Mini is directly connected so use open drain output
@@ -191,40 +183,33 @@ void platform_init(void)
 	 */
 	platform_nrst_set_val(false);
 	gpio_set_mode(NRST_PORT, GPIO_MODE_OUTPUT_50_MHZ,
-			(((platform_hwversion() == 0) ||
-			  (platform_hwversion() >= 3))
-			 ? GPIO_CNF_OUTPUT_PUSHPULL
-			 : GPIO_CNF_OUTPUT_OPENDRAIN),
-			NRST_PIN);
+		(((platform_hwversion() == 0) || (platform_hwversion() >= 3)) ? GPIO_CNF_OUTPUT_PUSHPULL
+																	  : GPIO_CNF_OUTPUT_OPENDRAIN),
+		NRST_PIN);
 	/* FIXME: Gareth, Esden, what versions need this fix? */
-	if (platform_hwversion() < 3) {
+	if (platform_hwversion() < 3)
 		/* FIXME: This pin in intended to be input, but the TXS0108 fails
 		 * to release the device from reset if this floats. */
-		gpio_set_mode(NRST_SENSE_PORT, GPIO_MODE_OUTPUT_2_MHZ,
-					  GPIO_CNF_OUTPUT_PUSHPULL, NRST_SENSE_PIN);
-	} else {
+		gpio_set_mode(NRST_SENSE_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, NRST_SENSE_PIN);
+	else {
 		gpio_set(NRST_SENSE_PORT, NRST_SENSE_PIN);
-		gpio_set_mode(NRST_SENSE_PORT, GPIO_MODE_INPUT,
-		              GPIO_CNF_INPUT_PULL_UPDOWN, NRST_SENSE_PIN);
+		gpio_set_mode(NRST_SENSE_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, NRST_SENSE_PIN);
 	}
 	/* Enable internal pull-up on PWR_BR so that we don't drive
 	   TPWR locally or inadvertently supply power to the target. */
-	if (platform_hwversion () == 1) {
+	if (platform_hwversion() == 1) {
 		gpio_set(PWR_BR_PORT, PWR_BR_PIN);
-		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_INPUT,
-		              GPIO_CNF_INPUT_PULL_UPDOWN, PWR_BR_PIN);
+		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, PWR_BR_PIN);
 	} else if (platform_hwversion() > 1) {
 		gpio_set(PWR_BR_PORT, PWR_BR_PIN);
-		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_OUTPUT_50_MHZ,
-		              GPIO_CNF_OUTPUT_OPENDRAIN, PWR_BR_PIN);
+		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_OPENDRAIN, PWR_BR_PIN);
 	}
 
-	if (platform_hwversion() > 0) {
+	if (platform_hwversion() > 0)
 		adc_init();
-	} else {
+	else {
 		gpio_clear(GPIOB, GPIO0);
-		gpio_set_mode(GPIOB, GPIO_MODE_INPUT,
-				GPIO_CNF_INPUT_PULL_UPDOWN, GPIO0);
+		gpio_set_mode(GPIOB, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, GPIO0);
 	}
 	/* Relocate interrupt vector table here */
 	extern int vector_table;
@@ -235,9 +220,7 @@ void platform_init(void)
 
 	/* On hardware version 1 and 2, UART and SWD share connector pins.
 	 * Don't enable UART if we're being debugged. */
-	if (platform_hwversion() == 0 ||
-	    platform_hwversion() >= 3 ||
-	    !(SCS_DEMCR & SCS_DEMCR_TRCENA))
+	if (platform_hwversion() == 0 || platform_hwversion() >= 3 || !(SCS_DEMCR & SCS_DEMCR_TRCENA))
 		usbuart_init();
 
 	setup_vbus_irq();

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -149,6 +149,8 @@ void platform_init(void)
 	rcc_periph_clock_enable(RCC_USB);
 	rcc_periph_clock_enable(RCC_GPIOA);
 	rcc_periph_clock_enable(RCC_GPIOB);
+	if (platform_hwversion() >= 6)
+		rcc_periph_clock_enable(RCC_GPIOC);
 	rcc_periph_clock_enable(RCC_AFIO);
 	rcc_periph_clock_enable(RCC_CRC);
 
@@ -172,6 +174,12 @@ void platform_init(void)
 
 	gpio_port_write(GPIOA, 0x8182);
 	gpio_port_write(GPIOB, 0x2002);
+
+	if (platform_hwversion() >= 6) {
+		gpio_set_mode(TCK_DIR_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TCK_DIR_PIN);
+		gpio_set_mode(TCK_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, TCK_PIN);
+		gpio_clear(TCK_DIR_PORT, TCK_DIR_PIN);
+	}
 
 	gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ,
 			GPIO_CNF_OUTPUT_PUSHPULL,
@@ -345,6 +353,12 @@ void platform_request_boot(void)
 	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ,
 			GPIO_CNF_OUTPUT_PUSHPULL, GPIO12);
 	gpio_clear(GPIOB, GPIO12);
+}
+
+void platform_target_clk_output_enable(bool enable)
+{
+	if (platform_hwversion() >= 6)
+		gpio_set_val(TCK_DIR_PORT, TCK_DIR_PIN, enable);
 }
 
 void exti15_10_isr(void)

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -190,27 +190,30 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define AUX_VBAT       GPIO0
 
 # define SWD_CR   GPIO_CRL(SWDIO_PORT)
-# define SWD_CR_MULT (1 << (4 << 2))
+# define SWD_CR_SHIFT (4U << 2U)
 
 #define TMS_SET_MODE() do { \
 	gpio_set(TMS_DIR_PORT, TMS_DIR_PIN); \
 	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_50_MHZ, \
 	              GPIO_CNF_OUTPUT_PUSHPULL, TMS_PIN); \
 } while(0)
+
 #define SWDIO_MODE_FLOAT() do { \
 	uint32_t cr = SWD_CR; \
-	cr  &= ~(0xf * SWD_CR_MULT); \
-	cr  |=  (0x4 * SWD_CR_MULT); \
+	cr  &= ~(0xfU << SWD_CR_SHIFT); \
+	cr  |=  (0x4U << SWD_CR_SHIFT); \
 	GPIO_BRR(SWDIO_DIR_PORT) = SWDIO_DIR_PIN; \
 	SWD_CR = cr; \
 } while(0)
+
 #define SWDIO_MODE_DRIVE() do { \
 	uint32_t cr = SWD_CR; \
-	cr  &= ~(0xf * SWD_CR_MULT); \
-	cr  |=  (0x1 * SWD_CR_MULT); \
+	cr  &= ~(0xfU << SWD_CR_SHIFT); \
+	cr  |=  (0x1U << SWD_CR_SHIFT); \
 	GPIO_BSRR(SWDIO_DIR_PORT) = SWDIO_DIR_PIN; \
 	SWD_CR = cr; \
 } while(0)
+
 #define UART_PIN_SETUP() do { \
 	gpio_set_mode(USBUSART_PORT, GPIO_MODE_OUTPUT_50_MHZ, \
 	              GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, USBUSART_TX_PIN); \

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -189,38 +189,39 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define AUX_BTN2       GPIO9
 #define AUX_VBAT       GPIO0
 
-# define SWD_CR   GPIO_CRL(SWDIO_PORT)
-# define SWD_CR_SHIFT (4U << 2U)
+#define SWD_CR       GPIO_CRL(SWDIO_PORT)
+#define SWD_CR_SHIFT (4U << 2U)
 
-#define TMS_SET_MODE() do { \
-	gpio_set(TMS_DIR_PORT, TMS_DIR_PIN); \
-	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_50_MHZ, \
-	              GPIO_CNF_OUTPUT_PUSHPULL, TMS_PIN); \
-} while(0)
+#define TMS_SET_MODE()                                                                       \
+	do {                                                                                     \
+		gpio_set(TMS_DIR_PORT, TMS_DIR_PIN);                                                 \
+		gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TMS_PIN); \
+	} while (0)
 
-#define SWDIO_MODE_FLOAT() do { \
-	uint32_t cr = SWD_CR; \
-	cr  &= ~(0xfU << SWD_CR_SHIFT); \
-	cr  |=  (0x4U << SWD_CR_SHIFT); \
-	GPIO_BRR(SWDIO_DIR_PORT) = SWDIO_DIR_PIN; \
-	SWD_CR = cr; \
-} while(0)
+#define SWDIO_MODE_FLOAT()                        \
+	do {                                          \
+		uint32_t cr = SWD_CR;                     \
+		cr &= ~(0xfU << SWD_CR_SHIFT);            \
+		cr |= (0x4U << SWD_CR_SHIFT);             \
+		GPIO_BRR(SWDIO_DIR_PORT) = SWDIO_DIR_PIN; \
+		SWD_CR = cr;                              \
+	} while (0)
 
-#define SWDIO_MODE_DRIVE() do { \
-	uint32_t cr = SWD_CR; \
-	cr  &= ~(0xfU << SWD_CR_SHIFT); \
-	cr  |=  (0x1U << SWD_CR_SHIFT); \
-	GPIO_BSRR(SWDIO_DIR_PORT) = SWDIO_DIR_PIN; \
-	SWD_CR = cr; \
-} while(0)
+#define SWDIO_MODE_DRIVE()                         \
+	do {                                           \
+		uint32_t cr = SWD_CR;                      \
+		cr &= ~(0xfU << SWD_CR_SHIFT);             \
+		cr |= (0x1U << SWD_CR_SHIFT);              \
+		GPIO_BSRR(SWDIO_DIR_PORT) = SWDIO_DIR_PIN; \
+		SWD_CR = cr;                               \
+	} while (0)
 
-#define UART_PIN_SETUP() do { \
-	gpio_set_mode(USBUSART_PORT, GPIO_MODE_OUTPUT_50_MHZ, \
-	              GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, USBUSART_TX_PIN); \
-	gpio_set_mode(USBUSART_PORT, GPIO_MODE_INPUT, \
-				  GPIO_CNF_INPUT_PULL_UPDOWN, USBUSART_RX_PIN); \
-	gpio_set(USBUSART_PORT, USBUSART_RX_PIN); \
-} while(0)
+#define UART_PIN_SETUP()                                                                                        \
+	do {                                                                                                        \
+		gpio_set_mode(USBUSART_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, USBUSART_TX_PIN); \
+		gpio_set_mode(USBUSART_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, USBUSART_RX_PIN);             \
+		gpio_set(USBUSART_PORT, USBUSART_RX_PIN);                                                               \
+	} while (0)
 
 #define USB_DRIVER st_usbfs_v1_usb_driver
 #define USB_IRQ    NVIC_USB_LP_CAN_RX0_IRQ

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -64,6 +64,7 @@ int usbuart_debug_write(const char *buf, size_t len);
  *          = PA7  (output) -- Hardware 6 and newer
  * TMS      = PA4  (input/output for SWDIO)
  * TCK      = PA5  (output SWCLK)
+ * TCK_DIR  = PC15 (output) -- Hardware 6 and newer
  * TDO      = PA6  (input)
  * TRACESWO = PB7  (input)  -- To allow trace decoding using USART1
  *                             Hardware 4 has a normally open jumper between TDO and TRACESWO
@@ -110,11 +111,13 @@ int usbuart_debug_write(const char *buf, size_t len);
 #define TMS_DIR_PORT	JTAG_PORT
 #define TMS_PORT	JTAG_PORT
 #define TCK_PORT	JTAG_PORT
+#define TCK_DIR_PORT GPIOC
 #define TDO_PORT	JTAG_PORT
 #define TDI_PIN		HW_SWITCH(6, GPIO3, GPIO7)
 #define TMS_DIR_PIN	GPIO1
 #define TMS_PIN		GPIO4
 #define TCK_PIN		GPIO5
+#define TCK_DIR_PIN GPIO15
 #define TDO_PIN		GPIO6
 
 #define SWDIO_DIR_PORT	JTAG_PORT

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -160,3 +160,8 @@ const char *platform_target_voltage(void)
 
 	return ret;
 }
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -190,3 +190,8 @@ void set_idle_state(int state)
 		break;
 	}
 }
+
+void platform_target_clk_output_enable(bool enable)
+{
+	(void)enable;
+}

--- a/src/remote.c
+++ b/src/remote.c
@@ -171,9 +171,9 @@ static void remote_packet_process_swd(unsigned i, char *packet)
 static void remote_packet_process_jtag(unsigned i, char *packet)
 {
 	uint32_t MS;
-	uint64_t DO;
+	uint64_t DO = 0;
 	size_t ticks;
-	uint64_t DI;
+	uint64_t DI = 0;
 	jtag_dev_t jtag_dev;
 	switch (packet[1]) {
 	case REMOTE_INIT: /* JS = initialise ============================= */
@@ -218,11 +218,9 @@ static void remote_packet_process_jtag(unsigned i, char *packet)
 		} else {
 			ticks = remotehston(2, &packet[2]);
 			DI = remotehston(-1, &packet[4]);
-			jtag_proc.jtagtap_tdi_tdo_seq((void *)&DO, (packet[1] == REMOTE_TDITDO_TMS), (void *)&DI, ticks);
-
-			/* Mask extra bits on return value... */
-			if (ticks < 64)
-				DO &= (1LL << ticks) - 1;
+			const uint8_t *const data_in = (uint8_t *)&DI;
+			uint8_t *data_out = (uint8_t *)&DO;
+			jtag_proc.jtagtap_tdi_tdo_seq(data_out, packet[1] == REMOTE_TDITDO_TMS, data_in, ticks);
 
 			remote_respond(REMOTE_RESP_OK, DO);
 		}

--- a/src/remote.c
+++ b/src/remote.c
@@ -261,7 +261,6 @@ static void remote_packet_process_jtag(unsigned i, char *packet)
 }
 
 static void remotePacketProcessGEN(unsigned i, char *packet)
-
 {
 	(void)i;
     uint32_t freq;
@@ -318,6 +317,11 @@ static void remotePacketProcessGEN(unsigned i, char *packet)
 #endif
 	case REMOTE_START:
 		remote_respond_string(REMOTE_RESP_OK, PLATFORM_IDENT ""  FIRMWARE_VERSION);
+		break;
+
+	case REMOTE_TARGET_CLK_OE:
+		platform_target_clk_output_enable(packet[2] != '0');
+		remote_respond(REMOTE_RESP_OK, 0);
 		break;
 
     default:

--- a/src/remote.c
+++ b/src/remote.c
@@ -117,7 +117,7 @@ static ADIv5_DP_t remote_dp = {
 	.mem_write_sized = firmware_mem_write_sized,
 };
 
-static void remotePacketProcessSWD(unsigned i, char *packet)
+static void remote_packet_process_swd(unsigned i, char *packet)
 {
 	uint8_t ticks;
 	uint32_t param;
@@ -168,7 +168,7 @@ static void remotePacketProcessSWD(unsigned i, char *packet)
 	}
 }
 
-static void remotePacketProcessJTAG(unsigned i, char *packet)
+static void remote_packet_process_jtag(unsigned i, char *packet)
 {
 	uint32_t MS;
 	uint64_t DO;
@@ -434,11 +434,11 @@ void remotePacketProcess(unsigned i, char *packet)
 {
 	switch (packet[0]) {
     case REMOTE_SWDP_PACKET:
-		remotePacketProcessSWD(i,packet);
+		remote_packet_process_swd(i,packet);
 		break;
 
     case REMOTE_JTAG_PACKET:
-		remotePacketProcessJTAG(i,packet);
+		remote_packet_process_jtag(i,packet);
 		break;
 
     case REMOTE_GEN_PACKET:

--- a/src/remote.c
+++ b/src/remote.c
@@ -31,32 +31,21 @@
 #include "target.h"
 #include "hex_utils.h"
 
+#define NTOH(x)    (((x) <= 9) ? (x) + '0' : 'a' + (x) - 10)
+#define HTON(x)    (((x) <= '9') ? (x) - '0' : ((TOUPPER(x)) - 'A' + 10))
+#define TOUPPER(x) ((((x) >= 'a') && ((x) <= 'z')) ? ((x) - ('a' - 'A')) : (x))
+#define ISHEX(x)   ((((x) >= '0') && ((x) <= '9')) || (((x) >= 'A') && ((x) <= 'F')) || (((x) >= 'a') && ((x) <= 'f')))
 
-#define NTOH(x) ((x<=9)?x+'0':'a'+x-10)
-#define HTON(x) ((x<='9')?x-'0':((TOUPPER(x))-'A'+10))
-#define TOUPPER(x) ((((x)>='a') && ((x)<='z'))?((x)-('a'-'A')):(x))
-#define ISHEX(x) (						\
-		(((x)>='0') && ((x)<='9')) ||					\
-		(((x)>='A') && ((x)<='F')) ||					\
-		(((x)>='a') && ((x)<='f'))						\
-		)
-
-
-uint64_t remotehston(uint32_t limit, char *s)
-
-/* Return numeric version of string, until illegal hex digit, or limit */
-
+/* Return numeric version of string, until illegal hex digit, or max */
+uint64_t remotehston(const uint32_t max, const char *const str)
 {
-	uint64_t ret=0L;
-	char c;
-
-	while (limit--) {
-		c=*s++;
-		if (!ISHEX(c))
+	uint64_t ret = 0;
+	for (size_t i = 0; i < max; ++i) {
+		const char value = str[i];
+		if (!ISHEX(value))
 			return ret;
-		ret=(ret<<4)|HTON(c);
-    }
-
+		ret = (ret << 4U) | HTON(value);
+	}
 	return ret;
 }
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -124,48 +124,48 @@ static void remotePacketProcessSWD(unsigned i, char *packet)
 	bool badParity;
 
 	switch (packet[1]) {
-    case REMOTE_INIT: /* SS = initialise =============================== */
-		if (i==2) {
+	case REMOTE_INIT: /* SS = initialise =============================== */
+		if (i == 2) {
 			remote_dp.dp_read = firmware_swdp_read;
 			remote_dp.low_access = firmware_swdp_low_access;
 			remote_dp.abort = firmware_swdp_abort;
 			swdptap_init(&remote_dp);
 			remote_respond(REMOTE_RESP_OK, 0);
 		} else {
-			remote_respond(REMOTE_RESP_ERR,REMOTE_ERROR_WRONGLEN);
+			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		}
 		break;
 
-    case REMOTE_IN_PAR: /* SI = In parity ============================= */
-		ticks=remotehston(2,&packet[2]);
+	case REMOTE_IN_PAR: /* SI = In parity ============================= */
+		ticks = remotehston(2, &packet[2]);
 		badParity = remote_dp.seq_in_parity(&param, ticks);
-		remote_respond(badParity?REMOTE_RESP_PARERR:REMOTE_RESP_OK,param);
+		remote_respond(badParity ? REMOTE_RESP_PARERR : REMOTE_RESP_OK, param);
 		break;
 
-    case REMOTE_IN: /* Si = In ======================================= */
-		ticks=remotehston(2,&packet[2]);
+	case REMOTE_IN: /* Si = In ======================================= */
+		ticks = remotehston(2, &packet[2]);
 		param = remote_dp.seq_in(ticks);
-		remote_respond(REMOTE_RESP_OK,param);
+		remote_respond(REMOTE_RESP_OK, param);
 		break;
 
-    case REMOTE_OUT: /* So= Out ====================================== */
-		ticks=remotehston(2,&packet[2]);
-		param=remotehston(-1, &packet[4]);
+	case REMOTE_OUT: /* So= Out ====================================== */
+		ticks = remotehston(2, &packet[2]);
+		param = remotehston(-1, &packet[4]);
 		remote_dp.seq_out(param, ticks);
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
 
-    case REMOTE_OUT_PAR: /* SO = Out parity ========================== */
-		ticks=remotehston(2,&packet[2]);
-		param=remotehston(-1, &packet[4]);
+	case REMOTE_OUT_PAR: /* SO = Out parity ========================== */
+		ticks = remotehston(2, &packet[2]);
+		param = remotehston(-1, &packet[4]);
 		remote_dp.seq_out_parity(param, ticks);
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
 
-    default:
-		remote_respond(REMOTE_RESP_ERR,REMOTE_ERROR_UNRECOGNISED);
+	default:
+		remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_UNRECOGNISED);
 		break;
-    }
+	}
 }
 
 static void remotePacketProcessJTAG(unsigned i, char *packet)
@@ -176,7 +176,7 @@ static void remotePacketProcessJTAG(unsigned i, char *packet)
 	uint64_t DI;
 	jtag_dev_t jtag_dev;
 	switch (packet[1]) {
-    case REMOTE_INIT: /* JS = initialise ============================= */
+	case REMOTE_INIT: /* JS = initialise ============================= */
 		remote_dp.dp_read = fw_adiv5_jtagdp_read;
 		remote_dp.low_access = fw_adiv5_jtagdp_low_access;
 		remote_dp.abort = adiv5_jtagdp_abort;
@@ -184,19 +184,19 @@ static void remotePacketProcessJTAG(unsigned i, char *packet)
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
 
-    case REMOTE_RESET: /* JR = reset ================================= */
+	case REMOTE_RESET: /* JR = reset ================================= */
 		jtag_proc.jtagtap_reset();
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
 
-    case REMOTE_TMS: /* JT = TMS Sequence ============================ */
-		ticks=remotehston(2,&packet[2]);
-		MS=remotehston(2,&packet[4]);
+	case REMOTE_TMS: /* JT = TMS Sequence ============================ */
+		ticks = remotehston(2, &packet[2]);
+		MS = remotehston(2, &packet[4]);
 
-		if (i<4) {
-			remote_respond(REMOTE_RESP_ERR,REMOTE_ERROR_WRONGLEN);
+		if (i < 4) {
+			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		} else {
-			jtag_proc.jtagtap_tms_seq( MS, ticks);
+			jtag_proc.jtagtap_tms_seq(MS, ticks);
 			remote_respond(REMOTE_RESP_OK, 0);
 		}
 		break;
@@ -213,12 +213,12 @@ static void remotePacketProcessJTAG(unsigned i, char *packet)
 	case REMOTE_TDITDO_TMS: /* JD = TDI/TDO  ========================================= */
 	case REMOTE_TDITDO_NOTMS:
 
-		if (i<5) {
-			remote_respond(REMOTE_RESP_ERR,REMOTE_ERROR_WRONGLEN);
+		if (i < 5) {
+			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		} else {
-			ticks=remotehston(2,&packet[2]);
-			DI=remotehston(-1,&packet[4]);
-			jtag_proc.jtagtap_tdi_tdo_seq((void *)&DO, (packet[1]==REMOTE_TDITDO_TMS), (void *)&DI, ticks);
+			ticks = remotehston(2, &packet[2]);
+			DI = remotehston(-1, &packet[4]);
+			jtag_proc.jtagtap_tdi_tdo_seq((void *)&DO, (packet[1] == REMOTE_TDITDO_TMS), (void *)&DI, ticks);
 
 			/* Mask extra bits on return value... */
 			if (ticks < 64)
@@ -228,7 +228,7 @@ static void remotePacketProcessJTAG(unsigned i, char *packet)
 		}
 		break;
 
-    case REMOTE_NEXT: /* JN = NEXT ======================================== */
+	case REMOTE_NEXT: /* JN = NEXT ======================================== */
 		if (i != 4)
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		else {
@@ -237,27 +237,27 @@ static void remotePacketProcessJTAG(unsigned i, char *packet)
 		}
 		break;
 
-    case REMOTE_ADD_JTAG_DEV: /* JJ = fill firmware jtag_devs */
+	case REMOTE_ADD_JTAG_DEV: /* JJ = fill firmware jtag_devs */
 		if (i < 22) {
-			remote_respond(REMOTE_RESP_ERR,REMOTE_ERROR_WRONGLEN);
+			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		} else {
 			memset(&jtag_dev, 0, sizeof(jtag_dev));
-			const uint32_t index = remotehston(2, &packet[ 2]);
-			jtag_dev.dr_prescan  = remotehston(2, &packet[ 4]);
-			jtag_dev.dr_postscan = remotehston(2, &packet[ 6]);
-			jtag_dev.ir_len      = remotehston(2, &packet[ 8]);
-			jtag_dev.ir_prescan  = remotehston(2, &packet[10]);
+			const uint32_t index = remotehston(2, &packet[2]);
+			jtag_dev.dr_prescan = remotehston(2, &packet[4]);
+			jtag_dev.dr_postscan = remotehston(2, &packet[6]);
+			jtag_dev.ir_len = remotehston(2, &packet[8]);
+			jtag_dev.ir_prescan = remotehston(2, &packet[10]);
 			jtag_dev.ir_postscan = remotehston(2, &packet[12]);
-			jtag_dev.current_ir  = remotehston(8, &packet[14]);
+			jtag_dev.current_ir = remotehston(8, &packet[14]);
 			jtag_add_device(index, &jtag_dev);
 			remote_respond(REMOTE_RESP_OK, 0);
 		}
 		break;
 
-    default:
-		remote_respond(REMOTE_RESP_ERR,REMOTE_ERROR_UNRECOGNISED);
+	default:
+		remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_UNRECOGNISED);
 		break;
-    }
+	}
 }
 
 static void remotePacketProcessGEN(unsigned i, char *packet)

--- a/src/remote.c
+++ b/src/remote.c
@@ -117,7 +117,6 @@ static ADIv5_DP_t remote_dp = {
 	.mem_write_sized = firmware_mem_write_sized,
 };
 
-
 static void remotePacketProcessSWD(unsigned i, char *packet)
 {
 	uint8_t ticks;

--- a/src/remote.h
+++ b/src/remote.h
@@ -62,26 +62,27 @@
 #define REMOTE_RESP '&'
 
 /* Generic protocol elements */
-#define REMOTE_START        'A'
-#define REMOTE_TDITDO_TMS   'D'
-#define REMOTE_TDITDO_NOTMS 'd'
-#define REMOTE_CYCLE        'c'
-#define REMOTE_IN_PAR       'I'
-#define REMOTE_FREQ_SET     'F'
-#define REMOTE_FREQ_GET     'f'
-#define REMOTE_IN           'i'
-#define REMOTE_NEXT         'N'
-#define REMOTE_OUT_PAR      'O'
-#define REMOTE_OUT          'o'
-#define REMOTE_PWR_SET      'P'
-#define REMOTE_PWR_GET      'p'
-#define REMOTE_RESET        'R'
-#define REMOTE_INIT         'S'
-#define REMOTE_TMS          'T'
-#define REMOTE_VOLTAGE      'V'
-#define REMOTE_NRST_SET     'Z'
-#define REMOTE_NRST_GET     'z'
-#define REMOTE_ADD_JTAG_DEV 'J'
+#define REMOTE_START         'A'
+#define REMOTE_TDITDO_TMS    'D'
+#define REMOTE_TDITDO_NOTMS  'd'
+#define REMOTE_CYCLE         'c'
+#define REMOTE_IN_PAR        'I'
+#define REMOTE_TARGET_CLK_OE 'E'
+#define REMOTE_FREQ_SET      'F'
+#define REMOTE_FREQ_GET      'f'
+#define REMOTE_IN            'i'
+#define REMOTE_NEXT          'N'
+#define REMOTE_OUT_PAR       'O'
+#define REMOTE_OUT           'o'
+#define REMOTE_PWR_SET       'P'
+#define REMOTE_PWR_GET       'p'
+#define REMOTE_RESET         'R'
+#define REMOTE_INIT          'S'
+#define REMOTE_TMS           'T'
+#define REMOTE_VOLTAGE       'V'
+#define REMOTE_NRST_SET      'Z'
+#define REMOTE_NRST_GET      'z'
+#define REMOTE_ADD_JTAG_DEV  'J'
 
 /* Protocol response options */
 #define REMOTE_RESP_OK     'K'
@@ -142,6 +143,11 @@
 	(char[])                                                         \
 	{                                                                \
 		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_PWR_GET, REMOTE_EOM, 0 \
+	}
+#define REMOTE_TARGET_CLK_OE_STR                                                     \
+	(char[])                                                                         \
+	{                                                                                \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_TARGET_CLK_OE, '%', 'c', REMOTE_EOM, 0 \
 	}
 
 /* SWDP protocol elements */

--- a/src/remote.h
+++ b/src/remote.h
@@ -187,7 +187,7 @@
 #define REMOTE_MEM_WRITE_SIZED_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_WRITE_SIZED, \
 			'%','0', '2', 'x', '%','0','2','x', HEX_U32(address), HEX_U32(count), 0}
 
-uint64_t remotehston(uint32_t limit, char *s);
+uint64_t remotehston(uint32_t limit, const char *s);
 void remotePacketProcess(unsigned int i, char *packet);
 
 #endif

--- a/src/remote.h
+++ b/src/remote.h
@@ -116,32 +116,61 @@
 
 /* SWDP protocol elements */
 #define REMOTE_SWDP_PACKET 'S'
-#define REMOTE_SWDP_INIT_STR (char []){ REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_INIT, REMOTE_EOM, 0 }
+#define REMOTE_SWDP_INIT_STR                                       \
+	(char[])                                                       \
+	{                                                              \
+		REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_INIT, REMOTE_EOM, 0 \
+	}
 
-#define REMOTE_SWDP_IN_PAR_STR (char []){ REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_IN_PAR, \
-                                          '%','0','2','x',REMOTE_EOM, 0 }
+#define REMOTE_SWDP_IN_PAR_STR                                                           \
+	(char[])                                                                             \
+	{                                                                                    \
+		REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_IN_PAR, '%', '0', '2', 'x', REMOTE_EOM, 0 \
+	}
 
-#define REMOTE_SWDP_IN_STR (char []){ REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_IN, \
-                                      '%','0','2','x',REMOTE_EOM, 0 }
+#define REMOTE_SWDP_IN_STR                                                           \
+	(char[])                                                                         \
+	{                                                                                \
+		REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_IN, '%', '0', '2', 'x', REMOTE_EOM, 0 \
+	}
 
-#define REMOTE_SWDP_OUT_STR (char []){ REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_OUT, \
-                                       '%','0','2','x','%','x',REMOTE_EOM, 0 }
+#define REMOTE_SWDP_OUT_STR                                                                     \
+	(char[])                                                                                    \
+	{                                                                                           \
+		REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_OUT, '%', '0', '2', 'x', '%', 'x', REMOTE_EOM, 0 \
+	}
 
-#define REMOTE_SWDP_OUT_PAR_STR (char []){ REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_OUT_PAR, \
-                                           '%','0','2','x','%','x',REMOTE_EOM, 0 }
+#define REMOTE_SWDP_OUT_PAR_STR                                                                     \
+	(char[])                                                                                        \
+	{                                                                                               \
+		REMOTE_SOM, REMOTE_SWDP_PACKET, REMOTE_OUT_PAR, '%', '0', '2', 'x', '%', 'x', REMOTE_EOM, 0 \
+	}
 
 /* JTAG protocol elements */
 #define REMOTE_JTAG_PACKET 'J'
+#define REMOTE_JTAG_INIT_STR                                                        \
+	(char[])                                                                        \
+	{                                                                               \
+		'+', REMOTE_EOM, REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_INIT, REMOTE_EOM, 0 \
+	}
 
-#define REMOTE_JTAG_INIT_STR (char []){ '+',REMOTE_EOM, REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_INIT, REMOTE_EOM, 0 }
+#define REMOTE_JTAG_RESET_STR                                                        \
+	(char[])                                                                         \
+	{                                                                                \
+		'+', REMOTE_EOM, REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_RESET, REMOTE_EOM, 0 \
+	}
 
-#define REMOTE_JTAG_RESET_STR (char []){ '+',REMOTE_EOM, REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_RESET, REMOTE_EOM, 0 }
+#define REMOTE_JTAG_TMS_STR                                                                     \
+	(char[])                                                                                    \
+	{                                                                                           \
+		REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_TMS, '%', '0', '2', 'x', '%', 'x', REMOTE_EOM, 0 \
+	}
 
-#define REMOTE_JTAG_TMS_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_TMS, \
-                                           '%','0','2','x','%','x',REMOTE_EOM, 0 }
-
-#define REMOTE_JTAG_TDIDO_STR (char []){ REMOTE_SOM, REMOTE_JTAG_PACKET, '%', 'c', \
-      '%','0','2','x','%','l', 'x', REMOTE_EOM, 0 }
+#define REMOTE_JTAG_TDIDO_STR                                                                      \
+	(char[])                                                                                       \
+	{                                                                                              \
+		REMOTE_SOM, REMOTE_JTAG_PACKET, '%', 'c', '%', '0', '2', 'x', '%', 'l', 'x', REMOTE_EOM, 0 \
+	}
 
 #define REMOTE_JTAG_CYCLE_STR                                                                               \
 	(char[])                                                                                                \
@@ -154,6 +183,7 @@
 	{                                                                                  \
 		REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_NEXT, '%', 'u', '%', 'u', REMOTE_EOM, 0 \
 	}
+
 /* HL protocol elements */
 #define HEX '%', '0', '2', 'x'
 #define HEX_U32(x) '%', '0', '8', 'x'

--- a/src/remote.h
+++ b/src/remote.h
@@ -57,9 +57,9 @@
 #define REMOTE_ERROR_WRONGLEN     2
 
 /* Start and end of message identifiers */
-#define REMOTE_SOM         '!'
-#define REMOTE_EOM         '#'
-#define REMOTE_RESP        '&'
+#define REMOTE_SOM  '!'
+#define REMOTE_EOM  '#'
+#define REMOTE_RESP '&'
 
 /* Generic protocol elements */
 #define REMOTE_START        'A'
@@ -90,29 +90,59 @@
 #define REMOTE_RESP_NOTSUP 'N'
 
 /* High level protocol elements */
-#define REMOTE_HL_CHECK     'C'
-#define REMOTE_HL_PACKET 'H'
-#define REMOTE_DP_READ      'd'
-#define REMOTE_LOW_ACCESS   'L'
-#define REMOTE_AP_READ      'a'
-#define REMOTE_AP_WRITE     'A'
-#define REMOTE_AP_MEM_READ  'M'
+#define REMOTE_HL_CHECK           'C'
+#define REMOTE_HL_PACKET          'H'
+#define REMOTE_DP_READ            'd'
+#define REMOTE_LOW_ACCESS         'L'
+#define REMOTE_AP_READ            'a'
+#define REMOTE_AP_WRITE           'A'
+#define REMOTE_AP_MEM_READ        'M'
 #define REMOTE_MEM_READ           'h'
 #define REMOTE_MEM_WRITE_SIZED    'H'
 #define REMOTE_AP_MEM_WRITE_SIZED 'm'
 
-
 /* Generic protocol elements */
 #define REMOTE_GEN_PACKET  'G'
-
-#define REMOTE_START_STR (char []){ '+', REMOTE_EOM, REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_START, REMOTE_EOM, 0 }
-#define REMOTE_VOLTAGE_STR (char []){ REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_VOLTAGE, REMOTE_EOM, 0 }
-#define REMOTE_NRST_SET_STR (char []){ REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_NRST_SET, '%', 'c', REMOTE_EOM, 0 }
-#define REMOTE_NRST_GET_STR (char []){ REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_NRST_GET, REMOTE_EOM, 0 }
-#define REMOTE_FREQ_SET_STR (char []){ REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_FREQ_SET, '%', '0', '8', 'x', REMOTE_EOM, 0 }
-#define REMOTE_FREQ_GET_STR (char []){ REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_FREQ_GET, REMOTE_EOM, 0 }
-#define REMOTE_PWR_SET_STR (char []){ REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_PWR_SET, '%', 'c', REMOTE_EOM, 0 }
-#define REMOTE_PWR_GET_STR (char []){ REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_PWR_GET, REMOTE_EOM, 0 }
+#define REMOTE_START_STR                                                            \
+	(char[])                                                                        \
+	{                                                                               \
+		'+', REMOTE_EOM, REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_START, REMOTE_EOM, 0 \
+	}
+#define REMOTE_VOLTAGE_STR                                           \
+	(char[])                                                         \
+	{                                                                \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_VOLTAGE, REMOTE_EOM, 0 \
+	}
+#define REMOTE_NRST_SET_STR                                                     \
+	(char[])                                                                    \
+	{                                                                           \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_NRST_SET, '%', 'c', REMOTE_EOM, 0 \
+	}
+#define REMOTE_NRST_GET_STR                                           \
+	(char[])                                                          \
+	{                                                                 \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_NRST_GET, REMOTE_EOM, 0 \
+	}
+#define REMOTE_FREQ_SET_STR                                                               \
+	(char[])                                                                              \
+	{                                                                                     \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_FREQ_SET, '%', '0', '8', 'x', REMOTE_EOM, 0 \
+	}
+#define REMOTE_FREQ_GET_STR                                           \
+	(char[])                                                          \
+	{                                                                 \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_FREQ_GET, REMOTE_EOM, 0 \
+	}
+#define REMOTE_PWR_SET_STR                                                     \
+	(char[])                                                                   \
+	{                                                                          \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_PWR_SET, '%', 'c', REMOTE_EOM, 0 \
+	}
+#define REMOTE_PWR_GET_STR                                           \
+	(char[])                                                         \
+	{                                                                \
+		REMOTE_SOM, REMOTE_GEN_PACKET, REMOTE_PWR_GET, REMOTE_EOM, 0 \
+	}
 
 /* SWDP protocol elements */
 #define REMOTE_SWDP_PACKET 'S'
@@ -200,22 +230,52 @@
 			HEX_U32(current_ir), /* current_ir */						\
 			REMOTE_EOM, 0}
 
-#define REMOTE_HL_CHECK_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_HL_CHECK, REMOTE_EOM, 0 }
-#define REMOTE_DP_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_DP_READ, \
-			'%','0', '2', 'x', 'f', 'f', '%', '0', '4', 'x', REMOTE_EOM, 0 }
-#define REMOTE_LOW_ACCESS_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_LOW_ACCESS, \
-			'%','0', '2', 'x', '%','0', '2', 'x', '%', '0', '4', 'x', HEX_U32(csw), REMOTE_EOM, 0 }
-#define REMOTE_AP_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_READ, \
-			'%','0', '2', 'x', '%','0','2','x', '%', '0', '4', 'x', REMOTE_EOM, 0 }
-#define REMOTE_AP_WRITE_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_WRITE, \
-			'%','0', '2', 'x', '%','0','2','x', '%', '0', '4', 'x', HEX_U32(csw), REMOTE_EOM, 0 }
-#define REMOTE_AP_MEM_READ_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_READ, \
-			'%','0', '2', 'x', '%','0','2','x',HEX_U32(csw), HEX_U32(address), HEX_U32(count), \
-			REMOTE_EOM, 0 }
-#define REMOTE_AP_MEM_WRITE_SIZED_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_WRITE_SIZED, \
-			'%','0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), '%', '0', '2', 'x', HEX_U32(address), HEX_U32(count), 0}
-#define REMOTE_MEM_WRITE_SIZED_STR (char []){ REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_WRITE_SIZED, \
-			'%','0', '2', 'x', '%','0','2','x', HEX_U32(address), HEX_U32(count), 0}
+#define REMOTE_HL_CHECK_STR                                          \
+	(char[])                                                         \
+	{                                                                \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_HL_CHECK, REMOTE_EOM, 0 \
+	}
+#define REMOTE_DP_READ_STR                                                                                            \
+	(char[])                                                                                                          \
+	{                                                                                                                 \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_DP_READ, '%', '0', '2', 'x', 'f', 'f', '%', '0', '4', 'x', REMOTE_EOM, 0 \
+	}
+#define REMOTE_LOW_ACCESS_STR                                                                                        \
+	(char[])                                                                                                         \
+	{                                                                                                                \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_LOW_ACCESS, '%', '0', '2', 'x', '%', '0', '2', 'x', '%', '0', '4', 'x', \
+			HEX_U32(csw), REMOTE_EOM, 0                                                                              \
+	}
+#define REMOTE_AP_READ_STR                                                                                        \
+	(char[])                                                                                                      \
+	{                                                                                                             \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_READ, '%', '0', '2', 'x', '%', '0', '2', 'x', '%', '0', '4', 'x', \
+			REMOTE_EOM, 0                                                                                         \
+	}
+#define REMOTE_AP_WRITE_STR                                                                                        \
+	(char[])                                                                                                       \
+	{                                                                                                              \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_WRITE, '%', '0', '2', 'x', '%', '0', '2', 'x', '%', '0', '4', 'x', \
+			HEX_U32(csw), REMOTE_EOM, 0                                                                            \
+	}
+#define REMOTE_AP_MEM_READ_STR                                                                                  \
+	(char[])                                                                                                    \
+	{                                                                                                           \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_READ, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), \
+			HEX_U32(address), HEX_U32(count), REMOTE_EOM, 0                                                     \
+	}
+#define REMOTE_AP_MEM_WRITE_SIZED_STR                                                                                  \
+	(char[])                                                                                                           \
+	{                                                                                                                  \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_WRITE_SIZED, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), \
+			'%', '0', '2', 'x', HEX_U32(address), HEX_U32(count), 0                                                    \
+	}
+#define REMOTE_MEM_WRITE_SIZED_STR                                                                       \
+	(char[])                                                                                             \
+	{                                                                                                    \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_WRITE_SIZED, '%', '0', '2', 'x', '%', '0', '2', 'x', \
+			HEX_U32(address), HEX_U32(count), 0                                                          \
+	}
 
 uint64_t remotehston(uint32_t limit, const char *s);
 void remotePacketProcess(unsigned int i, char *packet);

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -89,6 +89,7 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 	if (swdptap_init(initial_dp))
 		return 0;
 
+	platform_target_clk_output_enable(true);
 	/* DORMANT-> SWD sequence*/
 	initial_dp->seq_out(0xFFFFFFFF, 32);
 	initial_dp->seq_out(0xFFFFFFFF, 32);

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -210,26 +210,26 @@ bool stm32g0_probe(target *t)
 	switch (t->part_id) {
 	case STM32G03_4:
 		/* SRAM 8 kiB, Flash up to 64 kiB */
-		ram_size = (uint32_t)RAM_SIZE_G03_4;
-		flash_size = (uint32_t)FLASH_SIZE_MAX_G03_4;
+		ram_size = RAM_SIZE_G03_4;
+		flash_size = FLASH_SIZE_MAX_G03_4;
 		t->driver = "STM32G03/4";
 		break;
 	case STM32G05_6:
 		/* SRAM 18 kiB, Flash up to 64 kiB */
-		ram_size = (uint32_t)RAM_SIZE_G05_6;
-		flash_size = (uint32_t)FLASH_SIZE_MAX_G05_6;
+		ram_size = RAM_SIZE_G05_6;
+		flash_size = FLASH_SIZE_MAX_G05_6;
 		t->driver = "STM32G05/6";
 		break;
 	case STM32G07_8:
 		/* SRAM 36 kiB, Flash up to 128 kiB */
-		ram_size = (uint32_t)RAM_SIZE_G07_8;
-		flash_size = (uint32_t)FLASH_SIZE_MAX_G07_8;
+		ram_size = RAM_SIZE_G07_8;
+		flash_size = FLASH_SIZE_MAX_G07_8;
 		t->driver = "STM32G07/8";
 		break;
 	case STM32G0B_C:
 		/* SRAM 144 kiB, Flash up to 512 kiB */
-		ram_size = (uint32_t)RAM_SIZE_G0B_C;
-		flash_size = (size_t)target_mem_read16(t, FLASH_MEMORY_SIZE);
+		ram_size = RAM_SIZE_G0B_C;
+		flash_size = target_mem_read16(t, FLASH_MEMORY_SIZE);
 		flash_size *= 1024U;
 		t->driver = "STM32G0B/C";
 		break;

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -315,9 +315,8 @@ static void stm32g0_flash_unlock(target *t)
 
 static void stm32g0_flash_lock(target *t)
 {
-	uint32_t flash_cr = target_mem_read32(t, FLASH_CR);
-	flash_cr |= (uint32_t)FLASH_CR_LOCK;
-	target_mem_write32(t, FLASH_CR, flash_cr);
+	const uint32_t ctrl = target_mem_read32(t, FLASH_CR) | FLASH_CR_LOCK;
+	target_mem_write32(t, FLASH_CR, ctrl);
 }
 
 static bool stm32g0_wait_busy(target *const t)

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -229,8 +229,7 @@ bool stm32g0_probe(target *t)
 	case STM32G0B_C:
 		/* SRAM 144 kiB, Flash up to 512 kiB */
 		ram_size = RAM_SIZE_G0B_C;
-		flash_size = target_mem_read16(t, FLASH_MEMORY_SIZE);
-		flash_size *= 1024U;
+		flash_size = target_mem_read16(t, FLASH_MEMORY_SIZE) * 1024U;
 		t->driver = "STM32G0B/C";
 		break;
 	default:

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -407,7 +407,7 @@ static int stm32g0_flash_write(target_flash_s *f, target_addr dest, const void *
 	target *const t = f->t;
 	stm32g0_priv_s *ps = (stm32g0_priv_s *)t->target_storage;
 
-	if ((dest >= (target_addr)FLASH_OTP_START) && !ps->irreversible_enabled) {
+	if (dest >= FLASH_OTP_START && !ps->irreversible_enabled) {
 		tc_printf(t, "Irreversible operations disabled\n");
 		stm32g0_flash_op_finish(t);
 		return -1;
@@ -418,25 +418,25 @@ static int stm32g0_flash_write(target_flash_s *f, target_addr dest, const void *
 	target_mem_write32(t, FLASH_CR, FLASH_CR_PG);
 	target_mem_write(t, dest, src, len);
 	/* Wait for completion or an error */
-	uint32_t flash_sr;
-	do {
-		flash_sr = target_mem_read32(t, FLASH_SR);
+	uint32_t status = FLASH_SR_BSY_MASK;
+	while (status & FLASH_SR_BSY_MASK) {
+		status = target_mem_read32(t, FLASH_SR);
 		if (target_check_error(t)) {
 			DEBUG_WARN("stm32g0 flash write: comm error\n");
 			stm32g0_flash_op_finish(t);
 			return -1;
 		}
-	} while (flash_sr & FLASH_SR_BSY_MASK);
+	}
 
-	if (flash_sr & FLASH_SR_ERROR_MASK) {
-		DEBUG_WARN("stm32g0 flash write error: sr 0x%" PRIx32 "\n", flash_sr);
+	if (status & FLASH_SR_ERROR_MASK) {
+		DEBUG_WARN("stm32g0 flash write error: sr 0x%" PRIx32 "\n", status);
 		stm32g0_flash_op_finish(t);
 		return -1;
 	}
-	if ((dest == (target_addr)FLASH_START) && target_mem_read32(t, FLASH_START) != 0xFFFFFFFF) {
-		uint32_t flash_acr = target_mem_read32(t, FLASH_ACR);
-		flash_acr &= ~(uint32_t)FLASH_ACR_EMPTY;
-		target_mem_write32(t, FLASH_ACR, flash_acr);
+
+	if (dest == FLASH_START && target_mem_read32(t, FLASH_START) != 0xFFFFFFFF) {
+		const uint32_t acr = target_mem_read32(t, FLASH_ACR) & ~FLASH_ACR_EMPTY;
+		target_mem_write32(t, FLASH_ACR, acr);
 	}
 
 	stm32g0_flash_op_finish(t);

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -336,13 +336,7 @@ static bool stm32g0_wait_busy(target *const t)
 static int stm32g0_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
-	const target_addr end = addr + len - 1U;
 	int ret = 0;
-
-	if (end > f->start + f->length - 1U)
-		goto exit_error;
-	if (!len)
-		goto exit_cleanup;
 
 	/* Wait for Flash ready */
 	if (!stm32g0_wait_busy(t))

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -168,10 +168,10 @@ static bool stm32g0_cmd_option(target *t, int argc, const char **argv);
 static bool stm32g0_cmd_irreversible(target *t, int argc, const char **argv);
 
 const struct command_s stm32g0_cmd_list[] = {
-	{ "erase_bank 1|2", (cmd_handler)stm32g0_cmd_erase_bank, "Erase specified Flash bank" },
-	{ "option", (cmd_handler)stm32g0_cmd_option, "Manipulate option bytes" },
-	{ "irreversible", (cmd_handler)stm32g0_cmd_irreversible, "Allow irreversible operations: (enable|disable)" },
-	{ NULL, NULL, NULL }
+	{ "erase_bank 1|2", stm32g0_cmd_erase_bank, "Erase specified Flash bank" },
+	{ "option", stm32g0_cmd_option, "Manipulate option bytes" },
+	{ "irreversible", stm32g0_cmd_irreversible, "Allow irreversible operations: (enable|disable)" },
+	{ NULL, NULL, NULL },
 };
 
 static void stm32g0_add_flash(target *t, uint32_t addr, size_t length,

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -158,8 +158,8 @@ struct stm32g0_priv_s {
 
 static bool stm32g0_attach(target *t);
 static void stm32g0_detach(target *t);
-static int stm32g0_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int stm32g0_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+static int stm32g0_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int stm32g0_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 static bool stm32g0_mass_erase(target *t);
 
 /* Custom commands */
@@ -177,7 +177,7 @@ const struct command_s stm32g0_cmd_list[] = {
 static void stm32g0_add_flash(target *t, uint32_t addr, size_t length,
                               size_t blocksize)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
+	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
@@ -326,7 +326,7 @@ static void stm32g0_flash_lock(target *t)
  * Flash erasure function.
  * OTP case: this function clears any previous error and returns.
  */
-static int stm32g0_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int stm32g0_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	target_addr end = addr + len - 1U;
@@ -411,7 +411,7 @@ exit_cleanup:
  * OTP area is programmed as the "program" area. It can be programmed 8-bytes
  * by 8-bytes.
  */
-static int stm32g0_flash_write(struct target_flash *f, target_addr dest,
+static int stm32g0_flash_write(target_flash_s *f, target_addr dest,
                                const void *src, size_t len)
 {
 	target *t = f->t;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -185,9 +185,12 @@ target *target_attach(target *t, struct target_controller *tc)
 		t->tc->destroy_callback(t->tc, t);
 
 	t->tc = tc;
+	platform_target_clk_output_enable(true);
 
-	if (!t->attach(t))
+	if (!t->attach(t)) {
+		platform_target_clk_output_enable(false);
 		return NULL;
+	}
 
 	t->attached = true;
 	return t;
@@ -378,6 +381,7 @@ void target_print_progress(platform_timeout *const timeout)
 void target_detach(target *t)
 {
 	t->detach(t);
+	platform_target_clk_output_enable(false);
 	t->attached = false;
 #if PC_HOSTED == 1
 	platform_buffer_flush();
@@ -387,8 +391,7 @@ void target_detach(target *t)
 bool target_check_error(target *t) {
 	if (t)
 		return t->check_error(t);
-	else
-		return false;
+	return false;
 }
 
 bool target_attached(target *t) { return t->attached; }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Certain low pin-count parts very heavily overload the device pins with functionality. This can mean it's inappropriate to drive TCK/SWCLK before initiating a scan, after scan but before attach, and after detach.

This PR introduces tristating support for these devices when running native hardware revision 6 and newer, allowing BMP to work around this problem. This also means BMP will play nicer with other devices on the roadmap.

This has been tested working against both the SWD and JTAG modes of the Tiva-C TM4C123GH6PM.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #945
