### PR TITLE
CH32F1x: More reliable chip detection, inverted function logic to be …

### DIFF
--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -65,10 +65,9 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 #define FLASH_SR_EOP             (1 << 5)           // End of programming
 #define FLASH_BEGIN_ADDRESS_CH32 0x8000000
 
-/**
-		\fn ch32f1_add_flash
-		\brief "fast" flash driver for CH32F10x chips
-*/
+/*
+ *	add "fast" flash driver for CH32F10x chips
+ */
 static void ch32f1_add_flash(target *t, uint32_t addr, size_t length, size_t erasesize)
 {
 	target_flash_s *f = calloc(1, sizeof(*f));

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -165,19 +165,18 @@ static bool ch32f1_flash_lock(target *t)
 	return true;
 }
 /**
-	\fn ch32f1_has_fastUnlock
-	\brief check fastUnlock is there, if so it is a CH32fx
+	\fn ch32f1_has_fast_unlock
+	\brief check fast_unlock is there, if so it is a CH32fx
 */
-static bool ch32f1_has_fastUnlock(target *t)
+static bool ch32f1_has_fast_unlock(target *t)
 {
-	DEBUG_INFO("CH32: has fatunlock \n");
+	DEBUG_INFO("CH32: has fast unlock \n");
 	// reset fast unlock
 	SET_CR(FLASH_CR_FLOCK_CH32);
 	platform_delay(1); // The flash controller is timing sensitive
-	uint32_t cr = target_mem_read32(t, FLASH_CR);
-	if (!(cr & FLASH_CR_FLOCK_CH32)) {
+	const uint32_t ctrl1 = target_mem_read32(t, FLASH_CR);
+	if (!(ctrl1 & FLASH_CR_FLOCK_CH32)) 
 		return false;
-	}
 	// send unlock sequence
 	target_mem_write32(t, FLASH_KEYR, KEY1);
 	target_mem_write32(t, FLASH_KEYR, KEY2);
@@ -187,8 +186,8 @@ static bool ch32f1_has_fastUnlock(target *t)
 	target_mem_write32(t, FLASH_MODEKEYR_CH32, KEY2);
 	platform_delay(1); // The flash controller is timing sensitive
 
-	cr = target_mem_read32(t, FLASH_CR);
-	return !(cr & FLASH_CR_FLOCK_CH32);
+	const uint32_t ctrl2 = target_mem_read32(t, FLASH_CR);
+	return !(ctrl2 & FLASH_CR_FLOCK_CH32);
 }
 
 /**
@@ -214,7 +213,7 @@ bool ch32f1_probe(target *t)
 		return false;
 
 	// try to flock (if this fails it is not a CH32 chip)
-	if (!ch32f1_has_fastUnlock(t)) {
+	if (!ch32f1_has_fast_unlock(t)) {
 		return false;
 	}
 	t->part_id = device_id;

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -140,9 +140,8 @@ static bool ch32f1_flash_unlock(target *t)
 	target_mem_write32(t, FLASH_MODEKEYR_CH32, KEY1);
 	target_mem_write32(t, FLASH_MODEKEYR_CH32, KEY2);
 	uint32_t cr = target_mem_read32(t, FLASH_CR);
-	if (cr & FLASH_CR_FLOCK_CH32) {
-		DEBUG_WARN("Fast unlock failed, cr: 0x%08" PRIx32 "\n", cr);		
-	}
+	if (cr & FLASH_CR_FLOCK_CH32)
+		DEBUG_WARN("Fast unlock failed, cr: 0x%08" PRIx32 "\n", cr);
 	return !(cr & FLASH_CR_FLOCK_CH32);
 }
 
@@ -157,9 +156,8 @@ static bool ch32f1_flash_lock(target *t)
 	// FLASH_CR_FLOCK_CH32 bit does not exists on *regular* clones and defaults to '0' (see PM0075 for STM32F1xx)
 	if (!(cr & FLASH_CR_FLOCK_CH32)) {
 		DEBUG_WARN("Fast lock failed, cr: 0x%08" PRIx32 "\n", cr);
-		return false;
 	}
-	return true;
+	return cr & FLASH_CR_FLOCK_CH32;
 }
 
 /*
@@ -253,11 +251,9 @@ bool ch32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 	}
 	sr = target_mem_read32(t, FLASH_SR);
 	ch32f1_flash_lock(t);
-	if (sr & SR_ERROR_MASK) {
+	if (sr & SR_ERROR_MASK)
 		DEBUG_WARN("ch32f1 flash erase error 0x%" PRIx32 "\n", sr);
-		return false;
-	}
-	return true;
+	return !(sr & SR_ERROR_MASK) ;
 }
 
 /*

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -38,32 +38,32 @@ static bool ch32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len
 static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 
 // these are common with stm32f1/gd32f1/...
-#define FPEC_BASE						0x40022000
-#define FLASH_ACR						(FPEC_BASE + 0x00)
-#define FLASH_KEYR						(FPEC_BASE + 0x04)
-#define FLASH_SR						(FPEC_BASE + 0x0C)
-#define FLASH_CR						(FPEC_BASE + 0x10)
-#define FLASH_AR						(FPEC_BASE + 0x14)
-#define FLASH_CR_LOCK					(1 << 7)
-#define FLASH_CR_STRT					(1 << 6)
-#define FLASH_SR_BSY					(1 << 0)
-#define KEY1 							0x45670123
-#define KEY2 							0xCDEF89AB
-#define SR_ERROR_MASK					0x14
-#define SR_EOP							0x20
-#define DBGMCU_IDCODE					0xE0042000
-#define FLASHSIZE	 					0x1FFFF7E0
+#define FPEC_BASE     0x40022000
+#define FLASH_ACR     (FPEC_BASE + 0x00)
+#define FLASH_KEYR    (FPEC_BASE + 0x04)
+#define FLASH_SR      (FPEC_BASE + 0x0C)
+#define FLASH_CR      (FPEC_BASE + 0x10)
+#define FLASH_AR      (FPEC_BASE + 0x14)
+#define FLASH_CR_LOCK (1 << 7)
+#define FLASH_CR_STRT (1 << 6)
+#define FLASH_SR_BSY  (1 << 0)
+#define KEY1          0x45670123
+#define KEY2          0xCDEF89AB
+#define SR_ERROR_MASK 0x14
+#define SR_EOP        0x20
+#define DBGMCU_IDCODE 0xE0042000
+#define FLASHSIZE     0x1FFFF7E0
 
 // these are specific to ch32f1
-#define FLASH_MAGIC			   			(FPEC_BASE + 0x34)
-#define FLASH_MODEKEYR_CH32 			(FPEC_BASE + 0x24) // Fast mode for CH32F10x
-#define FLASH_CR_FLOCK_CH32	   			(1 << 15) // fast unlock
-#define FLASH_CR_FTPG_CH32				(1 << 16) // fast page program
-#define FLASH_CR_FTER_CH32				(1 << 17) // fast page erase
-#define FLASH_CR_BUF_LOAD_CH32			(1 << 18) // Buffer load
-#define FLASH_CR_BUF_RESET_CH32   		(1 << 19) // Buffer reset
-#define FLASH_SR_EOP			  		(1 << 5)  // End of programming
-#define FLASH_BEGIN_ADDRESS_CH32  		0x8000000
+#define FLASH_MAGIC              (FPEC_BASE + 0x34)
+#define FLASH_MODEKEYR_CH32      (FPEC_BASE + 0x24) // Fast mode for CH32F10x
+#define FLASH_CR_FLOCK_CH32      (1 << 15)          // fast unlock
+#define FLASH_CR_FTPG_CH32       (1 << 16)          // fast page program
+#define FLASH_CR_FTER_CH32       (1 << 17)          // fast page erase
+#define FLASH_CR_BUF_LOAD_CH32   (1 << 18)          // Buffer load
+#define FLASH_CR_BUF_RESET_CH32  (1 << 19)          // Buffer reset
+#define FLASH_SR_EOP             (1 << 5)           // End of programming
+#define FLASH_BEGIN_ADDRESS_CH32 0x8000000
 
 /**
 		\fn ch32f1_add_flash
@@ -87,41 +87,46 @@ static void ch32f1_add_flash(target *t, uint32_t addr, size_t length, size_t era
 	target_add_flash(t, f);
 }
 
-#define WAIT_BUSY() do { \
-	sr = target_mem_read32(t, FLASH_SR); \
-	if (target_check_error(t)) { \
-		DEBUG_WARN("ch32f1 flash write: comm error\n"); \
-		return -1; \
-	} \
-} while (sr & FLASH_SR_BSY);
+#define WAIT_BUSY()                                         \
+	do {                                                    \
+		sr = target_mem_read32(t, FLASH_SR);                \
+		if (target_check_error(t)) {                        \
+			DEBUG_WARN("ch32f1 flash write: comm error\n"); \
+			return -1;                                      \
+		}                                                   \
+	} while (sr & FLASH_SR_BSY);
 
-#define WAIT_EOP() do { \
-	sr = target_mem_read32(t, FLASH_SR); \
-	if (target_check_error(t)) { \
-		DEBUG_WARN("ch32f1 flash write: comm error\n"); \
-		return -1; \
-	} \
-} while (!(sr & FLASH_SR_EOP));
+#define WAIT_EOP()                                          \
+	do {                                                    \
+		sr = target_mem_read32(t, FLASH_SR);                \
+		if (target_check_error(t)) {                        \
+			DEBUG_WARN("ch32f1 flash write: comm error\n"); \
+			return -1;                                      \
+		}                                                   \
+	} while (!(sr & FLASH_SR_EOP));
 
-#define CLEAR_EOP()	target_mem_write32(t, FLASH_SR,FLASH_SR_EOP)
+#define CLEAR_EOP() target_mem_write32(t, FLASH_SR, FLASH_SR_EOP)
 
-#define SET_CR(bit) do { \
-	const uint32_t cr = target_mem_read32(t, FLASH_CR) | (bit); \
-	target_mem_write32(t, FLASH_CR, cr); \
-} while(0)
+#define SET_CR(bit)                                                 \
+	do {                                                            \
+		const uint32_t cr = target_mem_read32(t, FLASH_CR) | (bit); \
+		target_mem_write32(t, FLASH_CR, cr);                        \
+	} while (0)
 
-#define CLEAR_CR(bit) do { \
-	const uint32_t cr = target_mem_read32(t, FLASH_CR) & (~(bit)); \
-	target_mem_write32(t, FLASH_CR, cr); \
-} while(0)
+#define CLEAR_CR(bit)                                                  \
+	do {                                                               \
+		const uint32_t cr = target_mem_read32(t, FLASH_CR) & (~(bit)); \
+		target_mem_write32(t, FLASH_CR, cr);                           \
+	} while (0)
 
 // Which one is the right value ?
 #define MAGIC_WORD 0x100
 // #define MAGIC_WORD 0x1000
-#define MAGIC(addr) do { \
-	magic = target_mem_read32(t, (addr) ^ MAGIC_WORD); \
-	target_mem_write32(t, FLASH_MAGIC , magic); \
-} while(0)
+#define MAGIC(addr)                                        \
+	do {                                                   \
+		magic = target_mem_read32(t, (addr) ^ MAGIC_WORD); \
+		target_mem_write32(t, FLASH_MAGIC, magic);         \
+	} while (0)
 
 /**
   \fn ch32f1_flash_unlock
@@ -139,7 +144,7 @@ static bool ch32f1_flash_unlock(target *t)
 	uint32_t cr = target_mem_read32(t, FLASH_CR);
 	if (cr & FLASH_CR_FLOCK_CH32) {
 		DEBUG_WARN("Fast unlock failed, cr: 0x%08" PRIx32 "\n", cr);
-		return false ;
+		return false;
 	}
 	return true;
 }
@@ -155,7 +160,7 @@ static bool ch32f1_flash_lock(target *t)
 	// FLASH_CR_FLOCK_CH32 bit does not exists on *regular* clones and defaults to '0' (see PM0075 for STM32F1xx)
 	if (!(cr & FLASH_CR_FLOCK_CH32)) {
 		DEBUG_WARN("Fast lock failed, cr: 0x%08" PRIx32 "\n", cr);
-		return  false ;
+		return false;
 	}
 	return true;
 }
@@ -168,23 +173,22 @@ static bool ch32f1_has_fastUnlock(target *t)
 	DEBUG_INFO("CH32: has fatunlock \n");
 	// reset fast unlock
 	SET_CR(FLASH_CR_FLOCK_CH32);
-	platform_delay(1); // The flash controller is timing sensitive 
-	uint32_t cr=target_mem_read32(t, FLASH_CR) ;
-	if(!(cr & FLASH_CR_FLOCK_CH32))
-	{
+	platform_delay(1); // The flash controller is timing sensitive
+	uint32_t cr = target_mem_read32(t, FLASH_CR);
+	if (!(cr & FLASH_CR_FLOCK_CH32)) {
 		return false;
 	}
 	// send unlock sequence
 	target_mem_write32(t, FLASH_KEYR, KEY1);
 	target_mem_write32(t, FLASH_KEYR, KEY2);
-	platform_delay(1); // The flash controller is timing sensitive 
+	platform_delay(1); // The flash controller is timing sensitive
 	// send fast unlock sequence
 	target_mem_write32(t, FLASH_MODEKEYR_CH32, KEY1);
 	target_mem_write32(t, FLASH_MODEKEYR_CH32, KEY2);
-	platform_delay(1); // The flash controller is timing sensitive 
-	
+	platform_delay(1); // The flash controller is timing sensitive
+
 	cr = target_mem_read32(t, FLASH_CR);
-	return !(cr  & FLASH_CR_FLOCK_CH32);
+	return !(cr & FLASH_CR_FLOCK_CH32);
 }
 
 /**
@@ -200,7 +204,8 @@ bool ch32f1_probe(target *t)
 	const uint32_t device_id = dbgmcu_idcode & 0x00000fffU;
 	const uint32_t revision_id = (dbgmcu_idcode & 0xffff0000U) >> 16;
 
-	DEBUG_WARN("DBGMCU_IDCODE 0x%" PRIx32 ", DEVID 0x%" PRIx32 ", REVID 0x%" PRIx32 " \n", dbgmcu_idcode, device_id, revision_id);
+	DEBUG_WARN("DBGMCU_IDCODE 0x%" PRIx32 ", DEVID 0x%" PRIx32 ", REVID 0x%" PRIx32 " \n", dbgmcu_idcode, device_id,
+		revision_id);
 
 	if (device_id != 0x410) // ch32f103, cks32f103, apm32f103
 		return false;
@@ -209,7 +214,7 @@ bool ch32f1_probe(target *t)
 		return false;
 
 	// try to flock (if this fails it is not a CH32 chip)
-	if(!ch32f1_has_fastUnlock(t)) {
+	if (!ch32f1_has_fastUnlock(t)) {
 		return false;
 	}
 	t->part_id = device_id;
@@ -239,7 +244,7 @@ bool ch32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 	}
 	// Fast Erase 128 bytes pages (ch32 mode)
 	while (len) {
-		SET_CR(FLASH_CR_FTER_CH32);// CH32 PAGE_ER
+		SET_CR(FLASH_CR_FTER_CH32); // CH32 PAGE_ER
 		/* write address to FMA */
 		target_mem_write32(t, FLASH_AR, addr);
 		/* Flash page erase start instruction */
