### PR TITLE
pace_poll: allow other platforms to delay

### DIFF
--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -28,9 +28,14 @@
 
 #if PC_HOSTED == 1
 void platform_init(int argc, char **argv);
-void platform_pace_poll(void);
+#define PLATFORM_HAS_PACE_POLL
 #else
 void platform_init(void);
+#endif
+
+#if defined(PLATFORM_HAS_PACE_POLL)
+void platform_pace_poll(void);
+#else
 inline void platform_pace_poll(void) { }
 #endif
 


### PR DESCRIPTION
## Detailed description

The RTT implementation normally spends most of its time in a tight loop. This can cause problems on some platforms where tight loops can starve other threads.

Add support for defining PLATFORM_HAS_PACE_POLL in `platform.h` in order to supply a `platform_pace_poll()` function that can implement this.

This prevents WDT triggers on ESP32 where RTT blocks the `IDLE` thread from running. The `IDLE` thread is responsible for resetting the WDT.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do