### PR TITLE
Hosted  fix error in copying data to bmp_info_s

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -92,6 +92,7 @@ static const uint32_t crc32_table[] = {
 	0xAFB010B1, 0xAB710D06, 0xA6322BDF, 0xA2F33668,
 	0xBCB4666D, 0xB8757BDA, 0xB5365D03, 0xB1F740B4,
 };
+/* clang-format on */
 
 /* clang-format on */
 

--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -120,6 +120,7 @@ void platform_request_boot(void)
 	magic[1] = BOOTMAGIC1;
 	scb_reset_system();
 }
+#pragma GCC diagnostic pop
 
 #pragma GCC diagnostic pop
 

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -187,24 +187,6 @@ size_t find_prefix_length(const char *name, const size_t name_len)
 	return 0;
 }
 
-char *extract_serial(const char *const device, const size_t length)
-{
-	const char *const last_underscore = strrchr(device, '_');
-	/* Fail the match if we can't find the _ just before the serial string. */
-	if (!last_underscore)
-		return NULL;
-	/* This represents the first byte of the serial number string */
-	const char *const begin = last_underscore + 1;
-	/* This represents one past the last byte of the serial number string */
-	const char *const end = device + length - 5;
-	/* We now allocate memory for the chunk and copy it */
-	const size_t result_length = end - begin;
-	char *const result = (char *)malloc(result_length);
-	memcpy(result, begin, result_length);
-	result[result_length - 1] = '\0';
-	return result;
-}
-
 static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_list)
 {
 	/* Starting with a string such as 'usb-Black_Magic_Debug_Black_Magic_Probe_v1.8.0-650-g829308db_8BB20695-if00' */

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -59,8 +59,7 @@ probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t ty
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;
-}
+	return probe_info;}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -44,7 +44,7 @@ probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_
 probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
 	const char *const mfr, const char *const product, const char *const serial, const char *const version)
 {
-	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version) ;
+	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version);
 }
 
 probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
@@ -65,7 +65,8 @@ probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t ty
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;}
+	return probe_info;
+}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -44,6 +44,12 @@ probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_
 probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
 	const char *const mfr, const char *const product, const char *const serial, const char *const version)
 {
+	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version) ;
+}
+
+probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
+	const char *const mfr, const char *const product, const char *const serial, const char *const version)
+{
 	probe_info_s *probe_info = malloc(sizeof(*probe_info));
 	if (!probe_info) {
 		DEBUG_INFO("Fatal: Failed to allocate memory for a probe info structure\n");
@@ -59,8 +65,7 @@ probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t ty
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;
-}
+	return probe_info;}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -119,8 +119,10 @@ const probe_info_s *probe_info_filter(const probe_info_s *const list, const char
 void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_s *info)
 {
 	info->bmp_type = probe->type;
+#if HOSTED_BMP_ONLY != 1
 	info->pid = probe->pid;
 	info->vid = probe->vid;
+#endif
 	const size_t serial_len = MIN(strlen(probe->serial), sizeof(info->serial) - 1U);
 	memcpy(info->serial, probe->serial, serial_len);
 	info->serial[serial_len] = '\0';

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -59,7 +59,8 @@ probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t ty
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;}
+	return probe_info;
+}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/stm32/dfu_f4.c
+++ b/src/platforms/stm32/dfu_f4.c
@@ -24,6 +24,7 @@
 #include <libopencm3/stm32/flash.h>
 #include <libopencm3/cm3/scb.h>
 
+/* clang-format off */
 static uint32_t sector_addr[] = {
 	0x8000000,
 	0x8004000,

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -401,6 +401,13 @@ static uint32_t stm32f1_bank_offset_for(target_addr_t addr)
 	return FLASH_BANK1_OFFSET;
 }
 
+static uint32_t stm32f1_bank_offset_for(target_addr_t addr)
+{
+	if (addr >= FLASH_BANK_SPLIT)
+		return FLASH_BANK2_OFFSET;
+	return FLASH_BANK1_OFFSET;
+}
+
 static bool stm32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len)
 {
 	target *t = f->t;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -567,6 +567,7 @@ static bool stm32f1_option_write(target *const t, const uint32_t addr, const uin
 	for (size_t i = 0; i < 8; i++)
 		if (!stm32f1_option_write_erased(t, FLASH_OBP_RDP + (i * 2U), opt_val[i], write16_broken))
 			return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Fix build error for BMDA BMP only

<!--

The VID and PID in the BMP info structure are only present when building all probes. They need guarding
with conditional clause.
-->

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

