### PR TITLE
rtt: Fix infinite loop in rtt_write

### DIFF
--- a/src/platforms/stm32/rtt_if.c
+++ b/src/platforms/stm32/rtt_if.c
@@ -128,7 +128,7 @@ uint32_t rtt_write(const char *buf, uint32_t len)
 		}
 		/* flush 64-byte packet on full-speed */
 		if (CDCACM_PACKET_SIZE == 64 && (len % CDCACM_PACKET_SIZE) == 0)
-			while(usbd_ep_write_packet(usbdev, CDCACM_UART_ENDPOINT, NULL, 0) <= 0);
+			usbd_ep_write_packet(usbdev, CDCACM_UART_ENDPOINT, NULL, 0);
 	}
 	return len;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

I ran into an issue with `rtt_write` hanging the BMP in some cases. Upon looking at the code it looks like there is a bug in the STM32 `rtt_write` implementation which causes execution to enter an infinite loop when hit.

The `usbd_ep_write_packet` function is documented to return `len` on success, and `0` on failure. In the offending code, the function is called with a `len` of zero, which means that it will only ever return zero, and as a consequence there is no way to distinguish failure from success (I am not well-versed enough with the USB code to know if a call with `len = 0` for flushing can ever fail).

Either way, since this function is called in a while loop until it returns a nonzero value, this would amount to an infinite loop, hanging the BMP forever. This is what I observe on my device. It's possibly quite difficult to hit this by chance since it only happens when the chunk length is a multiple of 64 bytes, so likely many programs using RTT would never trigger it.

This change simply removes the while loop; since there is no way to tell apart failure from success anyway, I have to assume it cannot fail and that it should only be called once. This fixes the immediate issue I was facing, and seems like the correct fix. But perhaps this flush isn't even needed at all, I don't know enough about USB to answer that.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
