### PR TITLE
gdb_main: move main loop into `main()`

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -115,7 +115,7 @@ target_controller_s gdb_controller = {
 
 /* execute gdb remote command stored in 'pbuf'. returns immediately, no busy waiting. */
 
-int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t size, bool in_syscall)
+int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t size, bool in_syscall)
 {
 	bool single_step = false;
 
@@ -134,7 +134,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t size, bool in_sysc
 			uint32_t addr, len;
 			ERROR_IF_NO_TARGET();
 			sscanf(pbuf, "m%" SCNx32 ",%" SCNx32, &addr, &len);
-			if (len > sizeof(pbuf) / 2U) {
+			if (len > pbuf_size / 2U) {
 				gdb_putpacketz("E02");
 				break;
 			}
@@ -662,9 +662,9 @@ static void handle_z_packet(char *packet, const size_t plen)
 		gdb_putpacketz("OK");
 }
 
-void gdb_main(char *pbuf, size_t size)
+void gdb_main(char *pbuf, size_t pbuf_size, size_t size)
 {
-	gdb_main_loop(&gdb_controller, pbuf, size, false);
+	gdb_main_loop(&gdb_controller, pbuf, pbuf_size, size, false);
 }
 
 /* halt target */

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -695,7 +695,7 @@ void gdb_poll_target(void)
 
 	/* poll target */
 	target_addr_t watch;
-	enum target_halt_reason reason = target_halt_poll(cur_target, &watch);
+	target_halt_reason_e reason = target_halt_poll(cur_target, &watch);
 	if (!reason)
 		return;
 

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -687,8 +687,6 @@ void gdb_halt_target(void)
 /* poll running target */
 void gdb_poll_target(void)
 {
-	target_addr_t watch;
-	enum target_halt_reason reason;
 	if (!cur_target) {
 		/* Report "target exited" if no target */
 		gdb_putpacketz("W00");
@@ -696,7 +694,8 @@ void gdb_poll_target(void)
 	}
 
 	/* poll target */
-	reason = target_halt_poll(cur_target, &watch);
+	target_addr_t watch;
+	enum target_halt_reason reason = target_halt_poll(cur_target, &watch);
 	if (!reason)
 		return;
 
@@ -722,5 +721,4 @@ void gdb_poll_target(void)
 	default:
 		gdb_putpacket_f("T%02X", GDB_SIGTRAP);
 	}
-	return;
 }

--- a/src/include/gdb_main.h
+++ b/src/include/gdb_main.h
@@ -25,6 +25,6 @@
 extern bool gdb_target_running;
 extern target_s *cur_target;
 void gdb_poll_target(void);
-void gdb_main(char *pbuf, size_t size);
+void gdb_main(char *pbuf, size_t pbuf_size, size_t size);
 
 #endif /* INCLUDE_GDB_MAIN_H */

--- a/src/include/gdb_main.h
+++ b/src/include/gdb_main.h
@@ -21,6 +21,10 @@
 #ifndef INCLUDE_GDB_MAIN_H
 #define INCLUDE_GDB_MAIN_H
 
-void gdb_main(void);
+#include "target.h"
+extern bool gdb_target_running;
+extern target_s *cur_target;
+void gdb_poll_target(void);
+void gdb_main(char *pbuf, size_t size);
 
 #endif /* INCLUDE_GDB_MAIN_H */

--- a/src/main.c
+++ b/src/main.c
@@ -54,10 +54,9 @@ int main(int argc, char **argv)
 
 				// Check again, as `gdb_poll_target()` may
 				// alter these variables.
-				if (!gdb_target_running || !cur_target) {
+				if (!gdb_target_running || !cur_target)
 					break;
-				}
-				char c = (char)gdb_if_getchar_to(0);
+				char c = gdb_if_getchar_to(0);
 				if (c == '\x03' || c == '\x04')
 					target_halt_request(cur_target);
 				platform_pace_poll();

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,34 @@
 #define BUF_SIZE 1024U
 static char pbuf[BUF_SIZE + 1U];
 
