### PR TITLE
Differentiate CH32F103 from CKS32F103 and APM32F103 based on REV ID

### DIFF
--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -161,8 +161,17 @@ bool ch32f1_probe(target *t)
 {
 	if ((t->cpuid & CPUID_PARTNO_MASK) != CORTEX_M3)
 		return false;
-	const uint32_t idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0x00000fffU;
-	if (idcode != 0x410) // only ch32f103
+
+	const uint32_t dbgmcu_idcode = target_mem_read32(t, DBGMCU_IDCODE);
+	const uint32_t idcode = dbgmcu_idcode & 0x00000fffU;
+	const uint32_t revid = (dbgmcu_idcode & 0xffff0000U) >> 16;
+
+	DEBUG_WARN("DBGMCU_IDCODE %x, DEVID %x, REVID %x \n", dbgmcu_idcode, idcode, revid);
+
+	if (idcode != 0x410) // ch32f103, cks32f103, apm32f103
+		return false;
+
+	if (revid != 0x2000) // (hopefully!) only ch32f103
 		return false;
 
 	// try to flock


### PR DESCRIPTION
Differentiate CH32F103 from CKS32F103 and APM32F103 based on REV ID (upper 16 bits of DBGMCU_IDCODE)

<!-- Filling this template is mandatory -->

## Detailed description

This patch allows for the differentiation between CH32F103 parts from CKS32F103 and APM32F103 parts since the latter parts will not upload firmware using the CH32F103 'fast' methodology.

(see Issue #1200: Loading firmware onto APM32F103CB fails)
<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1200 
