### PR TITLE
Fix: newlib file IO hooks

### DIFF
--- a/src/platforms/f072/platform.h
+++ b/src/platforms/f072/platform.h
@@ -145,7 +145,6 @@
 
 #ifdef ENABLE_DEBUG
 extern bool debug_bmp;
-int usbuart_debug_write(const char *buf, size_t len);
 # define DEBUG printf
 #else
 # define DEBUG(...)

--- a/src/platforms/f3/platform.h
+++ b/src/platforms/f3/platform.h
@@ -138,7 +138,6 @@
 
 #ifdef ENABLE_DEBUG
 extern bool debug_bmp;
-int usbuart_debug_write(const char *buf, size_t len);
 # define DEBUG printf
 #else
 # define DEBUG(...)

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -228,7 +228,7 @@ void platform_init(void)
 
 void platform_nrst_set_val(bool assert)
 {
-	gpio_set_val(TMS_PORT, TMS_PIN, 1);
+	gpio_set(TMS_PORT, TMS_PIN);
 	if ((platform_hwversion() == 0) ||
 	    (platform_hwversion() >= 3)) {
 		gpio_set_val(NRST_PORT, NRST_PIN, assert);
@@ -270,8 +270,7 @@ static void adc_init(void)
 {
 	rcc_periph_clock_enable(RCC_ADC1);
 
-	gpio_set_mode(GPIOB, GPIO_MODE_INPUT,
-			GPIO_CNF_INPUT_ANALOG, GPIO0);
+	gpio_set_mode(GPIOB, GPIO_MODE_INPUT, GPIO_CNF_INPUT_ANALOG, GPIO0);
 
 	adc_power_off(ADC1);
 	adc_disable_scan_mode(ADC1);
@@ -333,8 +332,7 @@ void platform_request_boot(void)
 	gpio_set_mode(USB_PU_PORT, GPIO_MODE_INPUT, 0, USB_PU_PIN);
 
 	/* Drive boot request pin */
-	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ,
-			GPIO_CNF_OUTPUT_PUSHPULL, GPIO12);
+	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO12);
 	gpio_clear(GPIOB, GPIO12);
 }
 

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -36,7 +36,6 @@
 # define PLATFORM_HAS_DEBUG
 # define USBUART_DEBUG
 extern bool debug_bmp;
-int usbuart_debug_write(const char *buf, size_t len);
 #endif
 
 #define PLATFORM_IDENT          " "

--- a/src/platforms/native/usbdfu.c
+++ b/src/platforms/native/usbdfu.c
@@ -39,7 +39,7 @@ int main(void)
 {
 	/* Check the force bootloader pin*/
 	rcc_periph_clock_enable(RCC_GPIOB);
-	if(gpio_get(GPIOB, GPIO12))
+	if (gpio_get(GPIOB, GPIO12))
 		dfu_jump_app_if_valid();
 
 	dfu_protect(false);
@@ -57,15 +57,13 @@ int main(void)
 	systick_counter_enable();
 
 	/* Configure the LED pins. */
-	gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ,
-			GPIO_CNF_OUTPUT_PUSHPULL, LED_0 | LED_1 | LED_2);
+	gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, LED_0 | LED_1 | LED_2);
 
 	dfu_init(&st_usbfs_v1_usb_driver);
 
 	/* Configure the USB pull up pin. */
 	gpio_set(GPIOA, GPIO8);
-	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ,
-			GPIO_CNF_OUTPUT_PUSHPULL, GPIO8);
+	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO8);
 
 	dfu_main();
 }
@@ -116,4 +114,3 @@ void sys_tick_handler(void)
 		}
 	}
 }
-

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -36,7 +36,6 @@
 # define PLATFORM_HAS_DEBUG
 # define USBUART_DEBUG
 extern bool debug_bmp;
-int usbuart_debug_write(const char *buf, size_t len);
 #endif
 
 #define PLATFORM_HAS_USBUART

--- a/src/platforms/stm32/usbuart.c
+++ b/src/platforms/stm32/usbuart.c
@@ -319,7 +319,7 @@ void usbuart_usb_out_cb(usbd_device *dev, uint8_t ep)
 #endif
 
 #ifdef USBUART_DEBUG
-int usbuart_debug_write(const char *buf, size_t len)
+size_t usbuart_debug_write(const char *buf, const size_t len)
 {
 	if (nvic_get_active_irq(USB_IRQ) || nvic_get_active_irq(USBUSART_IRQ) || nvic_get_active_irq(USBUSART_DMA_RX_IRQ))
 		return 0;

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -33,7 +33,6 @@
 # define PLATFORM_HAS_DEBUG
 # define USBUART_DEBUG
 extern bool debug_bmp;
-int usbuart_debug_write(const char *buf, size_t len);
 #endif
 
 #define PLATFORM_HAS_USBUART


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

While trying to figure out how printf() worked for the umpteenth time in the code base, we finally stumbled across the RDI file IO halo code which serves `_write()`, `isatty()` and other parts of newlib's `FILE *` support via the SVC interrupt.

Having stared at the code long and hard, we figured out that we can make use of the weak linkage of the two aforementioned functions to avoid having to do this interrupt vector halo, saving around 200 bytes of Flash space, and then write out the manual assembly to insert the RDI vector routine by careful manipulation of state in a bare function.

We've then added documentation to make this easier to find in future, and removed a private function from the public platform headers. This PR is the result.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
