### PR TITLE
Fix: RP ROM call progress reporting

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -381,14 +381,14 @@ static bool rp_rom_call(target *t, uint32_t *regs, uint32_t cmd, uint32_t timeou
 	platform_timeout_set(&operation_timeout, timeout);
 	platform_timeout wait_timeout;
 	platform_timeout_set(&wait_timeout, 500);
-	do {
+	while (!target_halt_poll(t, NULL)) {
 		if (ps->is_monitor)
 			target_print_progress(&wait_timeout);
 		if (platform_timeout_is_expired(&operation_timeout)) {
 			DEBUG_WARN("RP Run timout %ums reached: ", timeout);
 			break;
 		}
-	} while (!target_halt_poll(t, NULL));
+	}
 	/* Debug */
 	target_regs_read(t, dbg_regs);
 	const bool result = (dbg_regs[REG_PC] & ~1U) == (ps->rom_debug_trampoline_end & ~1U);

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -364,8 +364,6 @@ static bool rp_read_rom_func_table(target *const t)
  */
 static bool rp_rom_call(target *t, uint32_t *regs, uint32_t cmd, uint32_t timeout)
 {
-	const char spinner[] = "|/-\\";
-	int spinindex = 0;
 	rp_priv_s *ps = (rp_priv_s *)t->target_storage;
 	regs[7] = cmd;
 	regs[REG_LR] = ps->rom_debug_trampoline_end;
@@ -381,20 +379,13 @@ static bool rp_rom_call(target *t, uint32_t *regs, uint32_t cmd, uint32_t timeou
 	DEBUG_INFO("Call cmd %04" PRIx32 "\n", cmd);
 	platform_timeout operation_timeout;
 	platform_timeout_set(&operation_timeout, timeout);
-	platform_timeout spinner_timeout;
-	if (timeout > 500)
-		platform_timeout_set(&spinner_timeout, 500);
-	else
-		/* never trigger if timeout is short */
-		platform_timeout_set(&spinner_timeout, timeout + 1);
+	platform_timeout wait_timeout;
+	platform_timeout_set(&wait_timeout, 500);
 	do {
-		if (platform_timeout_is_expired(&spinner_timeout)) {
-			if (ps->is_monitor)
-				tc_printf(t, "\b%c", spinner[spinindex++ % 4]);
-			platform_timeout_set(&spinner_timeout, 500);
-		}
+		if (ps->is_monitor)
+			target_print_progress(&wait_timeout);
 		if (platform_timeout_is_expired(&operation_timeout)) {
-			DEBUG_WARN("RP Run timout %d ms reached: ", (int)timeout);
+			DEBUG_WARN("RP Run timout %ums reached: ", timeout);
 			break;
 		}
 	} while (!target_halt_poll(t, NULL));


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As part of reviewing James Turton's RP2040 fixes, we noticed that the ROM call function is still using a progress spinner when run in monitor mode. This PR seeks to address this using the `target_print_progress` call introduced with the mass erase overhaul which also results in a nice drop in Flash usage.

Targeting to v1.9 as this is clean up and doesn't functionally change the routine.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
