### PR TITLE
hosted: Moved function "extract_serial" from bmp_serial to probe_info to allow reuse in bmp_libusb

### DIFF
--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -187,24 +187,6 @@ size_t find_prefix_length(const char *name, const size_t name_len)
 	return 0;
 }
 
-char *extract_serial(const char *const device, const size_t length)
-{
-	const char *const last_underscore = strrchr(device, '_');
-	/* Fail the match if we can't find the _ just before the serial string. */
-	if (!last_underscore)
-		return NULL;
-	/* This represents the first byte of the serial number string */
-	const char *const begin = last_underscore + 1;
-	/* This represents one past the last byte of the serial number string */
-	const char *const end = device + length - 5;
-	/* We now allocate memory for the chunk and copy it */
-	const size_t result_length = end - begin;
-	char *const result = (char *)malloc(result_length);
-	memcpy(result, begin, result_length);
-	result[result_length - 1] = '\0';
-	return result;
-}
-
 static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_list)
 {
 	/* Starting with a string such as 'usb-Black_Magic_Debug_Black_Magic_Probe_v1.8.0-650-g829308db_8BB20695-if00' */

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -35,6 +35,24 @@
 #include "probe_info.h"
 #include "general.h"
 
+char *extract_serial(const char *const device, const size_t length)
+{
+	const char *const last_underscore = strrchr(device, '_');
+	/* Fail the match if we can't find the _ just before the serial string. */
+	if (!last_underscore)
+		return NULL;
+	/* This represents the first byte of the serial number string */
+	const char *const begin = last_underscore + 1;
+	/* This represents one past the last byte of the serial number string */
+	const char *const end = device + length - 5;
+	/* We now allocate memory for the chunk and copy it */
+	const size_t result_length = end - begin;
+	char *const result = (char *)malloc(result_length);
+	memcpy(result, begin, result_length);
+	result[result_length - 1] = '\0';
+	return result;
+}
+
 probe_info_s *probe_info_add(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
 	const char *const product, const char *const serial, const char *const version)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -35,7 +35,7 @@
 #include "probe_info.h"
 #include "general.h"
 
-char *extract_serial(const char *const device, const size_t length)
+char *extract_serial(const char *device, size_t length)
 {
 	const char *const last_underscore = strrchr(device, '_');
 	/* Fail the match if we can't find the _ just before the serial string. */

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -48,7 +48,7 @@ typedef struct probe_info {
 	struct probe_info *next;
 } probe_info_s;
 
-char *extract_serial(const char *const device, const size_t length) ;
+char *extract_serial(const char *device, size_t length);
 probe_info_s *probe_info_add(
 	probe_info_s *list, bmp_type_t type, const char *mfr, const char *product, const char *serial, const char *version);
 size_t probe_info_count(const probe_info_s *list);

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -48,6 +48,7 @@ typedef struct probe_info {
 	struct probe_info *next;
 } probe_info_s;
 
+char *extract_serial(const char *const device, const size_t length) ;
 probe_info_s *probe_info_add(
 	probe_info_s *list, bmp_type_t type, const char *mfr, const char *product, const char *serial, const char *version);
 size_t probe_info_count(const probe_info_s *list);


### PR DESCRIPTION
## Moved function "extract_serial" from bmp_serial to bmp_libusb

Moving this function allows it to be re-used in the USB scanning of probes.

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
