### PR TITLE
Cleanup include guards.

### DIFF
--- a/src/gdb_hostio.h
+++ b/src/gdb_hostio.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __GDB_SYSCALLS_H
-#define __GDB_SYSCALLS_H
+
+#ifndef GDB_HOSTIO_H
+#define GDB_HOSTIO_H
 
 #include "target.h"
 
@@ -49,5 +50,4 @@ int hostio_isatty(struct target_controller *, int fd);
 int hostio_system(struct target_controller *,
 	           target_addr cmd, size_t cmd_len);
 
-#endif
-
+#endif /* GDB_HOSTIO_H */

--- a/src/include/command.h
+++ b/src/include/command.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __COMMAND_H
-#define __COMMAND_H
+#ifndef INCLUDE_COMMAND_H
+#define INCLUDE_COMMAND_H
 
 #include <stdbool.h>
 
@@ -35,5 +35,4 @@ int command_process(target *t, char *cmd);
  */
 bool parse_enable_or_disable(const char *s, bool *out);
 
-#endif
-
+#endif /* INCLUDE_COMMAND_H */

--- a/src/include/crc32.h
+++ b/src/include/crc32.h
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __CRC32_H
-#define __CRC32_H
+#ifndef INCLUDE_CRC32_H
+#define INCLUDE_CRC32_H
 
 int generic_crc32(target *t, uint32_t *crc, uint32_t base, int len);
 
-#endif
+#endif /* INCLUDE_CRC32_H */

--- a/src/include/exception.h
+++ b/src/include/exception.h
@@ -39,8 +39,8 @@
  * Can't use break, return, goto, etc from inside the TRY_CATCH block.
  */
 
-#ifndef __EXCEPTION_H
-#define __EXCEPTION_H
+#ifndef INCLUDE_EXCEPTION_H
+#define INCLUDE_EXCEPTION_H
 
 #include <setjmp.h>
 #include <stdint.h>
@@ -70,5 +70,4 @@ extern struct exception *innermost_exception;
 
 void raise_exception(uint32_t type, const char *msg);
 
-#endif
-
+#endif /* INCLUDE_EXCEPTION_H */

--- a/src/include/gdb_if.h
+++ b/src/include/gdb_if.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __GDB_IF_H
-#define __GDB_IF_H
+#ifndef INCLUDE_GDB_IF_H
+#define INCLUDE_GDB_IF_H
 
 #if PC_HOSTED == 0
 #include <libopencm3/usb/usbd.h>
@@ -33,5 +33,4 @@ unsigned char gdb_if_getchar_to(int timeout);
 /* sending gdb_if_putchar(0, true) seems to work as keep alive */
 void gdb_if_putchar(unsigned char c, int flush);
 
-#endif
-
+#endif /* INCLUDE_GDB_IF_H */

--- a/src/include/gdb_main.h
+++ b/src/include/gdb_main.h
@@ -18,10 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __GDB_MAIN_H
-#define __GDB_MAIN_H
+#ifndef INCLUDE_GDB_MAIN_H
+#define INCLUDE_GDB_MAIN_H
 
 void gdb_main(void);
 
-#endif
-
+#endif /* INCLUDE_GDB_MAIN_H */

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __GDB_PACKET_H
-#define __GDB_PACKET_H
+#ifndef INCLUDE_GDB_PACKET_H
+#define INCLUDE_GDB_PACKET_H
 
 #include <stddef.h>
 #include <stdarg.h>
@@ -36,4 +36,4 @@ void gdb_out(const char *buf);
 void gdb_voutf(const char *fmt, va_list);
 void gdb_outf(const char *fmt, ...);
 
-#endif
+#endif /* INCLUDE_GDB_PACKET_H */

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __GENERAL_H
-#define __GENERAL_H
+#ifndef INCLUDE_GENERAL_H
+#define INCLUDE_GENERAL_H
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -175,4 +175,4 @@ static inline void DEBUG_WIRE(const char *format, ...)
 #define SYSTICKMS (1000 / SYSTICKHZ)
 #define MORSECNT ((SYSTICKHZ / 10) - 1)
 
-#endif
+#endif /* INCLUDE_GENERAL_H */

