### PR TITLE
rtt_if: fix build when libopencm3 is not used

### DIFF
--- a/src/include/rtt_if.h
+++ b/src/include/rtt_if.h
@@ -29,9 +29,12 @@
 
 /* rtt i/o to terminal */
 
+/* Define NO_LIBOPENCM3 either in "platform.h" or on the command line
+ * in order to avoid including "libopencm3/usb/usbd.h".
+ */
 #include "platform.h"
 
-#if PC_HOSTED == 0 && NO_LIBOPENCM3 != 1
+#if PC_HOSTED == 0 && !defined(NO_LIBOPENCM3)
 #include <libopencm3/usb/usbd.h>
 
 /* usb rx callback */

--- a/src/include/rtt_if.h
+++ b/src/include/rtt_if.h
@@ -29,6 +29,8 @@
 
 /* rtt i/o to terminal */
 
+#include "platform.h"
+
 #if PC_HOSTED == 0 && NO_LIBOPENCM3 != 1
 #include <libopencm3/usb/usbd.h>
 

--- a/src/include/rtt_if.h
+++ b/src/include/rtt_if.h
@@ -29,7 +29,7 @@
 
 /* rtt i/o to terminal */
 
-#if PC_HOSTED == 0
+#if PC_HOSTED == 0 && NO_LIBOPENCM3 != 1
 #include <libopencm3/usb/usbd.h>
 
 /* usb rx callback */


### PR DESCRIPTION
## Detailed description

With the inclusion of a89689f3cbd32661375054f2f54669f4fcae1122, `libopencm3/usb/usbd.h` is now unconditionally included on all non-hosted builds. This causes the build to fail if libopencm3 is not present, which occurs on platforms where this library is not used.

As a separate issue, the ESP32 build uses ccache which appears to ignore the CMake `add_definitions()` directive, and thus does not get the `NO_LIBOPENCM3=1` parameter during ccache generation.

This patch makes two minor changes to `rtt_if.h`:

1. It gates the inclusion of `libopencm3/usb/usbd.h` by both `PC_HOSTED=0` and `NO_LIBOPENCM3=1`, meaning both of these must be true in order to include that file
2. `rtt_if.h` now explicitly includes `platform.h`, which fixes the ccache issue as well as ensuring that `RTT_DOWN_BUF_SIZE` and `RTT_UP_BUF_SIZE` come from `platform.h`

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do