### PR TITLE
sam4l: fix debug formatting

### DIFF
--- a/src/target/sam4l.c
+++ b/src/target/sam4l.c
@@ -32,7 +32,7 @@
 /*
  * Flash Controller defines
  */
-#define FLASHCALW_BASE				0x400A0000
+#define FLASHCALW_BASE				UINT32_C(0x400A0000)
 
 /* Flash Control Register */
 #define	FLASHCALW_FCR				(FLASHCALW_BASE + 0x00)
@@ -295,7 +295,8 @@ sam4l_extended_reset(target *t)
 static bool sam4l_flash_command(target *t, uint32_t page, uint32_t cmd)
 {
 	DEBUG_INFO(
-		"\nSAM4L: sam4l_flash_command: FSR: 0x%08" PRIx32 ", page = %lu, command = %lu\n", FLASHCALW_FSR, page, cmd);
+		"\nSAM4L: sam4l_flash_command: FSR: 0x%08" PRIx32
+		", page = %" PRIu32 ", command = %" PRIu32 "\n", FLASHCALW_FSR, page, cmd);
 
 	/* wait for Flash controller ready */
 	platform_timeout timeout;


### PR DESCRIPTION
SAM4L added a DEBUG_INFO command that uses insufficiently-specific formatting.
This breaks compiles on ESP32.

Use specific formatters. Additionally, ensure that FLASHCALW_BASE is
defined as a long int, which allows it to be formatted with "%x".

Signed-off-by: Sean Cross <sean@xobs.io>

<!-- Filling this template is mandatory -->

## Detailed description

This fixes the build for ESP32 by adding more formatting information to sam4l

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do