### PR TITLE
hosted/bmp_serial: Added product to probe info structure. Serial NOT updated

### DIFF
--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -41,6 +41,7 @@
 typedef struct probe_info {
 	bmp_type_t type;
 	const char *manufacturer;
+	const char *product;
 	const char *serial;
 	const char *version;
 


### PR DESCRIPTION
## Addition of Product string to probe info structure

This PR simply adds an entry in the probe info structure for the probe product name string. No additional changes are made to the serial code, this PR enables the structure to then be used in the USB probe scanning.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

