### PR TITLE
stm32f4: fix wrong idcode when probing

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -207,16 +207,17 @@ static void stm32f4_detach(target *t)
 
 bool stm32f4_probe(target *t)
 {
-	const uint16_t mcu_idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfffU;
-	switch (mcu_idcode) {
-	/* F405 revision A has the wrong IDCODE, use ARM_CPUID to make the
-	 * distinction vs the F205. Revision is also wrong (0x2000 instead
-	 * of 0x1000). See F40x/F41x errata. */
-	case ID_STM32F20X:
-		if ((t->cpuid & 0xfff0U) != CORTEX_M4)
-			break;
-		mcu_idcode = ID_STM32F40X;
+	uint16_t mcu_idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfffU;
 
+	if (mcu_idcode == ID_STM32F20X) {
+		/* F405 revision A have a wrong IDCODE, use ARM_CPUID to make the
+		 * distinction with F205. Revision is also wrong (0x2000 instead
+		 * of 0x1000). See F40x/F41x errata. */
+		if ((t->cpuid & 0xFFF0) == CORTEX_M4)
+			mcu_idcode = ID_STM32F40X;
+	}
+
+	switch (mcu_idcode) {
 	case ID_STM32F74X: /* F74x RM0385 Rev.4 */
 	case ID_STM32F76X: /* F76x F77x RM0410 */
 	case ID_STM32F72X: /* F72x F73x RM0431 */

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -207,37 +207,35 @@ static void stm32f4_detach(target *t)
 
 bool stm32f4_probe(target *t)
 {
-	uint16_t stored_idcode = t->idcode;
 	t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xFFF;
 
 	if (t->idcode == ID_STM32F20X) {
 		/* F405 revision A have a wrong IDCODE, use ARM_CPUID to make the
-		* distinction with F205. Revision is also wrong (0x2000 instead
-		* of 0x1000). See F40x/F41x errata. */
+		 * distinction with F205. Revision is also wrong (0x2000 instead
+		 * of 0x1000). See F40x/F41x errata. */
 		if ((t->cpuid & 0xFFF0) == CORTEX_M4)
-		t->idcode = ID_STM32F40X;
+			t->idcode = ID_STM32F40X;
 	}
 	switch (t->idcode) {
-		case ID_STM32F74X:  /* F74x RM0385 Rev.4 */
-		case ID_STM32F76X:  /* F76x F77x RM0410 */
-		case ID_STM32F72X:  /* F72x F73x RM0431 */
-		case ID_STM32F40X:
-		case ID_STM32F42X:  /* 427/437 */
-		case ID_STM32F46X:  /* 469/479 */
-		case ID_STM32F20X:  /* F205 */
-		case ID_STM32F446:  /* F446 */
-		case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
-		case ID_STM32F411:  /* F411     RM0383 Rev.4 */
-		case ID_STM32F412:  /* F412     RM0402 Rev.4, 256 kB Ram */
-		case ID_STM32F401E: /* F401 D/E RM0368 Rev.3 */
-		case ID_STM32F413:  /* F413     RM0430 Rev.2, 320 kB Ram, 1.5 MB flash. */
-			t->detach = stm32f4_detach;
-			t->driver = stm32f4_get_chip_name(t->idcode);
-			t->attach = stm32f4_attach;
+	case ID_STM32F74X: /* F74x RM0385 Rev.4 */
+	case ID_STM32F76X: /* F76x F77x RM0410 */
+	case ID_STM32F72X: /* F72x F73x RM0431 */
+	case ID_STM32F40X:
+	case ID_STM32F42X:  /* 427/437 */
+	case ID_STM32F46X:  /* 469/479 */
+	case ID_STM32F20X:  /* F205 */
+	case ID_STM32F446:  /* F446 */
+	case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
+	case ID_STM32F411:  /* F411     RM0383 Rev.4 */
+	case ID_STM32F412:  /* F412     RM0402 Rev.4, 256 kB Ram */
+	case ID_STM32F401E: /* F401 D/E RM0368 Rev.3 */
+	case ID_STM32F413:  /* F413     RM0430 Rev.2, 320 kB Ram, 1.5 MB flash. */
+		t->detach = stm32f4_detach;
+		t->driver = stm32f4_get_chip_name(t->idcode);
+		t->attach = stm32f4_attach;
 		target_add_commands(t, stm32f4_cmd_list, t->driver);
 		return true;
-		default:
-			t->idcode = stored_idcode;
+	default:
 		return false;
 	}
 }

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -233,6 +233,7 @@ bool stm32f4_probe(target *t)
 	case ID_STM32F413:  /* F413     RM0430 Rev.2, 320 kB Ram, 1.5 MB flash. */
 		t->attach = stm32f4_attach;
 		t->detach = stm32f4_detach;
+		t->mass_erase = stm32f4_mass_erase;
 		t->driver = stm32f4_get_chip_name(t->part_id);
 		t->part_id = mcu_idcode;
 		target_add_commands(t, stm32f4_cmd_list, t->driver);

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -207,34 +207,37 @@ static void stm32f4_detach(target *t)
 
 bool stm32f4_probe(target *t)
 {
-	if (t->part_id == ID_STM32F20X) {
+	uint16_t stored_idcode = t->idcode;
+	t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xFFF;
+
+	if (t->idcode == ID_STM32F20X) {
 		/* F405 revision A have a wrong IDCODE, use ARM_CPUID to make the
-		 * distinction with F205. Revision is also wrong (0x2000 instead
-		 * of 0x1000). See F40x/F41x errata. */
+		* distinction with F205. Revision is also wrong (0x2000 instead
+		* of 0x1000). See F40x/F41x errata. */
 		if ((t->cpuid & 0xFFF0) == CORTEX_M4)
-			t->part_id = ID_STM32F40X;
+		t->idcode = ID_STM32F40X;
 	}
-	switch(t->part_id) {
-	case ID_STM32F74X: /* F74x RM0385 Rev.4 */
-	case ID_STM32F76X: /* F76x F77x RM0410 */
-	case ID_STM32F72X: /* F72x F73x RM0431 */
-	case ID_STM32F40X:
-	case ID_STM32F42X: /* 427/437 */
-	case ID_STM32F46X: /* 469/479 */
-	case ID_STM32F20X: /* F205 */
-	case ID_STM32F446: /* F446 */
-	case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
-	case ID_STM32F411: /* F411     RM0383 Rev.4 */
-	case ID_STM32F412: /* F412     RM0402 Rev.4, 256 kB Ram */
-	case ID_STM32F401E: /* F401 D/E RM0368 Rev.3 */
-	case ID_STM32F413: /* F413     RM0430 Rev.2, 320 kB Ram, 1.5 MB flash. */
-		t->mass_erase = stm32f4_mass_erase;
-		t->detach = stm32f4_detach;
-		t->driver = stm32f4_get_chip_name(t->part_id);
-		t->attach = stm32f4_attach;
+	switch (t->idcode) {
+		case ID_STM32F74X:  /* F74x RM0385 Rev.4 */
+		case ID_STM32F76X:  /* F76x F77x RM0410 */
+		case ID_STM32F72X:  /* F72x F73x RM0431 */
+		case ID_STM32F40X:
+		case ID_STM32F42X:  /* 427/437 */
+		case ID_STM32F46X:  /* 469/479 */
+		case ID_STM32F20X:  /* F205 */
+		case ID_STM32F446:  /* F446 */
+		case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
+		case ID_STM32F411:  /* F411     RM0383 Rev.4 */
+		case ID_STM32F412:  /* F412     RM0402 Rev.4, 256 kB Ram */
+		case ID_STM32F401E: /* F401 D/E RM0368 Rev.3 */
+		case ID_STM32F413:  /* F413     RM0430 Rev.2, 320 kB Ram, 1.5 MB flash. */
+			t->detach = stm32f4_detach;
+			t->driver = stm32f4_get_chip_name(t->idcode);
+			t->attach = stm32f4_attach;
 		target_add_commands(t, stm32f4_cmd_list, t->driver);
 		return true;
-	default:
+		default:
+			t->idcode = stored_idcode;
 		return false;
 	}
 }

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -207,37 +207,37 @@ static void stm32f4_detach(target *t)
 
 bool stm32f4_probe(target *t)
 {
-	t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xFFF;
+	const uint16_t mcu_idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfffU;
+	switch (mcu_idcode) {
+	/* F405 revision A has the wrong IDCODE, use ARM_CPUID to make the
+	 * distinction vs the F205. Revision is also wrong (0x2000 instead
+	 * of 0x1000). See F40x/F41x errata. */
+	case ID_STM32F20X:
+		if ((t->cpuid & 0xfff0U) != CORTEX_M4)
+			break;
+		mcu_idcode = ID_STM32F40X;
 
-	if (t->idcode == ID_STM32F20X) {
-		/* F405 revision A have a wrong IDCODE, use ARM_CPUID to make the
-		 * distinction with F205. Revision is also wrong (0x2000 instead
-		 * of 0x1000). See F40x/F41x errata. */
-		if ((t->cpuid & 0xFFF0) == CORTEX_M4)
-			t->idcode = ID_STM32F40X;
-	}
-	switch (t->idcode) {
 	case ID_STM32F74X: /* F74x RM0385 Rev.4 */
 	case ID_STM32F76X: /* F76x F77x RM0410 */
 	case ID_STM32F72X: /* F72x F73x RM0431 */
+	case ID_STM32F42X: /* 427/437 */
+	case ID_STM32F46X: /* 469/479 */
+	case ID_STM32F20X: /* F205 */
 	case ID_STM32F40X:
-	case ID_STM32F42X:  /* 427/437 */
-	case ID_STM32F46X:  /* 469/479 */
-	case ID_STM32F20X:  /* F205 */
 	case ID_STM32F446:  /* F446 */
 	case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
 	case ID_STM32F411:  /* F411     RM0383 Rev.4 */
 	case ID_STM32F412:  /* F412     RM0402 Rev.4, 256 kB Ram */
 	case ID_STM32F401E: /* F401 D/E RM0368 Rev.3 */
 	case ID_STM32F413:  /* F413     RM0430 Rev.2, 320 kB Ram, 1.5 MB flash. */
-		t->detach = stm32f4_detach;
-		t->driver = stm32f4_get_chip_name(t->idcode);
 		t->attach = stm32f4_attach;
+		t->detach = stm32f4_detach;
+		t->driver = stm32f4_get_chip_name(t->part_id);
+		t->part_id = mcu_idcode;
 		target_add_commands(t, stm32f4_cmd_list, t->driver);
 		return true;
-	default:
-		return false;
 	}
+	return false;
 }
 
 static bool stm32f4_attach(target *t)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

STM32F4 has bug in stm32f4_probe() function

## Detailed description

When program reach stm32f4_probe() function, target structure had wrongly fulfilled `t->idcode` field (with value `1041`). Which causes wrong chip selection ahead in the program. This issue doesn't present in [BMP ver 1.7.1](https://github.com/blackmagic-debug/blackmagic/tree/v1.7.1).
My fix works for me with the STM32F446 board. But maybe similar bugs are present in other targets as well. 

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
