### PR TITLE
cortexm: fix printf format for cpuid_partno

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -526,7 +526,7 @@ static void cortexm_read_cpuid(target *const t, const ADIv5_AP_t *const ap)
 		break;
 	default:
 		if (ap->designer_code != JEP106_MANUFACTURER_ATMEL) /* Protected Atmel device?*/
-			DEBUG_WARN("Unexpected Cortex-M CPU partno %04" PRIx32 "\n", cpuid_partno);
+			DEBUG_WARN("Unexpected Cortex-M CPU partno %04x\n", cpuid_partno);
 	}
 	DEBUG_INFO("CPUID 0x%08" PRIx32 " (%s var %" PRIx32 " rev %" PRIx32 ")\n", t->cpuid, t->core,
 		(t->cpuid & CPUID_REVISION_MASK) >> 20, t->cpuid & CPUID_PATCH_MASK);


### PR DESCRIPTION
## Detailed description

Fix build on ESP32

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do