@@ -291,7 +296,7 @@ static bool ch32f1_wait_flash_ready(target *t, uint32_t addr)
 static int ch32f1_upload(target *t, uint32_t dest, const void *src, uint32_t offset)
 {
 	volatile uint32_t sr, magic;
-	const uint32_t *ss = (const uint32_t *)(src+offset);
+	const uint32_t *ss = (const uint32_t *)(src + offset);
 	uint32_t dd = dest + offset;
 
 	SET_CR(FLASH_CR_FTPG_CH32);
@@ -313,10 +318,10 @@ static int ch32f1_upload(target *t, uint32_t dest, const void *src, uint32_t off
 static int ch32f1_buffer_clear(target *t)
 {
 	volatile uint32_t sr;
-	SET_CR(FLASH_CR_FTPG_CH32); // Fast page program 4-
+	SET_CR(FLASH_CR_FTPG_CH32);      // Fast page program 4-
 	SET_CR(FLASH_CR_BUF_RESET_CH32); // BUF_RESET 5-
-	WAIT_BUSY(); // 6-
-	CLEAR_CR(FLASH_CR_FTPG_CH32); // Fast page program 4-
+	WAIT_BUSY();                     // 6-
+	CLEAR_CR(FLASH_CR_FTPG_CH32);    // Fast page program 4-
 	return 0;
 }
 //#define CH32_VERIFY
@@ -335,8 +340,7 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 #endif
 	DEBUG_INFO("CH32: flash write 0x%" PRIx32 " ,size=%" PRIu32 "\n", dest, (uint32_t)len);
 
-	while (length > 0)
-	{
+	while (length > 0) {
 		if (!ch32f1_flash_unlock(t)) {
 			DEBUG_WARN("ch32f1 cannot fast unlock\n");
 			return false;
@@ -346,20 +350,20 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 		// Buffer reset...
 		ch32f1_buffer_clear(t);
 		// Load 128 bytes to buffer
-		if (!ch32f1_wait_flash_ready(t,dest))
+		if (!ch32f1_wait_flash_ready(t, dest))
 			return false;
 
 		for (size_t i = 0; i < 8; i++) {
 			if (ch32f1_upload(t, dest, src, i * 16U)) {
-	  			DEBUG_WARN("Cannot upload to buffer\n");
+				DEBUG_WARN("Cannot upload to buffer\n");
 				return false;
 			}
 		}
 		// write buffer
 		SET_CR(FLASH_CR_FTPG_CH32);
 		target_mem_write32(t, FLASH_AR, dest); // 10
-		SET_CR(FLASH_CR_STRT); // 11 Start
-		WAIT_EOP(); // 12
+		SET_CR(FLASH_CR_STRT);                 // 11 Start
+		WAIT_EOP();                            // 12
 		CLEAR_EOP();
 		CLEAR_CR(FLASH_CR_FTPG_CH32);
 
@@ -367,7 +371,7 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 
 		// next
 		if (length > 128)
-			length -=128;
+			length -= 128;
 		else
 			length = 0;
 		dest += 128;
@@ -383,12 +387,10 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 
 #ifdef CH32_VERIFY
 	DEBUG_INFO("Verifying\n");
-	for (size_t i = 0; i < len; i += 4)
-	{
+	for (size_t i = 0; i < len; i += 4) {
 		const uint32_t expected = *(uint32_t *)(org_src + i);
 		const uint32_t actual = target_mem_read32(t, org_dest + i);
-		if (expected != actual)
-		{
+		if (expected != actual) {
 			DEBUG_WARN(">>>>write mistmatch at address 0x%" PRIx32 "\n", org_dest + i);
 			DEBUG_WARN(">>>>expected: 0x%" PRIx32 "\n", expected);
 			DEBUG_WARN(">>>>  actual: 0x%" PRIx32 "\n", actual);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses the current detection reliability issues of CH32F1 series devices. When it is misidentified as another clone, flash writing simply does not work as it is way too slow. That chip flash is timing sensitive, which is a possible cause of the unreliability. This PR does a check on both setting & clearing the CH32 specific bit, waiting 1 ms in between. This should improve the reliability so that it SHOULD not misidentified other clones, but i cannot be 100% sure.

Additionally, this PR inverts the logic on the CH32F1 functions for locking, unlocking and checking the Flash lock status so that it reads more sensibly with 'true' returned for success, and 'false for failure.

Tested to work on STM32F103, GD32F303 and CH32F103 (i.e. does not miss-detect STM32/GD32)

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->

