### PR TITLE
Fix: stm32f1 Flash routine functionality fixes

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -367,6 +367,13 @@ static bool stm32f1_flash_busy_wait(target *const t, const uint32_t bank_offset,
 {
 	/* Read FLASH_SR to poll for BSY bit */
 	uint32_t status = FLASH_SR_BSY;
+	/*
+	 * Please note that checking EOP here is only legal because every operation is preceeded by
+	 * a call to stm32f1_flash_clear_eop. Without this the flag could be stale from a previous
+	 * operation and is always set at the end of every program/erase operation.
+	 * For more information, see FLASH_SR register description §3.4 pg 25.
+	 * https://www.st.com/resource/en/programming_manual/pm0075-stm32f10xxx-flash-memory-microcontrollers-stmicroelectronics.pdf
+	 */
 	while (!(status & SR_EOP) && (status & FLASH_SR_BSY)) {
 		status = target_mem_read32(t, FLASH_SR + bank_offset);
 		if (target_check_error(t)) {

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -357,25 +357,25 @@ static int stm32f1_flash_unlock(target *t, uint32_t bank_offset)
 	return 0;
 }
 
-static inline void stm32f1_flash_clear_eop(target * const t, const uint32_t bank_offset)
+static inline void stm32f1_flash_clear_eop(target *const t, const uint32_t bank_offset)
 {
 	const uint32_t status = target_mem_read32(t, FLASH_SR + bank_offset);
 	target_mem_write32(t, FLASH_SR + bank_offset, status | SR_EOP); /* EOP is W1C */
 }
 
-static bool stm32f1_flash_busy_wait(target * const t, const uint32_t bank_offset, platform_timeout * const timeout)
+static bool stm32f1_flash_busy_wait(target *const t, const uint32_t bank_offset, platform_timeout *const timeout)
 {
 	/* Read FLASH_SR to poll for BSY bit */
-	uint32_t sr;
+	uint32_t status;
 	do {
-		sr = target_mem_read32(t, FLASH_SR + bank_offset);
-		if ((sr & SR_ERROR_MASK) || target_check_error(t)) {
-			DEBUG_WARN("stm32f1 flash error 0x%" PRIx32 "\n", sr);
+		status = target_mem_read32(t, FLASH_SR + bank_offset);
+		if ((status & SR_ERROR_MASK) || target_check_error(t)) {
+			DEBUG_WARN("stm32f1 flash error 0x%" PRIx32 "\n", status);
 			return false;
 		}
 		if (timeout)
 			target_print_progress(timeout);
-	} while (!(sr & SR_EOP) && (sr & FLASH_SR_BSY));
+	} while (!(status & SR_EOP) && (status & FLASH_SR_BSY));
 
 	return true;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the issues found in the STM32F1 Flash operation wait code which cause early exits and incomplete operations erroneously. This also includes some documentation on the chosen steps for operation and mode of operation to hopefully stave off future breakage by well intentioned hands.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1257
