### PR TITLE
Fix: JTAG-TAP cleanup

### DIFF
--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -62,13 +62,13 @@ typedef struct jtag_proc_s {
 extern jtag_proc_t jtag_proc;
 
 /* generic soft reset: 1, 1, 1, 1, 1, 0 */
-#define jtagtap_soft_reset() jtag_proc.jtagtap_tms_seq(0x1F, 6)
+#define jtagtap_soft_reset() jtag_proc.jtagtap_tms_seq(0x1fU, 6)
 
 /* Goto Shift-IR: 1, 1, 0, 0 */
-#define jtagtap_shift_ir() jtag_proc.jtagtap_tms_seq(0x03, 4)
+#define jtagtap_shift_ir() jtag_proc.jtagtap_tms_seq(0x03U, 4)
 
 /* Goto Shift-DR: 1, 0, 0 */
-#define jtagtap_shift_dr() jtag_proc.jtagtap_tms_seq(0x01, 3)
+#define jtagtap_shift_dr() jtag_proc.jtagtap_tms_seq(0x01U, 3)
 
 /* Goto Run-test/Idle: 1, 1, 0 */
 #define jtagtap_return_idle(cycles) jtag_proc.jtagtap_tms_seq(0x01, (cycles) + 1U)

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -99,31 +99,30 @@ static bool jtagtap_next(const bool tms, const bool tdi)
 		return jtagtap_next_no_delay();
 }
 
-static void jtagtap_tms_seq_swd_delay(uint32_t tms_states, size_t ticks)
+static void jtagtap_tms_seq_swd_delay(uint32_t tms_states, const size_t clock_cycles)
 {
-	while (ticks) {
-		const bool state = tms_states & 1;
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+		const bool state = tms_states & 1U;
 		gpio_set_val(TMS_PORT, TMS_PIN, state);
 		gpio_set(TCK_PORT, TCK_PIN);
 		for (volatile int32_t cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
 			continue;
-		tms_states >>= 1;
-		ticks--;
+		tms_states >>= 1U;
 		gpio_clear(TCK_PORT, TCK_PIN);
 		for (volatile int32_t cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
 			continue;
 	}
 }
 
-static void jtagtap_tms_seq_no_delay(uint32_t tms_states, size_t ticks)
+static void jtagtap_tms_seq_no_delay(uint32_t tms_states, const size_t clock_cycles)
 {
-	while (ticks) {
-		const bool state = tms_states & 1;
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+		const bool state = tms_states & 1U;
 		gpio_set_val(TMS_PORT, TMS_PIN, state);
 		gpio_set(TCK_PORT, TCK_PIN);
-		tms_states >>= 1;
+		tms_states >>= 1U;
 		__asm__("nop");
-		ticks--;
+		__asm__("nop");
 		gpio_clear(TCK_PORT, TCK_PIN);
 	}
 }

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -138,25 +138,24 @@ static void jtagtap_tms_seq(const uint32_t tms_states, const size_t ticks)
 }
 
 static void jtagtap_tdi_tdo_seq_swd_delay(
-	const uint8_t *const data_in, uint8_t *const data_out, const bool final_tms, size_t clock_cycles)
+	const uint8_t *const data_in, uint8_t *const data_out, const bool final_tms, const size_t clock_cycles)
 {
-	size_t byte = 0;
-	size_t index = 0;
 	uint8_t value = 0;
-	while (clock_cycles--) {
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+		const size_t bit = cycle & 7U;
+		const size_t byte = cycle >> 3U;
 		/* On the last cycle, assert final_tms to TMS_PIN */
-		gpio_set_val(TMS_PORT, TMS_PIN, clock_cycles ? false : final_tms);
+		gpio_set_val(TMS_PORT, TMS_PIN, cycle + 1 >= clock_cycles && final_tms);
 		/* Set up the TDI pin and start the clock cycle */
-		gpio_set_val(TDI_PORT, TDI_PIN, data_in[byte] & (1U << index));
+		gpio_set_val(TDI_PORT, TDI_PIN, data_in[byte] & (1U << bit));
 		gpio_set(TCK_PORT, TCK_PIN);
 		for (volatile int32_t cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
 			continue;
 		/* If TDO is high, store a 1 in the appropriate position in the value being accumulated */
 		if (gpio_get(TDO_PORT, TDO_PIN))
-			value |= (1 << index);
-		if (index++ == 7U) {
-			data_out[byte++] = value;
-			index = 0;
+			value |= (1 << bit);
+		if (bit == 7U) {
+			data_out[byte] = value;
 			value = 0;
 		}
 		/* Finish the clock cycle */
@@ -164,7 +163,9 @@ static void jtagtap_tdi_tdo_seq_swd_delay(
 		for (volatile int32_t cnt = swd_delay_cnt - 2; cnt > 0; cnt--)
 			continue;
 	}
-	if (index)
+	const size_t bit = (clock_cycles - 1U) & 7U;
+	const size_t byte = (clock_cycles - 1U) >> 3U;
+	if (bit)
 		data_out[byte] = value;
 }
 

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -48,12 +48,11 @@ int jtagtap_init()
 	jtag_proc.jtagtap_cycle = jtagtap_cycle;
 	jtag_proc.tap_idle_cycles = 1;
 
-	/* Go to JTAG mode for SWJ-DP */
+	/* Ensure we're in JTAG mode */
 	for (size_t i = 0; i <= 50U; ++i)
-		jtagtap_next(1, 0);        /* Reset SW-DP */
+		jtagtap_next(true, false); /* 50 idle cylces for SWD reset */
 	jtagtap_tms_seq(0xe73cU, 16U); /* SWD to JTAG sequence */
 	jtagtap_soft_reset();
-
 	return 0;
 }
 

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -199,14 +199,14 @@ static void jtagtap_tdi_tdo_seq_no_delay(
 }
 
 static void jtagtap_tdi_tdo_seq(
-	uint8_t *const data_out, const bool final_tms, const uint8_t *const data_in, size_t ticks)
+	uint8_t *const data_out, const bool final_tms, const uint8_t *const data_in, size_t clock_cycles)
 {
 	gpio_clear(TMS_PORT, TMS_PIN);
 	gpio_clear(TDI_PORT, TDI_PIN);
 	if (swd_delay_cnt)
-		jtagtap_tdi_tdo_seq_swd_delay(data_in, data_out, final_tms, ticks);
+		jtagtap_tdi_tdo_seq_swd_delay(data_in, data_out, final_tms, clock_cycles);
 	else
-		jtagtap_tdi_tdo_seq_no_delay(data_in, data_out, final_tms, ticks);
+		jtagtap_tdi_tdo_seq_no_delay(data_in, data_out, final_tms, clock_cycles);
 }
 
 static void jtagtap_tdi_seq_swd_delay(const uint8_t *const data_in, const bool final_tms, size_t clock_cycles)

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -81,12 +81,12 @@ uint32_t fw_adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW, uint16_t addr, 
 	uint64_t response;
 	uint8_t ack;
 
-	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, APnDP ? IR_APACC : IR_DPACC);
+	jtag_dev_write_ir(dp->dp_jd_index, APnDP ? IR_APACC : IR_DPACC);
 
 	platform_timeout timeout;
 	platform_timeout_set(&timeout, 250);
 	do {
-		jtag_dev_shift_dr(&jtag_proc, dp->dp_jd_index, (uint8_t *)&response, (uint8_t *)&request, 35);
+		jtag_dev_shift_dr(dp->dp_jd_index, (uint8_t *)&response, (uint8_t *)&request, 35);
 		ack = response & 0x07;
 	} while (!platform_timeout_is_expired(&timeout) && ack == JTAGDP_ACK_WAIT);
 
