### PR TITLE
rp: invert success logic in rp_flash_write

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -461,7 +461,7 @@ static bool rp_flash_write(target_flash_s *f, target_addr_t dest, const void *sr
 	rp_priv_s *ps = (rp_priv_s *)t->target_storage;
 	/* Write payload to target ram */
 	rp_flash_prepare(t);
-	bool ret = 0;
+	bool ret = true;
 #define MAX_WRITE_CHUNK 0x1000
 	while (len) {
 		uint32_t chunksize = (len <= MAX_WRITE_CHUNK) ? len : MAX_WRITE_CHUNK;
@@ -474,8 +474,8 @@ static bool rp_flash_write(target_flash_s *f, target_addr_t dest, const void *sr
 		 * however it takes much longer if the XOSC is not enabled
 		 * so lets give ourselves a little bit more time (x10)
 		 */
-		ret |= rp_rom_call(t, ps->regs, ps->rom_flash_range_program, (3 * chunksize * 10) >> 8);
-		if (ret) {
+		ret = rp_rom_call(t, ps->regs, ps->rom_flash_range_program, (3 * chunksize * 10) >> 8);
+		if (!ret) {
 			DEBUG_WARN("Write failed!\n");
 			break;
 		}
@@ -485,7 +485,7 @@ static bool rp_flash_write(target_flash_s *f, target_addr_t dest, const void *sr
 	}
 	rp_flash_resume(t);
 	DEBUG_INFO("Write done!\n");
-	return !ret;
+	return ret;
 }
 
 static bool rp_mass_erase(target *t)


### PR DESCRIPTION
## Detailed description

Target write operations return boolean values: `true` indicates a write
was successful, while `false` indicates there was a failure.

Inside the rpi target, there is a delegate function `rp_rom_call` that
performs the heavy lifting. It also returns `true` on success and
`false` on failure.

The rp_flash_write() function was inverting this logic, which caused it
to return `false` on success and `true` on failure. This behaviour was
exhibited as only the first 0x89c bytes successfully write to the
device.

Invert this logic in order to get rpi working again.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
