### PR TITLE
add rtt

### DIFF
--- a/UsingRTT.md
+++ b/UsingRTT.md
@@ -40,6 +40,12 @@ max poll ms: 256 min poll ms: 8 max errs: 10
 The terminal emulator displays RTT output from the target, and characters typed
 in the terminal emulator are sent via RTT to the target.
 
+It is possible to use RTT and the built-in serial port at the same time. If both RTT and the built-in serial port are used at the same time, the terminal will show both RTT and serial port output, interleaved.
+
+Characters typed in at the terminal go to either RTT or serial port.
+
+-  ``monitor rtt``: If RTT is enabled, characters typed in at the terminal are sent to target RTT.
+- ``monitor rtt disable``: if RTT is disabled, characters typed in at the terminal are sent to the built-in serial port.
 
 ## GDB Commands
 

--- a/src/include/rtt_if.h
+++ b/src/include/rtt_if.h
@@ -29,6 +29,13 @@
 
 /* rtt i/o to terminal */
 
+#if PC_HOSTED == 0
+#include <libopencm3/usb/usbd.h>
+
+/* usb rx callback */
+void rtt_serial_receive_callback(usbd_device *dev, uint8_t ep);
+#endif
+
 /* default buffer sizes, 8 bytes added to up buffer for alignment and padding */
 /* override RTT_UP_BUF_SIZE and RTT_DOWN_BUF_SIZE in platform.h if needed */
 

--- a/src/platforms/common/usb_serial.h
+++ b/src/platforms/common/usb_serial.h
@@ -32,8 +32,4 @@ bool gdb_serial_get_dtr(void);
 void debug_serial_run(void);
 uint32_t debug_serial_fifo_send(const char *fifo, uint32_t fifo_begin, uint32_t fifo_end);
 
-#ifdef ENABLE_RTT
-void debug_serial_receive_callback(usbd_device *dev, uint8_t ep);
-#endif
-
 #endif /* PLATFORMS_COMMON_USB_SERIAL_H */

