### PR TITLE
hosted/serial_unix: Fix error building hosted on Linux

### DIFF
--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -126,7 +126,7 @@ static bool match_serial(const char *const device, const char *const serial)
 	return constains_substring(begin, end - begin, serial);
 }
 
-int serial_open(const BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
+int serial_open(BMP_CL_OPTIONS_t *cl_opts, const char *const serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -126,7 +126,7 @@ static bool match_serial(const char *const device, const char *const serial)
 	return constains_substring(begin, end - begin, serial);
 }
 
-int serial_open(BMP_CL_OPTIONS_t *cl_opts, const char *const serial)
+int serial_open(BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {


### PR DESCRIPTION
## Compiler error building hosted on Linux

This PR fixes a compiler error introduced with the clang-format work done previously.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
