### PR TITLE
Fix: adiv5 nuisance CID warnings

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -606,10 +606,9 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, const size_t re
 
 			const cid_class_e adjusted_class = adiv5_class_from_cid(part_number, arch_id, cid_class);
 			/* Perform sanity check, if we know what to expect as * component ID class. */
-			if (arm_component_lut[i].cidc != cidc_unknown && adjusted_class != arm_component_lut[i].cidc) {
-				DEBUG_WARN("%sWARNING: \"%s\" !match expected \"%s\"\n", indent + 1, cidc_debug_strings[adjusted_class],
-					cidc_debug_strings[arm_component_lut[i].cidc]);
-			}
+			if (arm_component_lut[i].cidc != cidc_unknown && adjusted_class != arm_component_lut[i].cidc)
+				DEBUG_WARN("%sWARNING: \"%s\" expected, got \"%s\"\n", indent + 1,
+					cidc_debug_strings[arm_component_lut[i].cidc], cidc_debug_strings[adjusted_class]);
 
 			switch (arm_component_lut[i].arch) {
 			case aa_cortexm:

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -71,7 +71,7 @@
 /* The following enum is based on the Component Class value table 13-3 of the
  * ADIv5 standard.
  */
-enum cid_class {
+typedef enum cid_class {
 	cidc_gvc = 0x0,    /* Generic verification component*/
 	cidc_romtab = 0x1, /* ROM Table, std. layout (ADIv5 Chapter 14) */
 	/* 0x2 - 0x8 */    /* Reserved */
@@ -83,7 +83,7 @@ enum cid_class {
 	cidc_gipc = 0xE,   /* Generic IP Component */
 	cidc_sys = 0xF,    /* CoreLink, PrimeCell, or other system component with no standard register layout */
 	cidc_unknown = 0x10
-};
+} cid_class_e;
 
 #ifdef ENABLE_DEBUG
 /* The reserved ones only have an R in them, to save a bit of space. */
@@ -443,7 +443,19 @@ static bool cortexm_prepare(ADIv5_AP_t *ap)
 	return true;
 }
 
-/* Return true if we find a debuggable device.*/
+static cid_class_e adiv5_class_from_cid(const uint16_t part_number, const uint16_t arch_id, const cid_class_e cid_class)
+{
+	/* Cortex-M23 and 33 incorectly list their SCS's as a debug component,
+	 * but they're a generic IP component, so we adjust the cid_class.
+	 */
+	if ((part_number == 0xd20U || part_number == 0xd21U) && arch_id == 0x2a04U && cid_class == cidc_dc)
+		return cidc_gipc;
+	return cid_class;
+}
+
+/*
+ * Return true if we find a debuggable device.
+ * NOLINTNEXTLINE(misc-no-recursion) */
 static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, const size_t recursion, const uint32_t num_entry)
 {
 	(void)num_entry;
@@ -592,9 +604,10 @@ static void adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, const size_t re
 				indent + 1, num_entry, addr, cidc_debug_strings[cid_class], arm_component_lut[i].type,
 				arm_component_lut[i].full, (uint32_t)(pidr >> 32U), (uint32_t)pidr, dev_type, arch_id);
 
+			const cid_class_e adjusted_class = adiv5_class_from_cid(part_number, arch_id, cid_class);
 			/* Perform sanity check, if we know what to expect as * component ID class. */
-			if (arm_component_lut[i].cidc != cidc_unknown && cid_class != arm_component_lut[i].cidc) {
-				DEBUG_WARN("%sWARNING: \"%s\" !match expected \"%s\"\n", indent + 1, cidc_debug_strings[cid_class],
+			if (arm_component_lut[i].cidc != cidc_unknown && adjusted_class != arm_component_lut[i].cidc) {
+				DEBUG_WARN("%sWARNING: \"%s\" !match expected \"%s\"\n", indent + 1, cidc_debug_strings[adjusted_class],
 					cidc_debug_strings[arm_component_lut[i].cidc]);
 			}
 
@@ -848,7 +861,7 @@ void adiv5_dp_init(ADIv5_DP_t *dp, const uint32_t idcode)
 			/* We have probably found all APs on this DP so no need to keep looking.
 			 * Continue with rest of init function down below.
 			 */
-			if (++invalid_aps == 8)				
+			if (++invalid_aps == 8)
 				break;
 
 			continue;


### PR DESCRIPTION
## Detailed description

In f4345e4 we made adjustments to the ADIv5 component table, which were based on the SCS classes not matching up which seemed like a copy-paste mistake. As it turns out this is actually that the Cortex-M23 and Cortex-M33 SCSs are defined as debug components in the processor TRMs, but this is actually incorrect as they're generic IP. This PR fixes this by detecting those two SCS's and adjusting the class ID going into the sanity check.

It additionally adjusts the sanity check message so it's a bit more clear what's wrong. This should fix the warning seen in #1243 which raised some eyebrows.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
