### PR TITLE
gdb_main: don't print debug for vMustReplyEmpty packets

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -668,7 +668,10 @@ static void handle_v_packet(char *packet, const size_t plen)
 			gdb_putpacketz("OK");
 
 	} else {
-		DEBUG_GDB("*** Unsupported packet: %s\n", packet);
+		/* The vMustReplyEmpty is used as a feature test to check how gdbserver handles unknown packets */
+		/* print only actually unknown packets */
+		if (strcmp(packet, "vMustReplyEmpty") != 0)
+			DEBUG_GDB("*** Unsupported packet: %s\n", packet);
 		gdb_putpacket("", 0);
 	}
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

vMustReplyEmpty is a known and correctly handled packet, and thus we should not be printing a warning for it

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
