### PR TITLE
fix: BMDA FTDI configuration for FT4232H

### DIFF
--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -243,12 +243,17 @@ cable_desc_t cable_desc[] = {
 		.name = "ft232h"
 	},
 	{
-		/* Direct connection from FTDI to Jtag/Swd assumed.*/
+		/* MPSSE-SK (AD0) ----------- SWCLK/JTCK
+		 * MPSSE-DO (AD1) ----------- SWDIO/JTMS
+		 * MPSSE-DI (AD2) -- 330 R -- SWDIO/JTMS
+		 *                  (470 R or similar also fine)
+		 */
 		.vendor = 0x0403,
 		.product = 0x6011,
 		.interface = INTERFACE_A,
-		.bb_swdio_in_port_cmd = GET_BITS_LOW,
-		.bb_swdio_in_pin = MPSSE_CS,
+		.mpsse_swd_read.set_data_low  = MPSSE_DI,
+		.mpsse_swd_write.set_data_low = MPSSE_DO,
+		.description = "FT4232H-56Q MiniModule",
 		.name = "ft4232h"
 	},
 	{


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

With thanks to sys64738 from the 1b² Discord, this PR addresses the current FTDI configuration data for the FT4242H being incorrect and leading to probes built around this device being non-functional with BMDA. This has been tested to work and adds some extra pinout information which is quite handy.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
