### PR TITLE
stm32wx: Fix device detection broken since ce6477886f

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -644,6 +644,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		PROBE(gd32f1_probe);
 		break;
 	case JEP106_MANUFACTURER_STM:
+		t->part_id = ap->partno;
 		PROBE(stm32f1_probe);
 		PROBE(stm32f4_probe);
 		PROBE(stm32h7_probe);

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -145,9 +145,9 @@ enum stm32h7_regs {
 #define FLASH_SECTOR_SIZE 	0x20000
 #define BANK2_START         0x08100000
 enum ID_STM32H7 {
-	ID_STM32H74x  = 0x4500,      /* RM0433, RM0399 */
-	ID_STM32H7Bx  = 0x4800,      /* RM0455 */
-	ID_STM32H72x  = 0x4830,      /* RM0468 */
+	ID_STM32H74x  = 0x450,      /* RM0433, RM0399 */
+	ID_STM32H7Bx  = 0x480,      /* RM0455 */
+	ID_STM32H72x  = 0x483,      /* RM0468 */
 };
 
 struct stm32h7_flash {


### PR DESCRIPTION
On STM32 DPv2 devices contain a DP_TARGETID with a zero added compared to the Romtable ID. In the DPIDR TARGETID rework around ce6477886f these IDs where changed for STM32H7 but not for STM32Wx.

<!-- Filling this template is mandatory -->

## Detailed description

Get STM32Wx devices recognized by their DPIDR TARGETID by the needed change.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
