### PR TITLE
stlink: set BLUEPILL compiler option if BLUEPILL environment variable set

### DIFF
--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -31,6 +31,10 @@ else
 SRC += traceswoasync.c
 endif
 
+ifeq ($(BLUEPILL), 1)
+CFLAGS += -DBLUEPILL=1
+endif
+
 VPATH += platforms/stm32
 
 SRC +=          \


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

When compiling stlink platform, set BLUEPILL compiler option if BLUEPILL environment variable set

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
