### PR TITLE
probe_info: Transfer VID and PID to bmp_info_s

### DIFF
--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -131,7 +131,8 @@ const probe_info_s *probe_info_filter(const probe_info_s *const list, const char
 void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_s *info)
 {
 	info->bmp_type = probe->type;
-
+	info->pid = probe->pid;
+	info->vid = probe->vid;
 	const size_t serial_len = MIN(strlen(probe->serial), sizeof(info->serial) - 1U);
 	memcpy(info->serial, probe->serial, serial_len);
 	info->serial[serial_len] = '\0';


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Add transfer of VID/PID to bmp_info_s structure

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do
