### PR TITLE
Feature/flash alignment optimization

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -62,6 +62,7 @@ SRC =			\
 	stm32l4.c	\
 	stm32g0.c	\
 	target.c	\
+	target_flash.c	\
 	target_probe.c
 
 include $(PLATFORM_DIR)/Makefile.inc

--- a/src/command.c
+++ b/src/command.c
@@ -641,10 +641,10 @@ static bool cmd_heapinfo(target *t, int argc, const char **argv)
 	if (t == NULL)
 		gdb_out("not attached\n");
 	else if (argc == 5) {
-		target_addr heap_base = strtoul(argv[1], NULL, 16);
-		target_addr heap_limit = strtoul(argv[2], NULL, 16);
-		target_addr stack_base = strtoul(argv[3], NULL, 16);
-		target_addr stack_limit = strtoul(argv[4], NULL, 16);
+		target_addr_t heap_base = strtoul(argv[1], NULL, 16);
+		target_addr_t heap_limit = strtoul(argv[2], NULL, 16);
+		target_addr_t stack_base = strtoul(argv[3], NULL, 16);
+		target_addr_t stack_limit = strtoul(argv[4], NULL, 16);
 		gdb_outf("heapinfo heap_base: %p heap_limit: %p stack_base: %p stack_limit: %p\n", heap_base, heap_limit,
 			stack_base, stack_limit);
 		target_set_heapinfo(t, heap_base, heap_limit, stack_base, stack_limit);

--- a/src/gdb_hostio.c
+++ b/src/gdb_hostio.c
@@ -47,9 +47,8 @@ int hostio_reply(struct target_controller *tc, char *pbuf, int len)
 }
 
 /* Interface to host system calls */