--- a/src/include/hex_utils.h
+++ b/src/include/hex_utils.h
@@ -18,11 +18,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __HEX_UTILS_H
-#define __HEX_UTILS_H
+#ifndef INCLUDE_HEX_UTILS_H
+#define INCLUDE_HEX_UTILS_H
 
 char * hexify(char *hex, const void *buf, size_t size);
 char * unhexify(void *buf, const char *hex, size_t size);
 
-#endif
-
+#endif /* INCLUDE_HEX_UTILS_H */

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __JTAGTAP_H
-#define __JTAGTAP_H
+#ifndef INCLUDE_JTAGTAP_H
+#define INCLUDE_JTAGTAP_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -79,4 +79,4 @@ int platform_jtagtap_init(void);
 int jtagtap_init(void);
 #endif
 
-#endif /*__JTAGTAP_H*/
+#endif /* INCLUDE_JTAGTAP_H */

--- a/src/include/morse.h
+++ b/src/include/morse.h
@@ -18,13 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __MORSE_H
-#define __MORSE_H
+#ifndef INCLUDE_MORSE_H
+#define INCLUDE_MORSE_H
 
 extern const char *morse_msg;
 
 void morse(const char *msg, char repeat);
 bool morse_update(void);
 
-#endif
-
+#endif /* INCLUDE_MORSE_H */

--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -17,10 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __PLATFORM_SUPPORT_H
-#define __PLATFORM_SUPPORT_H
+#ifndef INCLUDE_PLATFORM_SUPPORT_H
+#define INCLUDE_PLATFORM_SUPPORT_H
 
-#ifndef __GENERAL_H
+#ifndef INCLUDE_GENERAL_H
 #	error "Include 'general.h' instead"
 #endif
 
@@ -52,4 +52,4 @@ uint32_t platform_max_frequency_get(void);
 
 void platform_target_clk_output_enable(bool enable);
 
-#endif
+#endif /* INCLUDE_PLATFORM_SUPPORT_H */

--- a/src/include/rtt.h
+++ b/src/include/rtt.h
@@ -24,8 +24,8 @@
  * SOFTWARE.
  */
 
-#ifndef RTT_H
-#define RTT_H
+#ifndef INCLUDE_RTT_H
+#define INCLUDE_RTT_H
 #include <target.h>
 
 #define MAX_RTT_CHAN 16
@@ -57,4 +57,5 @@ extern struct rtt_channel_struct rtt_channel[MAX_RTT_CHAN];
 // true if target memory access does not work when target running
 bool target_no_background_memory_access(target *cur_target);
 void poll_rtt(target *cur_target);
-#endif
+
+#endif /* INCLUDE_RTT_H */

--- a/src/include/rtt_if.h
+++ b/src/include/rtt_if.h
@@ -24,8 +24,9 @@
  * SOFTWARE.
  */
 
-#ifndef RTT_IF_H
-#define RTT_IF_H
+#ifndef INCLUDE_RTT_IF_H
+#define INCLUDE_RTT_IF_H
+
 /* rtt i/o to terminal */
 
 /* default buffer sizes, 8 bytes added to up buffer for alignment and padding */
@@ -59,4 +60,4 @@ int32_t rtt_getchar();
 /* host to target: true if no characters available for reading */
 bool rtt_nodata();
 
-#endif
+#endif /* INCLUDE_RTT_IF_H */

--- a/src/include/serialno.h
+++ b/src/include/serialno.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __SERIALNO_H
-#define __SERIALNO_H
+
+#ifndef INCLUDE_SERIALNO_H
+#define INCLUDE_SERIALNO_H
 
 #ifndef DFU_SERIAL_LENGTH
 #define DFU_SERIAL_LENGTH
@@ -28,4 +29,4 @@ extern char serial_no[DFU_SERIAL_LENGTH];
 
 void read_serial_number(void);
 
-#endif
+#endif /* INCLUDE_SERIALNO_H */

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -22,8 +22,8 @@
  * implemented by a target driver when a supported device is detected.
  */
 
-#ifndef __TARGET_H
-#define __TARGET_H
+#ifndef INCLUDE_TARGET_H
+#define INCLUDE_TARGET_H
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -178,4 +178,4 @@ struct target_controller {
 	bool interrupted;
 };
 
-#endif
+#endif /* INCLUDE_TARGET_H */