--- a/src/platforms/launchpad-icdi/rtt_if.c
+++ b/src/platforms/launchpad-icdi/rtt_if.c
@@ -1,0 +1,134 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2021 Koen De Vleeschauwer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "general.h"
+#include "platform.h"
+#include <assert.h>
+#include "usb_serial.h"
+#include "rtt.h"
+#include "rtt_if.h"
+
+/*********************************************************************
+*
+*       rtt terminal i/o
+*
+**********************************************************************
+*/
+
+/* usb uart receive buffer */
+static char recv_buf[RTT_DOWN_BUF_SIZE];
+static uint32_t recv_head = 0;
+static uint32_t recv_tail = 0;
+
+/* data from host to target: number of free bytes in usb receive buffer */
+inline static uint32_t recv_bytes_free()
+{
+	if (recv_tail <= recv_head)
+		return sizeof(recv_buf) - recv_head + recv_tail - 1;
+	else
+		return recv_tail - recv_head - 1;
+}
+
+/* data from host to target: true if not enough free buffer space and we need to close flow control */
+inline static bool recv_set_nak()
+{
+	assert(sizeof(recv_buf) > 2 * CDCACM_PACKET_SIZE);
+	return recv_bytes_free() < 2 * CDCACM_PACKET_SIZE;
+}
+
+/* debug_serial_receive_callback is called when usb uart has received new data for target.
+   this routine has to be fast */
+
+void debug_serial_receive_callback(usbd_device *dev, uint8_t ep)
+{
+	(void)dev;
+	(void)ep;
+	char usb_buf[CDCACM_PACKET_SIZE];
+
+	/* close flow control while processing packet */
+	usbd_ep_nak_set(usbdev, CDCACM_UART_ENDPOINT, 1);
+
+	const uint16_t len = usbd_ep_read_packet(usbdev, CDCACM_UART_ENDPOINT, usb_buf, CDCACM_PACKET_SIZE);
+
+	/* skip flag: drop packet if not enough free buffer space */
+	if (rtt_flag_skip && len > recv_bytes_free()) {
+		usbd_ep_nak_set(usbdev, CDCACM_UART_ENDPOINT, 0);
+		return;
+	}
+
+	/* copy data to recv_buf */
+	for (int i = 0; i < len; i++) {
+		uint32_t next_recv_head = (recv_head + 1) % sizeof(recv_buf);
+		if (next_recv_head == recv_tail)
+			break; /* overflow */
+		recv_buf[recv_head] = usb_buf[i];
+		recv_head = next_recv_head;
+	}
+
+	/* block flag: flow control closed if not enough free buffer space */
+	if (!(rtt_flag_block && recv_set_nak()))
+		usbd_ep_nak_set(usbdev, CDCACM_UART_ENDPOINT, 0);
+
+	return;
+}
+
+/* rtt host to target: read one character */
+int32_t rtt_getchar()
+{
+	int retval;
+
+	if (recv_head == recv_tail)
+		return -1;
+	retval = recv_buf[recv_tail];
+	recv_tail = (recv_tail + 1) % sizeof(recv_buf);
+
+	/* open flow control if enough free buffer space */
+	if (!recv_set_nak())
+		usbd_ep_nak_set(usbdev, CDCACM_UART_ENDPOINT, 0);
+
+	return retval;
+}
+
+/* rtt host to target: true if no characters available for reading */
+bool rtt_nodata()
+{
+	return recv_head == recv_tail;
+}
+
+/* rtt target to host: write string */
+uint32_t rtt_write(const char *buf, uint32_t len)
+{
+	if (len != 0 && usbdev && usb_get_config() && gdb_serial_get_dtr()) {
+		for (uint32_t p = 0; p < len; p += CDCACM_PACKET_SIZE) {
+			uint32_t plen = MIN(CDCACM_PACKET_SIZE, len - p);
+			while(usbd_ep_write_packet(usbdev, CDCACM_UART_ENDPOINT, buf + p, plen) <= 0);
+		}
+		/* flush 64-byte packet on full-speed */
+		if (CDCACM_PACKET_SIZE == 64 && (len % CDCACM_PACKET_SIZE) == 0)
+			usbd_ep_write_packet(usbdev, CDCACM_UART_ENDPOINT, NULL, 0);
+	}
+	return len;
+}

--- a/src/platforms/launchpad-icdi/rtt_if.c
+++ b/src/platforms/launchpad-icdi/rtt_if.c
@@ -62,7 +62,7 @@ inline static bool recv_set_nak()
 /* debug_serial_receive_callback is called when usb uart has received new data for target.
    this routine has to be fast */
 
-void debug_serial_receive_callback(usbd_device *dev, uint8_t ep)
+void rtt_serial_receive_callback(usbd_device *dev, uint8_t ep)
 {
 	(void)dev;
 	(void)ep;

--- a/src/platforms/stm32/rtt_if.c
+++ b/src/platforms/stm32/rtt_if.c
@@ -62,7 +62,7 @@ inline static bool recv_set_nak()
 /* debug_serial_receive_callback is called when usb uart has received new data for target.
    this routine has to be fast */
 
-void debug_serial_receive_callback(usbd_device *dev, uint8_t ep)
+void rtt_serial_receive_callback(usbd_device *dev, uint8_t ep)
 {
 	(void)dev;
 	(void)ep;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

- Current behavior:
When compiled with ENABLE_RTT=1, characters typed at the terminal /dev/ttyBmpTarg are always sent to RTT
This is unpleasant for people who wish to use the built-in serial port.
- New behavior:
When compiled with ENABLE_RTT=1, if rtt is enabled (``mon rtt``) then characters typed at the terminal are sent to RTT.
If rtt is not enabled (default) then characters typed at the terminal are sent to the built-in serial

While testing this PR noticed the following:
``make all_platforms ENABLE_RTT=1`` fails. ``src/platforms/launchpad-icdi/rtt_if.c`` is missing.
fix:
copied  ``src/platforms/stm32/rtt_if.c`` to ``src/platforms/launchpad-icdi/rtt_if.c``
