### PR TITLE
Fix USART on SWIM pins for STLINK

### DIFF
--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -27,6 +27,8 @@ endif
 
 ifeq ($(SWIM_AS_UART), 1)
 CFLAGS += -DSWIM_AS_UART=1
+else
+SRC += traceswoasync.c
 endif
 
 VPATH += platforms/stm32
@@ -36,7 +38,6 @@ SRC +=          \
 	timing.c	\
 	timing_stm32.c	\
 	traceswodecode.c	\
-	traceswoasync.c	\
 	stlink_common.c \
 
 ifeq ($(ST_BOOTLOADER), 1)

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -65,7 +65,10 @@ extern bool debug_bmp;
 #define LED_PORT_UART	GPIOA
 #define LED_UART	GPIO9
 
+#ifndef SWIM_AS_UART
 #define PLATFORM_HAS_TRACESWO	1
+#endif
+
 #define NUM_TRACE_PACKETS		(128)		/* This is an 8K buffer */
 #define TRACESWO_PROTOCOL		2			/* 1 = Manchester, 2 = NRZ / async */
 
@@ -112,6 +115,15 @@ extern bool debug_bmp;
 #define USBUSART_IRQ NVIC_USART1_IRQ
 #define USBUSART_CLK RCC_USART1
 #define USBUSART_ISR(x) usart1_isr(x)
+#define USBUSART_PORT GPIOB
+#define USBUSART_TX_PIN GPIO6
+#define USBUSART_RX_PIN GPIO7
+#define USBUSART_DMA_TX_CHAN DMA_CHANNEL4
+#define USBUSART_DMA_TX_IRQ NVIC_DMA1_CHANNEL4_IRQ
+#define USBUSART_DMA_TX_ISR(x) dma1_channel4_isr(x)
+#define USBUSART_DMA_RX_CHAN DMA_CHANNEL5
+#define USBUSART_DMA_RX_IRQ NVIC_DMA1_CHANNEL5_IRQ
+#define USBUSART_DMA_RX_ISR(x) dma1_channel5_isr(x)
 #else
 #define USBUSART USART2
 #define USBUSART_CR1 USART2_CR1
@@ -119,19 +131,19 @@ extern bool debug_bmp;
 #define USBUSART_IRQ NVIC_USART2_IRQ
 #define USBUSART_CLK RCC_USART2
 #define USBUSART_ISR(x) usart2_isr(x)
-#endif
 #define USBUSART_PORT GPIOA
 #define USBUSART_TX_PIN GPIO2
 #define USBUSART_RX_PIN GPIO3
-
-#define USBUSART_DMA_BUS DMA1
-#define USBUSART_DMA_CLK RCC_DMA1
 #define USBUSART_DMA_TX_CHAN DMA_CHANNEL7
 #define USBUSART_DMA_TX_IRQ NVIC_DMA1_CHANNEL7_IRQ
 #define USBUSART_DMA_TX_ISR(x) dma1_channel7_isr(x)
 #define USBUSART_DMA_RX_CHAN DMA_CHANNEL6
 #define USBUSART_DMA_RX_IRQ NVIC_DMA1_CHANNEL6_IRQ
 #define USBUSART_DMA_RX_ISR(x) dma1_channel6_isr(x)
+#endif
+
+#define USBUSART_DMA_BUS DMA1
+#define USBUSART_DMA_CLK RCC_DMA1
 
 /* On F103, only USART1 is on AHB2 and can reach 4.5 MBaud at 72 MHz.*/
 #define SWO_UART				USART1


### PR DESCRIPTION
Hi,
I checked if `SWIM_AS_UART` mode mentioned [here](https://github.com/blackmagic-debug/blackmagic/blob/main/src/platforms/stlink/README.md) is working as expected, and it turns out there is an issue. The flag was correctly switching USART port to 1 and setting up pin remap, however it left DMA channels and GPIO pins configured for USART2.

SWO output feature was using the same first UART controller, so I had to switch it off for this particular quirk.

Tested on random STLINK dongle from Aliexpress.

I don't like that a lot of those macros are basically duplicated twice (with the port number being the only difference), but I can't figure if there is a nice way to address it.

## Your checklist for this pull request

* [ x ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [ x ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ x ] It builds for hardware native (`make PROBE_HOST=native`)
* [ x ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ x ] I've tested it to the best of my ability
* [ x ] My commit messages provide a useful short description of what the commits do
