### PR TITLE
rp: fix format for debug print

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -385,7 +385,7 @@ static bool rp_rom_call(target *t, uint32_t *regs, uint32_t cmd, uint32_t timeou
 		if (ps->is_monitor)
 			target_print_progress(&wait_timeout);
 		if (platform_timeout_is_expired(&operation_timeout)) {
-			DEBUG_WARN("RP Run timout %ums reached: ", timeout);
+			DEBUG_WARN("RP Run timout %" PRIu32 "ms reached: ", timeout);
 			break;
 		}
 	}


### PR DESCRIPTION
## Detailed description

Use PRIu32 instead of `%u` for printing the timeout.

This fixes a build issue on ESP32.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do