### PR TITLE
probe_info: Fix probe filtering by probe number

### DIFF
--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -121,7 +121,7 @@ const probe_info_s *probe_info_correct_order(probe_info_s *list)
 const probe_info_s *probe_info_filter(const probe_info_s *const list, const char *const serial, const size_t position)
 {
 	const probe_info_s *probe_info = list;
-	for (size_t probe = 0; probe_info; probe_info = probe_info->next, ++probe) {
+	for (size_t probe = 1; probe_info; probe_info = probe_info->next, ++probe) {
 		if ((serial && strstr(probe_info->serial, serial)) || (position && probe == position))
 			return probe_info;
 	}


### PR DESCRIPTION
## Fix filtering of probes by probe number

<!--
The filtering function had the starting probe number initialized to "0", it should be started at "1" since the input probe selection uses one-based numbers.

-->

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do
