### PR TITLE
support for another lpc11u6x part id

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -682,8 +682,10 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		PROBE(renesas_probe);
 		break;
 	case JEP106_MANUFACTURER_ARM:
-		if (t->part_id == 0x4c0 || t->part_id == 0x4c1) { /* Cortex-M0+ ROM (0x4c1 is for some newer LPC11U6xx)*/
+		if (t->part_id == 0x4c0) {        /* Cortex-M0+ ROM */
 			PROBE(lpc11xx_probe);         /* LPC8 */
+		}else if (  t->part_id == 0x4c1) { /* Cortex-M0+ ROM */
+			PROBE(lpc11xx_probe);         /* newer LPC11U6x */
 		} else if (t->part_id == 0x4c3) { /* Cortex-M3 ROM */
 			PROBE(lmi_probe);
 			PROBE(ch32f1_probe);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -682,7 +682,7 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 		PROBE(renesas_probe);
 		break;
 	case JEP106_MANUFACTURER_ARM:
-		if (t->part_id == 0x4c0) {        /* Cortex-M0+ ROM */
+		if (t->part_id == 0x4c0 || t->part_id == 0x4c1) { /* Cortex-M0+ ROM (0x4c1 is for some newer LPC11U6xx)*/
 			PROBE(lpc11xx_probe);         /* LPC8 */
 		} else if (t->part_id == 0x4c3) { /* Cortex-M3 ROM */
 			PROBE(lmi_probe);


### PR DESCRIPTION
Hi,
* Is a new feature implemented?  No
* What existing problem(s) does the pull request solve? Compatibility with some LPC11U67/LPC11U68
* How does the pull request solve these problems? MCU not identified without

Trivial patch attached to add support for another LPC11U6x part_id.
Works fine with the patch. 

Thank you