+static void bmp_poll_loop(void)
+{
+	SET_IDLE_STATE(false);
+	while (gdb_target_running && cur_target) {
+		gdb_poll_target();
+
+		// Check again, as `gdb_poll_target()` may
+		// alter these variables.
+		if (!gdb_target_running || !cur_target)
+			break;
+		char c = gdb_if_getchar_to(0);
+		if (c == '\x03' || c == '\x04')
+			target_halt_request(cur_target);
+		platform_pace_poll();
+#ifdef ENABLE_RTT
+		if (rtt_enabled)
+			poll_rtt(cur_target);
+#endif
+	}
+
+	SET_IDLE_STATE(true);
+	size_t size = gdb_getpacket(pbuf, BUF_SIZE);
+	// If port closed and target detached, stay idle
+	if (pbuf[0] != '\x04' || cur_target)
+		SET_IDLE_STATE(false);
+	gdb_main(pbuf, sizeof(pbuf), size);
+}
+
 int main(int argc, char **argv)
 {
 #if PC_HOSTED == 1
@@ -48,30 +76,7 @@ int main(int argc, char **argv)
 	while (true) {
 		volatile exception_s e;
 		TRY_CATCH (e, EXCEPTION_ALL) {
-			SET_IDLE_STATE(false);
-			while (gdb_target_running && cur_target) {
-				gdb_poll_target();
-
-				// Check again, as `gdb_poll_target()` may
-				// alter these variables.
-				if (!gdb_target_running || !cur_target)
-					break;
-				char c = gdb_if_getchar_to(0);
-				if (c == '\x03' || c == '\x04')
-					target_halt_request(cur_target);
-				platform_pace_poll();
-#ifdef ENABLE_RTT
-				if (rtt_enabled)
-					poll_rtt(cur_target);
-#endif
-			}
-
-			SET_IDLE_STATE(true);
-			size_t size = gdb_getpacket(pbuf, BUF_SIZE);
-			// If port closed and target detached, stay idle
-			if (pbuf[0] != 0x04 || cur_target)
-				SET_IDLE_STATE(false);
-			gdb_main(pbuf, sizeof(pbuf), size);
+			bmp_poll_loop();
 		}
 		if (e.type) {
 			gdb_putpacketz("EFF");

--- a/src/main.c
+++ b/src/main.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 			// If port closed and target detached, stay idle
 			if (pbuf[0] != 0x04 || cur_target)
 				SET_IDLE_STATE(false);
-			gdb_main(pbuf, size);
+			gdb_main(pbuf, sizeof(pbuf), size);
 		}
 		if (e.type) {
 			gdb_putpacketz("EFF");

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -41,8 +41,12 @@ char *platform_ident(void);
 void platform_buffer_flush(void);
 
 #define PLATFORM_IDENT "(Black Magic Debug App) "
-#define SET_IDLE_STATE(x)
-#define SET_RUN_STATE(x)
+#define SET_IDLE_STATE(x) \
+	do {                  \
+	} while (0)
+#define SET_RUN_STATE(x) \
+	do {                 \
+	} while (0)
 #define PLATFORM_HAS_POWER_SWITCH
 
 #define SYSTICKHZ 1000U


### PR DESCRIPTION
## Detailed description

This is a rewrite of the main loop as suggested in https://github.com/blackmagic-debug/blackmagic/pull/1281. Rather
than constantly sitting inside `gdb_main()`, the program's main loop does its own polling of the target. This enables
a host to do its own waiting without needing to insert hooks in various functions.

This prevents WDT triggers on ESP32 where RTT blocks the IDLE thread from running. The IDLE thread is responsible for resetting the WDT. It can also be used inside the main loop to regulate hosts such as `PC_HOSTED` where constant USB polling is undesirable.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do