### PR TITLE
stm32f1: Identify GD32F330 correctly

### DIFF
--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -243,12 +243,17 @@ cable_desc_t cable_desc[] = {
 		.name = "ft232h"
 	},
 	{
-		/* Direct connection from FTDI to Jtag/Swd assumed.*/
+		/* MPSSE-SK (AD0) ----------- SWCLK/JTCK
+		 * MPSSE-DO (AD1) ----------- SWDIO/JTMS
+		 * MPSSE-DI (AD2) -- 330 R -- SWDIO/JTMS
+		 *                  (470 R or similar also fine)
+		 */
 		.vendor = 0x0403,
 		.product = 0x6011,
 		.interface = INTERFACE_A,
-		.bb_swdio_in_port_cmd = GET_BITS_LOW,
-		.bb_swdio_in_pin = MPSSE_CS,
+		.mpsse_swd_read.set_data_low  = MPSSE_DI,
+		.mpsse_swd_write.set_data_low = MPSSE_DO,
+		.description = "FT4232H-56Q MiniModule",
 		.name = "ft4232h"
 	},
 	{

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -136,6 +136,8 @@ bool gd32f1_probe(target *t)
 	case 0x410: /* Gigadevice gd32f103, gd32e230 */
 		if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
 			t->driver = "GD32E230";
+		else if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M4)
+			t->driver = "GD32F3";
 		else
 			t->driver = "GD32F1";
 		break;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

stm32f1: small update to identification logic to correctly identify GD32F330 parts as GD32F3 M4. Without the patch they are identified as GD32F1 M4.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

None
