### PR TITLE
Add VID/PID to probe_info structure

### DIFF
--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -271,7 +271,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 		return probe_list;
 	}
 
-	return probe_info_add(probe_list, BMP_TYPE_BMP, type, product, serial, version);
+	return probe_info_add_by_serial(probe_list, BMP_TYPE_BMP, type, product, serial, version);
 }
 
 static const probe_info_s *scan_for_devices(void)
@@ -286,7 +286,7 @@ static const probe_info_s *scan_for_devices(void)
 			break;
 		if (device_is_bmp_gdb_port(entry->d_name)) {
 			probe_info_s *probe_info = parse_device_node(entry->d_name, probe_list);
-			/* If the operation would have succeeded but probe_info_add fails, we exhausted memory. */
+			/* If the operation would have succeeded but probe_info_add_by_serial fails, we exhausted memory. */
 			if (!probe_info) {
 				probe_info_list_free(probe_list);
 				probe_list = NULL;

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -56,7 +56,7 @@ char *extract_serial(const char *device, size_t length)
 probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
 	const char *const product, const char *const serial, const char *const version)
 {
-	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version) ;
+	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version);
 }
 
 probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
@@ -69,15 +69,16 @@ probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t ty
 	}
 
 	probe_info->type = type;
-	probe_info->vid  = vid ;
-	probe_info->pid = pid ;
+	probe_info->vid = vid;
+	probe_info->pid = pid;
 	probe_info->manufacturer = mfr;
 	probe_info->product = product;
 	probe_info->serial = serial;
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;}
+	return probe_info;
+}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -56,6 +56,12 @@ char *extract_serial(const char *device, size_t length)
 probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
 	const char *const product, const char *const serial, const char *const version)
 {
+	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version) ;
+}
+
+probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
+	const char *const mfr, const char *const product, const char *const serial, const char *const version)
+{
 	probe_info_s *probe_info = malloc(sizeof(*probe_info));
 	if (!probe_info) {
 		DEBUG_INFO("Fatal: Failed to allocate memory for a probe info structure\n");
@@ -63,14 +69,15 @@ probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_
 	}
 
 	probe_info->type = type;
+	probe_info->vid  = vid ;
+	probe_info->pid = pid ;
 	probe_info->manufacturer = mfr;
 	probe_info->product = product;
 	probe_info->serial = serial;
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;
-}
+	return probe_info;}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -53,7 +53,7 @@ char *extract_serial(const char *device, size_t length)
 	return result;
 }
 
-probe_info_s *probe_info_add(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
+probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
 	const char *const product, const char *const serial, const char *const version)
 {
 	probe_info_s *probe_info = malloc(sizeof(*probe_info));

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -40,6 +40,8 @@
 
 typedef struct probe_info {
 	bmp_type_t type;
+	uint16_t vid;
+	uint16_t pid;
 	const char *manufacturer;
 	const char *product;
 	const char *serial;
@@ -49,7 +51,7 @@ typedef struct probe_info {
 } probe_info_s;
 
 char *extract_serial(const char *device, size_t length);
-probe_info_s *probe_info_add(
+probe_info_s *probe_info_add_by_serial(
 	probe_info_s *list, bmp_type_t type, const char *mfr, const char *product, const char *serial, const char *version);
 size_t probe_info_count(const probe_info_s *list);
 void probe_info_list_free(const probe_info_s *list);

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -53,6 +53,8 @@ typedef struct probe_info {
 char *extract_serial(const char *device, size_t length);
 probe_info_s *probe_info_add_by_serial(
 	probe_info_s *list, bmp_type_t type, const char *mfr, const char *product, const char *serial, const char *version);
+probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
+	const char *const mfr, const char *const product, const char *const serial, const char *const version);
 size_t probe_info_count(const probe_info_s *list);
 void probe_info_list_free(const probe_info_s *list);
 


### PR DESCRIPTION
Add VID/PID to probe_info structure.
Rename probe_info_add function to probe_info_add_by_serial and add a function probe_info_add_by_id.

Call "by_id" function from "by_serial" with default VID/PID.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

