### PR TITLE
Feature: improved code guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,16 @@ to dip into the commit descriptions as this improves the general Git experience 
 Try to keep commits focused on a single small and atomic change to ease review, and aid the process if we end up having to `git bisect` through your changes, or `git revert` in the extreme case something seriously broke.
 
 We use rebasing to merge pull requests, so please keep this in mind.
+
+## Licensing
+
+When making contributions to existing code, we ask that you update the copyright and authorship notice at
+the top with any authorship information you wish to provide. This is so you get proper attribution.
+The contribution must be made under the existing code's license terms as stated per file.
+
+When making original contributions as new files to the project, this presents a choice on licensing.
+Historically the project uses GPLv3+, however contributions have been made using compatible licensing such
+as MIT and BSD-3-Clause. We would ask that you preferentially choose between GPLv3+ and BSD-3-Clause.
+
+Keep in mind that the resulting binary is GPLv3+ licensed due to how the license is worded, but the individual
+contributions retain their source licensing when considering re-use in other projects.

--- a/HACKING
+++ b/HACKING
@@ -1,1 +1,0 @@
-See https://black-magic.org/hacking/hacking.html

--- a/src/target/HACKING.md
+++ b/src/target/HACKING.md
@@ -52,3 +52,30 @@ notice, and then close the check block at the bottom of the file with a matching
 
 #endif /*PATH_TO_HEADER_H*/
 ```
+
+## typedef and structure, enumeration and union naming
+
+Within the code base you will find all kinds of `struct`s, `enum`s, etc. If you find yourself needing to write
+a new one or modify an existing one, here are the naming rules we expect to see applied when submitting a pull
+request:
+
+* The identifiers used should use lower_snake_case
+* The type's name should not be prefixed or suffixed in any way - for example, if you are writing a structure
+  to hold information on the Flash for the LPC43xx series, name it `lpc43xx_flash`.
+* The type should be `typedef`d as part of its definition with the same name as the bare type, but with a suffix
+  for what kind of definition is being `typedef`d added.
+
+The suffixes expected are `_s` for a `struct`, `_e` for an `enum`, `_u` for a `union`, and `_t` for other
+miscelaneous types.
+
+A complete example for what this looks like is this:
+
+```c
+typedef enum target_halt_reason {
+	/* values */
+} target_halt_reason_e;
+
+typedef struct lpc43xx_flash {
+	/* contents */
+} lpc43xx_flash_s;
+```

--- a/src/target/HACKING.md
+++ b/src/target/HACKING.md
@@ -1,5 +1,11 @@
 # Information and terminology guide
 
+Table of Contents:
+
+* [Reset nomenclature](#reset-nomenclature)
+* [Multiple-inclusion guarding](#multiple-inclusion-guarding)
+* [typedef and structure, enumeration and union naming](#typedef-and-structure-enumeration-and-union-naming)
+
 ## Reset nomenclature
 
 Within this code base, we refer to the physical reset pin of a target device by 'nRST'/'nRESET'.

--- a/src/target/HACKING.md
+++ b/src/target/HACKING.md
@@ -25,3 +25,30 @@ In summary, the following applies:
 
 The upshot of this is that to inhibit physical reset in the ARM ADIv5/Cortex-M code, set
 `CORTEXM_TOPT_INHIBIT_NRST`, which refers to inhibiting the ADIv5 spec 'SRST'.
+
+## Multiple-inclusion guarding
+
+At this time, the project uses include guard macros in headers to prevent multiple-inclusion issues.
+It's simple enough, and it works across platforms and configurations - but how to name the guard macro?
+
+The answer to this question is that you should take the full path to the file, including its name, relative
+to the src/ directory this file is in, and turn that into a capitalised, underscored name - for example:
+
+`src/platforms/common/usb.h` => `PLATFORMS_COMMON_USB_H`
+
+This creates a consistent, standards compliant name for the macro that's unique to that header and so
+free from conflicts. Please check and define it at the top of the header under the copyright and license
+notice, and then close the check block at the bottom of the file with a matching comment like so:
+
+```c
+/*
+ * [copyright notice]
+ */
+
+#ifndef PATH_TO_HEADER_H
+#define PATH_TO_HEADER_H
+
+/* [...] contents here */
+
+#endif /*PATH_TO_HEADER_H*/
+```


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Over the last month or so various conventions and rules have been agreed for the project, but had not been documented to date. This PR rectifies this by writing out things like the `typedef` naming convention as entries in HACKING.md.

This solves a documentation problem which has lead to excess review comments and a slightly more difficult contribution process, which this should ease.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