-int hostio_open(struct target_controller *tc,
-	        target_addr path, size_t path_len,
-                enum target_open_flags flags, mode_t mode)
+int hostio_open(
+	struct target_controller *tc, target_addr_t path, size_t path_len, enum target_open_flags flags, mode_t mode)
 {
 	gdb_putpacket_f("Fopen,%08X/%X,%08X,%08X", path, path_len, flags, mode);
 	return gdb_main_loop(tc, true);
@@ -61,58 +60,50 @@ int hostio_close(struct target_controller *tc, int fd)
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_read(struct target_controller *tc,
-	         int fd, target_addr buf, unsigned int count)
+int hostio_read(struct target_controller *tc, int fd, target_addr_t buf, unsigned int count)
 {
 	gdb_putpacket_f("Fread,%08X,%08X,%08X", fd, buf, count);
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_write(struct target_controller *tc,
-	          int fd, target_addr buf, unsigned int count)
+int hostio_write(struct target_controller *tc, int fd, target_addr_t buf, unsigned int count)
 {
 	gdb_putpacket_f("Fwrite,%08X,%08X,%08X", fd, buf, count);
 	return gdb_main_loop(tc, true);
 }
 
-long hostio_lseek(struct target_controller *tc,
-	           int fd, long offset, enum target_seek_flag flag)
+long hostio_lseek(struct target_controller *tc, int fd, long offset, enum target_seek_flag flag)
 {
 	gdb_putpacket_f("Flseek,%08X,%08X,%08X", fd, offset, flag);
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_rename(struct target_controller *tc,
-	           target_addr oldpath, size_t old_len,
-	           target_addr newpath, size_t new_len)
+int hostio_rename(
+	struct target_controller *tc, target_addr_t oldpath, size_t old_len, target_addr_t newpath, size_t new_len)
 {
-	gdb_putpacket_f("Frename,%08X/%X,%08X/%X",
-	                oldpath, old_len, newpath, new_len);
+	gdb_putpacket_f("Frename,%08X/%X,%08X/%X", oldpath, old_len, newpath, new_len);
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_unlink(struct target_controller *tc,
-	           target_addr path, size_t path_len)
+int hostio_unlink(struct target_controller *tc, target_addr_t path, size_t path_len)
 {
 	gdb_putpacket_f("Funlink,%08X/%X", path, path_len);
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_stat(struct target_controller *tc,
-	         target_addr path, size_t path_len, target_addr buf)
+int hostio_stat(struct target_controller *tc, target_addr_t path, size_t path_len, target_addr_t buf)
 {
 	gdb_putpacket_f("Fstat,%08X/%X,%08X", path, path_len, buf);
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_fstat(struct target_controller *tc, int fd, target_addr buf)
+int hostio_fstat(struct target_controller *tc, int fd, target_addr_t buf)
 {
 	gdb_putpacket_f("Ffstat,%X,%08X", fd, buf);
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_gettimeofday(struct target_controller *tc,
-		         target_addr tv, target_addr tz)
+int hostio_gettimeofday(struct target_controller *tc, target_addr_t tv, target_addr_t tz)
 {
 	gdb_putpacket_f("Fgettimeofday,%08X,%08X", tv, tz);
 	return gdb_main_loop(tc, true);
@@ -124,8 +115,7 @@ int hostio_isatty(struct target_controller *tc, int fd)
 	return gdb_main_loop(tc, true);
 }
 
-int hostio_system(struct target_controller *tc,
-	          target_addr cmd, size_t cmd_len)
+int hostio_system(struct target_controller *tc, target_addr_t cmd, size_t cmd_len)
 {
 	gdb_putpacket_f("Fsystem,%08X/%X", cmd, cmd_len);
 	return gdb_main_loop(tc, true);

--- a/src/gdb_hostio.h
+++ b/src/gdb_hostio.h
@@ -26,28 +26,19 @@
 int hostio_reply(struct target_controller *tc, char *packet, int len);
 
 /* Interface to host system calls */
-int hostio_open(struct target_controller *,
-	        target_addr path, size_t path_len,
-                enum target_open_flags flags, mode_t mode);
+int hostio_open(
+	struct target_controller *, target_addr_t path, size_t path_len, enum target_open_flags flags, mode_t mode);
 int hostio_close(struct target_controller *, int fd);
-int hostio_read(struct target_controller *,
-	         int fd, target_addr buf, unsigned int count);
-int hostio_write(struct target_controller *,
-	          int fd, target_addr buf, unsigned int count);
-long hostio_lseek(struct target_controller *,
-	           int fd, long offset, enum target_seek_flag flag);
-int hostio_rename(struct target_controller *,
-	           target_addr oldpath, size_t old_len,
-	           target_addr newpath, size_t new_len);
-int hostio_unlink(struct target_controller *,
-	           target_addr path, size_t path_len);
-int hostio_stat(struct target_controller *,
-	         target_addr path, size_t path_len, target_addr buf);
-int hostio_fstat(struct target_controller *, int fd, target_addr buf);
-int hostio_gettimeofday(struct target_controller *,
-		         target_addr tv, target_addr tz);
+int hostio_read(struct target_controller *, int fd, target_addr_t buf, unsigned int count);
+int hostio_write(struct target_controller *, int fd, target_addr_t buf, unsigned int count);
+long hostio_lseek(struct target_controller *, int fd, long offset, enum target_seek_flag flag);
+int hostio_rename(
+	struct target_controller *, target_addr_t oldpath, size_t old_len, target_addr_t newpath, size_t new_len);
+int hostio_unlink(struct target_controller *, target_addr_t path, size_t path_len);
+int hostio_stat(struct target_controller *, target_addr_t path, size_t path_len, target_addr_t buf);
+int hostio_fstat(struct target_controller *, int fd, target_addr_t buf);
+int hostio_gettimeofday(struct target_controller *, target_addr_t tv, target_addr_t tz);
 int hostio_isatty(struct target_controller *, int fd);
-int hostio_system(struct target_controller *,
-	           target_addr cmd, size_t cmd_len);
+int hostio_system(struct target_controller *, target_addr_t cmd, size_t cmd_len);
 
 #endif /* GDB_HOSTIO_H */

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -208,7 +208,7 @@ int gdb_main_loop(struct target_controller *tc, bool in_syscall)
 		case '?': {	/* '?': Request reason for target halt */
 			/* This packet isn't documented as being mandatory,
 			 * but GDB doesn't work without it. */
-			target_addr watch;
+			target_addr_t watch;
 			enum target_halt_reason reason;
 
 			if (!cur_target) {

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -630,7 +630,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 			return;
 		}
 
-		if (target_flash_erase(cur_target, addr, len) == 0)
+		if (target_flash_erase(cur_target, addr, len))
 			gdb_putpacketz("OK");
 		else {
 			target_flash_complete(cur_target);
@@ -641,7 +641,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 		/* Write Flash Memory */
 		const uint32_t count = plen - bin;
 		DEBUG_GDB("Flash Write %08" PRIX32 " %08" PRIX32 "\n", addr, count);
-		if (cur_target && target_flash_write(cur_target, addr, (void*)packet + bin, count) == 0)
+		if (cur_target && target_flash_write(cur_target, addr, (void*)packet + bin, count))
 			gdb_putpacketz("OK");
 		else {
 			target_flash_complete(cur_target);
@@ -650,7 +650,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 
 	} else if (!strcmp(packet, "vFlashDone")) {
 		/* Commit flash operations. */
-		if (target_flash_complete(cur_target) == 0)
+		if (target_flash_complete(cur_target))
 			gdb_putpacketz("OK");
 		else
 			gdb_putpacketz("EFF");

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -61,7 +61,7 @@ int target_mem_write(target *t, target_addr_t dest, const void *src, size_t len)
 /* Flash memory access functions */
 int target_flash_erase(target *t, target_addr_t addr, size_t len);
 int target_flash_write(target *t, target_addr_t dest, const void *src, size_t len);
-int target_flash_done(target *t);
+int target_flash_complete(target *t);
 
 /* Register access functions */
 size_t target_regs_size(target *t);

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -31,7 +31,7 @@
 #include <sys/types.h>
 
 typedef struct target_s target;
-typedef uint32_t target_addr;
+typedef uint32_t target_addr_t;
 struct target_controller;
 
 #if PC_HOSTED == 1
@@ -56,11 +56,11 @@ unsigned int target_part_id(target *t);
 
 /* Memory access functions */
 bool target_mem_map(target *t, char *buf, size_t len);
-int target_mem_read(target *t, void *dest, target_addr src, size_t len);
-int target_mem_write(target *t, target_addr dest, const void *src, size_t len);
+int target_mem_read(target *t, void *dest, target_addr_t src, size_t len);
+int target_mem_write(target *t, target_addr_t dest, const void *src, size_t len);
 /* Flash memory access functions */
-int target_flash_erase(target *t, target_addr addr, size_t len);
-int target_flash_write(target *t, target_addr dest, const void *src, size_t len);
+int target_flash_erase(target *t, target_addr_t addr, size_t len);
+int target_flash_write(target *t, target_addr_t dest, const void *src, size_t len);
 int target_flash_done(target *t);
 
 /* Register access functions */
@@ -84,11 +84,11 @@ enum target_halt_reason {
 
 void target_reset(target *t);
 void target_halt_request(target *t);
-enum target_halt_reason target_halt_poll(target *t, target_addr *watch);
+enum target_halt_reason target_halt_poll(target *t, target_addr_t *watch);
 void target_halt_resume(target *t, bool step);
 void target_set_cmdline(target *t, char *cmdline);
-void target_set_heapinfo(target *t, target_addr heap_base, target_addr heap_limit,
-	target_addr stack_base, target_addr stack_limit);
+void target_set_heapinfo(
+	target *t, target_addr_t heap_base, target_addr_t heap_limit, target_addr_t stack_base, target_addr_t stack_limit);
 
 /* Break-/watchpoint functions */
 enum target_breakwatch {
@@ -98,8 +98,8 @@ enum target_breakwatch {
 	TARGET_WATCH_READ,
 	TARGET_WATCH_ACCESS,
 };
-int target_breakwatch_set(target *t, enum target_breakwatch, target_addr, size_t);
-int target_breakwatch_clear(target *t, enum target_breakwatch, target_addr, size_t);
+int target_breakwatch_set(target *t, enum target_breakwatch, target_addr_t, size_t);
+int target_breakwatch_clear(target *t, enum target_breakwatch, target_addr_t, size_t);
 
 /* Command interpreter */
 void target_command_help(target *t);
@@ -151,29 +151,20 @@ struct target_controller {
 	void (*printf)(struct target_controller *, const char *fmt, va_list);
 
 	/* Interface to host system calls */
-	int (*open)(struct target_controller *,
-	            target_addr path, size_t path_len,
-	            enum target_open_flags flags, mode_t mode);
+	int (*open)(
+		struct target_controller *, target_addr_t path, size_t path_len, enum target_open_flags flags, mode_t mode);
 	int (*close)(struct target_controller *, int fd);
-	int (*read)(struct target_controller *,
-	            int fd, target_addr buf, unsigned int count);
-	int (*write)(struct target_controller *,
-	             int fd, target_addr buf, unsigned int count);
-	long (*lseek)(struct target_controller *,
-	              int fd, long offset, enum target_seek_flag flag);
-	int (*rename)(struct target_controller *,
-	              target_addr oldpath, size_t old_len,
-	              target_addr newpath, size_t new_len);
-	int (*unlink)(struct target_controller *,
-	              target_addr path, size_t path_len);
-	int (*stat)(struct target_controller *,
-	            target_addr path, size_t path_len, target_addr buf);
-	int (*fstat)(struct target_controller *, int fd, target_addr buf);
-	int (*gettimeofday)(struct target_controller *,
-	                    target_addr tv, target_addr tz);
+	int (*read)(struct target_controller *, int fd, target_addr_t buf, unsigned int count);
+	int (*write)(struct target_controller *, int fd, target_addr_t buf, unsigned int count);
+	long (*lseek)(struct target_controller *, int fd, long offset, enum target_seek_flag flag);
+	int (*rename)(
+		struct target_controller *, target_addr_t oldpath, size_t old_len, target_addr_t newpath, size_t new_len);
+	int (*unlink)(struct target_controller *, target_addr_t path, size_t path_len);
+	int (*stat)(struct target_controller *, target_addr_t path, size_t path_len, target_addr_t buf);
+	int (*fstat)(struct target_controller *, int fd, target_addr_t buf);
+	int (*gettimeofday)(struct target_controller *, target_addr_t tv, target_addr_t tz);
 	int (*isatty)(struct target_controller *, int fd);
-	int (*system)(struct target_controller *,
-	              target_addr cmd, size_t cmd_len);
+	int (*system)(struct target_controller *, target_addr_t cmd, size_t cmd_len);
 	enum target_errno errno_;
 	bool interrupted;
 };

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -59,9 +59,9 @@ bool target_mem_map(target *t, char *buf, size_t len);
 int target_mem_read(target *t, void *dest, target_addr_t src, size_t len);
 int target_mem_write(target *t, target_addr_t dest, const void *src, size_t len);
 /* Flash memory access functions */
-int target_flash_erase(target *t, target_addr_t addr, size_t len);
-int target_flash_write(target *t, target_addr_t dest, const void *src, size_t len);
-int target_flash_complete(target *t);
+bool target_flash_erase(target *t, target_addr_t addr, size_t len);
+bool target_flash_write(target *t, target_addr_t dest, const void *src, size_t len);
+bool target_flash_complete(target *t);
 
 /* Register access functions */
 size_t target_regs_size(target *t);

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -577,7 +577,7 @@ found_targets:
 													  map.data, map.size);
 			/* Buffered write cares for padding*/
 			if (!flashed)
-				flashed = target_flash_done(t);
+				flashed = target_flash_complete(t);
 			if (flashed) {
 				DEBUG_WARN("Flashing failed!\n");
 				res = -1;

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -478,10 +478,10 @@ found_targets:
 	uint32_t lowest_flash_start = 0xffffffff;
 	uint32_t lowest_flash_size = 0;
 	int n_flash = 0;
-	for (struct target_flash *f = t->flash; f; f = f->next)
+	for (target_flash_s *f = t->flash; f; f = f->next)
 		n_flash++;
-	for (int n = n_flash; n >= 0; n --) {
-		struct target_flash *f = t->flash;
+	for (int n = n_flash; n >= 0; n--) {
+		target_flash_s *f = t->flash;
 		for (int i = 1; f; f = f->next, i++)
 			if (i == n) {
 				DEBUG_INFO("Flash Start: 0x%08" PRIx32 " length = 0x%" PRIx32

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -549,36 +549,24 @@ found_targets:
 	if (opt->opt_mode == BMP_MODE_RESET) {
 		target_reset(t);
 	} else if (opt->opt_mode == BMP_MODE_FLASH_ERASE) {
-		DEBUG_INFO("Erase %zu bytes at 0x%08" PRIx32 "\n", opt->opt_flash_size,
-			  opt->opt_flash_start);
-		unsigned int erased = target_flash_erase(t, opt->opt_flash_start,
-												 opt->opt_flash_size);
-		if (erased) {
+		DEBUG_INFO("Erase %zu bytes at 0x%08" PRIx32 "\n", opt->opt_flash_size, opt->opt_flash_start);
+		if (!target_flash_erase(t, opt->opt_flash_start, opt->opt_flash_size)) {
 			DEBUG_WARN("Erasure failed!\n");
 			res = -1;
 			goto free_map;
 		}
 		target_reset(t);
-	} else if ((opt->opt_mode == BMP_MODE_FLASH_WRITE) ||
-	           (opt->opt_mode == BMP_MODE_FLASH_WRITE_VERIFY)) {
-		DEBUG_INFO("Erase    %zu bytes at 0x%08" PRIx32 "\n", map.size,
-			  opt->opt_flash_start);
+	} else if ((opt->opt_mode == BMP_MODE_FLASH_WRITE) || (opt->opt_mode == BMP_MODE_FLASH_WRITE_VERIFY)) {
+		DEBUG_INFO("Erase    %zu bytes at 0x%08" PRIx32 "\n", map.size, opt->opt_flash_start);
 		uint32_t start_time = platform_time_ms();
-		unsigned int erased = target_flash_erase(t, opt->opt_flash_start,
-												 map.size);
-		if (erased) {
+		if (!target_flash_erase(t, opt->opt_flash_start, map.size)) {
 			DEBUG_WARN("Erasure failed!\n");
 			res = -1;
 			goto free_map;
 		} else {
-			DEBUG_INFO("Flashing %zu bytes at 0x%08" PRIx32 "\n",
-				  map.size, opt->opt_flash_start);
-			unsigned int flashed = target_flash_write(t, opt->opt_flash_start,
-													  map.data, map.size);
+			DEBUG_INFO("Flashing %zu bytes at 0x%08" PRIx32 "\n", map.size, opt->opt_flash_start);
 			/* Buffered write cares for padding*/
-			if (!flashed)
-				flashed = target_flash_complete(t);
-			if (flashed) {
+			if (!target_flash_write(t, opt->opt_flash_start, map.data, map.size) || !target_flash_complete(t)) {
 				DEBUG_WARN("Flashing failed!\n");
 				res = -1;
 				goto free_map;

--- a/src/rtt.c
+++ b/src/rtt.c
@@ -285,7 +285,7 @@ static rtt_retval read_rtt(target *cur_target, uint32_t i)
 /* target_mem_read, word aligned for speed.
    note: dest has to be len + 8 bytes, to allow for alignment and padding.
  */
-int target_aligned_mem_read(target *t, void *dest, target_addr src, size_t len)
+int target_aligned_mem_read(target *t, void *dest, target_addr_t src, size_t len)
 {
 	uint32_t src0 = src;
 	uint32_t len0 = len;
@@ -395,7 +395,7 @@ void poll_rtt(target *cur_target)
 	bool rtt_busy = false;
 
 	if (last_poll_ms + poll_ms <= now || now < last_poll_ms) {
-		target_addr watch;
+		target_addr_t watch;
 		enum target_halt_reason reason;
 		bool resume_target = false;
 		if (!rtt_found)

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -34,8 +34,8 @@
 
 extern const struct command_s stm32f1_cmd_list[]; // Reuse stm32f1 stuff
 
-static int ch32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int ch32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int ch32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 
 // these are common with stm32f1/gd32f1/...
 #define FPEC_BASE						0x40022000
@@ -200,7 +200,7 @@ bool ch32f1_probe(target *t)
   \fn ch32f1_flash_erase
   \brief fast erase of CH32
 */
-int ch32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+int ch32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	volatile uint32_t sr, magic;
 	target *t = f->t;
@@ -297,13 +297,13 @@ static int ch32f1_buffer_clear(target *t)
 /**
 
 */
-static int ch32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	volatile uint32_t sr, magic;
 	target *t = f->t;
 	size_t length = len;
 #ifdef CH32_VERIFY
-	target_addr org_dest = dest;
+	target_addr_t org_dest = dest;
 	const void *org_src = src;
 #endif
 	DEBUG_INFO("CH32: flash write 0x%" PRIx32 " ,size=%" PRIu32 "\n", dest, (uint32_t)len);

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -34,10 +34,8 @@
 
 extern const struct command_s stm32f1_cmd_list[]; // Reuse stm32f1 stuff
 
-static int ch32f1_flash_erase(struct target_flash *f,
-	target_addr addr, size_t len);
-static int ch32f1_flash_write(struct target_flash *f,
-	target_addr dest, const void *src, size_t len);
+static int ch32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int ch32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 
 // these are common with stm32f1/gd32f1/...
 #define FPEC_BASE						0x40022000
@@ -73,8 +71,8 @@ static int ch32f1_flash_write(struct target_flash *f,
 */
 static void ch32f1_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
-	if (!f) {			/* calloc failed: heap exhaustion */
+	target_flash_s *f = calloc(1, sizeof(*f));
+	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
@@ -84,7 +82,7 @@ static void ch32f1_add_flash(target *t, uint32_t addr, size_t length, size_t era
 	f->blocksize = erasesize;
 	f->erase = ch32f1_flash_erase;
 	f->write = ch32f1_flash_write;
-	f->buf_size = erasesize;
+	f->writesize = erasesize;
 	f->erased = 0xff;
 	target_add_flash(t, f);
 }
@@ -202,7 +200,7 @@ bool ch32f1_probe(target *t)
   \fn ch32f1_flash_erase
   \brief fast erase of CH32
 */
-int ch32f1_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+int ch32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	volatile uint32_t sr, magic;
 	target *t = f->t;
@@ -299,8 +297,7 @@ static int ch32f1_buffer_clear(target *t)
 /**
 
 */
-static int ch32f1_flash_write(struct target_flash *f,
-	target_addr dest, const void *src, size_t len)
+static int ch32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	volatile uint32_t sr, magic;
 	target *t = f->t;

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -46,9 +46,8 @@ static void cortexa_regs_write_internal(target *t);
 static ssize_t cortexa_reg_read(target *t, int reg, void *data, size_t max);
 static ssize_t cortexa_reg_write(target *t, int reg, const void *data, size_t max);
 
-
 static void cortexa_reset(target *t);
-static enum target_halt_reason cortexa_halt_poll(target *t, target_addr *watch);
+static enum target_halt_reason cortexa_halt_poll(target *t, target_addr_t *watch);
 static void cortexa_halt_request(target *t);
 
 static int cortexa_breakwatch_set(target *t, struct breakwatch *);
@@ -234,7 +233,7 @@ static uint32_t va_to_pa(target *t, uint32_t va)
 	return pa;
 }
 
-static void cortexa_slow_mem_read(target *t, void *dest, target_addr src, size_t len)
+static void cortexa_slow_mem_read(target *t, void *dest, target_addr_t src, size_t len)
 {
 	struct cortexa_priv *priv = t->priv;
 	unsigned words = (len + (src & 3) + 3) / 4;
@@ -273,7 +272,7 @@ static void cortexa_slow_mem_read(target *t, void *dest, target_addr src, size_t
 	}
 }
 
-static void cortexa_slow_mem_write_bytes(target *t, target_addr dest, const uint8_t *src, size_t len)
+static void cortexa_slow_mem_write_bytes(target *t, target_addr_t dest, const uint8_t *src, size_t len)
 {
 	struct cortexa_priv *priv = t->priv;
 
@@ -292,7 +291,7 @@ static void cortexa_slow_mem_write_bytes(target *t, target_addr dest, const uint
 	}
 }
 
-static void cortexa_slow_mem_write(target *t, target_addr dest, const void *src, size_t len)
+static void cortexa_slow_mem_write(target *t, target_addr_t dest, const void *src, size_t len)
 {
 	struct cortexa_priv *priv = t->priv;
 	if (len == 0)
@@ -622,7 +621,7 @@ static void cortexa_halt_request(target *t)
 	}
 }
 
-static enum target_halt_reason cortexa_halt_poll(target *t, target_addr *watch)
+static enum target_halt_reason cortexa_halt_poll(target *t, target_addr_t *watch)
 {
 	volatile uint32_t dbgdscr = 0;
 	volatile struct exception e;

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -191,6 +191,6 @@ ADIv5_AP_t *cortexm_ap(target *t);
 bool cortexm_attach(target *t);
 void cortexm_detach(target *t);
 int cortexm_run_stub(target *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3);
-int cortexm_mem_write_sized(target *t, target_addr dest, const void *src, size_t len, enum align align);
+int cortexm_mem_write_sized(target *t, target_addr_t dest, const void *src, size_t len, enum align align);
 
 #endif /* TARGET_CORTEXM_H */

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -45,8 +45,8 @@
 #define SRAM_BASE        0x20000000
 #define STUB_BUFFER_BASE ALIGN(SRAM_BASE + sizeof(efm32_flash_write_stub), 4)
 
-static int efm32_flash_erase(struct target_flash *t, target_addr addr, size_t len);
-static int efm32_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+static int efm32_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int efm32_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 static bool efm32_mass_erase(target *t);
 
 static const uint16_t efm32_flash_write_stub[] = {
@@ -496,7 +496,7 @@ static efm32_v2_di_miscchip_t efm32_v2_read_miscchip(target *t, uint8_t di_versi
 
 static void efm32_add_flash(target *t, target_addr addr, size_t length, size_t page_size)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
+	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
@@ -507,7 +507,7 @@ static void efm32_add_flash(target *t, target_addr addr, size_t length, size_t p
 	f->blocksize = page_size;
 	f->erase = efm32_flash_erase;
 	f->write = efm32_flash_write;
-	f->buf_size = page_size;
+	f->writesize = page_size;
 	target_add_flash(t, f);
 }
 
@@ -595,7 +595,7 @@ bool efm32_probe(target *t)
 }
 
 /* Erase flash row by row */
-static int efm32_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int efm32_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 
@@ -636,7 +636,7 @@ static int efm32_flash_erase(struct target_flash *f, target_addr addr, size_t le
 }
 
 /* Write flash page by page */
-static int efm32_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len)
+static int efm32_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	(void)len;
 

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -45,8 +45,8 @@
 #define SRAM_BASE        0x20000000
 #define STUB_BUFFER_BASE ALIGN(SRAM_BASE + sizeof(efm32_flash_write_stub), 4)
 
-static int efm32_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int efm32_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int efm32_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int efm32_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool efm32_mass_erase(target *t);
 
 static const uint16_t efm32_flash_write_stub[] = {
@@ -494,7 +494,7 @@ static efm32_v2_di_miscchip_t efm32_v2_read_miscchip(target *t, uint8_t di_versi
 /* Shared Functions                                                           */
 /* -------------------------------------------------------------------------- */
 
-static void efm32_add_flash(target *t, target_addr addr, size_t length, size_t page_size)
+static void efm32_add_flash(target *t, target_addr_t addr, size_t length, size_t page_size)
 {
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
@@ -595,7 +595,7 @@ bool efm32_probe(target *t)
 }
 
 /* Erase flash row by row */
-static int efm32_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int efm32_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 
@@ -636,7 +636,7 @@ static int efm32_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 }
 
 /* Write flash page by page */
-static int efm32_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int efm32_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	(void)len;
 

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -111,12 +111,12 @@ static bool kinetis_cmd_unsafe(target *t, int argc, char **argv)
 	return true;
 }
 
-static int kinetis_flash_cmd_erase(struct target_flash *f, target_addr addr, size_t len);
-static int kinetis_flash_cmd_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
-static int kinetis_flash_done(struct target_flash *f);
+static int kinetis_flash_cmd_erase(target_flash_s *f, target_addr addr, size_t len);
+static int kinetis_flash_cmd_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int kinetis_flash_done(target_flash_s *f);
 
 struct kinetis_flash {
-	struct target_flash f;
+	target_flash_s f;
 	uint8_t write_len;
 };
 
@@ -124,7 +124,7 @@ static void kinetis_add_flash(
 	target *const t, const uint32_t addr, const size_t length, const size_t erasesize, const size_t write_len)
 {
 	struct kinetis_flash *kf = calloc(1, sizeof(*kf));
-	struct target_flash *f;
+	target_flash_s *f;
 
 	if (!kf) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
@@ -432,7 +432,7 @@ static bool kinetis_fccob_cmd(target *t, uint8_t cmd, uint32_t addr, const uint3
 	return true;
 }
 
-static int kinetis_flash_cmd_erase(struct target_flash *const f, target_addr addr, size_t len)
+static int kinetis_flash_cmd_erase(target_flash_s *const f, target_addr addr, size_t len)
 {
 	while (len) {
 		if (kinetis_fccob_cmd(f->t, FTFx_CMD_ERASE_SECTOR, addr, NULL, 0)) {
@@ -449,7 +449,7 @@ static int kinetis_flash_cmd_erase(struct target_flash *const f, target_addr add
 	return 0;
 }
 
-static int kinetis_flash_cmd_write(struct target_flash *f, target_addr dest, const void *src, size_t len)
+static int kinetis_flash_cmd_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	struct kinetis_flash *const kf = (struct kinetis_flash *)f;
 
@@ -479,7 +479,7 @@ static int kinetis_flash_cmd_write(struct target_flash *f, target_addr dest, con
 	return 0;
 }
 
-static int kinetis_flash_done(struct target_flash *const f)
+static int kinetis_flash_done(target_flash_s *const f)
 {
 	struct kinetis_flash *const kf = (struct kinetis_flash *)f;
 

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -113,7 +113,7 @@ static bool kinetis_cmd_unsafe(target *t, int argc, char **argv)
 
 static int kinetis_flash_cmd_erase(target_flash_s *f, target_addr_t addr, size_t len);
 static int kinetis_flash_cmd_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
-static int kinetis_flash_done(target_flash_s *f);
+static bool kinetis_flash_done(target_flash_s *f);
 
 struct kinetis_flash {
 	target_flash_s f;
@@ -479,15 +479,15 @@ static int kinetis_flash_cmd_write(target_flash_s *f, target_addr_t dest, const 
 	return 0;
 }
 
-static int kinetis_flash_done(target_flash_s *const f)
+static bool kinetis_flash_done(target_flash_s *const f)
 {
 	struct kinetis_flash *const kf = (struct kinetis_flash *)f;
 
 	if (f->t->unsafe_enabled)
-		return 0;
+		return true;
 
 	if (target_mem_read8(f->t, FLASH_SECURITY_BYTE_ADDRESS) == FLASH_SECURITY_BYTE_UNSECURED)
-		return 0;
+		return true;
 
 	/* Load the security byte based on the alignment (determine 8 byte phrases
 	 * vs 4 byte phrases).
@@ -505,7 +505,7 @@ static int kinetis_flash_done(target_flash_s *const f)
 		kinetis_fccob_cmd(f->t, FTFx_CMD_PROGRAM_LONGWORD, FLASH_SECURITY_BYTE_ADDRESS, &val, 1);
 	}
 
-	return 0;
+	return true;
 }
 
 /*** Kinetis recovery mode using the MDM-AP ***/

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -111,8 +111,8 @@ static bool kinetis_cmd_unsafe(target *t, int argc, char **argv)
 	return true;
 }
 
-static int kinetis_flash_cmd_erase(target_flash_s *f, target_addr addr, size_t len);
-static int kinetis_flash_cmd_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int kinetis_flash_cmd_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int kinetis_flash_cmd_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static int kinetis_flash_done(target_flash_s *f);
 
 struct kinetis_flash {
@@ -432,7 +432,7 @@ static bool kinetis_fccob_cmd(target *t, uint8_t cmd, uint32_t addr, const uint3
 	return true;
 }
 
-static int kinetis_flash_cmd_erase(target_flash_s *const f, target_addr addr, size_t len)
+static int kinetis_flash_cmd_erase(target_flash_s *const f, target_addr_t addr, size_t len)
 {
 	while (len) {
 		if (kinetis_fccob_cmd(f->t, FTFx_CMD_ERASE_SECTOR, addr, NULL, 0)) {
@@ -449,7 +449,7 @@ static int kinetis_flash_cmd_erase(target_flash_s *const f, target_addr addr, si
 	return 0;
 }
 
-static int kinetis_flash_cmd_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int kinetis_flash_cmd_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	struct kinetis_flash *const kf = (struct kinetis_flash *)f;
 
@@ -524,7 +524,7 @@ const struct command_s kinetis_mdm_cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
-enum target_halt_reason mdm_halt_poll(target *t, const target_addr *const watch)
+enum target_halt_reason mdm_halt_poll(target *t, const target_addr_t *const watch)
 {
 	(void)t;
 	(void)watch;

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -60,8 +60,8 @@
 #define LMI_FLASH_FMC_COMT   (1 << 3)
 #define LMI_FLASH_FMC_WRKEY  0xA4420000
 
-static int lmi_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int lmi_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+static int lmi_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int lmi_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 static bool lmi_mass_erase(target *t);
 
 static const char lmi_driver_str[] = "TI Stellaris/Tiva";
@@ -72,7 +72,7 @@ static const uint16_t lmi_flash_write_stub[] = {
 
 static void lmi_add_flash(target *t, size_t length)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
+	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) {			/* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
@@ -156,7 +156,7 @@ bool lmi_probe(target *const t)
 	}
 }
 
-static int lmi_flash_erase(struct target_flash *f, target_addr addr, const size_t len)
+static int lmi_flash_erase(target_flash_s *f, target_addr addr, const size_t len)
 {
 	target  *t = f->t;
 	target_check_error(t);
@@ -181,7 +181,7 @@ static int lmi_flash_erase(struct target_flash *f, target_addr addr, const size_
 	return 0;
 }
 
-static int lmi_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len)
+static int lmi_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	target  *t = f->t;
 	target_check_error(t);

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -60,8 +60,8 @@
 #define LMI_FLASH_FMC_COMT   (1 << 3)
 #define LMI_FLASH_FMC_WRKEY  0xA4420000
 
-static int lmi_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int lmi_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int lmi_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int lmi_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool lmi_mass_erase(target *t);
 
 static const char lmi_driver_str[] = "TI Stellaris/Tiva";
@@ -156,7 +156,7 @@ bool lmi_probe(target *const t)
 	}
 }
 
-static int lmi_flash_erase(target_flash_s *f, target_addr addr, const size_t len)
+static int lmi_flash_erase(target_flash_s *f, target_addr_t addr, const size_t len)
 {
 	target  *t = f->t;
 	target_check_error(t);
@@ -181,7 +181,7 @@ static int lmi_flash_erase(target_flash_s *f, target_addr addr, const size_t len
 	return 0;
 }
 
-static int lmi_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int lmi_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target  *t = f->t;
 	target_check_error(t);

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -64,7 +64,7 @@ static void lpc11xx_add_flash(target *t, const uint32_t addr, const size_t len, 
 {
 	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
 	lf->f.blocksize = erase_block_len;
-	lf->f.buf_size = IAP_PGM_CHUNKSIZE;
+	lf->f.writesize = IAP_PGM_CHUNKSIZE;
 	lf->f.write = lpc_flash_write_magic_vect;
 	lf->iap_entry = iap_entry;
 	lf->iap_ram = IAP_RAM_BASE;

--- a/src/target/lpc15xx.c
+++ b/src/target/lpc15xx.c
@@ -59,7 +59,7 @@ static void lpc15xx_add_flash(target *t, uint32_t addr, size_t len, size_t erase
 {
 	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
 	lf->f.blocksize = erasesize;
-	lf->f.buf_size = IAP_PGM_CHUNKSIZE;
+	lf->f.writesize = IAP_PGM_CHUNKSIZE;
 	lf->f.write = lpc_flash_write_magic_vect;
 	lf->iap_entry = IAP_ENTRYPOINT;
 	lf->iap_ram = IAP_RAM_BASE;

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -52,7 +52,7 @@ static void lpc17xx_add_flash(target *t, uint32_t addr, size_t len, size_t erase
 	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
 	lf->f.blocksize = erasesize;
 	lf->base_sector = base_sector;
-	lf->f.buf_size = IAP_PGM_CHUNKSIZE;
+	lf->f.writesize = IAP_PGM_CHUNKSIZE;
 	lf->f.write = lpc_flash_write_magic_vect;
 	lf->iap_entry = IAP_ENTRYPOINT;
 	lf->iap_ram = IAP_RAM_BASE;

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -48,7 +48,7 @@
 static bool lpc43xx_cmd_reset(target *t, int argc, const char *argv[]);
 static bool lpc43xx_cmd_mkboot(target *t, int argc, const char *argv[]);
 static int lpc43xx_flash_init(target *t);
-static int lpc43xx_flash_erase(struct target_flash *f, target_addr addr, size_t len);
+static int lpc43xx_flash_erase(target_flash_s *f, target_addr addr, size_t len);
 static bool lpc43xx_mass_erase(target *t);
 static void lpc43xx_set_internal_clock(target *t);
 static void lpc43xx_wdt_set_period(target *t);
@@ -60,14 +60,13 @@ const struct command_s lpc43xx_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static void lpc43xx_add_flash(target *t, uint32_t iap_entry,
-                       uint8_t bank, uint8_t base_sector,
-                       uint32_t addr, size_t len, size_t erasesize)
+static void lpc43xx_add_flash(
+	target *t, uint32_t iap_entry, uint8_t bank, uint8_t base_sector, uint32_t addr, size_t len, size_t erasesize)
 {
 	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
 	lf->f.erase = lpc43xx_flash_erase;
 	lf->f.blocksize = erasesize;
-	lf->f.buf_size = IAP_PGM_CHUNKSIZE;
+	lf->f.writesize = IAP_PGM_CHUNKSIZE;
 	lf->bank = bank;
 	lf->base_sector = base_sector;
 	lf->iap_entry = iap_entry;
@@ -187,7 +186,7 @@ static int lpc43xx_flash_init(target *t)
 	return 0;
 }
 
-static int lpc43xx_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int lpc43xx_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	if (lpc43xx_flash_init(f->t))
 		return -1;

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -48,7 +48,7 @@
 static bool lpc43xx_cmd_reset(target *t, int argc, const char *argv[]);
 static bool lpc43xx_cmd_mkboot(target *t, int argc, const char *argv[]);
 static int lpc43xx_flash_init(target *t);
-static int lpc43xx_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int lpc43xx_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
 static bool lpc43xx_mass_erase(target *t);
 static void lpc43xx_set_internal_clock(target *t);
 static void lpc43xx_wdt_set_period(target *t);
@@ -186,7 +186,7 @@ static int lpc43xx_flash_init(target *t)
 	return 0;
 }
 
-static int lpc43xx_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int lpc43xx_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	if (lpc43xx_flash_init(f->t))
 		return -1;

--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -54,7 +54,7 @@ static bool lpc546xx_cmd_write_sector(target *t, int argc, const char *argv[]);
 
 static void lpc546xx_reset_attach(target *t);
 static int lpc546xx_flash_init(target *t);
-static int lpc546xx_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int lpc546xx_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
 static bool lpc546xx_mass_erase(target *t);
 static void lpc546xx_wdt_set_period(target *t);
 static void lpc546xx_wdt_pet(target *t);
@@ -291,7 +291,7 @@ static int lpc546xx_flash_init(target *t)
 	return 0;
 }
 
-static int lpc546xx_flash_erase(target_flash_s *tf, target_addr addr, size_t len)
+static int lpc546xx_flash_erase(target_flash_s *tf, target_addr_t addr, size_t len)
 {
 	if (lpc546xx_flash_init(tf->t))
 		return -1;

--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -54,7 +54,7 @@ static bool lpc546xx_cmd_write_sector(target *t, int argc, const char *argv[]);
 
 static void lpc546xx_reset_attach(target *t);
 static int lpc546xx_flash_init(target *t);
-static int lpc546xx_flash_erase(struct target_flash *f, target_addr addr, size_t len);
+static int lpc546xx_flash_erase(target_flash_s *f, target_addr addr, size_t len);
 static bool lpc546xx_mass_erase(target *t);
 static void lpc546xx_wdt_set_period(target *t);
 static void lpc546xx_wdt_pet(target *t);
@@ -73,9 +73,8 @@ const struct command_s lpc546xx_cmd_list[] = {
 	{ NULL, NULL, NULL }
 };
 
-static void lpc546xx_add_flash(target *t, uint32_t iap_entry,
-			uint8_t base_sector, uint32_t addr,
-			size_t len, size_t erasesize)
+static void lpc546xx_add_flash(
+	target *t, uint32_t iap_entry, uint8_t base_sector, uint32_t addr, size_t len, size_t erasesize)
 {
 	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
 	lf->f.erase = lpc546xx_flash_erase;
@@ -85,7 +84,7 @@ static void lpc546xx_add_flash(target *t, uint32_t iap_entry,
 	lf->f.write = lpc_flash_write_magic_vect;
 
 	lf->f.blocksize = erasesize;
-	lf->f.buf_size = IAP_PGM_CHUNKSIZE;
+	lf->f.writesize = IAP_PGM_CHUNKSIZE;
 	lf->bank = 0;
 	lf->base_sector = base_sector;
 	lf->iap_entry = iap_entry;
@@ -292,7 +291,7 @@ static int lpc546xx_flash_init(target *t)
 	return 0;
 }
 
-static int lpc546xx_flash_erase(struct target_flash *tf, target_addr addr, size_t len)
+static int lpc546xx_flash_erase(target_flash_s *tf, target_addr addr, size_t len)
 {
 	if (lpc546xx_flash_init(tf->t))
 		return -1;

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -70,13 +70,12 @@ char *iap_error[] = {
 	"Page is invalid",
 };
 
-static int lpc_flash_write(struct target_flash *tf,
-						   target_addr dest, const void *src, size_t len);
+static int lpc_flash_write(target_flash_s *tf, target_addr dest, const void *src, size_t len);
 
 struct lpc_flash *lpc_add_flash(target *t, target_addr addr, size_t length)
 {
 	struct lpc_flash *lf = calloc(1, sizeof(*lf));
-	struct target_flash *f;
+	target_flash_s *f;
 
 	if (!lf) {			/* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
@@ -183,7 +182,7 @@ enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd
 #define LPX80X_SECTOR_SIZE 0x400
 #define LPX80X_PAGE_SIZE    0x40
 
-int lpc_flash_erase(struct target_flash *tf, target_addr addr, size_t len)
+int lpc_flash_erase(target_flash_s *tf, target_addr addr, size_t len)
 {
 	struct lpc_flash *f = (struct lpc_flash *)tf;
 	const uint32_t start = lpc_sector_for_addr(f, addr);
@@ -221,8 +220,7 @@ int lpc_flash_erase(struct target_flash *tf, target_addr addr, size_t len)
 	return 0;
 }
 
-static int lpc_flash_write(struct target_flash *tf,
-                    target_addr dest, const void *src, size_t len)
+static int lpc_flash_write(target_flash_s *tf, target_addr dest, const void *src, size_t len)
 {
 	struct lpc_flash *f = (struct lpc_flash *)tf;
 	/* prepare... */
@@ -259,8 +257,7 @@ static int lpc_flash_write(struct target_flash *tf,
 	return 0;
 }
 
-int lpc_flash_write_magic_vect(struct target_flash *f,
-                               target_addr dest, const void *src, size_t len)
+int lpc_flash_write_magic_vect(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	if (dest == 0) {
 		/* Fill in the magic vector to allow booting the flash */

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -70,9 +70,9 @@ char *iap_error[] = {
 	"Page is invalid",
 };
 
-static int lpc_flash_write(target_flash_s *tf, target_addr dest, const void *src, size_t len);
+static int lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *src, size_t len);
 
-struct lpc_flash *lpc_add_flash(target *t, target_addr addr, size_t length)
+struct lpc_flash *lpc_add_flash(target *t, target_addr_t addr, size_t length)
 {
 	struct lpc_flash *lf = calloc(1, sizeof(*lf));
 	target_flash_s *f;
@@ -99,7 +99,7 @@ static uint8_t lpc_sector_for_addr(struct lpc_flash *f, uint32_t addr)
 
 static inline bool lpc_is_full_erase(struct lpc_flash *f, const uint32_t begin, const uint32_t end)
 {
-	const target_addr addr = f->f.start;
+	const target_addr_t addr = f->f.start;
 	const size_t len = f->f.length;
 	return begin == lpc_sector_for_addr(f, addr) && end == lpc_sector_for_addr(f, addr + len - 1U);
 }
@@ -182,7 +182,7 @@ enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd
 #define LPX80X_SECTOR_SIZE 0x400
 #define LPX80X_PAGE_SIZE    0x40
 
-int lpc_flash_erase(target_flash_s *tf, target_addr addr, size_t len)
+int lpc_flash_erase(target_flash_s *tf, target_addr_t addr, size_t len)
 {
 	struct lpc_flash *f = (struct lpc_flash *)tf;
 	const uint32_t start = lpc_sector_for_addr(f, addr);
@@ -220,7 +220,7 @@ int lpc_flash_erase(target_flash_s *tf, target_addr addr, size_t len)
 	return 0;
 }
 
-static int lpc_flash_write(target_flash_s *tf, target_addr dest, const void *src, size_t len)
+static int lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *src, size_t len)
 {
 	struct lpc_flash *f = (struct lpc_flash *)tf;
 	/* prepare... */
@@ -257,7 +257,7 @@ static int lpc_flash_write(target_flash_s *tf, target_addr dest, const void *src
 	return 0;
 }
 
-int lpc_flash_write_magic_vect(target_flash_s *f, target_addr dest, const void *src, size_t len)
+int lpc_flash_write_magic_vect(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	if (dest == 0) {
 		/* Fill in the magic vector to allow booting the flash */

--- a/src/target/lpc_common.h
+++ b/src/target/lpc_common.h
@@ -69,7 +69,7 @@ enum iap_status {
 #define CPU_CLK_KHZ 12000
 
 struct lpc_flash {
-	struct target_flash f;
+	target_flash_s f;
 	uint8_t base_sector;
 	uint8_t bank;
 	uint8_t reserved_pages;
@@ -82,8 +82,7 @@ struct lpc_flash {
 
 struct lpc_flash *lpc_add_flash(target *t, target_addr addr, size_t length);
 enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd, ...);
-int lpc_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-int lpc_flash_write_magic_vect(struct target_flash *f,
-                               target_addr dest, const void *src, size_t len);
+int lpc_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+int lpc_flash_write_magic_vect(target_flash_s *f, target_addr dest, const void *src, size_t len);
 
 #endif /* TARGET_LPC_COMMON_H */

--- a/src/target/lpc_common.h
+++ b/src/target/lpc_common.h
@@ -80,9 +80,9 @@ struct lpc_flash {
 	uint32_t iap_msp;
 };
 
-struct lpc_flash *lpc_add_flash(target *t, target_addr addr, size_t length);
+struct lpc_flash *lpc_add_flash(target *t, target_addr_t addr, size_t length);
 enum iap_status lpc_iap_call(struct lpc_flash *f, void *result, enum iap_cmd cmd, ...);
-int lpc_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-int lpc_flash_write_magic_vect(target_flash_s *f, target_addr dest, const void *src, size_t len);
+int lpc_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+int lpc_flash_write_magic_vect(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 
 #endif /* TARGET_LPC_COMMON_H */

--- a/src/target/msp432.c
+++ b/src/target/msp432.c
@@ -101,25 +101,25 @@
 /* Support variables to call code in ROM */
 struct msp432_flash {
 	target_flash_s f;
-	target_addr flash_protect_register; /* Address of the WEPROT register*/
-	target_addr FlashCtl_eraseSector;   /* Erase flash sector routine in ROM*/
-	target_addr FlashCtl_programMemory; /* Flash programming routine in ROM */
+	target_addr_t flash_protect_register; /* Address of the WEPROT register*/
+	target_addr_t FlashCtl_eraseSector;   /* Erase flash sector routine in ROM*/
+	target_addr_t FlashCtl_programMemory; /* Flash programming routine in ROM */
 };
 
 /* Flash operations */
-static bool msp432_sector_erase(target_flash_s *f, target_addr addr);
-static int msp432_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int msp432_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static bool msp432_sector_erase(target_flash_s *f, target_addr_t addr);
+static int msp432_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int msp432_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 
 /* Utility functions */
 /* Find the the target flash that conatins a specific address */
-static target_flash_s *get_target_flash(target *t, target_addr addr);
+static target_flash_s *get_target_flash(target *t, target_addr_t addr);
 
 /* Call a subroutine in the MSP432 ROM (or anywhere else...)*/
 static void msp432_call_ROM(target *t, uint32_t address, uint32_t regs[]);
 
 /* Protect or unprotect the sector containing address */
-static inline uint32_t msp432_sector_unprotect(struct msp432_flash *mf, target_addr addr)
+static inline uint32_t msp432_sector_unprotect(struct msp432_flash *mf, target_addr_t addr)
 {
 	/* Read the old protection register */
 	uint32_t old_mask = target_mem_read32(mf->f.t, mf->flash_protect_register);
@@ -143,7 +143,7 @@ const struct command_s msp432_cmd_list[] = {
 	{"sector_erase", (cmd_handler)msp432_cmd_sector_erase, "Erase sector containing given address"},
 	{NULL, NULL, NULL}};
 
-static void msp432_add_flash(target *t, uint32_t addr, size_t length, target_addr prot_reg)
+static void msp432_add_flash(target *t, uint32_t addr, size_t length, target_addr_t prot_reg)
 {
 	struct msp432_flash *mf = calloc(1, sizeof(*mf));
 	target_flash_s *f;
@@ -227,7 +227,7 @@ bool msp432_probe(target *t)
 
 /* Flash operations */
 /* Erase a single sector at addr calling the ROM routine*/
-static bool msp432_sector_erase(target_flash_s *f, target_addr addr)
+static bool msp432_sector_erase(target_flash_s *f, target_addr_t addr)
 {
 	target *t = f->t;
 	struct msp432_flash *mf = (struct msp432_flash *)f;
@@ -257,7 +257,7 @@ static bool msp432_sector_erase(target_flash_s *f, target_addr addr)
 }
 
 /* Erase from addr for len bytes */
-static int msp432_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int msp432_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	int ret = 0;
 	while (len) {
@@ -275,7 +275,7 @@ static int msp432_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 }
 
 /* Program flash */
-static int msp432_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int msp432_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	struct msp432_flash *mf = (struct msp432_flash *)f;
 	target *t = f->t;
@@ -347,7 +347,7 @@ static bool msp432_cmd_sector_erase(target *t, int argc, const char **argv)
 }
 
 /* Returns flash bank containing addr, or NULL if not found */
-static target_flash_s *get_target_flash(target *t, target_addr addr)
+static target_flash_s *get_target_flash(target *t, target_addr_t addr)
 {
 	target_flash_s *f = t->flash;
 	while (f) {

--- a/src/target/msp432.c
+++ b/src/target/msp432.c
@@ -99,23 +99,21 @@
 #define WDT_A_HOLD 0x5A88u       /* Clears and halts the watchdog */
 
 /* Support variables to call code in ROM */
-struct msp432_flash
-{
-	struct target_flash f;
+struct msp432_flash {
+	target_flash_s f;
 	target_addr flash_protect_register; /* Address of the WEPROT register*/
 	target_addr FlashCtl_eraseSector;   /* Erase flash sector routine in ROM*/
 	target_addr FlashCtl_programMemory; /* Flash programming routine in ROM */
 };
 
 /* Flash operations */
-static bool msp432_sector_erase(struct target_flash *f, target_addr addr);
-static int msp432_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int msp432_flash_write(struct target_flash *f, target_addr dest,
-			      const void *src, size_t len);
+static bool msp432_sector_erase(target_flash_s *f, target_addr addr);
+static int msp432_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int msp432_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 
 /* Utility functions */
 /* Find the the target flash that conatins a specific address */
-static struct target_flash *get_target_flash(target *t, target_addr addr);
+static target_flash_s *get_target_flash(target *t, target_addr addr);
 
 /* Call a subroutine in the MSP432 ROM (or anywhere else...)*/
 static void msp432_call_ROM(target *t, uint32_t address, uint32_t regs[]);
@@ -148,8 +146,8 @@ const struct command_s msp432_cmd_list[] = {
 static void msp432_add_flash(target *t, uint32_t addr, size_t length, target_addr prot_reg)
 {
 	struct msp432_flash *mf = calloc(1, sizeof(*mf));
-	struct target_flash *f;
-	if (!mf) {			/* calloc failed: heap exhaustion */
+	target_flash_s *f;
+	if (!mf) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
@@ -160,16 +158,13 @@ static void msp432_add_flash(target *t, uint32_t addr, size_t length, target_add
 	f->blocksize = SECTOR_SIZE;
 	f->erase = msp432_flash_erase;
 	f->write = msp432_flash_write;
-	f->buf_size = SRAM_WRITE_BUF_SIZE;
+	f->writesize = SRAM_WRITE_BUF_SIZE;
 	f->erased = 0xff;
 	target_add_flash(t, f);
 	/* Initialize ROM call pointers. Silicon rev B is not supported */
-	uint32_t flashctltable =
-		target_mem_read32(t, ROM_APITABLE + OFS_FLASHCTLTABLE);
-	mf->FlashCtl_eraseSector =
-		target_mem_read32(t, flashctltable + OFS_FlashCtl_eraseSector);
-	mf->FlashCtl_programMemory =
-		target_mem_read32(t, flashctltable + OFS_FlashCtl_programMemory);
+	uint32_t flashctltable = target_mem_read32(t, ROM_APITABLE + OFS_FLASHCTLTABLE);
+	mf->FlashCtl_eraseSector = target_mem_read32(t, flashctltable + OFS_FlashCtl_eraseSector);
+	mf->FlashCtl_programMemory = target_mem_read32(t, flashctltable + OFS_FlashCtl_programMemory);
 	mf->flash_protect_register = prot_reg;
 }
 
@@ -232,7 +227,7 @@ bool msp432_probe(target *t)
 
 /* Flash operations */
 /* Erase a single sector at addr calling the ROM routine*/
-static bool msp432_sector_erase(struct target_flash *f, target_addr addr)
+static bool msp432_sector_erase(target_flash_s *f, target_addr addr)
 {
 	target *t = f->t;
 	struct msp432_flash *mf = (struct msp432_flash *)f;
@@ -262,7 +257,7 @@ static bool msp432_sector_erase(struct target_flash *f, target_addr addr)
 }
 
 /* Erase from addr for len bytes */
-static int msp432_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int msp432_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	int ret = 0;
 	while (len) {
@@ -280,8 +275,7 @@ static int msp432_flash_erase(struct target_flash *f, target_addr addr, size_t l
 }
 
 /* Program flash */
-static int msp432_flash_write(struct target_flash *f, target_addr dest,
-			      const void *src, size_t len)
+static int msp432_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	struct msp432_flash *mf = (struct msp432_flash *)f;
 	target *t = f->t;
@@ -326,7 +320,7 @@ static bool msp432_cmd_erase_main(target *t, int argc, const char **argv)
 	DEBUG_INFO("Bank Size: 0x%08"PRIX32"\n", banksize);
 
 	/* Erase first bank */
-	struct target_flash *f = get_target_flash(t, MAIN_FLASH_BASE);
+	target_flash_s *f = get_target_flash(t, MAIN_FLASH_BASE);
 	bool ret = msp432_flash_erase(f, MAIN_FLASH_BASE, banksize);
 
 	/* Erase second bank */
@@ -344,7 +338,7 @@ static bool msp432_cmd_sector_erase(target *t, int argc, const char **argv)
 	uint32_t addr = strtoul(argv[1], NULL, 0);
 
 	/* Find the flash structure (for the rigth protect register) */
-	struct target_flash *f = get_target_flash(t, addr);
+	target_flash_s *f = get_target_flash(t, addr);
 
 	if (f)
 		return msp432_sector_erase(f, addr);
@@ -353,9 +347,9 @@ static bool msp432_cmd_sector_erase(target *t, int argc, const char **argv)
 }
 
 /* Returns flash bank containing addr, or NULL if not found */
-static struct target_flash *get_target_flash(target *t, target_addr addr)
+static target_flash_s *get_target_flash(target *t, target_addr addr)
 {
-	struct target_flash *f = t->flash;
+	target_flash_s *f = t->flash;
 	while (f) {
 		if ((f->start <= addr) && (addr < f->start + f->length))
 			break;

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -27,8 +27,8 @@
 #include "cortexm.h"
 #include "adiv5.h"
 
-static int nrf51_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int nrf51_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int nrf51_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int nrf51_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool nrf51_mass_erase(target *t);
 
 static bool nrf51_cmd_erase_uicr(target *t, int argc, const char **argv);
@@ -159,7 +159,7 @@ bool nrf51_probe(target *t)
 	return true;
 }
 
-static int nrf51_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int nrf51_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	/* Enable erase */
@@ -203,7 +203,7 @@ static int nrf51_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int nrf51_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int nrf51_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target *t = f->t;
 

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -27,9 +27,8 @@
 #include "cortexm.h"
 #include "adiv5.h"
 
-static int nrf51_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int nrf51_flash_write(struct target_flash *f,
-                             target_addr dest, const void *src, size_t len);
+static int nrf51_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int nrf51_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 static bool nrf51_mass_erase(target *t);
 
 static bool nrf51_cmd_erase_uicr(target *t, int argc, const char **argv);
@@ -104,7 +103,7 @@ const struct command_s nrf51_read_cmd_list[] = {
 static void nrf51_add_flash(target *t,
                             uint32_t addr, size_t length, size_t erasesize)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
+	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) {			/* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
@@ -160,7 +159,7 @@ bool nrf51_probe(target *t)
 	return true;
 }
 
-static int nrf51_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int nrf51_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	/* Enable erase */
@@ -204,8 +203,7 @@ static int nrf51_flash_erase(struct target_flash *f, target_addr addr, size_t le
 	return 0;
 }
 
-static int nrf51_flash_write(struct target_flash *f,
-                             target_addr dest, const void *src, size_t len)
+static int nrf51_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	target *t = f->t;
 

--- a/src/target/nxpke04.c
+++ b/src/target/nxpke04.c
@@ -116,8 +116,8 @@ static const uint8_t cmdLen[] = {
 
 /* Flash routines */
 static bool ke04_command(target *t, uint8_t cmd, uint32_t addr, const uint8_t data[8]);
-static int ke04_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int ke04_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int ke04_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int ke04_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static int ke04_flash_done(target_flash_s *f);
 static bool ke04_mass_erase(target *t);
 
@@ -322,7 +322,7 @@ static bool ke04_command(target *t, uint8_t cmd, uint32_t addr, const uint8_t da
 	return true;
 }
 
-static int ke04_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int ke04_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	while (len) {
 		if (ke04_command(f->t, CMD_ERASE_FLASH_SECTOR, addr, NULL)) {
@@ -336,7 +336,7 @@ static int ke04_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int ke04_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int ke04_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	/* Ensure we don't write something horrible over the security byte */
 	target *t = f->t;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -150,14 +150,14 @@ const struct command_s rp_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static int rp_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int rp_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int rp_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int rp_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 
 static bool rp_read_rom_func_table(target *t);
 static bool rp_attach(target *t);
 static void rp_flash_prepare(target *t);
 static void rp_flash_resume(target *t);
-static void rp_spi_read(target *t, uint16_t command, target_addr address, void *buffer, size_t length);
+static void rp_spi_read(target *t, uint16_t command, target_addr_t address, void *buffer, size_t length);
 static uint32_t rp_get_flash_length(target *t);
 static bool rp_mass_erase(target *t);
 
@@ -383,7 +383,7 @@ static void rp_flash_resume(target *t)
  * chip erase       5000/25000 ms
  * page programm       0.4/  3 ms
  */
-static int rp_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int rp_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	DEBUG_INFO("Erase addr 0x%08" PRIx32 " len 0x%" PRIx32 "\n", addr, (uint32_t)len);
 	target *t = f->t;
@@ -449,7 +449,7 @@ static int rp_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return ret;
 }
 
-static int rp_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int rp_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	DEBUG_INFO("RP Write 0x%08" PRIx32 " len 0x%" PRIx32 "\n", dest, (uint32_t)len);
 	target *t = f->t;
@@ -505,7 +505,7 @@ static void rp_spi_chip_select(target *const t, const bool active)
 }
 
 static void rp_spi_read(
-	target *const t, const uint16_t command, const target_addr address, void *const buffer, const size_t length)
+	target *const t, const uint16_t command, const target_addr_t address, void *const buffer, const size_t length)
 {
 	/* Ensure the controller is in the correct serial SPI mode and select the Flash */
 	const uint32_t ssi_enabled = target_mem_read32(t, RP_SSI_ENABLE);

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -193,7 +193,7 @@ static void rp_add_flash(target *t)
 	f->blocksize = spi_parameters.sector_size;
 	f->erase = rp_flash_erase;
 	f->write = rp_flash_write;
-	f->buf_size = 2048; /* Max buffer size used otherwise */
+	f->writesize = 2048; /* Max buffer size used otherwise */
 	f->erased = 0xffU;
 	target_add_flash(t, f);
 

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -28,9 +28,9 @@
 #include "target.h"
 #include "target_internal.h"
 
-static int sam_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int sam3_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int sam_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int sam_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int sam3_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int sam_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 
 static int sam_gpnvm_get(target *t, uint32_t base, uint32_t *gpnvm);
 
@@ -535,7 +535,7 @@ static enum sam_driver sam_driver(target *t)
 	return DRIVER_SAMX7X;
 }
 
-static int sam_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int sam_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	uint32_t base = ((struct sam_flash *)f)->eefc_base;
@@ -561,7 +561,7 @@ static int sam_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int sam3_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int sam3_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	/* The SAM3X/SAM3N don't really have a page erase function.
 	 * We do nothing here and use Erase/Write page in flash_write.
@@ -570,7 +570,7 @@ static int sam3_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int sam_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int sam_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target *t = f->t;
 	struct sam_flash *sf = (struct sam_flash *)f;

--- a/src/target/sam4l.c
+++ b/src/target/sam4l.c
@@ -103,8 +103,8 @@
 #define FLASHCALW_FGPFRLO			(FLASHCALW_BASE + 0x18)
 
 static void sam4l_extended_reset(target *t);
-static int sam4l_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int sam4l_flash_write_buf(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int sam4l_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int sam4l_flash_write_buf(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 
 /* why Atmel couldn't make it sequential ... */
 static const size_t __ram_size[16] = {
@@ -329,7 +329,7 @@ sam4l_flash_command(target *t, uint32_t page, uint32_t cmd)
  * Write data from 'src' into flash using the algorithim provided by
  * Atmel in their data sheet.
  */
-static int sam4l_flash_write_buf(target_flash_s *f, target_addr addr, const void *src, size_t len)
+static int sam4l_flash_write_buf(target_flash_s *f, target_addr_t addr, const void *src, size_t len)
 {
 	target *t = f->t;
 	uint32_t *src_data = (uint32_t *)src;
@@ -377,7 +377,7 @@ static int sam4l_flash_write_buf(target_flash_s *f, target_addr addr, const void
 /*
  * Erase flash across the addresses specified by addr and len
  */
-static int sam4l_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int sam4l_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	uint16_t page;

--- a/src/target/sam4l.c
+++ b/src/target/sam4l.c
@@ -103,9 +103,8 @@
 #define FLASHCALW_FGPFRLO			(FLASHCALW_BASE + 0x18)
 
 static void sam4l_extended_reset(target *t);
-static int sam4l_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int sam4l_flash_write_buf(struct target_flash *f, target_addr dest,
-									const void *src, size_t len);
+static int sam4l_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int sam4l_flash_write_buf(target_flash_s *f, target_addr dest, const void *src, size_t len);
 
 /* why Atmel couldn't make it sequential ... */
 static const size_t __ram_size[16] = {
@@ -168,8 +167,8 @@ static const size_t __nvp_size[16] = {
  */
 static void sam4l_add_flash(target *t, uint32_t addr, size_t length)
 {
-	struct target_flash *f = calloc(1, sizeof(struct target_flash));
-	if (!f) {			/* calloc failed: heap exhaustion */
+	target_flash_s *f = calloc(1, sizeof(target_flash_s));
+	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
@@ -179,7 +178,7 @@ static void sam4l_add_flash(target *t, uint32_t addr, size_t length)
 	f->blocksize = SAM4L_PAGE_SIZE;
 	f->erase = sam4l_flash_erase;
 	f->write = sam4l_flash_write_buf;
-	f->buf_size = SAM4L_PAGE_SIZE;
+	f->writesize = SAM4L_PAGE_SIZE;
 	f->erased = 0xff;
 	/* add it into the target structures flash chain */
 	target_add_flash(t, f);
@@ -330,8 +329,7 @@ sam4l_flash_command(target *t, uint32_t page, uint32_t cmd)
  * Write data from 'src' into flash using the algorithim provided by
  * Atmel in their data sheet.
  */
-static int
-sam4l_flash_write_buf(struct target_flash *f, target_addr addr, const void *src, size_t len)
+static int sam4l_flash_write_buf(target_flash_s *f, target_addr addr, const void *src, size_t len)
 {
 	target *t = f->t;
 	uint32_t *src_data = (uint32_t *)src;
@@ -379,8 +377,7 @@ sam4l_flash_write_buf(struct target_flash *f, target_addr addr, const void *src,
 /*
  * Erase flash across the addresses specified by addr and len
  */
-static int
-sam4l_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int sam4l_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	uint16_t page;

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -39,8 +39,8 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
-static int samd_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int samd_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int samd_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int samd_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 bool samd_mass_erase(target *t);
 
 static bool samd_cmd_lock_flash(target *t, int argc, const char **argv);
@@ -579,7 +579,7 @@ static void samd_unlock_current_address(target *t)
 /*
  * Erase flash row by row
  */
-static int samd_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int samd_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	while (len) {
@@ -615,7 +615,7 @@ static int samd_flash_erase(target_flash_s *f, target_addr addr, size_t len)
  * Write flash page by page
  */
 static int samd_flash_write(target_flash_s *f,
-                            target_addr dest, const void *src, size_t len)
+                            target_addr_t dest, const void *src, size_t len)
 {
 	target *t = f->t;
 

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -39,8 +39,8 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
-static int samd_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int samd_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+static int samd_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int samd_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 bool samd_mass_erase(target *t);
 
 static bool samd_cmd_lock_flash(target *t, int argc, const char **argv);
@@ -445,8 +445,8 @@ struct samd_descr samd_parse_device_id(uint32_t did)
 
 static void samd_add_flash(target *t, uint32_t addr, size_t length)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
-	if (!f) {			/* calloc failed: heap exhaustion */
+	target_flash_s *f = calloc(1, sizeof(*f));
+	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
@@ -456,7 +456,7 @@ static void samd_add_flash(target *t, uint32_t addr, size_t length)
 	f->blocksize = SAMD_ROW_SIZE;
 	f->erase = samd_flash_erase;
 	f->write = samd_flash_write;
-	f->buf_size = SAMD_PAGE_SIZE;
+	f->writesize = SAMD_PAGE_SIZE;
 	target_add_flash(t, f);
 }
 
@@ -579,7 +579,7 @@ static void samd_unlock_current_address(target *t)
 /*
  * Erase flash row by row
  */
-static int samd_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int samd_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	while (len) {
@@ -614,7 +614,7 @@ static int samd_flash_erase(struct target_flash *f, target_addr addr, size_t len
 /*
  * Write flash page by page
  */
-static int samd_flash_write(struct target_flash *f,
+static int samd_flash_write(target_flash_s *f,
                             target_addr dest, const void *src, size_t len)
 {
 	target *t = f->t;

--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -38,8 +38,8 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
-static int samx5x_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int samx5x_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int samx5x_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int samx5x_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool samx5x_cmd_lock_flash(target *t, int argc, const char **argv);
 static bool samx5x_cmd_unlock_flash(target *t, int argc, const char **argv);
 static bool samx5x_cmd_unlock_bootprot(target *t, int argc, const char **argv);
@@ -496,7 +496,7 @@ static int samx5x_check_nvm_error(target *t)
 /**
  * Erase flash block by block
  */
-static int samx5x_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int samx5x_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	uint16_t errs = samx5x_read_nvm_error(t);
@@ -562,7 +562,7 @@ static int samx5x_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 /**
  * Write flash page by page
  */
-static int samx5x_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int samx5x_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target *t = f->t;
 	bool error = false;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -46,8 +46,8 @@ const struct command_s stm32f1_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static int stm32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int stm32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int stm32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int stm32f1_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool stm32f1_mass_erase(target *t);
 
 /* Flash Program ad Erase Controller Register Map */
@@ -357,11 +357,11 @@ static int stm32f1_flash_unlock(target *t, uint32_t bank_offset)
 	return 0;
 }
 
-static int stm32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int stm32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
-	target_addr end = addr + len - 1;
-	target_addr start = addr;
+	target_addr_t end = addr + len - 1;
+	target_addr_t start = addr;
 
 	if (t->part_id == 0x430 && end >= FLASH_BANK_SPLIT)
 		if (stm32f1_flash_unlock(t, FLASH_BANK2_OFFSET))
@@ -418,7 +418,7 @@ static int stm32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int stm32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int stm32f1_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target *t = f->t;
 	uint32_t sr;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -46,8 +46,8 @@ const struct command_s stm32f1_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static int stm32f1_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int stm32f1_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+static int stm32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int stm32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 static bool stm32f1_mass_erase(target *t);
 
 /* Flash Program ad Erase Controller Register Map */
@@ -96,7 +96,7 @@ static bool stm32f1_mass_erase(target *t);
 
 static void stm32f1_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
+	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
@@ -107,7 +107,7 @@ static void stm32f1_add_flash(target *t, uint32_t addr, size_t length, size_t er
 	f->blocksize = erasesize;
 	f->erase = stm32f1_flash_erase;
 	f->write = stm32f1_flash_write;
-	f->buf_size = erasesize;
+	f->writesize = erasesize;
 	f->erased = 0xff;
 	target_add_flash(t, f);
 }
@@ -357,7 +357,7 @@ static int stm32f1_flash_unlock(target *t, uint32_t bank_offset)
 	return 0;
 }
 
-static int stm32f1_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int stm32f1_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	target_addr end = addr + len - 1;
@@ -418,7 +418,7 @@ static int stm32f1_flash_erase(struct target_flash *f, target_addr addr, size_t 
 	return 0;
 }
 
-static int stm32f1_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len)
+static int stm32f1_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	target *t = f->t;
 	uint32_t sr;

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -47,8 +47,8 @@ const struct command_s stm32f4_cmd_list[] = {
 };
 
 static bool stm32f4_attach(target *t);
-static int stm32f4_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int stm32f4_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int stm32f4_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int stm32f4_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool stm32f4_mass_erase(target *t);
 
 /* Flash Program and Erase Controller Register Map */
@@ -390,7 +390,7 @@ static void stm32f4_flash_unlock(target *t)
 	}
 }
 
-static int stm32f4_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int stm32f4_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	struct stm32f4_flash *sf = (struct stm32f4_flash *)f;
@@ -437,7 +437,7 @@ static int stm32f4_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int stm32f4_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int stm32f4_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	/* Translate ITCM addresses to AXIM */
 	if ((dest >= ITCM_BASE) && (dest < AXIM_BASE)) {

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -189,7 +189,7 @@ static void stm32g0_add_flash(target *t, uint32_t addr, size_t length, size_t bl
 	f->blocksize = blocksize;
 	f->erase = stm32g0_flash_erase;
 	f->write = stm32g0_flash_write;
-	f->buf_size = blocksize;
+	f->writesize = blocksize;
 	f->erased = 0xffU;
 	target_add_flash(t, f);
 }

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -160,8 +160,8 @@ typedef struct stm32g0_priv {
 
 static bool stm32g0_attach(target *t);
 static void stm32g0_detach(target *t);
-static int stm32g0_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int stm32g0_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int stm32g0_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int stm32g0_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool stm32g0_mass_erase(target *t);
 
 /* Custom commands */
@@ -340,7 +340,7 @@ static void stm32g0_flash_op_finish(target *t)
  * Flash erasure function.
  * OTP case: this function clears any previous error and returns.
  */
-static int stm32g0_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int stm32g0_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *const t = f->t;
 
@@ -402,7 +402,7 @@ static int stm32g0_flash_erase(target_flash_s *f, target_addr addr, size_t len)
  * OTP area is programmed as the "program" area. It can be programmed 8-bytes
  * by 8-bytes.
  */
-static int stm32g0_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int stm32g0_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target *const t = f->t;
 	stm32g0_priv_s *ps = (stm32g0_priv_s *)t->target_storage;

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -52,8 +52,8 @@ const struct command_s stm32h7_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static int stm32h7_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int stm32h7_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int stm32h7_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int stm32h7_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool stm32h7_mass_erase(target *t);
 
 static const char stm32h7_driver_str[] = "STM32H7";
@@ -267,7 +267,7 @@ static bool stm32h7_flash_unlock(target *t, const uint32_t addr)
 	return !(target_mem_read32(t, regbase + FLASH_CR) & FLASH_CR_LOCK);
 }
 
-static int stm32h7_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int stm32h7_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	struct stm32h7_flash *sf = (struct stm32h7_flash *)f;
@@ -307,7 +307,7 @@ static int stm32h7_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int stm32h7_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int stm32h7_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target *t = f->t;
 	struct stm32h7_flash *sf = (struct stm32h7_flash *)f;

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -143,11 +143,11 @@
 #define STM32L1_NVM_OPTR_BOR_LEV_M  (0xf)
 #define STM32L1_NVM_OPTR_SPRMOD     (1 << 8)
 
-static int stm32lx_nvm_prog_erase(struct target_flash *f, target_addr addr, size_t len);
-static int stm32lx_nvm_prog_write(struct target_flash *f, target_addr destination, const void *src, size_t size);
+static int stm32lx_nvm_prog_erase(target_flash_s *f, target_addr addr, size_t len);
+static int stm32lx_nvm_prog_write(target_flash_s *f, target_addr destination, const void *src, size_t size);
 
-static int stm32lx_nvm_data_erase(struct target_flash *f, target_addr addr, size_t len);
-static int stm32lx_nvm_data_write(struct target_flash *f, target_addr destination, const void *source, size_t size);
+static int stm32lx_nvm_data_erase(target_flash_s *f, target_addr addr, size_t len);
+static int stm32lx_nvm_data_write(target_flash_s *f, target_addr destination, const void *source, size_t size);
 
 static bool stm32lx_cmd_option(target *t, int argc, char **argv);
 static bool stm32lx_cmd_eeprom(target *t, int argc, char **argv);
@@ -220,7 +220,7 @@ static uint32_t stm32lx_nvm_option_size(target *t)
 
 static void stm32l_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
+	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
@@ -231,13 +231,13 @@ static void stm32l_add_flash(target *t, uint32_t addr, size_t length, size_t era
 	f->blocksize = erasesize;
 	f->erase = stm32lx_nvm_prog_erase;
 	f->write = stm32lx_nvm_prog_write;
-	f->buf_size = erasesize / 2;
+	f->writesize = erasesize / 2;
 	target_add_flash(t, f);
 }
 
 static void stm32l_add_eeprom(target *t, uint32_t addr, size_t length)
 {
-	struct target_flash *f = calloc(1, sizeof(*f));
+	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
@@ -325,7 +325,7 @@ static bool stm32lx_nvm_opt_unlock(target *t, uint32_t nvm)
     interface.  This is slower than stubbed versions(see NOTES).  The
     flash array is erased for all pages from addr to addr+len
     inclusive.  NVM register file address chosen from target. */
-static int stm32lx_nvm_prog_erase(struct target_flash *f, target_addr addr, size_t len)
+static int stm32lx_nvm_prog_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	const size_t page_size = f->blocksize;
@@ -372,7 +372,7 @@ static int stm32lx_nvm_prog_erase(struct target_flash *f, target_addr addr, size
 
 /** Write to program flash using operations through the debug
     interface. */
-static int stm32lx_nvm_prog_write(struct target_flash *f, target_addr dest, const void *src, size_t size)
+static int stm32lx_nvm_prog_write(target_flash_s *f, target_addr dest, const void *src, size_t size)
 {
 	target *t = f->t;
 	const uint32_t nvm = stm32lx_nvm_phys(t);
@@ -408,7 +408,7 @@ static int stm32lx_nvm_prog_write(struct target_flash *f, target_addr dest, cons
     interface .  The flash is erased for all pages from addr to
     addr+len, inclusive, on a word boundary.  NVM register file
     address chosen from target. */
-static int stm32lx_nvm_data_erase(struct target_flash *f, target_addr addr, size_t len)
+static int stm32lx_nvm_data_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	const size_t page_size = f->blocksize;
@@ -458,7 +458,7 @@ static int stm32lx_nvm_data_erase(struct target_flash *f, target_addr addr, size
     NVM register file address chosen from target.  Unaligned
     destination writes are supported (though unaligned sources are
     not). */
-static int stm32lx_nvm_data_write(struct target_flash *f, target_addr destination, const void *src, size_t size)
+static int stm32lx_nvm_data_write(target_flash_s *f, target_addr destination, const void *src, size_t size)
 {
 	target *t = f->t;
 	const uint32_t nvm = stm32lx_nvm_phys(t);

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -143,11 +143,11 @@
 #define STM32L1_NVM_OPTR_BOR_LEV_M  (0xf)
 #define STM32L1_NVM_OPTR_SPRMOD     (1 << 8)
 
-static int stm32lx_nvm_prog_erase(target_flash_s *f, target_addr addr, size_t len);
-static int stm32lx_nvm_prog_write(target_flash_s *f, target_addr destination, const void *src, size_t size);
+static int stm32lx_nvm_prog_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int stm32lx_nvm_prog_write(target_flash_s *f, target_addr_t destination, const void *src, size_t size);
 
-static int stm32lx_nvm_data_erase(target_flash_s *f, target_addr addr, size_t len);
-static int stm32lx_nvm_data_write(target_flash_s *f, target_addr destination, const void *source, size_t size);
+static int stm32lx_nvm_data_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int stm32lx_nvm_data_write(target_flash_s *f, target_addr_t destination, const void *source, size_t size);
 
 static bool stm32lx_cmd_option(target *t, int argc, char **argv);
 static bool stm32lx_cmd_eeprom(target *t, int argc, char **argv);
@@ -325,7 +325,7 @@ static bool stm32lx_nvm_opt_unlock(target *t, uint32_t nvm)
     interface.  This is slower than stubbed versions(see NOTES).  The
     flash array is erased for all pages from addr to addr+len
     inclusive.  NVM register file address chosen from target. */
-static int stm32lx_nvm_prog_erase(target_flash_s *f, target_addr addr, size_t len)
+static int stm32lx_nvm_prog_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	const size_t page_size = f->blocksize;
@@ -372,7 +372,7 @@ static int stm32lx_nvm_prog_erase(target_flash_s *f, target_addr addr, size_t le
 
 /** Write to program flash using operations through the debug
     interface. */
-static int stm32lx_nvm_prog_write(target_flash_s *f, target_addr dest, const void *src, size_t size)
+static int stm32lx_nvm_prog_write(target_flash_s *f, target_addr_t dest, const void *src, size_t size)
 {
 	target *t = f->t;
 	const uint32_t nvm = stm32lx_nvm_phys(t);
@@ -408,7 +408,7 @@ static int stm32lx_nvm_prog_write(target_flash_s *f, target_addr dest, const voi
     interface .  The flash is erased for all pages from addr to
     addr+len, inclusive, on a word boundary.  NVM register file
     address chosen from target. */
-static int stm32lx_nvm_data_erase(target_flash_s *f, target_addr addr, size_t len)
+static int stm32lx_nvm_data_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	const size_t page_size = f->blocksize;
@@ -458,7 +458,7 @@ static int stm32lx_nvm_data_erase(target_flash_s *f, target_addr addr, size_t le
     NVM register file address chosen from target.  Unaligned
     destination writes are supported (though unaligned sources are
     not). */
-static int stm32lx_nvm_data_write(target_flash_s *f, target_addr destination, const void *src, size_t size)
+static int stm32lx_nvm_data_write(target_flash_s *f, target_addr_t destination, const void *src, size_t size)
 {
 	target *t = f->t;
 	const uint32_t nvm = stm32lx_nvm_phys(t);

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -53,8 +53,8 @@ const struct command_s stm32l4_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static int stm32l4_flash_erase(target_flash_s *f, target_addr addr, size_t len);
-static int stm32l4_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
+static int stm32l4_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
+static int stm32l4_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 static bool stm32l4_mass_erase(target *t);
 
 /* Flash Program ad Erase Controller Register Map */
@@ -569,7 +569,7 @@ static void stm32l4_flash_unlock(target *t)
 	}
 }
 
-static int stm32l4_flash_erase(target_flash_s *f, target_addr addr, size_t len)
+static int stm32l4_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;
 	stm32l4_flash_unlock(t);
@@ -614,7 +614,7 @@ static int stm32l4_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 	return 0;
 }
 
-static int stm32l4_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
+static int stm32l4_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
 	target *t = f->t;
 	stm32l4_flash_write32(t, FLASH_CR, FLASH_CR_PG);

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -53,8 +53,8 @@ const struct command_s stm32l4_cmd_list[] = {
 	{NULL, NULL, NULL}
 };
 
-static int stm32l4_flash_erase(struct target_flash *f, target_addr addr, size_t len);
-static int stm32l4_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len);
+static int stm32l4_flash_erase(target_flash_s *f, target_addr addr, size_t len);
+static int stm32l4_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len);
 static bool stm32l4_mass_erase(target *t);
 
 /* Flash Program ad Erase Controller Register Map */
@@ -128,7 +128,7 @@ enum {
 #define L5_FLASH_SIZE_REG  0x0bfa05e0
 
 struct stm32l4_flash {
-	struct target_flash f;
+	target_flash_s f;
 	uint32_t bank1_start;
 };
 
@@ -367,18 +367,18 @@ static void stm32l4_flash_write32(target *t, enum stm32l4_flash_regs reg, uint32
 static void stm32l4_add_flash(target *t, uint32_t addr, size_t length, size_t blocksize, uint32_t bank1_start)
 {
 	struct stm32l4_flash *sf = calloc(1, sizeof(*sf));
-	if (!sf) {			/* calloc failed: heap exhaustion */
+	if (!sf) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
 
-	struct target_flash *f = &sf->f;
+	target_flash_s *f = &sf->f;
 	f->start = addr;
 	f->length = length;
 	f->blocksize = blocksize;
 	f->erase = stm32l4_flash_erase;
 	f->write = stm32l4_flash_write;
-	f->buf_size = 2048;
+	f->writesize = 2048;
 	f->erased = 0xff;
 	sf->bank1_start = bank1_start;
 	target_add_flash(t, f);
@@ -569,7 +569,7 @@ static void stm32l4_flash_unlock(target *t)
 	}
 }
 
-static int stm32l4_flash_erase(struct target_flash *f, target_addr addr, size_t len)
+static int stm32l4_flash_erase(target_flash_s *f, target_addr addr, size_t len)
 {
 	target *t = f->t;
 	stm32l4_flash_unlock(t);
@@ -614,7 +614,7 @@ static int stm32l4_flash_erase(struct target_flash *f, target_addr addr, size_t 
 	return 0;
 }
 
-static int stm32l4_flash_write(struct target_flash *f, target_addr dest, const void *src, size_t len)
+static int stm32l4_flash_write(target_flash_s *f, target_addr dest, const void *src, size_t len)
 {
 	target *t = f->t;
 	stm32l4_flash_write32(t, FLASH_CR, FLASH_CR_PG);

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -211,6 +211,8 @@ void target_add_flash(target *t, target_flash_s *f)
 {
 	if (f->writesize == 0)
 		f->writesize = f->blocksize;
+	if (f->writebufsize == 0)
+		f->writebufsize = f->writesize;
 	f->t = t;
 	f->next = t->flash;
 	t->flash = f;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -29,9 +29,6 @@ target *target_list = NULL;
 
 #define STDOUT_READ_BUF_SIZE	64
 
-static int target_flash_write_buffered(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
-static int target_flash_done_buffered(target_flash_s *f);
-
 static bool target_cmd_mass_erase(target *t, int argc, const char **argv);
 static bool target_cmd_range_erase(target *t, int argc, const char **argv);
 
@@ -253,122 +250,6 @@ bool target_mem_map(target *t, char *tmp, size_t len)
 	if (i > (len -2))
 		return false;
 	return true;
-}
-
-target_flash_s *target_flash_for_addr(target *t, uint32_t addr)
-{
-	for (target_flash_s *f = t->flash; f; f = f->next)
-		if ((f->start <= addr) &&
-		    (addr < (f->start + f->length)))
-			return f;
-	return NULL;
-}
-
-int target_flash_erase(target *t, target_addr_t addr, size_t len)
-{
-	int ret = 0;
-	while (len) {
-		target_flash_s *f = target_flash_for_addr(t, addr);
-		if (!f) {
-			DEBUG_WARN("Requested address is outside the valid range 0x%06" PRIx32 "\n", addr);
-			return 1;
-		}
-
-		const target_addr_t local_start_addr = addr & ~(f->blocksize - 1U);
-		const target_addr_t local_end_addr = local_start_addr + f->blocksize;
-
-		ret |= f->erase(f, local_start_addr, f->blocksize);
-
-		len -= MIN(local_end_addr - addr, len);
-		addr = local_end_addr;
-	}
-	return ret;
-}
-
-int target_flash_write(target *t, target_addr_t dest, const void *src, size_t len)
-{
-	int ret = 0;
-	while (len) {
-		target_flash_s *f = target_flash_for_addr(t, dest);
-		if (!f)
-			return 1;
-		size_t tmptarget = MIN(dest + len, f->start + f->length);
-		size_t tmplen = tmptarget - dest;
-		ret |= target_flash_write_buffered(f, dest, src, tmplen);
-		dest += tmplen;
-		src += tmplen;
-		len -= tmplen;
-		/* If the current chunk of Flash is now full from this operation
-		 * then finish operations on the Flash chunk and free the internal buffer.
-		 */
-		if (dest == f->start + f->length)
-			ret |= target_flash_done_buffered(f);
-	}
-	return ret;
-}
-
-int target_flash_done(target *t)
-{
-	for (target_flash_s *f = t->flash; f; f = f->next) {
-		int tmp = target_flash_done_buffered(f);
-		if (tmp)
-			return tmp;
-		if (f->done) {
-			tmp = f->done(f);
-			if (tmp)
-				return tmp;
-		}
-	}
-	return 0;
-}
-
-int target_flash_write_buffered(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
-{
-	int ret = 0;
-
-	if (f->buf == NULL) {
-		/* Allocate flash sector buffer */
-		f->buf = malloc(f->writesize);
-		if (!f->buf) { /* malloc failed: heap exhaustion */
-			DEBUG_WARN("malloc: failed in %s\n", __func__);
-			return 1;
-		}
-		f->buf_addr = -1;
-	}
-	while (len) {
-		uint32_t offset = dest % f->writesize;
-		uint32_t base = dest - offset;
-		if (base != f->buf_addr) {
-			if (f->buf_addr != (uint32_t)-1) {
-				/* Write sector to flash if valid */
-				ret |= f->write(f, f->buf_addr, f->buf, f->writesize);
-			}
-			/* Setup buffer for a new sector */
-			f->buf_addr = base;
-			memset(f->buf, f->erased, f->writesize);
-		}
-		/* Copy chunk into sector buffer */
-		size_t sectlen = MIN(f->writesize - offset, len);
-		memcpy(f->buf + offset, src, sectlen);
-		dest += sectlen;
-		src += sectlen;
-		len -= sectlen;
-	}
-	return ret;
-}
-
-int target_flash_done_buffered(target_flash_s *f)
-{
-	int ret = 0;
-	if ((f->buf != NULL) && (f->buf_addr != (uint32_t)-1)) {
-		/* Write sector to flash if valid */
-		ret = f->write(f, f->buf_addr, f->buf, f->writesize);
-		f->buf_addr = -1;
-		free(f->buf);
-		f->buf = NULL;
-	}
-
-	return ret;
 }
 
 void target_print_progress(platform_timeout *const timeout)

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -1,0 +1,157 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rafael Silva <perigoso@riseup.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* This file implements target flash interaction routines.
+ * Provides functionality for buffered flash operations
+ * It depends on target flash implementations
+ */
+
+#include "general.h"
+#include "target_internal.h"
+
+static int target_flash_write_buffered(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
+static int target_flash_done_buffered(target_flash_s *f);
+
+target_flash_s *target_flash_for_addr(target *t, uint32_t addr)
+{
+	for (target_flash_s *f = t->flash; f; f = f->next)
+		if ((f->start <= addr) && (addr < (f->start + f->length)))
+			return f;
+	return NULL;
+}
+
+int target_flash_erase(target *t, target_addr_t addr, size_t len)
+{
+	int ret = 0;
+	while (len) {
+		target_flash_s *f = target_flash_for_addr(t, addr);
+		if (!f) {
+			DEBUG_WARN("Requested address is outside the valid range 0x%06" PRIx32 "\n", addr);
+			return 1;
+		}
+
+		const target_addr_t local_start_addr = addr & ~(f->blocksize - 1U);
+		const target_addr_t local_end_addr = local_start_addr + f->blocksize;
+
+		ret |= f->erase(f, local_start_addr, f->blocksize);
+
+		len -= MIN(local_end_addr - addr, len);
+		addr = local_end_addr;
+	}
+	return ret;
+}
+
+int target_flash_write(target *t, target_addr_t dest, const void *src, size_t len)
+{
+	int ret = 0;
+	while (len) {
+		target_flash_s *f = target_flash_for_addr(t, dest);
+		if (!f)
+			return 1;
+		size_t tmptarget = MIN(dest + len, f->start + f->length);
+		size_t tmplen = tmptarget - dest;
+		ret |= target_flash_write_buffered(f, dest, src, tmplen);
+		dest += tmplen;
+		src += tmplen;
+		len -= tmplen;
+		/* If the current chunk of Flash is now full from this operation
+		 * then finish operations on the Flash chunk and free the internal buffer.
+		 */
+		if (dest == f->start + f->length)
+			ret |= target_flash_done_buffered(f);
+	}
+	return ret;
+}
+
+int target_flash_done(target *t)
+{
+	for (target_flash_s *f = t->flash; f; f = f->next) {
+		int tmp = target_flash_done_buffered(f);
+		if (tmp)
+			return tmp;
+		if (f->done) {
+			tmp = f->done(f);
+			if (tmp)
+				return tmp;
+		}
+	}
+	return 0;
+}
+
+int target_flash_write_buffered(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
+{
+	int ret = 0;
+
+	if (f->buf == NULL) {
+		/* Allocate flash sector buffer */
+		f->buf = malloc(f->writesize);
+		if (!f->buf) { /* malloc failed: heap exhaustion */
+			DEBUG_WARN("malloc: failed in %s\n", __func__);
+			return 1;
+		}
+		f->buf_addr = -1;
+	}
+	while (len) {
+		uint32_t offset = dest % f->writesize;
+		uint32_t base = dest - offset;
+		if (base != f->buf_addr) {
+			if (f->buf_addr != (uint32_t)-1) {
+				/* Write sector to flash if valid */
+				ret |= f->write(f, f->buf_addr, f->buf, f->writesize);
+			}
+			/* Setup buffer for a new sector */
+			f->buf_addr = base;
+			memset(f->buf, f->erased, f->writesize);
+		}
+		/* Copy chunk into sector buffer */
+		size_t sectlen = MIN(f->writesize - offset, len);
+		memcpy(f->buf + offset, src, sectlen);
+		dest += sectlen;
+		src += sectlen;
+		len -= sectlen;
+	}
+	return ret;
+}
+
+int target_flash_done_buffered(target_flash_s *f)
+{
+	int ret = 0;
+	if ((f->buf != NULL) && (f->buf_addr != (uint32_t)-1)) {
+		/* Write sector to flash if valid */
+		ret = f->write(f, f->buf_addr, f->buf, f->writesize);
+		f->buf_addr = -1;
+		free(f->buf);
+		f->buf = NULL;
+	}
+
+	return ret;
+}

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -266,13 +266,8 @@ static bool flash_buffered_flush(target_flash_s *f)
 		const uint8_t *src = f->buf + (aligned_addr - f->buf_addr_base);
 		uint32_t len = f->buf_addr_high - aligned_addr;
 
-		while (len) {
-			ret &= f->write(f, aligned_addr, src, f->writesize) == 0;
-
-			aligned_addr += f->writesize;
-			src += f->writesize;
-			len -= MIN(len, f->writesize);
-		}
+		for (size_t offset = 0; offset < len; offset += f->writesize)
+			ret &= f->write(f, aligned_addr + offset, src + offset, f->writesize) == 0;
 
 		f->buf_addr_base = UINT32_MAX;
 		f->buf_addr_low = UINT32_MAX;

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -211,7 +211,7 @@ static int flash_buffered_write(target_flash_s *f, target_addr_t dest, const voi
 {
 	if (f->buf == NULL) {
 		/* Allocate buffer */
-		f->buf = malloc(f->blocksize);
+		f->buf = malloc(f->writebufsize);
 		if (!f->buf) { /* malloc failed: heap exhaustion */
 			DEBUG_WARN("malloc: failed in %s\n", __func__);
 			return -1;
@@ -223,7 +223,7 @@ static int flash_buffered_write(target_flash_s *f, target_addr_t dest, const voi
 
 	int ret = 0;
 	while (len) {
-		const target_addr_t base_addr = dest & ~(f->blocksize - 1U);
+		const target_addr_t base_addr = dest & ~(f->writebufsize - 1U);
 
 		/* check for base address change */
 		if (base_addr != f->buf_addr_base) {
@@ -231,11 +231,11 @@ static int flash_buffered_write(target_flash_s *f, target_addr_t dest, const voi
 
 			/* Setup buffer */
 			f->buf_addr_base = base_addr;
-			memset(f->buf, f->erased, f->blocksize);
+			memset(f->buf, f->erased, f->writebufsize);
 		}
 
-		const size_t offset = dest % f->blocksize;
-		const size_t local_len = MIN(f->blocksize - offset, len);
+		const size_t offset = dest % f->writebufsize;
+		const size_t local_len = MIN(f->writebufsize - offset, len);
 
 		/* Copy chunk into sector buffer */
 		memcpy(f->buf + offset, src, local_len);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -34,10 +34,10 @@ struct target_ram {
 
 typedef struct target_flash target_flash_s;
 
-typedef int (*flash_prepare_func)(target_flash_s *f);
+typedef bool (*flash_prepare_func)(target_flash_s *f);
 typedef int (*flash_erase_func)(target_flash_s *f, target_addr_t addr, size_t len);
 typedef int (*flash_write_func)(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
-typedef int (*flash_done_func)(target_flash_s *f);
+typedef bool (*flash_done_func)(target_flash_s *f);
 
 struct target_flash {
 	target *t;                   /* Target this flash is attached to */

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -46,6 +46,7 @@ struct target_flash {
 	size_t blocksize;           /* erase block size */
 	size_t writesize;           /* write operation size, must be <= blocksize */
 	uint8_t erased;             /* byte erased state */
+	bool ready;              	/* true if flash is in flash mode/prepared */
 	flash_prepare_func prepare; /* prepare for flash operations */
 	flash_erase_func erase;     /* erase a range of flash */
 	flash_write_func write;     /* write to flash */

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -27,7 +27,7 @@ extern target *target_list;
 target *target_new(void);
 
 struct target_ram {
-	target_addr start;
+	target_addr_t start;
 	size_t length;
 	struct target_ram *next;
 };
@@ -35,13 +35,13 @@ struct target_ram {
 typedef struct target_flash target_flash_s;
 
 typedef int (*flash_prepare_func)(target_flash_s *f);
-typedef int (*flash_erase_func)(target_flash_s *f, target_addr addr, size_t len);
-typedef int (*flash_write_func)(target_flash_s *f, target_addr dest, const void *src, size_t len);
+typedef int (*flash_erase_func)(target_flash_s *f, target_addr_t addr, size_t len);
+typedef int (*flash_write_func)(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 typedef int (*flash_done_func)(target_flash_s *f);
 
 struct target_flash {
 	target *t;                  /* Target this flash is attached to */
-	target_addr start;          /* start address of flash */
+	target_addr_t start;        /* start address of flash */
 	size_t length;              /* flash length */
 	size_t blocksize;           /* erase block size */
 	size_t writesize;           /* write operation size, must be <= blocksize */
@@ -51,7 +51,7 @@ struct target_flash {
 	flash_write_func write;     /* write to flash */
 	flash_done_func done;       /* finish flash operations */
 	void *buf;                  /* buffer for flash operations */
-	target_addr buf_addr;       /* address of block this buffer is for */
+	target_addr_t buf_addr;     /* address of block this buffer is for */
 	target_flash_s *next;       /* next flash in list */
 };
 
@@ -72,7 +72,7 @@ struct target_command_s {
 struct breakwatch {
 	struct breakwatch *next;
 	enum target_breakwatch type;
-	target_addr addr;
+	target_addr_t addr;
 	size_t size;
 	uint32_t reserved[4]; /* for use by the implementing driver */
 };
@@ -89,8 +89,8 @@ struct target_s {
 	bool (*check_error)(target *t);
 
 	/* Memory access functions */
-	void (*mem_read)(target *t, void *dest, target_addr src, size_t len);
-	void (*mem_write)(target *t, target_addr dest, const void *src, size_t len);
+	void (*mem_read)(target *t, void *dest, target_addr_t src, size_t len);
+	void (*mem_write)(target *t, target_addr_t dest, const void *src, size_t len);
 
 	/* Register access functions */
 	size_t regs_size;
@@ -104,7 +104,7 @@ struct target_s {
 	void (*reset)(target *t);
 	void (*extended_reset)(target *t);
 	void (*halt_request)(target *t);
-	enum target_halt_reason (*halt_poll)(target *t, target_addr *watch);
+	enum target_halt_reason (*halt_poll)(target *t, target_addr_t *watch);
 	void (*halt_resume)(target *t, bool step);
 
 	/* Break-/watchpoint functions */
@@ -132,7 +132,7 @@ struct target_s {
 	uint32_t cpuid;
 	char *core;
 	char cmdline[MAX_CMDLINE];
-	target_addr heapinfo[4];
+	target_addr_t heapinfo[4];
 	struct target_command_s *commands;
 #ifdef PLATFORM_HAS_USBUART
 	bool stdout_redirected;
@@ -156,7 +156,7 @@ void target_ram_map_free(target *t);
 void target_flash_map_free(target *t);
 void target_mem_map_free(target *t);
 void target_add_commands(target *t, const struct command_s *cmds, const char *name);
-void target_add_ram(target *t, target_addr start, uint32_t len);
+void target_add_ram(target *t, target_addr_t start, uint32_t len);
 void target_add_flash(target *t, target_flash_s *f);
 
 target_flash_s *target_flash_for_addr(target *t, uint32_t addr);
@@ -174,17 +174,17 @@ bool target_check_error(target *t);
 void tc_printf(target *t, const char *fmt, ...);
 
 /* Interface to host system calls */
-int tc_open(target *, target_addr path, size_t plen, enum target_open_flags flags, mode_t mode);
+int tc_open(target *, target_addr_t path, size_t plen, enum target_open_flags flags, mode_t mode);
 int tc_close(target *t, int fd);
-int tc_read(target *t, int fd, target_addr buf, unsigned int count);
-int tc_write(target *t, int fd, target_addr buf, unsigned int count);
+int tc_read(target *t, int fd, target_addr_t buf, unsigned int count);
+int tc_write(target *t, int fd, target_addr_t buf, unsigned int count);
 long tc_lseek(target *t, int fd, long offset, enum target_seek_flag flag);
-int tc_rename(target *t, target_addr oldpath, size_t oldlen, target_addr newpath, size_t newlen);
-int tc_unlink(target *t, target_addr path, size_t plen);
-int tc_stat(target *t, target_addr path, size_t plen, target_addr buf);
-int tc_fstat(target *t, int fd, target_addr buf);
-int tc_gettimeofday(target *t, target_addr tv, target_addr tz);
+int tc_rename(target *t, target_addr_t oldpath, size_t oldlen, target_addr_t newpath, size_t newlen);
+int tc_unlink(target *t, target_addr_t path, size_t plen);
+int tc_stat(target *t, target_addr_t path, size_t plen, target_addr_t buf);
+int tc_fstat(target *t, int fd, target_addr_t buf);
+int tc_gettimeofday(target *t, target_addr_t tv, target_addr_t tz);
 int tc_isatty(target *t, int fd);
-int tc_system(target *t, target_addr cmd, size_t cmdlen);
+int tc_system(target *t, target_addr_t cmd, size_t cmdlen);
 
 #endif /* TARGET_TARGET_INTERNAL_H */

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -115,6 +115,11 @@ struct target_s {
 	/* Recovery functions */
 	bool (*mass_erase)(target *t);
 
+	/* Flash functions */
+	int (*enter_flash_mode)(target *t);
+	int (*exit_flash_mode)(target *t);
+	bool flash_mode;
+
 	/* target-defined options */
 	unsigned target_options;
 

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -44,7 +44,8 @@ struct target_flash {
 	target_addr_t start;         /* start address of flash */
 	size_t length;               /* flash length */
 	size_t blocksize;            /* erase block size */
-	size_t writesize;            /* write operation size, must be <= blocksize */
+	size_t writesize;            /* write operation size, must be <= blocksize/writebufsize */
+	size_t writebufsize;         /* size of write buffer */
 	uint8_t erased;              /* byte erased state */
 	bool ready;                  /* true if flash is in flash mode/prepared */
 	flash_prepare_func prepare;  /* prepare for flash operations */

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -40,20 +40,22 @@ typedef int (*flash_write_func)(target_flash_s *f, target_addr_t dest, const voi
 typedef int (*flash_done_func)(target_flash_s *f);
 
 struct target_flash {
-	target *t;                  /* Target this flash is attached to */
-	target_addr_t start;        /* start address of flash */
-	size_t length;              /* flash length */
-	size_t blocksize;           /* erase block size */
-	size_t writesize;           /* write operation size, must be <= blocksize */
-	uint8_t erased;             /* byte erased state */
-	bool ready;              	/* true if flash is in flash mode/prepared */
-	flash_prepare_func prepare; /* prepare for flash operations */
-	flash_erase_func erase;     /* erase a range of flash */
-	flash_write_func write;     /* write to flash */
-	flash_done_func done;       /* finish flash operations */
-	void *buf;                  /* buffer for flash operations */
-	target_addr_t buf_addr;     /* address of block this buffer is for */
-	target_flash_s *next;       /* next flash in list */
+	target *t;                   /* Target this flash is attached to */
+	target_addr_t start;         /* start address of flash */
+	size_t length;               /* flash length */
+	size_t blocksize;            /* erase block size */
+	size_t writesize;            /* write operation size, must be <= blocksize */
+	uint8_t erased;              /* byte erased state */
+	bool ready;                  /* true if flash is in flash mode/prepared */
+	flash_prepare_func prepare;  /* prepare for flash operations */
+	flash_erase_func erase;      /* erase a range of flash */
+	flash_write_func write;      /* write to flash */
+	flash_done_func done;        /* finish flash operations */
+	void *buf;                   /* buffer for flash operations */
+	target_addr_t buf_addr_base; /* address of block this buffer is for */
+	target_addr_t buf_addr_low;  /* address of lowest byte written */
+	target_addr_t buf_addr_high; /* address of highest byte written */
+	target_flash_s *next;        /* next flash in list */
 };
 
 typedef bool (*cmd_handler)(target *t, int argc, const char **argv);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

This pr tries to improve the robustness of the target flash memory handling, mainly by ensuring aligned writes and erases.

The topology of the flashing changed a bit, but it should be backwards compatible until changes trickle down to the target code. this change is mainly that now writes and erases are commited in monolitic chunks of size f->blocksize or f->writesize, so loops through the data are no longer necessary on the target code side, ther was also the addition of a setup function along the existing done function, this can be used to prepare the flash for incoming data only once, before data chunks start coming in, when no more operations in a particular target flash are required, or writes to a different flash are needed, a call to done is done. this is mainly an optimization for the incoming target support for renesas RA chips, that require a lot of queries to the flash to setup the flash for incoming data.

This comes with a couple cleanups to other behaviours, like the allocation and deallocation of bufferes, that should happen less often, and more predictably; And a possible bug, likely not reproducible with gdb, where the flash buffer may not have been flushed on non contiguous writes accross the flash; Flash operations not done through GDB also did not reset the target before, aka putting it in "Flash mode", this is now fixed as it was abstracted away in the target flash code.

included are cleanups to the naming of target_flash and target_addr, this was done before and then rebased on main, so I adopted a different naming style to one that had happened concurrently on main.

note/fixme: the return values are a mess, unsure what the project wants to unify as, so left as is.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->

## Test Logs

These may not be very useful, as they may be hard to read if you don't know what to look for or what I was trying to achieve, and the prints may be obfuscated.

GDB does a bit of helping with aligning through the write lengths, meaning I could not get the truly cursed writes I was trying to do to test properly, but I trust the code to behave in such situations.

### legend
- flash_prepare(flash_start_address)
- flash_erase(flash_start_address): start_address <- length
- flash_done(flash_start_address)
- flash_buffered_write(f:flash_start_address, dest:destination_address, src:source_address, len:length)
- flash_buffered_flush(f:flash_start_address, base:block_aligned_address, low:lowest_written_byte, high:highest_written_byte)
- flash_write(flash_start_address): start_address <- length

tests done on a fake target with 2 flash blocks:
0x00100000 @ 0x00000000
0x00100000 @ 0x00100000

### Erase range
blocksize = 4096U;

##### missaligned
`mon erase_range 0x10 0x80`
```
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x00000000 <- 4096
flash_done(0x00000000)
```

##### missaligned on block 2
`mon erase_range 0x1010 0x80`
```
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x00001000 <- 4096
flash_done(0x00000000)
```

##### missaligned on block boundary
`mon erase_range 0xC00 0x1000`
```
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x00000000 <- 4096
flash_done(0x00000000)
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x00001000 <- 4096
flash_done(0x00000000)
```

##### missaligned on block boundary, higher length
`mon erase_range 0xC00 0x2000`
```
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x00000000 <- 4096
flash_done(0x00000000)
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x00001000 <- 4096
flash_done(0x00000000)
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x00002000 <- 4096
flash_done(0x00000000)
```

##### missaligned on flash boundary
`mon erase_range 0xFFC00 0x1000`
```
flash_prepare(0x00000000)
flash_erase(0x00000000): 0x000ff000 <- 4096
flash_done(0x00000000)
flash_prepare(0x00100000)
flash_erase(0x00100000): 0x00100000 <- 4096
flash_done(0x00100000)
```

### Flash write

##### 1

load binary len:1824 @ 0x0
blocksize = 4096U;
writesize = 1024U;

```
Flash Erase 00000000 00001000
	flash_prepare(0x00000000)
		flash_erase(0x00000000): 0x00000000 <- 4096
	flash_done(0x00000000)
Flash Write 00000000 000003E0
	flash_buffered_write(f:0x00000000, dest:0x00000000, src:0x2f5684ce, len:992)
Flash Write 000003E0 00000340
	flash_buffered_write(f:0x00000000, dest:0x000003e0, src:0x2f5684d0, len:832)
		flash_buffered_flush(f:0x00000000, base:0x00000000, low:0x00000000, high:0x00000720)
			flash_prepare(0x00000000)
			flash_write(0x00000000): 0x00000000 <- 1024
			flash_write(0x00000000): 0x00000400 <- 1024
			flash_done(0x00000000)
```

##### 2

load binary len:1824 @ 0x0
blocksize = 4096U;
writesize = 4096U;

```
Flash Erase 00000000 00001000
	flash_prepare(0x00000000)
		flash_erase(0x00000000): 0x00000000 <- 4096
	flash_done(0x00000000)
Flash Write 00000000 000003E0
	flash_buffered_write(f:0x00000000, dest:0x00000000, src:0x898534ce, len:992)
Flash Write 000003E0 00000340
	flash_buffered_write(f:0x00000000, dest:0x000003e0, src:0x898534d0, len:832)
		flash_buffered_flush(f:0x00000000, base:0x00000000, low:0x00000000, high:0x00000720)
			flash_prepare(0x00000000)
				flash_write(0x00000000): 0x00000000 <- 4096
				flash_done(0x00000000)
```

##### 3

load binary len:1824 @ 0x0
blocksize = 4096U;
writesize = 128U;

```
Flash Erase 00000000 00001000
	flash_prepare(0x00000000)
		flash_erase(0x00000000): 0x00000000 <- 4096
	flash_done(0x00000000)
Flash Write 00000000 000003E0
	flash_buffered_write(f:0x00000000, dest:0x00000000, src:0x0b0204ce, len:992)
Flash Write 000003E0 00000340
	flash_buffered_write(f:0x00000000, dest:0x000003e0, src:0x0b0204d0, len:832)
		flash_buffered_flush(f:0x00000000, base:0x00000000, low:0x00000000, high:0x00000720)
			flash_prepare(0x00000000)
			flash_write(0x00000000): 0x00000000 <- 128
			flash_write(0x00000000): 0x00000080 <- 128
			flash_write(0x00000000): 0x00000100 <- 128
			flash_write(0x00000000): 0x00000180 <- 128
			flash_write(0x00000000): 0x00000200 <- 128
			flash_write(0x00000000): 0x00000280 <- 128
			flash_write(0x00000000): 0x00000300 <- 128
			flash_write(0x00000000): 0x00000380 <- 128
			flash_write(0x00000000): 0x00000400 <- 128
			flash_write(0x00000000): 0x00000480 <- 128
			flash_write(0x00000000): 0x00000500 <- 128
			flash_write(0x00000000): 0x00000580 <- 128
			flash_write(0x00000000): 0x00000600 <- 128
			flash_write(0x00000000): 0x00000680 <- 128
			flash_write(0x00000000): 0x00000700 <- 128
			flash_done(0x00000000)

```

##### 4

load binary len:323292 @ 0x0
blocksize = 4096U;
writesize = 1024U;

```
No. Att Driver
 1      Fake Target Flux capacitor core
(gdb) at 1
Attaching to Remote target
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
0x0000c9b4 in ?? ()
(gdb) load bridge-pro-large.elf 
Loading section .text, size 0x4dcf0 lma 0x0
Loading section .ARM.exidx, size 0x8 lma 0x4dcf0
Loading section .data, size 0x11e4 lma 0x4dcf8
Start address 0x0000c9b4, load size 323292
Transfer rate: 617 KB/sec, 973 bytes/write.
```

```
...
...
...
Flash Write 0004B070 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004b070, src:0x2f5684d2, len:992)
Flash Write 0004B450 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004b450, src:0x2f5684d2, len:992)
Flash Write 0004B830 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004b830, src:0x2f5684d2, len:992)
Flash Write 0004BC10 000003D0
	flash_buffered_write(f:0x00000000, dest:0x0004bc10, src:0x2f5684d2, len:976)
Flash Write 0004BFE0 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004bfe0, src:0x2f5684d2, len:992)
		flash_buffered_flush(f:0x00000000, base:0x0004b000, low:0x0004b000, high:0x0004c000)
			flash_write(0x00000000): 0x0004b000 <- 1024
			flash_write(0x00000000): 0x0004b400 <- 1024
			flash_write(0x00000000): 0x0004b800 <- 1024
			flash_write(0x00000000): 0x0004bc00 <- 1024
Flash Write 0004C3C0 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004c3c0, src:0x2f5684d2, len:992)
Flash Write 0004C7A0 000003D0
	flash_buffered_write(f:0x00000000, dest:0x0004c7a0, src:0x2f5684d2, len:976)
Flash Write 0004CB70 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004cb70, src:0x2f5684d2, len:992)
Flash Write 0004CF50 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004cf50, src:0x2f5684d2, len:992)
		flash_buffered_flush(f:0x00000000, base:0x0004c000, low:0x0004c000, high:0x0004d000)
			flash_write(0x00000000): 0x0004c000 <- 1024
			flash_write(0x00000000): 0x0004c400 <- 1024
			flash_write(0x00000000): 0x0004c800 <- 1024
			flash_write(0x00000000): 0x0004cc00 <- 1024
Flash Write 0004D330 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004d330, src:0x2f5684d2, len:992)
Flash Write 0004D710 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004d710, src:0x2f5684d2, len:992)
Flash Write 0004DAF0 00000200
	flash_buffered_write(f:0x00000000, dest:0x0004daf0, src:0x2f5684d2, len:512)
Flash Write 0004DCF0 00000008
	flash_buffered_write(f:0x00000000, dest:0x0004dcf0, src:0x2f5684d2, len:8)
Flash Write 0004DCF8 000003D8
	flash_buffered_write(f:0x00000000, dest:0x0004dcf8, src:0x2f5684d2, len:984)
		flash_buffered_flush(f:0x00000000, base:0x0004d000, low:0x0004d000, high:0x0004e000)
			flash_write(0x00000000): 0x0004d000 <- 1024
			flash_write(0x00000000): 0x0004d400 <- 1024
			flash_write(0x00000000): 0x0004d800 <- 1024
			flash_write(0x00000000): 0x0004dc00 <- 1024
Flash Write 0004E0D0 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004e0d0, src:0x2f5684d2, len:992)
Flash Write 0004E4B0 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004e4b0, src:0x2f5684d2, len:992)
Flash Write 0004E890 000003E0
	flash_buffered_write(f:0x00000000, dest:0x0004e890, src:0x2f5684d2, len:992)
Flash Write 0004EC70 0000026C
	flash_buffered_write(f:0x00000000, dest:0x0004ec70, src:0x2f5684d2, len:620)
		flash_buffered_flush(f:0x00000000, base:0x0004e000, low:0x0004e000, high:0x0004eedc)
			flash_write(0x00000000): 0x0004e000 <- 1024
			flash_write(0x00000000): 0x0004e400 <- 1024
			flash_write(0x00000000): 0x0004e800 <- 1024
			flash_write(0x00000000): 0x0004ec00 <- 1024
	flash_done(0x00000000)
```

##### 5

load binary len:1362 @ 0xffc00
(missaligned by -1024 at flash boundry)
blocksize = 4096U;
writesize = 1024U;

```
Flash Erase 000FF000 00002000
	flash_prepare(0x00000000)
		flash_erase(0x00000000): 0x000ff000 <- 4096
	flash_done(0x00000000)
	flash_prepare(0x00100000)
		flash_erase(0x00100000): 0x00100000 <- 4096
	flash_done(0x00100000)
Flash Write 000FFC00 000003E0
	flash_buffered_write(f:0x00000000, dest:0x000ffc00, src:0x521954d2, len:992)
Flash Write 000FFFE0 00000020
	flash_buffered_write(f:0x00000000, dest:0x000fffe0, src:0x521954d2, len:32)
		flash_buffered_flush(f:0x00000000, base:0x000ff000, low:0x000ffc00, high:0x00100000)
			flash_prepare(0x00000000)
			flash_write(0x00000000): 0x000ffc00 <- 1024
			flash_done(0x00000000)
Flash Write 00100000 00000152
	flash_buffered_write(f:0x00100000, dest:0x00100000, src:0x521954d3, len:338)
		flash_buffered_flush(f:0x00100000, base:0x00100000, low:0x00100000, high:0x00100152)
			flash_prepare(0x00100000)
			flash_write(0x00100000): 0x00100000 <- 1024
			flash_done(0x00100000)
```

##### 6

load binary len:1362 @ 0xffe00
(missaligned by -512 at flash boundry)
blocksize = 4096U;
writesize = 1024U;
```
Flash Erase 000FF000 00002000
	flash_prepare(0x00000000)
		flash_erase(0x00000000): 0x000ff000 <- 4096
	flash_done(0x00000000)
	flash_prepare(0x00100000)
		flash_erase(0x00100000): 0x00100000 <- 4096
	flash_done(0x00100000)
Flash Write 000FFE00 00000200
	flash_buffered_write(f:0x00000000, dest:0x000ffe00, src:0x93d374d2, len:512)
		flash_buffered_flush(f:0x00000000, base:0x000ff000, low:0x000ffe00, high:0x00100000)
			flash_prepare(0x00000000)
			flash_write(0x00000000): 0x000ffc00 <- 1024
			flash_done(0x00000000)
Flash Write 00100000 00000352
	flash_buffered_write(f:0x00100000, dest:0x00100000, src:0x93d374d3, len:850)
		flash_buffered_flush(f:0x00100000, base:0x00100000, low:0x00100000, high:0x00100352)
			flash_prepare(0x00100000)
			flash_write(0x00100000): 0x00100000 <- 1024
			flash_done(0x00100000)
```

##### 7

load binary len:1362 @ 0xffe03
(missaligned by -509 at flash boundry)
blocksize = 4096U;
writesize = 1024U;
```
Flash Erase 000FF000 00002000
	flash_prepare(0x00000000)
		flash_erase(0x00000000): 0x000ff000 <- 4096
	flash_done(0x00000000)
	flash_prepare(0x00100000)
		flash_erase(0x00100000): 0x00100000 <- 4096
	flash_done(0x00100000)
Flash Write 000FFE03 000001FD
	flash_buffered_write(f:0x00000000, dest:0x000ffe03, src:0x93d374d2, len:509)
		flash_buffered_flush(f:0x00000000, base:0x000ff000, low:0x000ffe03, high:0x00100000)
			flash_prepare(0x00000000)
			flash_write(0x00000000): 0x000ffc00 <- 1024
			flash_done(0x00000000)
Flash Write 00100000 00000355
	flash_buffered_write(f:0x00100000, dest:0x00100000, src:0x93d374d3, len:853)
		flash_buffered_flush(f:0x00100000, base:0x00100000, low:0x00100000, high:0x00100355)
			flash_prepare(0x00100000)
			flash_write(0x00100000): 0x00100000 <- 1024
			flash_done(0x00100000)
```

### Buffer content test

load binary len:1248 @ 0xffe03
(missaligned by -509 at flash boundry)
blocksize = 4096U;
writesize = 1024U;
```
Flash Erase 000FF000 00002000
	flash_prepare(0x00000000)
		flash_erase(0x00000000): 0x000ff000 <- 4096
	flash_done(0x00000000)
	flash_prepare(0x00100000)
		flash_erase(0x00100000): 0x00100000 <- 4096
	flash_done(0x00100000)
Flash Write 000FFE03 000001FD
	flash_buffered_write(f:0x00000000, dest:0x000ffe03, src:0xccc5d4d2, len:509)
		flash_prepare(0x00000000)
		flash_write(0x00000000): 0x000ffc00 <- 1024:  FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
		flash_done(0x00000000)
Flash Write 00100000 000002E3
	flash_buffered_write(f:0x00100000, dest:0x00100000, src:0xccc5d4d3, len:739)
		flash_prepare(0x00100000)
		flash_write(0x00100000): 0x00100000 <- 1024:  30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
		flash_done(0x00100000)
```