@@ -104,6 +104,6 @@ uint32_t fw_adiv5_jtagdp_low_access(ADIv5_DP_t *dp, uint8_t RnW, uint16_t addr, 
 void adiv5_jtagdp_abort(ADIv5_DP_t *dp, uint32_t abort)
 {
 	uint64_t request = (uint64_t)abort << 3;
-	jtag_dev_write_ir(&jtag_proc, dp->dp_jd_index, IR_ABORT);
-	jtag_dev_shift_dr(&jtag_proc, dp->dp_jd_index, NULL, (const uint8_t *)&request, 35);
+	jtag_dev_write_ir(dp->dp_jd_index, IR_ABORT);
+	jtag_dev_shift_dr(dp->dp_jd_index, NULL, (const uint8_t *)&request, 35);
 }

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -231,7 +231,7 @@ uint32_t jtag_scan(const uint8_t *irlens)
 	return jtag_dev_count;
 }
 
-void jtag_dev_write_ir(jtag_proc_t *jp, const uint8_t dev_index, const uint32_t ir)
+void jtag_dev_write_ir(const uint8_t dev_index, const uint32_t ir)
 {
 	jtag_dev_t *device = &jtag_devs[dev_index];
 	if (ir == device->current_ir)
@@ -242,22 +242,22 @@ void jtag_dev_write_ir(jtag_proc_t *jp, const uint8_t dev_index, const uint32_t 
 	device->current_ir = ir;
 
 	jtagtap_shift_ir();
-	jp->jtagtap_tdi_seq(false, ones, device->ir_prescan);
-	jp->jtagtap_tdi_seq(!device->ir_postscan, (const uint8_t *)&ir, device->ir_len);
-	jp->jtagtap_tdi_seq(true, ones, device->ir_postscan);
+	jtag_proc.jtagtap_tdi_seq(false, ones, device->ir_prescan);
+	jtag_proc.jtagtap_tdi_seq(!device->ir_postscan, (const uint8_t *)&ir, device->ir_len);
+	jtag_proc.jtagtap_tdi_seq(true, ones, device->ir_postscan);
 	jtagtap_return_idle(1);
 }
 
-void jtag_dev_shift_dr(
-	jtag_proc_t *jp, const uint8_t dev_index, uint8_t *data_out, const uint8_t *data_in, const size_t clock_cycles)
+void jtag_dev_shift_dr(const uint8_t dev_index, uint8_t *data_out, const uint8_t *data_in, const size_t clock_cycles)
 {
 	jtag_dev_t *device = &jtag_devs[dev_index];
 	jtagtap_shift_dr();
-	jp->jtagtap_tdi_seq(false, ones, device->dr_prescan);
+	jtag_proc.jtagtap_tdi_seq(false, ones, device->dr_prescan);
 	if (data_out)
-		jp->jtagtap_tdi_tdo_seq((uint8_t *)data_out, !device->dr_postscan, (const uint8_t *)data_in, clock_cycles);
+		jtag_proc.jtagtap_tdi_tdo_seq(
+			(uint8_t *)data_out, !device->dr_postscan, (const uint8_t *)data_in, clock_cycles);
 	else
-		jp->jtagtap_tdi_seq(!device->dr_postscan, (const uint8_t *)data_in, clock_cycles);
-	jp->jtagtap_tdi_seq(true, ones, device->dr_postscan);
+		jtag_proc.jtagtap_tdi_seq(!device->dr_postscan, (const uint8_t *)data_in, clock_cycles);
+	jtag_proc.jtagtap_tdi_seq(true, ones, device->dr_postscan);
 	jtagtap_return_idle(1);
 }

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -47,8 +47,8 @@ typedef struct jtag_dev_s {
 extern struct jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1U];
 extern uint32_t jtag_dev_count;
 
-void jtag_dev_write_ir(jtag_proc_t *jp, uint8_t jd_index, uint32_t ir);
-void jtag_dev_shift_dr(jtag_proc_t *jp, uint8_t jd_index, uint8_t *dout, const uint8_t *din, size_t ticks);
+void jtag_dev_write_ir(uint8_t jd_index, uint32_t ir);
+void jtag_dev_shift_dr(uint8_t jd_index, uint8_t *dout, const uint8_t *din, size_t ticks);
 void jtag_add_device(uint32_t dev_index, const jtag_dev_t *jtag_dev);
 
 #endif /* TARGET_JTAG_SCAN_H */

--- a/src/target/jtagtap_generic.c
+++ b/src/target/jtagtap_generic.c
@@ -24,11 +24,11 @@
 #include "general.h"
 #include "jtagtap.h"
 
-void jtagtap_tms_seq(uint32_t MS, int ticks)
+void jtagtap_tms_seq(const uint32_t tms_states, const size_t clock_cycles)
 {
-	while (ticks--) {
-		jtagtap_next(MS & 1, 1);
-		MS >>= 1;
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+		const bool tms = (tms_states >> cycle) & 1U;
+		jtag_proc.jtagtap_next(tms, true);
 	}
 }
 

--- a/src/target/jtagtap_generic.c
+++ b/src/target/jtagtap_generic.c
@@ -32,19 +32,22 @@ void jtagtap_tms_seq(const uint32_t tms_states, const size_t clock_cycles)
 	}
 }
 
