### PR TITLE
Fix: Flash operation completions

### DIFF
--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -147,6 +147,10 @@ bool target_flash_erase(target *t, target_addr_t addr, size_t len)
 			return false;
 
 		ret &= f->erase(f, local_start_addr, f->blocksize);
+		if (!ret) {
+			DEBUG_WARN("Erase failed at %" PRIx32 "\n", local_start_addr);
+			break;
+		}
 
 		len -= MIN(local_end_addr - addr, len);
 		addr = local_end_addr;

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -123,7 +123,7 @@ bool target_flash_erase(target *t, target_addr_t addr, size_t len)
 		return false;
 
 	target_flash_s *active_flash = target_flash_for_addr(t, addr);
-	bool ret = true; /* catch false returns with &= */
+	bool ret = true; /* Catch false returns with &= */
 	while (len) {
 		target_flash_s *f = target_flash_for_addr(t, addr);
 		if (!f) {
@@ -131,7 +131,7 @@ bool target_flash_erase(target *t, target_addr_t addr, size_t len)
 			return false;
 		}
 
-		/* terminate flash operations if we're not in the same target flash */
+		/* Terminate flash operations if we're not in the same target flash */
 		if (f != active_flash) {
 			ret &= flash_done(active_flash);
 			active_flash = f;
@@ -173,7 +173,7 @@ bool flash_buffer_alloc(target_flash_s *flash)
 
 static bool flash_buffered_flush(target_flash_s *f)
 {
-	bool ret = true; /* catch false returns with &= */
+	bool ret = true; /* Catch false returns with &= */
 	if (f->buf && f->buf_addr_base != UINT32_MAX && f->buf_addr_low != UINT32_MAX &&
 		f->buf_addr_low < f->buf_addr_high) {
 		/* Write buffer to flash */
@@ -199,11 +199,11 @@ static bool flash_buffered_flush(target_flash_s *f)
 
 static bool flash_buffered_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
 {
-	bool ret = true; /* catch false returns with &= */
+	bool ret = true; /* Catch false returns with &= */
 	while (len) {
 		const target_addr_t base_addr = dest & ~(f->writebufsize - 1U);
 
-		/* check for base address change */
+		/* Check for base address change */
 		if (base_addr != f->buf_addr_base) {
 			ret &= flash_buffered_flush(f);
 
@@ -218,7 +218,7 @@ static bool flash_buffered_write(target_flash_s *f, target_addr_t dest, const vo
 		/* Copy chunk into sector buffer */
 		memcpy(f->buf + offset, src, local_len);
 
-		/* this allows for writes smaller than blocksize when flushing in the future */
+		/* This allows for writes smaller than writebufsize when flushing in the future */
 		f->buf_addr_low = MIN(f->buf_addr_low, dest);
 		f->buf_addr_high = MAX(f->buf_addr_high, dest + local_len);
 
@@ -287,7 +287,7 @@ bool target_flash_complete(target *t)
 	if (!t->flash_mode)
 		return false;
 
-	bool ret = true; /* catch false returns with &= */
+	bool ret = true; /* Catch false returns with &= */
 	for (target_flash_s *f = t->flash; f; f = f->next) {
 		ret &= flash_buffered_flush(f);
 		ret &= flash_done(f);

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -183,6 +183,10 @@ bool target_flash_write(target *t, target_addr_t dest, const void *src, size_t l
 		const target_addr_t local_length = local_end_addr - dest;
 
 		ret &= flash_buffered_write(f, dest, src, local_length);
+		if (!ret) {
+			DEBUG_WARN("Write failed at %" PRIx32 "\n", dest);
+			break;
+		}
 
 		dest = local_end_addr;
 		src += local_length;

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -43,9 +43,10 @@ static bool flash_buffered_flush(target_flash_s *f);
 
 target_flash_s *target_flash_for_addr(target *t, uint32_t addr)
 {
-	for (target_flash_s *f = t->flash; f; f = f->next)
-		if ((f->start <= addr) && (addr < (f->start + f->length)))
+	for (target_flash_s *f = t->flash; f; f = f->next) {
+		if (f->start <= addr && addr < f->start + f->length)
 			return f;
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

While reviewing the conversation on #1230 we noticed that the Flash erase and write routines could be improved on with their handling for end-of-Flash block operations and the failure diagnostics for both erase and write improved on, allowing per-target diagnostics to be eliminated in due course for a debug build Flash usage improvement.

This PR is the culmination of that which should not semantically change the routines but which does improve their speed and Flash usage slightly while making it easier to do the right thing going forward.

Opening as draft as this has not yet been tested and we will endeavour to so in the next few days.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
