### PR TITLE
Fix: SWD timings

### DIFF
--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -71,8 +71,7 @@ static uint32_t swdptap_seq_in_swd_delay(const size_t clock_cycles)
 	uint32_t value = 0;
 	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
 		gpio_clear(SWCLK_PORT, SWCLK_PIN);
-		if (gpio_get(SWDIO_PORT, SWDIO_PIN))
-			value |= (1U << cycle);
+		value |= gpio_get(SWDIO_PORT, SWDIO_PIN) ? 1U << cycle : 0U;
 		for (volatile int32_t cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
 			continue;
 		gpio_set(SWCLK_PORT, SWCLK_PIN);
@@ -89,9 +88,9 @@ static uint32_t swdptap_seq_in_no_delay(const size_t clock_cycles)
 	uint32_t value = 0;
 	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
 		gpio_clear(SWCLK_PORT, SWCLK_PIN);
-		if (gpio_get(SWDIO_PORT, SWDIO_PIN))
-			value |= (1U << cycle);
+		value |= gpio_get(SWDIO_PORT, SWDIO_PIN) ? 1U << cycle : 0U;
 		gpio_set(SWCLK_PORT, SWCLK_PIN);
+		__asm__("nop");
 	}
 	gpio_clear(SWCLK_PORT, SWCLK_PIN);
 	return value;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR seeks to address the SWD reliability issues that have been plaguing BMP for the last couple of releases. It does so by re-timing the SWD routines and attempting to make sure we are as clean about setup-and-hold timings as we reasonably can be. The results speak for themselves we think.

Before:
![image](https://user-images.githubusercontent.com/691140/187553181-9ba3ef63-868a-4c87-86ba-216fbbc94cca.png)

After:
![image](https://user-images.githubusercontent.com/691140/187554530-85bf8d31-d7bf-46fd-abf7-a19d9425eead.png)
![image](https://user-images.githubusercontent.com/691140/187554572-862ccbfc-3f3e-4328-921f-14a5af9927ce.png)

The provided screenshots represent the same area of BMP's transactions with a STM32F411 for both cases.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
