### PR TITLE
Fix: JTAG ADIv5 DPv0 detection

### DIFF
--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -136,7 +136,7 @@ uint32_t jlink_swdp_scan(bmp_info_t *info)
 
 	jlink_adiv5_swdp_error(dp);
 
-	adiv5_dp_init(dp);
+	adiv5_dp_init(dp, 0);
 
 	return target_list ? 1U : 0U;
 }

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1099,7 +1099,7 @@ uint32_t stlink_swdp_scan(bmp_info_t *info)
 
 	stlink_dp_error(dp);
 
-	adiv5_dp_init(dp);
+	adiv5_dp_init(dp, 0);
 
 	return target_list ? 1U : 0U;
 }

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -162,6 +162,8 @@
 #define JTAG_IDCODE_DESIGNER_OFFSET 1U
 #define JTAG_IDCODE_DESIGNER_MASK   (0x7ffU << JTAG_IDCODE_DESIGNER_OFFSET)
 
+#define JTAG_IDCODE_ARM_DPv0 0x4ba00477U
+
 /* Constants to make RnW parameters more clear in code */
 #define ADIV5_LOW_WRITE 0
 #define ADIV5_LOW_READ  1
@@ -358,7 +360,7 @@ void adiv5_mem_write_sized(ADIv5_AP_t *ap, uint32_t dest, const void *src, size_
 void adiv5_dp_write(ADIv5_DP_t *dp, uint16_t addr, uint32_t value);
 #endif
 
-void adiv5_dp_init(ADIv5_DP_t *dp);
+void adiv5_dp_init(ADIv5_DP_t *dp, uint32_t idcode);
 void platform_adiv5_dp_defaults(ADIv5_DP_t *dp);
 ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel);
 void remote_jtag_dev(const jtag_dev_t *jtag_dev);

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -56,7 +56,7 @@ void adiv5_jtag_dp_handler(uint8_t jd_index)
 		dp->abort = adiv5_jtagdp_abort;
 	}
 
-	adiv5_dp_init(dp);
+	adiv5_dp_init(dp, jtag_devs[jd_index].jd_idcode);
 }
 
 uint32_t fw_adiv5_jtagdp_read(ADIv5_DP_t *dp, uint16_t addr)

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -194,7 +194,7 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 		memcpy(dp, initial_dp, sizeof(ADIv5_DP_t));
 		dp->instance = i;
 
-		adiv5_dp_init(dp);
+		adiv5_dp_init(dp, 0);
 	}
 	return target_list ? 1U : 0U;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As part of the ongoing work to improve our ADIv5 compliance correctness, Perigoso had to "brick" support for ADIv5 JTAG for version 0 Debug Ports as the standard provides no reasonable way to detect these. As it happens, unfortunately, both the Tiva-C and the LPC43xx devices have version 0 DPs in JTAG mode (but not SWD!).

This PR restores JTAG on these parts to working by looking for a "magic" JTAG ID Code which Perigoso and us have jointly determined a probable safe way to detect at least some of these DPv0 parts.

This is tested on and works to detect both the aforementioned processor series.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
