### PR TITLE
target/nrf52: stop inverting return on nrf51_cmd_read_*

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -420,7 +420,7 @@ static bool nrf51_cmd_read(target *t, int argc, const char **argv)
 			 * So 'mon ver' will match 'monitor version'
 			 */
 			if(!strncmp(argv[1], c->cmd, strlen(argv[1])))
-				return !c->handler(t, argc - 1, &argv[1]);
+				return c->handler(t, argc - 1, &argv[1]);
 		}
 	}
 	return nrf51_cmd_read_help(t, 0, NULL);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

NRF52 read command had a wrong inversion causing `Failed` commands when they where in fact successful, likely a leftover of the command return type change

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
