### PR TITLE
target/cortex: dynamically generate target description strings to save code size

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,7 @@ SRC =			\
 	gdb_main.c	\
 	gdb_hostio.c	\
 	gdb_packet.c	\
+	gdb_reg.c   \
 	hex_utils.c	\
 	jtag_devs.c	\
 	jtag_scan.c	\

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -42,6 +42,8 @@
 #include "platform.h"
 #include "platform_support.h"
 
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+
 extern uint32_t delay_cnt;
 
 enum BMP_DEBUG {

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -42,7 +42,9 @@
 #include "platform.h"
 #include "platform_support.h"
 
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+#ifndef ARRAY_LENGTH
+#define ARRAY_LENGTH(arr) (sizeof(arr) / sizeof(arr[0]))
+#endif
 
 extern uint32_t delay_cnt;
 

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -36,8 +36,6 @@
 
 #include <assert.h>
 
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
-
 static const char cortexa_driver_str[] = "ARM Cortex-A";
 
 static bool cortexa_attach(target *t);

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -174,7 +174,7 @@ static const gdb_reg_type_e cortex_a_spr_types[] = {
 	GDB_TYPE_UNSPECIFIED // cpsr
 };
 
-static_assert(ARRAY_SIZE(cortex_a_spr_types) == ARRAY_SIZE(cortex_a_spr_names), "SPR array length mixmatch! SPR type "
+static_assert(ARRAY_LENGTH(cortex_a_spr_types) == ARRAY_LENGTH(cortex_a_spr_names), "SPR array length mixmatch! SPR type "
                                                                                 "array should have the same length as "
                                                                                 "SPR name array.");
 
@@ -270,7 +270,7 @@ static size_t create_tdesc_cortex_a(char *buffer, size_t max_len)
 	// all of the Cortex-A target description SPRs have the same bitsize, and none of them
 	// have a specified save-restore value. So we only need one "associative array" here.
 	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
-	for (size_t i = 0; i < ARRAY_SIZE(cortex_a_spr_names); ++i) {
+	for (size_t i = 0; i < ARRAY_LENGTH(cortex_a_spr_names); ++i) {
 		gdb_reg_type_e type = cortex_a_spr_types[i];
 
 		if (max_len != 0)

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -49,7 +49,6 @@ static void cortexa_regs_write_internal(target *t);
 static ssize_t cortexa_reg_read(target *t, int reg, void *data, size_t max);
 static ssize_t cortexa_reg_write(target *t, int reg, const void *data, size_t max);
 
-
 static void cortexa_reset(target *t);
 static enum target_halt_reason cortexa_halt_poll(target *t, target_addr *watch);
 static void cortexa_halt_request(target *t);
@@ -82,13 +81,13 @@ struct cortexa_priv {
 };
 
 /* This may be specific to Cortex-A9 */
-#define CACHE_LINE_LENGTH        (8*4)
+#define CACHE_LINE_LENGTH (8 * 4)
 
 /* Debug APB registers */
-#define DBGDIDR                  0
+#define DBGDIDR 0
 
-#define DBGDTRRX                 32 /* DCC: Host to target */
-#define DBGITR                   33
+#define DBGDTRRX 32 /* DCC: Host to target */
+#define DBGITR   33
 
 #define DBGDSCR                  34
 #define DBGDSCR_TXFULL           (1 << 29)
@@ -108,55 +107,53 @@ struct cortexa_priv {
 #define DBGDSCR_RESTARTED        (1 << 1)
 #define DBGDSCR_HALTED           (1 << 0)
 
-#define DBGDTRTX                 35 /* DCC: Target to host */
+#define DBGDTRTX 35 /* DCC: Target to host */
 
-#define DBGDRCR                  36
-#define DBGDRCR_CSE              (1 << 2)
-#define DBGDRCR_RRQ              (1 << 1)
-#define DBGDRCR_HRQ              (1 << 0)
+#define DBGDRCR     36
+#define DBGDRCR_CSE (1 << 2)
+#define DBGDRCR_RRQ (1 << 1)
+#define DBGDRCR_HRQ (1 << 0)
 
-#define DBGBVR(i)                (64+(i))
-#define DBGBCR(i)                (80+(i))
-#define DBGBCR_INST_MISMATCH     (4 << 20)
-#define DBGBCR_BAS_ANY           (0xf << 5)
-#define DBGBCR_BAS_LOW_HW        (0x3 << 5)
-#define DBGBCR_BAS_HIGH_HW       (0xc << 5)
-#define DBGBCR_EN                (1 << 0)
+#define DBGBVR(i)            (64 + (i))
+#define DBGBCR(i)            (80 + (i))
+#define DBGBCR_INST_MISMATCH (4 << 20)
+#define DBGBCR_BAS_ANY       (0xf << 5)
+#define DBGBCR_BAS_LOW_HW    (0x3 << 5)
+#define DBGBCR_BAS_HIGH_HW   (0xc << 5)
+#define DBGBCR_EN            (1 << 0)
 
-#define DBGWVR(i)                (96+(i))
-#define DBGWCR(i)                (112+(i))
-#define DBGWCR_LSC_LOAD          (0b01 << 3)
-#define DBGWCR_LSC_STORE         (0b10 << 3)
-#define DBGWCR_LSC_ANY           (0b11 << 3)
-#define DBGWCR_BAS_BYTE          (0b0001 << 5)
-#define DBGWCR_BAS_HALFWORD      (0b0011 << 5)
-#define DBGWCR_BAS_WORD          (0b1111 << 5)
-#define DBGWCR_PAC_ANY           (0b11 << 1)
-#define DBGWCR_EN                (1 << 0)
+#define DBGWVR(i)           (96 + (i))
+#define DBGWCR(i)           (112 + (i))
+#define DBGWCR_LSC_LOAD     (0b01 << 3)
+#define DBGWCR_LSC_STORE    (0b10 << 3)
+#define DBGWCR_LSC_ANY      (0b11 << 3)
+#define DBGWCR_BAS_BYTE     (0b0001 << 5)
+#define DBGWCR_BAS_HALFWORD (0b0011 << 5)
+#define DBGWCR_BAS_WORD     (0b1111 << 5)
+#define DBGWCR_PAC_ANY      (0b11 << 1)
+#define DBGWCR_EN           (1 << 0)
 
 /* Instruction encodings for accessing the coprocessor interface */
 #define MCR 0xee000010
 #define MRC 0xee100010
 #define CPREG(coproc, opc1, rt, crn, crm, opc2) \
-	(((opc1) << 21) | ((crn) << 16) | ((rt) << 12) | \
-        ((coproc) << 8) | ((opc2) << 5) | (crm))
+	(((opc1) << 21) | ((crn) << 16) | ((rt) << 12) | ((coproc) << 8) | ((opc2) << 5) | (crm))
 
 /* Debug registers CP14 */
 #define DBGDTRRXint CPREG(14, 0, 0, 0, 5, 0)
 #define DBGDTRTXint CPREG(14, 0, 0, 0, 5, 0)
 
 /* Address translation registers CP15 */
-#define PAR         CPREG(15, 0, 0, 7, 4, 0)
-#define ATS1CPR     CPREG(15, 0, 0, 7, 8, 0)
+#define PAR     CPREG(15, 0, 0, 7, 4, 0)
+#define ATS1CPR CPREG(15, 0, 0, 7, 8, 0)
 
 /* Cache management registers CP15 */
-#define ICIALLU     CPREG(15, 0, 0, 7, 5, 0)
-#define DCCIMVAC    CPREG(15, 0, 0, 7, 14, 1)
-#define DCCMVAC     CPREG(15, 0, 0, 7, 10, 1)
+#define ICIALLU  CPREG(15, 0, 0, 7, 5, 0)
+#define DCCIMVAC CPREG(15, 0, 0, 7, 14, 1)
+#define DCCMVAC  CPREG(15, 0, 0, 7, 10, 1)
 
 /* Thumb mode bit in CPSR */
-#define CPSR_THUMB               (1 << 5)
-
+#define CPSR_THUMB (1 << 5)
 
 /**
  * Fields for Cortex-A special purpose registers, used in the generation of GDB's target description XML.
@@ -167,12 +164,7 @@ struct cortexa_priv {
  */
 
 // Strings for the names of the Cortex-A's special purpose registers.
-static const char *cortex_a_spr_names[] = {
-	"sp",
-	"lr",
-	"pc",
-	"cpsr"
-};
+static const char *cortex_a_spr_names[] = {"sp", "lr", "pc", "cpsr"};
 
 // The "type" field for each Cortex-A special purpose register.
 static const gdb_reg_type_e cortex_a_spr_types[] = {
@@ -182,10 +174,9 @@ static const gdb_reg_type_e cortex_a_spr_types[] = {
 	GDB_TYPE_UNSPECIFIED // cpsr
 };
 
-static_assert(ARRAY_SIZE(cortex_a_spr_types) == ARRAY_SIZE(cortex_a_spr_names),
-	"SPR array length mixmatch! SPR type array should have the same length as SPR name array."
-);
-
+static_assert(ARRAY_SIZE(cortex_a_spr_types) == ARRAY_SIZE(cortex_a_spr_names), "SPR array length mixmatch! SPR type "
+                                                                                "array should have the same length as "
+                                                                                "SPR name array.");
 
 // Creates the target description XML string for a Cortex-A. Like snprintf(), this function
 // will write no more than max_len and returns the amount of bytes written. Or, if max_len is 0,
@@ -264,15 +255,12 @@ static size_t create_tdesc_cortex_a(char *buffer, size_t max_len)
 	total += snprintf(buffer, printsz,
 		"%s feature %s "
 		"<feature name=\"org.gnu.gdb.arm.core\">",
-		gdb_arm_preamble_first,
-		gdb_arm_preamble_second
-	);
+		gdb_arm_preamble_first, gdb_arm_preamble_second);
 
 	// Then the general purpose registers, which have names of r0 to r12.
 	for (uint8_t i = 0; i <= 12; ++i) {
-
 		if (max_len != 0)
-			printsz = max_len - (size_t) total;
+			printsz = max_len - (size_t)total;
 
 		total += snprintf(buffer + total, printsz, "<reg name=\"r%u\" bitsize=\"32\"/>", i);
 	}
@@ -283,42 +271,35 @@ static size_t create_tdesc_cortex_a(char *buffer, size_t max_len)
 	// have a specified save-restore value. So we only need one "associative array" here.
 	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
 	for (size_t i = 0; i < ARRAY_SIZE(cortex_a_spr_names); ++i) {
-
 		gdb_reg_type_e type = cortex_a_spr_types[i];
 
 		if (max_len != 0)
-			printsz = max_len - (size_t) total;
+			printsz = max_len - (size_t)total;
 
-		total += snprintf(buffer + total, printsz, "<reg name=\"%s\" bitsize=\"32\"%s/>",
-			cortex_a_spr_names[i],
-			gdb_reg_type_strings[type]
-		);
+		total += snprintf(buffer + total, printsz, "<reg name=\"%s\" bitsize=\"32\"%s/>", cortex_a_spr_names[i],
+			gdb_reg_type_strings[type]);
 	}
 
 	if (max_len != 0)
-		printsz = max_len - (size_t) total;
+		printsz = max_len - (size_t)total;
 
 	// Now onto the floating point registers.
 	// The first register is unique; the rest all follow the same format.
 	total += snprintf(buffer + total, printsz,
 		"</feature>"
 		"<feature name=\"org.gnu.gdb.arm.vfp\">"
-		"<reg name=\"fpscr\" bitsize=\"32\"/>"
-	);
+		"<reg name=\"fpscr\" bitsize=\"32\"/>");
 
 	// Now onto the simple ones.
 	for (uint8_t i = 0; i <= 15; ++i) {
 		if (max_len != 0)
-			printsz = max_len - (size_t) total;
+			printsz = max_len - (size_t)total;
 
-		total += snprintf(buffer + total, printsz,
-			"<reg name=\"d%u\" bitsize=\"64\" type=\"float\"/>",
-			i
-		);
+		total += snprintf(buffer + total, printsz, "<reg name=\"d%u\" bitsize=\"64\" type=\"float\"/>", i);
 	}
 
 	if (max_len != 0)
-		printsz = max_len - (size_t) total;
+		printsz = max_len - (size_t)total;
 
 	total += snprintf(buffer + total, printsz, "</feature></target>");
 
@@ -326,15 +307,14 @@ static size_t create_tdesc_cortex_a(char *buffer, size_t max_len)
 	// these functions are given static input that should not ever be able to fail -- and if it
 	// does, then there's nothing we can do about it, so we'll just discard the signedness
 	// of total when we return it.
-	return (size_t) total;
+	return (size_t)total;
 }
-
 
 static void apb_write(target *t, uint16_t reg, uint32_t val)
 {
 	struct cortexa_priv *priv = t->priv;
 	ADIv5_AP_t *ap = priv->apb;
-	uint32_t addr = priv->base + 4*reg;
+	uint32_t addr = priv->base + 4 * reg;
 	adiv5_ap_write(ap, ADIV5_AP_TAR, addr);
 	adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DRW, val);
 }
@@ -343,7 +323,7 @@ static uint32_t apb_read(target *t, uint16_t reg)
 {
 	struct cortexa_priv *priv = t->priv;
 	ADIv5_AP_t *ap = priv->apb;
-	uint32_t addr = priv->base + 4*reg;
+	uint32_t addr = priv->base + 4 * reg;
 	adiv5_ap_write(ap, ADIV5_AP_TAR, addr);
 	adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_AP_DRW, 0);
 	return adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
@@ -359,8 +339,7 @@ static uint32_t va_to_pa(target *t, uint32_t va)
 	if (par & 1)
 		priv->mmu_fault = true;
 	uint32_t pa = (par & ~0xfff) | (va & 0xfff);
-	DEBUG_INFO("%s: VA = 0x%08"PRIx32", PAR = 0x%08"PRIx32", PA = 0x%08"PRIX32"\n",
-              __func__, va, par, pa);
+	DEBUG_INFO("%s: VA = 0x%08" PRIx32 ", PAR = 0x%08" PRIx32 ", PA = 0x%08" PRIX32 "\n", __func__, va, par, pa);
 	return pa;
 }
 
@@ -388,7 +367,7 @@ static void cortexa_slow_mem_read(target *t, void *dest, target_addr src, size_t
 	for (unsigned i = 0; i < words; i++)
 		dest32[i] = apb_read(t, DBGDTRTX);
 
-	memcpy(dest, (uint8_t*)dest32 + (src & 3), len);
+	memcpy(dest, (uint8_t *)dest32 + (src & 3), len);
 
 	/* Switch back to stalling DCC mode */
 	dbgdscr = (dbgdscr & ~DBGDSCR_EXTDCCMODE_MASK) | DBGDSCR_EXTDCCMODE_STALL;
@@ -465,7 +444,6 @@ static bool cortexa_check_error(target *t)
 	return err;
 }
 
-
 bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 {
 	target *t;
@@ -477,7 +455,7 @@ bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 
 	adiv5_ap_ref(apb);
 	struct cortexa_priv *priv = calloc(1, sizeof(*priv));
-	if (!priv) {			/* calloc failed: heap exhaustion */
+	if (!priv) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return false;
 	}
@@ -493,8 +471,8 @@ bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 	uint32_t csw = apb->csw | ADIV5_AP_CSW_SIZE_WORD;
 	adiv5_ap_write(apb, ADIV5_AP_CSW, csw);
 	uint32_t dbgdidr = apb_read(t, DBGDIDR);
-	priv->hw_breakpoint_max = ((dbgdidr >> 24) & 15)+1;
-	priv->hw_watchpoint_max = ((dbgdidr >> 28) & 15)+1;
+	priv->hw_breakpoint_max = ((dbgdidr >> 24) & 15) + 1;
+	priv->hw_watchpoint_max = ((dbgdidr >> 28) & 15) + 1;
 
 	t->check_error = cortexa_check_error;
 
@@ -543,17 +521,17 @@ bool cortexa_attach(target *t)
 	dbgdscr |= DBGDSCR_HDBGEN | DBGDSCR_ITREN;
 	dbgdscr = (dbgdscr & ~DBGDSCR_EXTDCCMODE_MASK) | DBGDSCR_EXTDCCMODE_STALL;
 	apb_write(t, DBGDSCR, dbgdscr);
-	DEBUG_INFO("DBGDSCR = 0x%08"PRIx32"\n", dbgdscr);
+	DEBUG_INFO("DBGDSCR = 0x%08" PRIx32 "\n", dbgdscr);
 
 	target_halt_request(t);
 	tries = 10;
-	while(!platform_nrst_get_val() && !target_halt_poll(t, NULL) && --tries)
+	while (!platform_nrst_get_val() && !target_halt_poll(t, NULL) && --tries)
 		platform_delay(200);
-	if(!tries)
+	if (!tries)
 		return false;
 
 	/* Clear any stale breakpoints */
-	for(unsigned i = 0; i < priv->hw_breakpoint_max; i++) {
+	for (unsigned i = 0; i < priv->hw_breakpoint_max; i++) {
 		apb_write(t, DBGBCR(i), 0);
 	}
 	priv->hw_breakpoint_mask = 0;
@@ -577,7 +555,7 @@ void cortexa_detach(target *t)
 	}
 
 	/* Clear any stale breakpoints */
-	for(unsigned i = 0; i < priv->hw_breakpoint_max; i++) {
+	for (unsigned i = 0; i < priv->hw_breakpoint_max; i++) {
 		apb_write(t, DBGBCR(i), 0);
 	}
 
@@ -593,8 +571,7 @@ void cortexa_detach(target *t)
 	uint32_t dbgdscr;
 	do {
 		dbgdscr = apb_read(t, DBGDSCR);
-	} while (!(dbgdscr & DBGDSCR_INSTRCOMPL) &&
-	         !platform_timeout_is_expired(&to));
+	} while (!(dbgdscr & DBGDSCR_INSTRCOMPL) && !platform_timeout_is_expired(&to));
 
 	/* Disable halting debug mode */
 	dbgdscr &= ~(DBGDSCR_HDBGEN | DBGDSCR_ITREN);
@@ -602,7 +579,6 @@ void cortexa_detach(target *t)
 	/* Clear sticky error and resume */
 	apb_write(t, DBGDRCR, DBGDRCR_CSE | DBGDRCR_RRQ);
 }
-
 
 static uint32_t read_gpreg(target *t, uint8_t regno)
 {
@@ -791,7 +767,7 @@ static enum target_halt_reason cortexa_halt_poll(target *t, target_addr *watch)
 	if (!(dbgdscr & DBGDSCR_HALTED)) /* Not halted */
 		return TARGET_HALT_RUNNING;
 
-	DEBUG_INFO("%s: DBGDSCR = 0x%08"PRIx32"\n", __func__, dbgdscr);
+	DEBUG_INFO("%s: DBGDSCR = 0x%08" PRIx32 "\n", __func__, dbgdscr);
 	/* Reenable DBGITR */
 	dbgdscr |= DBGDSCR_ITREN;
 	apb_write(t, DBGDSCR, dbgdscr);
@@ -807,9 +783,8 @@ static enum target_halt_reason cortexa_halt_poll(target *t, target_addr *watch)
 		/* How do we know which watchpoint was hit? */
 		/* If there is only one set, it's that */
 		for (struct breakwatch *bw = t->bw_list; bw; bw = bw->next) {
-			if ((bw->type != TARGET_WATCH_READ) &&
-			    (bw->type != TARGET_WATCH_WRITE) &&
-			    (bw->type != TARGET_WATCH_ACCESS))
+			if ((bw->type != TARGET_WATCH_READ) && (bw->type != TARGET_WATCH_WRITE) &&
+				(bw->type != TARGET_WATCH_ACCESS))
 				continue;
 			if (reason == TARGET_HALT_WATCHPOINT) {
 				/* More than one watchpoint set,
@@ -837,11 +812,10 @@ void cortexa_halt_resume(target *t, bool step)
 	if (step) {
 		uint32_t addr = priv->reg_cache.r[15];
 		uint32_t bas = bp_bas(addr, (priv->reg_cache.cpsr & CPSR_THUMB) ? 2 : 4);
-		DEBUG_INFO("step 0x%08"PRIx32"  %"PRIx32"\n", addr, bas);
+		DEBUG_INFO("step 0x%08" PRIx32 "  %" PRIx32 "\n", addr, bas);
 		/* Set match any breakpoint */
 		apb_write(t, DBGBVR(0), priv->reg_cache.r[15] & ~3);
-		apb_write(t, DBGBCR(0), DBGBCR_INST_MISMATCH | bas |
-		                             DBGBCR_EN);
+		apb_write(t, DBGBCR(0), DBGBCR_INST_MISMATCH | bas | DBGBCR_EN);
 	} else {
 		apb_write(t, DBGBVR(0), priv->bvr0);
 		apb_write(t, DBGBCR(0), priv->bcr0);
@@ -859,10 +833,9 @@ void cortexa_halt_resume(target *t, bool step)
 	uint32_t dbgdscr;
 	do {
 		dbgdscr = apb_read(t, DBGDSCR);
-	} while (!(dbgdscr & DBGDSCR_INSTRCOMPL) &&
-	         !platform_timeout_is_expired(&to));
+	} while (!(dbgdscr & DBGDSCR_INSTRCOMPL) && !platform_timeout_is_expired(&to));
 
-	 /* Disable DBGITR.  Not sure why, but RRQ is ignored otherwise. */
+	/* Disable DBGITR.  Not sure why, but RRQ is ignored otherwise. */
 	if (step)
 		dbgdscr |= DBGDSCR_INTDIS;
 	else
@@ -873,9 +846,8 @@ void cortexa_halt_resume(target *t, bool step)
 	do {
 		apb_write(t, DBGDRCR, DBGDRCR_CSE | DBGDRCR_RRQ);
 		dbgdscr = apb_read(t, DBGDSCR);
-		DEBUG_INFO("%s: DBGDSCR = 0x%08"PRIx32"\n", __func__, dbgdscr);
-	} while (!(dbgdscr & DBGDSCR_RESTARTED) &&
-	         !platform_timeout_is_expired(&to));
+		DEBUG_INFO("%s: DBGDSCR = 0x%08" PRIx32 "\n", __func__, dbgdscr);
+	} while (!(dbgdscr & DBGDSCR_RESTARTED) && !platform_timeout_is_expired(&to));
 }
 
 /* Breakpoints */
@@ -923,7 +895,7 @@ static int cortexa_breakwatch_set(target *t, struct breakwatch *bw)
 		priv->hw_breakpoint_mask |= (1 << i);
 
 		uint32_t addr = va_to_pa(t, bw->addr);
-		uint32_t bcr =  bp_bas(addr, bw->size) | DBGBCR_EN;
+		uint32_t bcr = bp_bas(addr, bw->size) | DBGBCR_EN;
 		apb_write(t, DBGBVR(i), addr & ~3);
 		apb_write(t, DBGBCR(i), bcr);
 		if (i == 0) {
@@ -949,28 +921,39 @@ static int cortexa_breakwatch_set(target *t, struct breakwatch *bw)
 		{
 			uint32_t wcr = DBGWCR_PAC_ANY | DBGWCR_EN;
 			uint32_t bas = 0;
-			switch(bw->size) { /* Convert bytes size to BAS bits */
-				case 1: bas = DBGWCR_BAS_BYTE; break;
-				case 2: bas = DBGWCR_BAS_HALFWORD; break;
-				case 4: bas = DBGWCR_BAS_WORD; break;
-				default:
-					return -1;
+			switch (bw->size) { /* Convert bytes size to BAS bits */
+			case 1:
+				bas = DBGWCR_BAS_BYTE;
+				break;
+			case 2:
+				bas = DBGWCR_BAS_HALFWORD;
+				break;
+			case 4:
+				bas = DBGWCR_BAS_WORD;
+				break;
+			default:
+				return -1;
 			}
 			/* Apply shift based on address LSBs */
 			wcr |= bas << (bw->addr & 3);
 
 			switch (bw->type) { /* Convert gdb type */
-				case TARGET_WATCH_WRITE: wcr |= DBGWCR_LSC_STORE; break;
-				case TARGET_WATCH_READ: wcr |= DBGWCR_LSC_LOAD; break;
-				case TARGET_WATCH_ACCESS: wcr |= DBGWCR_LSC_ANY; break;
-				default:
-					return -1;
+			case TARGET_WATCH_WRITE:
+				wcr |= DBGWCR_LSC_STORE;
+				break;
+			case TARGET_WATCH_READ:
+				wcr |= DBGWCR_LSC_LOAD;
+				break;
+			case TARGET_WATCH_ACCESS:
+				wcr |= DBGWCR_LSC_ANY;
+				break;
+			default:
+				return -1;
 			}
 
 			apb_write(t, DBGWCR(i), wcr);
 			apb_write(t, DBGWVR(i), bw->addr & ~3);
-			DEBUG_INFO("Watchpoint set WCR = 0x%08"PRIx32", WVR = %08"PRIx32"\n",
-				apb_read(t, DBGWCR(i)),
+			DEBUG_INFO("Watchpoint set WCR = 0x%08" PRIx32 ", WVR = %08" PRIx32 "\n", apb_read(t, DBGWCR(i)),
 				apb_read(t, DBGWVR(i)));
 		}
 		return 0;

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -258,10 +258,6 @@ static size_t create_tdesc_cortex_a(char *buffer, size_t max_len)
 	// that subtraction.
 	size_t printsz = max_len;
 
-
-	if (buffer != NULL)
-		memset(buffer, 0, max_len);
-
 	// Start with the "preamble", which is generic across ARM targets,
 	// ...save for one word, so we'll have to do the preamble in halves, and then we'll
 	// follow it with the GDB ARM Core feature tag.
@@ -285,6 +281,7 @@ static size_t create_tdesc_cortex_a(char *buffer, size_t max_len)
 	// Some of them have different types specified, however unlike the Cortex-M SPRs,
 	// all of the Cortex-A target description SPRs have the same bitsize, and none of them
 	// have a specified save-restore value. So we only need one "associative array" here.
+	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
 	for (size_t i = 0; i < ARRAY_SIZE(cortex_a_spr_names); ++i) {
 
 		gdb_reg_type_e type = cortex_a_spr_types[i];
@@ -532,7 +529,7 @@ bool cortexa_attach(target *t)
 		// Find the buffer size needed for the target description string we need to send to GDB,
 		// and then compute the string itself.
 		size_t size_needed = create_tdesc_cortex_a(NULL, 0) + 1;
-		t->tdesc = malloc(size_needed);
+		t->tdesc = calloc(1, size_needed);
 		create_tdesc_cortex_a(t->tdesc, size_needed);
 	} else {
 		DEBUG_WARN("Cortex-A: target description already allocated before attach");

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -506,13 +506,6 @@ bool cortexa_probe(ADIv5_AP_t *apb, uint32_t debug_base)
 	t->attach = cortexa_attach;
 	t->detach = cortexa_detach;
 
-	// Find the buffer size needed for the target description string we need to send to GDB,
-	// and then compute the string itself.
-	size_t size_needed = create_tdesc_cortex_a(NULL, 0) + 1;
-	char *buffer = malloc(size_needed);
-	create_tdesc_cortex_a(buffer, size_needed);
-
-	t->tdesc = buffer;
 	t->regs_read = cortexa_regs_read;
 	t->regs_write = cortexa_regs_write;
 	t->reg_read = cortexa_reg_read;
@@ -534,6 +527,16 @@ bool cortexa_attach(target *t)
 {
 	struct cortexa_priv *priv = t->priv;
 	int tries;
+
+	if (!t->tdesc) {
+		// Find the buffer size needed for the target description string we need to send to GDB,
+		// and then compute the string itself.
+		size_t size_needed = create_tdesc_cortex_a(NULL, 0) + 1;
+		t->tdesc = malloc(size_needed);
+		create_tdesc_cortex_a(t->tdesc, size_needed);
+	} else {
+		DEBUG_WARN("Cortex-A: target description already allocated before attach");
+	}
 
 	/* Clear any pending fault condition */
 	target_check_error(t);
@@ -567,6 +570,14 @@ bool cortexa_attach(target *t)
 void cortexa_detach(target *t)
 {
 	struct cortexa_priv *priv = t->priv;
+
+	if (t->tdesc) {
+		// Free the target description string that was allocated in cortexa_attach().
+		free(t->tdesc);
+		t->tdesc = NULL;
+	} else {
+		DEBUG_WARN("Cortex-A: target description already NULL before detach");
+	}
 
 	/* Clear any stale breakpoints */
 	for(unsigned i = 0; i < priv->hw_breakpoint_max; i++) {

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -63,8 +63,6 @@
 #include <fcntl.h>
 #endif
 
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
-
 static const char cortexm_driver_str[] = "ARM Cortex-M";
 
 static bool cortexm_vector_catch(target *t, int argc, char *argv[]);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -140,8 +140,6 @@ static const uint32_t regnum_cortex_mf[] = {
 	0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, /* s24-s31 */
 };
 
-
-
 /**
  * Fields for Cortex-M special purpose registers, used in the generation of GDB's target description XML.
  * The general purpose registers r0-r12 and the vector floating point registers d0-d15 all follow a very
@@ -149,7 +147,6 @@ static const uint32_t regnum_cortex_mf[] = {
  * The arrays for each SPR field have the same order as each other, making each of them a pseudo
  * 'associative array'.
  */
-
 
 // Strings for the names of the Cortex-M's special purpose registers.
 static const char *cortex_m_spr_names[] = {
@@ -179,10 +176,9 @@ static const gdb_reg_type_e cortex_m_spr_types[] = {
 	GDB_TYPE_UNSPECIFIED, // control
 };
 
-static_assert(ARRAY_SIZE(cortex_m_spr_types) == ARRAY_SIZE(cortex_m_spr_names),
-	"SPR array length mismatch! SPR type array should have the same length as SPR name array."
-);
-
+static_assert(ARRAY_SIZE(cortex_m_spr_types) == ARRAY_SIZE(cortex_m_spr_names), "SPR array length mismatch! SPR type "
+                                                                                "array should have the same length as "
+                                                                                "SPR name array.");
 
 // The "save-restore" field of each SPR.
 static const gdb_reg_save_restore_e cortex_m_spr_save_restores[] = {
@@ -198,10 +194,10 @@ static const gdb_reg_save_restore_e cortex_m_spr_save_restores[] = {
 	GDB_SAVE_RESTORE_NO,          // control
 };
 
-static_assert(ARRAY_SIZE(cortex_m_spr_save_restores) == ARRAY_SIZE(cortex_m_spr_names),
-	"SPR array length mismatch! SPR save-restore array should have the same length as SPR name array."
-);
-
+static_assert(ARRAY_SIZE(cortex_m_spr_save_restores) == ARRAY_SIZE(cortex_m_spr_names), "SPR array length mismatch! "
+                                                                                        "SPR save-restore array should "
+                                                                                        "have the same length as SPR "
+                                                                                        "name array.");
 
 // The "bitsize" field of each SPR.
 static const uint8_t cortex_m_spr_bitsizes[] = {
@@ -211,16 +207,15 @@ static const uint8_t cortex_m_spr_bitsizes[] = {
 	32, // xpsr
 	32, // msp
 	32, // psp
-	 8, // primask
-	 8, // basepri
-	 8, // faultmask
-	 8, // control
+	8,  // primask
+	8,  // basepri
+	8,  // faultmask
+	8,  // control
 };
 
-static_assert(ARRAY_SIZE(cortex_m_spr_bitsizes) == ARRAY_SIZE(cortex_m_spr_names),
-	"SPR array length mismatch! SPR bitsize array should have the same length as SPR name array."
-);
-
+static_assert(ARRAY_SIZE(cortex_m_spr_bitsizes) == ARRAY_SIZE(cortex_m_spr_names), "SPR array length mismatch! SPR "
+                                                                                   "bitsize array should have the same "
+                                                                                   "length as SPR name array.");
 
 // Creates the target description XML string for a Cortex-M. Like snprintf(), this function
 // will write no more than max_len and returns the amount of bytes written. Or, if max_len is 0,
@@ -284,16 +279,13 @@ static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
 	total += snprintf(buffer, printsz,
 		"%s target %s "
 		"<feature name=\"org.gnu.gdb.arm.m-profile\">",
-		gdb_arm_preamble_first,
-		gdb_arm_preamble_second
-	);
+		gdb_arm_preamble_first, gdb_arm_preamble_second);
 
 	// Then the general purpose registers, which have names of r0 to r12,
 	// and all the same bitsize.
 	for (uint8_t i = 0; i <= 12; ++i) {
-
 		if (max_len != 0)
-			printsz = max_len - (size_t) total;
+			printsz = max_len - (size_t)total;
 
 		total += snprintf(buffer + total, printsz, "<reg name=\"r%u\" bitsize=\"32\"/>", i);
 	}
@@ -304,23 +296,18 @@ static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
 	// We'll use the 'associative arrays' defined for those values.
 	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
 	for (size_t i = 0; i < ARRAY_SIZE(cortex_m_spr_names); ++i) {
-
 		if (max_len != 0)
-			printsz = max_len - (size_t) total;
+			printsz = max_len - (size_t)total;
 
 		gdb_reg_type_e type = cortex_m_spr_types[i];
 		gdb_reg_save_restore_e save_restore = cortex_m_spr_save_restores[i];
 
-		total += snprintf(buffer + total, printsz, "<reg name=\"%s\" bitsize=\"%u\"%s%s/>",
-			cortex_m_spr_names[i],
-			cortex_m_spr_bitsizes[i],
-			gdb_reg_save_restore_strings[save_restore],
-			gdb_reg_type_strings[type]
-		);
+		total += snprintf(buffer + total, printsz, "<reg name=\"%s\" bitsize=\"%u\"%s%s/>", cortex_m_spr_names[i],
+			cortex_m_spr_bitsizes[i], gdb_reg_save_restore_strings[save_restore], gdb_reg_type_strings[type]);
 	}
 
 	if (max_len != 0)
-		printsz = max_len - (size_t) total;
+		printsz = max_len - (size_t)total;
 
 	total += snprintf(buffer + total, printsz, "</feature></target>");
 
@@ -328,7 +315,7 @@ static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
 	// these functions are given static input that should not ever be able to fail -- and if it
 	// does, then there's nothing we can do about it, so we'll just discard the signedness
 	// of total when we return it.
-	return (size_t) total;
+	return (size_t)total;
 }
 
 // Creates the target description XML string for a Cortex-MF. Like snprintf(), this function
@@ -404,7 +391,7 @@ static size_t create_tdesc_cortex_mf(char *buffer, size_t max_len)
 
 	// The first part of the target description for the Cortex-MF is identical to the Cortex-M
 	// target description.
-	total = (int) create_tdesc_cortex_m(buffer, max_len);
+	total = (int)create_tdesc_cortex_m(buffer, max_len);
 
 	// We can't just repeatedly pass max_len to snprintf, because we keep changing the start
 	// of buffer (effectively changing its size), so we have to repeatedly compute the size
@@ -418,26 +405,23 @@ static size_t create_tdesc_cortex_mf(char *buffer, size_t max_len)
 		// Minor hack: subtract the target closing tag, since we have a bit more to add.
 		total -= strlen("</target>");
 
-		printsz = max_len - (size_t) total;
+		printsz = max_len - (size_t)total;
 	}
-
 
 	total += snprintf(buffer + total, printsz,
 		"<feature name=\"org.gnu.gdb.arm.vfp\">"
-		"<reg name=\"fpscr\" bitsize=\"32\"/>"
-	);
+		"<reg name=\"fpscr\" bitsize=\"32\"/>");
 
 	// After fpscr, the rest of the vfp registers follow a regular format: d0-d15, bitsize 64, type float.
 	for (uint8_t i = 0; i <= 15; ++i) {
-
 		if (max_len != 0)
-			printsz = max_len - (size_t) total;
+			printsz = max_len - (size_t)total;
 
 		total += snprintf(buffer + total, printsz, "<reg name=\"d%u\" bitsize=\"64\" type=\"float\"/>", i);
 	}
 
 	if (max_len != 0)
-		printsz = max_len - (size_t) total;
+		printsz = max_len - (size_t)total;
 
 	total += snprintf(buffer + total, printsz, "</feature></target>");
 
@@ -445,9 +429,8 @@ static size_t create_tdesc_cortex_mf(char *buffer, size_t max_len)
 	// these functions are given static input that should not ever be able to fail -- and if it
 	// does, then there's nothing we can do about it, so we'll just discard the signedness
 	// of total when we return it.
-	return (size_t) total;
+	return (size_t)total;
 }
-
 
 ADIv5_AP_t *cortexm_ap(target *t)
 {
@@ -589,7 +572,6 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 	if (target_mem_read32(t, CORTEXM_CPACR) == cpacr)
 		is_cortexmf = true;
 
-
 	/* Should probe here to make sure it's Cortex-M3 */
 
 	t->regs_read = cortexm_regs_read;
@@ -710,7 +692,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 			LPC43xx detection. */
 			PROBE(lpc546xx_probe);
 			PROBE(lpc43xx_probe);
-			PROBE(kinetis_probe);         /* Older K-series */
+			PROBE(kinetis_probe); /* Older K-series */
 			PROBE(at32fxx_probe);
 		} else if (t->part_id == 0x4cb) { /* Cortex-M23 ROM */
 			PROBE(gd32f1_probe);          /* GD32E23x uses GD32F1 peripherals */
@@ -756,7 +738,6 @@ bool cortexm_attach(target *t)
 	} else {
 		DEBUG_WARN("Cortex-M: target description already allocated before attach");
 	}
-
 
 	ADIv5_AP_t *ap = cortexm_ap(t);
 	ap->dp->fault = 1; /* Force switch to this multi-drop device*/

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -279,9 +279,6 @@ static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
 	// that subtraction.
 	size_t printsz = max_len;
 
-	if (buffer != NULL)
-		memset(buffer, 0, max_len);
-
 	// Start with the "preamble", which is generic across ARM targets,
 	// ...save for one word, so we'll have to do the preamble in halves.
 	total += snprintf(buffer, printsz,
@@ -305,6 +302,7 @@ static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
 	// These special purpose registers are a little more complicated.
 	// Some of them have different bitsizes, specified types, or specified save-restore values.
 	// We'll use the 'associative arrays' defined for those values.
+	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
 	for (size_t i = 0; i < ARRAY_SIZE(cortex_m_spr_names); ++i) {
 
 		if (max_len != 0)
@@ -748,11 +746,11 @@ bool cortexm_attach(target *t)
 		size_t size_needed;
 		if (!is_cortexmf) {
 			size_needed = create_tdesc_cortex_m(NULL, 0) + 1;
-			t->tdesc = malloc(size_needed);
+			t->tdesc = calloc(1, size_needed);
 			create_tdesc_cortex_m(t->tdesc, size_needed);
 		} else {
 			size_needed = create_tdesc_cortex_mf(NULL, 0) + 1;
-			t->tdesc = malloc(size_needed);
+			t->tdesc = calloc(1, size_needed);
 			create_tdesc_cortex_mf(t->tdesc, size_needed);
 		}
 	} else {

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -176,7 +176,7 @@ static const gdb_reg_type_e cortex_m_spr_types[] = {
 	GDB_TYPE_UNSPECIFIED, // control
 };
 
-static_assert(ARRAY_SIZE(cortex_m_spr_types) == ARRAY_SIZE(cortex_m_spr_names), "SPR array length mismatch! SPR type "
+static_assert(ARRAY_LENGTH(cortex_m_spr_types) == ARRAY_LENGTH(cortex_m_spr_names), "SPR array length mismatch! SPR type "
                                                                                 "array should have the same length as "
                                                                                 "SPR name array.");
 
@@ -194,7 +194,7 @@ static const gdb_reg_save_restore_e cortex_m_spr_save_restores[] = {
 	GDB_SAVE_RESTORE_NO,          // control
 };
 
-static_assert(ARRAY_SIZE(cortex_m_spr_save_restores) == ARRAY_SIZE(cortex_m_spr_names), "SPR array length mismatch! "
+static_assert(ARRAY_LENGTH(cortex_m_spr_save_restores) == ARRAY_LENGTH(cortex_m_spr_names), "SPR array length mismatch! "
                                                                                         "SPR save-restore array should "
                                                                                         "have the same length as SPR "
                                                                                         "name array.");
@@ -213,7 +213,7 @@ static const uint8_t cortex_m_spr_bitsizes[] = {
 	8,  // control
 };
 
-static_assert(ARRAY_SIZE(cortex_m_spr_bitsizes) == ARRAY_SIZE(cortex_m_spr_names), "SPR array length mismatch! SPR "
+static_assert(ARRAY_LENGTH(cortex_m_spr_bitsizes) == ARRAY_LENGTH(cortex_m_spr_names), "SPR array length mismatch! SPR "
                                                                                    "bitsize array should have the same "
                                                                                    "length as SPR name array.");
 
@@ -295,7 +295,7 @@ static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
 	// Some of them have different bitsizes, specified types, or specified save-restore values.
 	// We'll use the 'associative arrays' defined for those values.
 	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
-	for (size_t i = 0; i < ARRAY_SIZE(cortex_m_spr_names); ++i) {
+	for (size_t i = 0; i < ARRAY_LENGTH(cortex_m_spr_names); ++i) {
 		if (max_len != 0)
 			printsz = max_len - (size_t)total;
 

--- a/src/target/gdb_reg.c
+++ b/src/target/gdb_reg.c
@@ -20,27 +20,21 @@
 
 #include "gdb_reg.h"
 
+const char *gdb_arm_preamble_first = "<?xml version=\"1.0\"?>"
+									 "<!DOCTYPE";
 
-const char *gdb_arm_preamble_first =
-	"<?xml version=\"1.0\"?>"
-	"<!DOCTYPE";
-
-const char *gdb_arm_preamble_second =
-	"SYSTEM "
-	"\"gdb-target.dtd\">"
-	"<target>"
-	"  <architecture>arm</architecture>";
-
-
+const char *gdb_arm_preamble_second = "SYSTEM "
+									  "\"gdb-target.dtd\">"
+									  "<target>"
+									  "  <architecture>arm</architecture>";
 
 const char *gdb_reg_type_strings[] = {
-	"", // GDB_TYPE_UNSPECIFIED.
+	"",                   // GDB_TYPE_UNSPECIFIED.
 	" type=\"data_ptr\"", // GDB_TYPE_DATA_PTR.
 	" type=\"code_ptr\"", // GDB_TYPE_CODE_PTR.
 };
 
-
 const char *gdb_reg_save_restore_strings[] = {
-	"", // GDB_SAVE_RESTORE_UNSPECIFIED.
+	"",                    // GDB_SAVE_RESTORE_UNSPECIFIED.
 	" save-restore=\"no\"" // GDB_SAVE_RESTORE_NO.
 };

--- a/src/target/gdb_reg.c
+++ b/src/target/gdb_reg.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022  1bitsquared - Mikaela Szekely <mikaela.szekely@qyriad.me>
+ * Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "gdb_reg.h"
+
+
+const char *gdb_arm_preamble_first =
+	"<?xml version=\"1.0\"?>"
+	"<!DOCTYPE";
+
+const char *gdb_arm_preamble_second =
+	"SYSTEM "
+	"\"gdb-target.dtd\">"
+	"<target>"
+	"  <architecture>arm</architecture>";
+
+
+
+const char *gdb_reg_type_strings[] = {
+	"", // GDB_TYPE_UNSPECIFIED.
+	" type=\"data_ptr\"", // GDB_TYPE_DATA_PTR.
+	" type=\"code_ptr\"", // GDB_TYPE_CODE_PTR.
+};
+
+
+const char *gdb_reg_save_restore_strings[] = {
+	"", // GDB_SAVE_RESTORE_UNSPECIFIED.
+	" save-restore=\"no\"" // GDB_SAVE_RESTORE_NO.
+};

--- a/src/target/gdb_reg.h
+++ b/src/target/gdb_reg.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __GDB_REG_H
-#define __GDB_REG_H
+#ifndef TARGET_GDB_REG_H
+#define TARGET_GDB_REG_H
 
 // The beginning XML for GDB target descriptions that are common to ARM targets,
 // save for one word: the word after DOCTYPE, which is "target" for Cortex-M, and "feature"

--- a/src/target/gdb_reg.h
+++ b/src/target/gdb_reg.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022  1bitsquared - Mikaela Szekely <mikaela.szekely@qyriad.me>
+ * Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __GDB_REG_H
+#define __GDB_REG_H
+
+
+// The beginning XML for GDB target descriptions that are common to ARM targets,
+// save for one word: the word after DOCTYPE, which is "target" for Cortex-M, and "feature"
+// for Cortex-A. The "preamble" is thus split into two halves, with this single word missing
+// and as the split point.
+extern const char *gdb_arm_preamble_first;
+
+// The beginning XML for GDB target descriptions that are common to ARM targets,
+// save for one word: the word after DOCTYPE, which is "target" for Cortex-M, and "feature"
+// for Cortex-A. The "preamble" is thus split into two halves, with this single word missing
+// and as the split point.
+extern const char *gdb_arm_preamble_second;
+
+
+// The "type" field of a register tag.
+typedef enum gdb_reg_type {
+	GDB_TYPE_UNSPECIFIED = 0,
+	GDB_TYPE_DATA_PTR,
+	GDB_TYPE_CODE_PTR,
+} gdb_reg_type_e;
+
+// The strings for the "type" field of a register tag, respective to its gdb_reg_type_e value.
+extern const char *gdb_reg_type_strings[];
+
+
+// The "save-restore" field of a register tag.
+typedef enum gdb_reg_save_restore {
+	GDB_SAVE_RESTORE_UNSPECIFIED = 0,
+	GDB_SAVE_RESTORE_NO,
+} gdb_reg_save_restore_e;
+
+// The strings for the "save-restore" field of a register tag, respective to its gdb_reg_save_restore_e value.
+extern const char *gdb_reg_save_restore_strings[];
+
+#endif

--- a/src/target/gdb_reg.h
+++ b/src/target/gdb_reg.h
@@ -21,7 +21,6 @@
 #ifndef __GDB_REG_H
 #define __GDB_REG_H
 
-
 // The beginning XML for GDB target descriptions that are common to ARM targets,
 // save for one word: the word after DOCTYPE, which is "target" for Cortex-M, and "feature"
 // for Cortex-A. The "preamble" is thus split into two halves, with this single word missing
@@ -34,7 +33,6 @@ extern const char *gdb_arm_preamble_first;
 // and as the split point.
 extern const char *gdb_arm_preamble_second;
 
-
 // The "type" field of a register tag.
 typedef enum gdb_reg_type {
 	GDB_TYPE_UNSPECIFIED = 0,
@@ -44,7 +42,6 @@ typedef enum gdb_reg_type {
 
 // The strings for the "type" field of a register tag, respective to its gdb_reg_type_e value.
 extern const char *gdb_reg_type_strings[];
-
 
 // The "save-restore" field of a register tag.
 typedef enum gdb_reg_save_restore {

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -95,7 +95,7 @@ struct target_s {
 
 	/* Register access functions */
 	size_t regs_size;
-	const char *tdesc;
+	char *tdesc;
 	void (*regs_read)(target *t, void *data);
 	void (*regs_write)(target *t, const void *data);
 	ssize_t (*reg_read)(target *t, int reg, void *data, size_t max);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

This PR size-optimizes the target description XML strings used for Cortex-M and Cortex-A targets, by removing the string literals which contained the verbatim XML and replacing them with functions `create_tdesc_cortex_m()`, `create_tdesc_cortexmf()`, and `create_tdesc_cortex_a()`. These functions generate the target description strings at runtime with sequences of string formatting instead of monolithic string literals.

The size-optimized code is, unfortunately, much less readable than the verbatim string literals, but the XML they generate has been left in as comments for clarity, and the string deduplication has overall saved ~3.2 KiB of flash space.

### Left to Do

As you may have noticed, this PR is marked as a draft. We have *not* tested this code on any Cortex-A targets (or non floating point Cortex-M targets, though `create_tdesc_cortex_mf()` uses `create_tdesc_cortex_m()` internally) as we don't have any on hand. We compiled and ran these functions as host code to compare their output with the string literals that were being used before, and did find them identical (post-format), but this code should still probably be tested on actual hardware before being merged.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