-void jtagtap_tdi_tdo_seq(uint8_t *DO, const uint8_t final_tms, const uint8_t *DI, int ticks)
+void jtagtap_tdi_tdo_seq(
+	uint8_t *const data_out, const uint8_t final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
-	uint8_t index = 1;
-	while (ticks--) {
-		if (jtagtap_next(ticks ? 0 : final_tms, *DI & index)) {
-			*DO |= index;
-		} else {
-			*DO &= ~index;
-		}
-		if (!(index <<= 1)) {
-			index = 1;
-			DI++;
-			DO++;
+	uint8_t value = 0;
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+		const size_t bit = cycle & 7U;
+		const size_t byte = cycle >> 3U;
+		const bool tms = cycle + 1 >= clock_cycles && final_tms;
+		const bool tdi = data_in[byte] & (1U << bit);
+
+		if (jtag_proc.jtagtap_next(tms, tdi))
+			value |= 1U << bit;
+
+		if (bit == 7U) {
+			data_out[byte] = value;
+			value = 0;
 		}
 	}
 }

--- a/src/target/jtagtap_generic.c
+++ b/src/target/jtagtap_generic.c
@@ -52,14 +52,13 @@ void jtagtap_tdi_tdo_seq(
 	}
 }
 
-void jtagtap_tdi_seq(const uint8_t final_tms, const uint8_t *DI, int ticks)
+void jtagtap_tdi_seq(const uint8_t final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
-	uint8_t index = 1;
-	while (ticks--) {
-		jtagtap_next(ticks ? 0 : final_tms, *DI & index);
-		if (!(index <<= 1)) {
-			index = 1;
-			DI++;
-		}
+	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+		const size_t bit = cycle & 7U;
+		const size_t byte = cycle >> 3U;
+		const bool tms = cycle + 1 >= clock_cycles && final_tms;
+		const bool tdi = data_in[byte] & (1U << bit);
+		jtag_proc.jtagtap_next(tms, tdi);
 	}
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address some conformity issues with the firmware-side JTAG-TAP code and remove a point of confusion (the `jtag_proc_t *jp` parameters in the JTAG abstraction layer). This finishes what was started in #1118 and #1131

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