--- a/src/include/timing.h
+++ b/src/include/timing.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __TIMING_H
-#define __TIMING_H
+
+#ifndef INCULUDE_TIMING_H
+#define INCULUDE_TIMING_H
 
 struct platform_timeout {
 	uint32_t time;
@@ -27,4 +28,4 @@ struct platform_timeout {
 extern int32_t swj_delay_cnt;
 uint32_t platform_time_ms(void);
 
-#endif /* __TIMING_H */
+#endif /* INCULUDE_TIMING_H */

--- a/src/platforms/96b_carbon/platform.h
+++ b/src/platforms/96b_carbon/platform.h
@@ -21,8 +21,9 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+
+#ifndef PLATFORMS_96B_CARBON_PLATFORM_H
+#define PLATFORMS_96B_CARBON_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -161,4 +162,4 @@ static inline int platform_hwversion(void)
 #define vasprintf vasiprintf
 #define snprintf sniprintf
 
-#endif
+#endif /* PLATFORMS_96B_CARBON_PLATFORM_H */

--- a/src/platforms/blackpillv2/platform.h
+++ b/src/platforms/blackpillv2/platform.h
@@ -21,8 +21,9 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+
+#ifndef PLATFORMS_BLACKPILLV2_PLATFORM_H
+#define PLATFORMS_BLACKPILLV2_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -191,4 +192,4 @@ static inline int platform_hwversion(void)
 #define snprintf sniprintf
 #endif
 
-#endif
+#endif /* PLATFORMS_BLACKPILLV2_PLATFORM_H */

--- a/src/platforms/common/aux_serial.h
+++ b/src/platforms/common/aux_serial.h
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef AUX_SERIAL_H
-#define AUX_SERIAL_H
+#ifndef PLATFORMS_COMMON_AUX_SERIAL_H
+#define PLATFORMS_COMMON_AUX_SERIAL_H
 
 #include <stddef.h>
 #include <libopencm3/usb/usbd.h>
@@ -71,4 +71,4 @@ void aux_serial_stage_debug_buffer(void);
 void aux_serial_stage_receive_buffer(void);
 #endif
 
-#endif /*AUX_SERIAL_H*/
+#endif /* PLATFORMS_COMMON_AUX_SERIAL_H */

--- a/src/platforms/common/traceswo.h
+++ b/src/platforms/common/traceswo.h
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __TRACESWO_H
-#define __TRACESWO_H
+#ifndef PLATFORMS_COMMON_TRACESWO_H
+#define PLATFORMS_COMMON_TRACESWO_H
 
 #include <libopencm3/usb/usbd.h>
 
@@ -39,4 +39,4 @@ void traceswo_setmask(uint32_t mask);
 uint16_t traceswo_decode(usbd_device *usbd_dev, uint8_t addr,
 				const void *buf, uint16_t len);
 
-#endif
+#endif /* PLATFORMS_COMMON_TRACESWO_H */

--- a/src/platforms/common/usb.h
+++ b/src/platforms/common/usb.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef USB_H
-#define USB_H
+#ifndef PLATFORMS_COMMON_USB_H
+#define PLATFORMS_COMMON_USB_H
 
 #include <stdint.h>
 #include <libopencm3/usb/usbd.h>
@@ -48,4 +48,4 @@ void blackmagic_usb_init(void);
 /* Returns current usb configuration, or 0 if not configured. */
 uint16_t usb_get_config(void);
 
-#endif /*USB_H*/
+#endif /* PLATFORMS_COMMON_USB_H */

--- a/src/platforms/common/usb_descriptors.h
+++ b/src/platforms/common/usb_descriptors.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef USB_DESCRIPTORS_H
-#define USB_DESCRIPTORS_H
+#ifndef PLATFORMS_COMMON_USB_DESCRIPTORS_H
+#define PLATFORMS_COMMON_USB_DESCRIPTORS_H
 
 #include <libopencm3/usb/usbd.h>
 #include <libopencm3/usb/cdc.h>
@@ -411,4 +411,4 @@ static const char *const usb_strings[] = {
 #endif
 };
 
-#endif /*USB_DESCRIPTORS_H*/
+#endif /* PLATFORMS_COMMON_USB_DESCRIPTORS_H */

--- a/src/platforms/common/usb_dfu_stub.h
+++ b/src/platforms/common/usb_dfu_stub.h
@@ -18,11 +18,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef USB_DFU_STUB_H
-#define USB_DFU_STUB_H
+#ifndef PLATFORMS_COMMON_USB_DFU_STUB_H
+#define PLATFORMS_COMMON_USB_DFU_STUB_H
 
 #include "usb.h"
 
 void dfu_set_config(usbd_device *dev, uint16_t value);
 
-#endif /*USB_DFU_STUB_H*/
+#endif /* PLATFORMS_COMMON_USB_DFU_STUB_H */

--- a/src/platforms/common/usb_serial.h
+++ b/src/platforms/common/usb_serial.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef USB_SERIAL_H
-#define USB_SERIAL_H
+#ifndef PLATFORMS_COMMON_USB_SERIAL_H
+#define PLATFORMS_COMMON_USB_SERIAL_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -36,4 +36,4 @@ uint32_t debug_serial_fifo_send(const char *fifo, uint32_t fifo_begin, uint32_t 
 void debug_serial_receive_callback(usbd_device *dev, uint8_t ep);
 #endif
 
-#endif /*USB_SERIAL_H*/
+#endif /* PLATFORMS_COMMON_USB_SERIAL_H */

--- a/src/platforms/f072/platform.h
+++ b/src/platforms/f072/platform.h
@@ -20,8 +20,8 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+#ifndef PLATFORMS_F072_PLATFORM_H
+#define PLATFORMS_F072_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -158,4 +158,4 @@ static inline int platform_hwversion(void)
 #define vasprintf vasiprintf
 #define snprintf sniprintf
 
-#endif
+#endif /* PLATFORMS_F072_PLATFORM_H */

--- a/src/platforms/f3/platform.h
+++ b/src/platforms/f3/platform.h
@@ -20,8 +20,9 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+
+#ifndef PLATFORMS_F3_PLATFORM_H
+#define PLATFORMS_F3_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -153,4 +154,4 @@ static inline int platform_hwversion(void)
 #define vasprintf vasiprintf
 #define snprintf sniprintf
 
-#endif
+#endif /* PLATFORMS_F3_PLATFORM_H */

--- a/src/platforms/f4discovery/platform.h
+++ b/src/platforms/f4discovery/platform.h
@@ -21,8 +21,9 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+
+#ifndef PLATFORMS_F4DISCOVERY_PLATFORM_H
+#define PLATFORMS_F4DISCOVERY_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -191,4 +192,4 @@ static inline int platform_hwversion(void)
 #define snprintf sniprintf
 #endif
 
-#endif
+#endif /* PLATFORMS_F4DISCOVERY_PLATFORM_H */

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -32,8 +32,8 @@
  * SUCH DAMAGE.
  */
 
-#if !defined(__BMP_LIBUSB_H)
-#define      __BMP_LIBUSB_H
+#ifndef PLATFORMS_HOSTED_BMP_HOSTED_H
+#define PLATFORMS_HOSTED_BMP_HOSTED_H
 
 #include "cli.h"
 
@@ -91,4 +91,4 @@ void libusb_exit_function(bmp_info_t *info);
 #define PRINT_INFO(fmt, ...) printf((fmt), ##__VA_ARGS__)
 #endif
 
-#endif
+#endif /* PLATFORMS_HOSTED_BMP_HOSTED_H */

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -16,8 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __BMP_REMOTE_H_
-#define __BMP_REMOTE_H_
+
+#ifndef PLATFORMS_HOSTED_BMP_REMOTE_H_
+#define PLATFORMS_HOSTED_BMP_REMOTE_H_
 
 #include "jtagtap.h"
 #include "adiv5.h"
@@ -44,4 +45,4 @@ void remote_target_clk_output_enable(bool enable);
 void remote_adiv5_dp_defaults(ADIv5_DP_t *dp);
 void remote_add_jtag_dev(uint32_t i, const jtag_dev_t *jtag_dev);
 
-#endif /*__BMP_REMOTE_H_*/
+#endif /* PLATFORMS_HOSTED_BMP_REMOTE_H */

--- a/src/platforms/hosted/cli.h
+++ b/src/platforms/hosted/cli.h
@@ -21,8 +21,8 @@
 /* This file implements the interface to command line command for PC-Hosted
  * platforms.
  */
-#if !defined(__CLI_H)
-#define __CLI_H
+#ifndef PLATFORMS_HOSTED_CLI_H
+#define PLATFORMS_HOSTED_CLI_H
 
 #include "cortexm.h"
 
@@ -73,4 +73,5 @@ void cl_init(BMP_CL_OPTIONS_t *opt, int argc, char **argv);
 int cl_execute(BMP_CL_OPTIONS_t *opt);
 int serial_open(BMP_CL_OPTIONS_t *opt, char *serial);
 void serial_close(void);
-#endif
+
+#endif /* PLATFORMS_HOSTED_CLI_H */

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -16,8 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
-#if !defined(__CMSIS_DAP_H_)
-#define __CMSIS_DAP_H_
+
+#ifndef PLATFORMS_HOSTED_CMSIS_DAP_H
+#define PLATFORMS_HOSTED_CMSIS_DAP_H
 
 #include "adiv5.h"
 #include "cli.h"
@@ -53,4 +54,4 @@ void dap_nrst_set_val(bool assert) { }
 
 #endif
 
-#endif
+#endif /* PLATFORMS_HOSTED_CMSIS_DAP_H */

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -26,8 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _DAP_H_
-#define _DAP_H_
+#ifndef PLATFORMS_HOSTED_DAP_H
+#define PLATFORMS_HOSTED_DAP_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -86,4 +86,4 @@ int dap_jtag_configure(void);
 void dap_swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 void dap_swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
-#endif // _DAP_H_
+#endif /* PLATFORMS_HOSTED_DAP_H */

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -19,8 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __FTDI_BMP_H
-#define __FTDI_BMP_H
+#ifndef PLATFORMS_HOSTED_FTDI_BMP_H
+#define PLATFORMS_HOSTED_FTDI_BMP_H
 
 #include "cli.h"
 #include "jtagtap.h"
@@ -151,4 +151,5 @@ bool libftdi_nrst_get_val(void);
 #define PIN5     0x20
 #define PIN6     0x40
 #define PIN7     0x80
-#endif
+
+#endif /* PLATFORMS_HOSTED_FTDI_BMP_H */

--- a/src/platforms/hosted/jlink.h
+++ b/src/platforms/hosted/jlink.h
@@ -16,8 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
-#if !defined(__JLINK_H_)
-#define __JLINK_H_
+
+#ifndef PLATFORMS_HOSTED_JLINK_H
+#define PLATFORMS_HOSTED_JLINK_H
 
 #include "bmp_hosted.h"
 #include "jtagtap.h"
@@ -105,4 +106,5 @@ bool jlink_nrst_get_val(bmp_info_t *info);
 void jlink_max_frequency_set(bmp_info_t *info, uint32_t freq);
 uint32_t jlink_max_frequency_get(bmp_info_t *info);
 #endif
-#endif
+
+#endif /* PLATFORMS_HOSTED_JLINK_H */

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -32,8 +32,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+#ifndef PLATFORMS_HOSTED_PLATFORM_H
+#define PLATFORMS_HOSTED_PLATFORM_H
 
 #include "timing.h"
 
@@ -75,4 +75,5 @@ typedef enum bmp_type_e {
 } bmp_type_t;
 
 void gdb_ident(char *p, int count);
-#endif
+
+#endif /* PLATFORMS_HOSTED_PLATFORM_H */

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -16,7 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
  */
-#if !defined(__STLINKV2_H_)
+
+#ifndef PLATFORMS_HOSTED_STLINKV2_H
+#define PLATFORMS_HOSTED_STLINKV2_H
 
 #define STLINK_ERROR_FAIL -1
 #define STLINK_ERROR_OK 0
@@ -54,4 +56,5 @@ void stlink_exit_function(bmp_info_t *info);
 void stlink_max_frequency_set(bmp_info_t *info, uint32_t freq);
 uint32_t stlink_max_frequency_get(bmp_info_t *info);
 #endif
-#endif
+
+#endif /* PLATFORMS_HOSTED_STLINKV2_H */

--- a/src/platforms/hydrabus/platform.h
+++ b/src/platforms/hydrabus/platform.h
@@ -22,8 +22,8 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+#ifndef PLATFORMS_HYDRABUS_PLATFORM_H
+#define PLATFORMS_HYDRABUS_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -189,4 +189,4 @@ static inline int platform_hwversion(void)
 #define snprintf sniprintf
 #endif
 
-#endif
+#endif /* PLATFORMS_HYDRABUS_PLATFORM_H */

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+#ifndef PLATFORMS_LAUNCHPAD_ICDI_PLATFORM_H
+#define PLATFORMS_LAUNCHPAD_ICDI_PLATFORM_H
 
 #include <libopencm3/lm4f/gpio.h>
 #include <libopencm3/usb/usbd.h>
@@ -114,4 +114,4 @@ inline static uint8_t gpio_get(uint32_t port, uint8_t pin) {
 
 static inline int platform_hwversion(void) { return 0; }
 
-#endif
+#endif /* PLATFORMS_LAUNCHPAD_ICDI_PLATFORM_H */

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -21,8 +21,9 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+
+#ifndef PLATFORMS_NATIVE_PLATFORM_H
+#define PLATFORMS_NATIVE_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -309,4 +310,4 @@ extern bool debug_bmp;
 #define snprintf sniprintf
 #endif
 
-#endif
+#endif /* PLATFORMS_NATIVE_PLATFORM_H */

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -21,8 +21,9 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+
+#ifndef PLATFORMS_STLINK_PLATFORM_H
+#define PLATFORMS_STLINK_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -187,4 +188,4 @@ extern uint32_t detect_rev(void);
 #define snprintf sniprintf
 #endif
 
-#endif
+#endif /* PLATFORMS_STLINK_PLATFORM_H */

--- a/src/platforms/stm32/gpio.h
+++ b/src/platforms/stm32/gpio.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __GPIO_H
-#define __GPIO_H
+
+#ifndef PLATFORMS_STM32_GPIO_H
+#define PLATFORMS_STM32_GPIO_H
 
 #include <libopencm3/cm3/common.h>
 
@@ -66,5 +67,4 @@ static inline uint16_t _gpio_get(uint32_t gpioport, uint16_t gpios)
 #define gpio_get _gpio_get
 #endif
 
-#endif
-
+#endif /* PLATFORMS_STM32_GPIO_H */

--- a/src/platforms/stm32/timing_stm32.h
+++ b/src/platforms/stm32/timing_stm32.h
@@ -16,13 +16,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __TIMING_STM32_H
-#define __TIMING_STM32_H
+
+#ifndef PLATFORMS_STM32_TIMING_STM32_H
+#define PLATFORMS_STM32_TIMING_STM32_H
 
 extern uint32_t swd_delay_cnt;
 extern uint8_t running_status;
 
 void platform_timing_init(void);
 
-#endif
-
+#endif /* PLATFORMS_STM32_TIMING_STM32_H */

--- a/src/platforms/stm32/usbdfu.h
+++ b/src/platforms/stm32/usbdfu.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __USBDFU_H
-#define __USBDFU_H
+#ifndef PLATFORMS_STM32_USBDFU_H
+#define PLATFORMS_STM32_USBDFU_H
 
 #include <libopencm3/usb/usbd.h>
 
@@ -42,4 +42,4 @@ void dfu_event(void);
 /* Platform specific function */
 void dfu_detach(void);
 
-#endif /* __USBDFU_H */
+#endif /* PLATFORMS_STM32_USBDFU_H */

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -22,8 +22,8 @@
 /* This file implements the platform specific functions for the STM32
  * implementation.
  */
-#ifndef __PLATFORM_H
-#define __PLATFORM_H
+#ifndef PLATFORMS_SWLINK_PLATFORM_H
+#define PLATFORMS_SWLINK_PLATFORM_H
 
 #include "gpio.h"
 #include "timing.h"
@@ -187,4 +187,4 @@ extern uint8_t detect_rev(void);
 #define snprintf sniprintf
 #endif
 
-#endif
+#endif /* PLATFORMS_SWLINK_PLATFORM_H */

--- a/src/remote.h
+++ b/src/remote.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _REMOTE_
-#define _REMOTE_
+#ifndef REMOTE_H
+#define REMOTE_H
 
 #include <inttypes.h>
 #include "general.h"
@@ -286,4 +286,4 @@
 uint64_t remotehston(uint32_t limit, const char *s);
 void remotePacketProcess(unsigned int i, char *packet);
 
-#endif
+#endif /* REMOTE_H */

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __ADIV5_H
-#define __ADIV5_H
+#ifndef TARGET_ADIV5_H
+#define TARGET_ADIV5_H
 
 #include "jtag_scan.h"
 
@@ -389,4 +389,5 @@ uint32_t firmware_swdp_error(ADIv5_DP_t *dp);
 
 void firmware_swdp_abort(ADIv5_DP_t *dp, uint32_t abort);
 void adiv5_jtagdp_abort(ADIv5_DP_t *dp, uint32_t abort);
-#endif
+
+#endif /* TARGET_ADIV5_H */

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -16,8 +16,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __CORTEXM_H
-#define __CORTEXM_H
+
+#ifndef TARGET_CORTEXM_H
+#define TARGET_CORTEXM_H
 
 #include "target.h"
 #include "adiv5.h"
@@ -192,4 +193,4 @@ void cortexm_detach(target *t);
 int cortexm_run_stub(target *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3);
 int cortexm_mem_write_sized(target *t, target_addr dest, const void *src, size_t len, enum align align);
 
-#endif
+#endif /* TARGET_CORTEXM_H */

--- a/src/target/flashstub/stub.h
+++ b/src/target/flashstub/stub.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __STUB_H
-#define __STUB_H
+
+#ifndef TARGET_FLASHSTUB_STUB_H
+#define TARGET_FLASHSTUB_STUB_H
 
 static inline void __attribute__((always_inline))
 stub_exit(const int code)
@@ -26,4 +27,4 @@ stub_exit(const int code)
 	__asm__("bkpt %0"::"i"(code));
 }
 
-#endif
+#endif /* TARGET_FLASHSTUB_STUB_H */

--- a/src/target/jtag_devs.h
+++ b/src/target/jtag_devs.h
@@ -18,6 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef TARGET_JTAG_DEVS_H
+#define TARGET_JTAG_DEVS_H
+
 typedef const struct jtag_dev_descr_s {
 	const uint32_t idcode;
 	const uint32_t idmask;
@@ -25,3 +28,5 @@ typedef const struct jtag_dev_descr_s {
 	void (*const handler)(uint8_t jd_index);
 } jtag_dev_descr_t;
 extern jtag_dev_descr_t dev_descr[];
+
+#endif /* TARGET_JTAG_DEVS_H */

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __JTAG_SCAN_H
-#define __JTAG_SCAN_H
+
+#ifndef TARGET_JTAG_SCAN_H
+#define TARGET_JTAG_SCAN_H
 
 #include <stddef.h>
 #include "jtagtap.h"
@@ -49,4 +50,4 @@ void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
 void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, size_t ticks);
 void jtag_add_device(uint32_t dev_index, const jtag_dev_t *jtag_dev);
 
-#endif /*__JTAG_SCAN_H*/
+#endif /* TARGET_JTAG_SCAN_H */

--- a/src/target/lpc_common.h
+++ b/src/target/lpc_common.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __LPC_COMMON_H
-#define __LPC_COMMON_H
+#ifndef TARGET_LPC_COMMON_H
+#define TARGET_LPC_COMMON_H
 
 enum iap_cmd {
 	IAP_CMD_READ_FACTORY_SETTINGS = 40,
@@ -86,5 +86,4 @@ int lpc_flash_erase(struct target_flash *f, target_addr addr, size_t len);
 int lpc_flash_write_magic_vect(struct target_flash *f,
                                target_addr dest, const void *src, size_t len);
 
-#endif
-
+#endif /* TARGET_LPC_COMMON_H */

--- a/src/target/semihosting.h
+++ b/src/target/semihosting.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __SEMIHOSTING_H
-#define __SEMIHOSTING_H
+#ifndef TARGET_SEMIHOSTING_H
+#define TARGET_SEMIHOSTING_H
 
 /* Semihosting support */
 
@@ -59,4 +59,4 @@
 #define SEMIHOSTING_SYS_WRITEC        0x03U
 #define SEMIHOSTING_SYS_WRITE0        0x04U
 
-#endif /* __SEMIHOSTING_H */
+#endif /* TARGET_SEMIHOSTING_H */

--- a/src/target/sfdp.h
+++ b/src/target/sfdp.h
@@ -31,8 +31,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SFDP_H
-#define SFDP_H
+#ifndef TARGET_SFDP_H
+#define TARGET_SFDP_H
 
 #include <stdint.h>
 #include <stddef.h>
@@ -57,4 +57,4 @@ typedef void (*read_sfdp_func)(target *t, uint32_t address, void *buffer, size_t
 
 bool sfdp_read_parameters(target *t, spi_parameters_s *params, read_sfdp_func sfdp_read);
 
-#endif /*SFDP_H*/
+#endif /* TARGET_SFDP_H */

--- a/src/target/sfdp_internal.h
+++ b/src/target/sfdp_internal.h
@@ -31,8 +31,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SFDP_INTERNAL_H
-#define SFDP_INTERNAL_H
+#ifndef TARGET_SFDP_INTERNAL_H
+#define TARGET_SFDP_INTERNAL_H
 
 #include "sfdp.h"
 
@@ -120,4 +120,4 @@ typedef struct sfdp_basic_parameter_table {
 	uint32_t status_and_addressing_mode;
 } sfdp_basic_parameter_table_s;
 
-#endif /*SFDP_INTERNAL_H*/
+#endif /* TARGET_SFDP_INTERNAL_H */

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TARGET_INTERNAL_H
-#define __TARGET_INTERNAL_H
+#ifndef TARGET_TARGET_INTERNAL_H
+#define TARGET_TARGET_INTERNAL_H
 
 #include "platform_support.h"
 
@@ -191,4 +191,4 @@ int tc_gettimeofday(target *t, target_addr tv, target_addr tz);
 int tc_isatty(target *t, int fd);
 int tc_system(target *t, target_addr cmd, size_t cmdlen);
 
-#endif
+#endif /* TARGET_TARGET_INTERNAL_H */

--- a/src/target/target_probe.h
+++ b/src/target/target_probe.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TARGET_PROBE_H
-#define __TARGET_PROBE_H
+#ifndef TARGET_TARGET_PROBE_H
+#define TARGET_TARGET_PROBE_H
 
 #include "target.h"
 #include "adiv5.h"
@@ -64,4 +64,4 @@ bool msp432_probe(target *t);
 bool ke04_probe(target *t);
 bool rp_probe(target *t);
 
-#endif /* __TARGET_PROBE_H */
+#endif /* TARGET_TARGET_PROBE_H */

--- a/upgrade/bindata.h
+++ b/upgrade/bindata.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __BINDATA_H
-#define __BINDATA_H
+
+#ifndef BINDATA_H
+#define BINDATA_H
 
 #ifndef WIN32
 #define bindatalen _bindatalen
@@ -28,5 +29,4 @@
 extern const uint32_t bindatalen;
 extern const uint8_t bindata[];
 
-#endif
-
+#endif /* BINDATA_H */

--- a/upgrade/dfu.h
+++ b/upgrade/dfu.h
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __DFU_H
-#define __DFU_H
+#ifndef DFU_H
+#define DFU_H
 
 #include <stdint.h>
 
@@ -82,5 +82,4 @@ int dfu_abort(usb_dev_handle *dev, uint16_t iface);
 int dfu_makeidle(usb_dev_handle *dev, uint16_t iface);
 
 
-#endif
-
+#endif /* DFU_H */

--- a/upgrade/stm32mem.h
+++ b/upgrade/stm32mem.h
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef __STM32MEM_H
-#define __STM32MEM_H
+
+#ifndef STM32MEM_H
+#define STM32MEM_H
 
 #ifdef WIN32
 #   include <lusb0_usb.h>
@@ -30,5 +31,4 @@ int stm32_mem_erase(usb_dev_handle *dev, uint16_t iface, uint32_t addr);
 int stm32_mem_write(usb_dev_handle *dev, uint16_t iface, void *data, int size, uint32_t addr);
 int stm32_mem_manifest(usb_dev_handle *dev, uint16_t iface);
 
-#endif
-
+#endif /* STM32MEM_H */


### PR DESCRIPTION

## Detailed description

This PR cleans up and makes all header include guards consistent.

Using underscore prefixes is not allowed for include guards as all
defines starting with underscore are reserved. At the same time made
file ends and spacing and style of include guards consistent in all
headers.

The new style of include guards also includes the directory of the
include file relative to `src` directory to prevent potential future
issues where we might end up with a name clash across directories.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

