### PR TITLE
Fix: BMDA security fixes

### DIFF
--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -57,9 +57,8 @@ typedef struct usb_link_s {
 	struct libusb_transfer *rep_trans;
 	void *priv;
 } usb_link_t;
-
-int send_recv(usb_link_t *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
 #endif
+
 typedef struct bmp_info {
 	bmp_type_t bmp_type;
 	char dev;
@@ -84,6 +83,12 @@ extern bmp_info_t info;
 void bmp_ident(bmp_info_t *info);
 int find_debuggers(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info);
 void libusb_exit_function(bmp_info_t *info);
+
+#if HOSTED_BMP_ONLY == 1
+bool device_is_bmp_gdb_port(const char *device);
+#else
+int send_recv(usb_link_t *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
+#endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <wchar.h>

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -19,10 +19,18 @@
 
 /* Find all known serial connected debuggers */
 
-#include "general.h"
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+#include <string.h>
 #include <dirent.h>
 #include <errno.h>
+#include "general.h"
 #include "bmp_hosted.h"
+#include "utils.h"
 #include "version.h"
 
 void bmp_ident(bmp_info_t *info)
@@ -161,61 +169,114 @@ print_probes_info:
 #define BMP_IDSTRING_1BITSQUARED "usb-1BitSquared_Black_Magic_Probe"
 #define DEVICE_BY_ID             "/dev/serial/by-id/"
 
+size_t find_prefix_length(const char *name, const size_t name_len)
+{
+	if (begins_with(name, name_len, BMP_IDSTRING_BLACKSPHERE))
+		return sizeof(BMP_IDSTRING_BLACKSPHERE);
+	if (begins_with(name, name_len, BMP_IDSTRING_BLACKMAGIC))
+		return sizeof(BMP_IDSTRING_BLACKMAGIC);
+	if (begins_with(name, name_len, BMP_IDSTRING_1BITSQUARED))
+		return sizeof(BMP_IDSTRING_1BITSQUARED);
+	return 0;
+}
+
+char *extract_serial(const char *const device, const size_t length)
+{
+	const char *const last_underscore = strrchr(device, '_');
+	/* Fail the match if we can't find the _ just before the serial string. */
+	if (!last_underscore)
+		return NULL;
+	/* This represents the first byte of the serial number string */
+	const char *const begin = last_underscore + 1;
+	/* This represents one past the last byte of the serial number string */
+	const char *const end = device + length - 5;
+	/* We now allocate memory for the chunk and copy it */
+	const size_t result_length = end - begin;
+	char *const result = (char *)malloc(result_length);
+	memcpy(result, begin, result_length);
+	result[result_length - 1] = '\0';
+	return result;
+}
+
 /*
  * Extract type, version and serial from /dev/serial/by_id
  * Return 0 on success
  *
  * Old versions have different strings. Try to cope!
  */
-static int scan_linux_id(char *name, char *type, char *version, char *serial)
+static int scan_linux_id(const char *name, char **const type, char **const version, char **const serial)
 {
-	name += strlen(BMP_IDSTRING_BLACKSPHERE) + 1;
-	while (*name == '_')
-		name++;
-	if (!*name) {
+	const size_t name_len = strlen(name);
+	/* Find the correct prefix */
+	size_t prefix_length = find_prefix_length(name, name_len);
+	/* and skip past any leading _'s */
+	while (name[prefix_length] == '_' && prefix_length < name_len)
+		++prefix_length;
+	if (prefix_length == name_len) {
 		DEBUG_WARN("Unexpected end\n");
 		return -1;
 	}
-	char *p = name;
-	char *delims[4] = {0, 0, 0, 0};
-	int underscores = 0;
-	while (*p) {
-		if (*p == '_') {
-			while (p[1] == '_')
-				p++; /* remove multiple underscores */
-			if (underscores > 2)
+
+	size_t offsets[2] = {0, 0};
+	size_t underscores = 0;
+	for (size_t offset = prefix_length; offset < name_len; ++offset) {
+		if (name[offset] == '_') {
+			/* Device paths with more than 2 underscore delimited sections can't be valid BMP strings. */
+			if (underscores >= 2)
 				return -1;
-			delims[underscores] = p;
-			underscores++;
+			/* Skip over consecutive strings of underscores */
+			while (name[offset + 1U] == '_' && offset < name_len)
+				++offset;
+			/* Bounds check it */
+			if (offset == name_len)
+				break;
+			offsets[underscores++] = offset;
 		}
-		p++;
 	}
-	if (underscores == 0) { /* Old BMP native */
-		int res;
-		res = sscanf(name, "%8s-if00", serial);
-		if (res != 1)
-			return -1;
-		strcpy(type, "Native");
-		strcpy(version, "Unknown");
+
+	*serial = extract_serial(name, name_len);
+	if (!*serial)
+		return -1;
+
+	/* If the device name has no underscores after the prefix, it's an original BMP */
+	if (underscores == 0) {
+		*version = strdup("Unknown");
+		*type = strdup("Native");
+	/*
+	 * If the device name has two underscores delimted sections after the prefix,
+	 * it's a non-native device running the Black Magic Firmware.
+	 */
 	} else if (underscores == 2) {
-		strncpy(type, name, delims[0] - name - 1);
-		strncpy(version, delims[0] + 1, delims[1] - delims[0] - 1);
-		int res = sscanf(delims[1] + 1, "%8s-if00", serial);
-		if (!res)
-			return -1;
+		*version = strndup(name + prefix_length, offsets[0] - prefix_length - 1U);
+		*type = strndup(name + offsets[0], offsets[1] - offsets[0] - 1U);
+	/* Otherwise it's a native BMP */
 	} else {
-		int res = sscanf(delims[0] + 1, "%8s-if00", serial);
-		if (!res)
-			return -1;
-		if (name[0] == 'v') {
-			strcpy(type, "Unknown");
-			strncpy(version, name, delims[0] - name - 1);
+		/* The first section should start with a 'v' indicating the version info */
+		if (name[prefix_length] == 'v') {
+			*version = strndup(name + prefix_length, offsets[0] - prefix_length - 1U);
+			*type = strdup("Native");
+		/* But if not then it's actually a non-native device and has no version string. */
 		} else {
-			strncpy(type, name, delims[0] - name);
-			strcpy(type, "Unknown");
+			*version = strdup("Unknown");
+			*type = strndup(name + prefix_length, offsets[0] - prefix_length - 1U);
 		}
 	}
 	return 0;
+}
+
+void copy_to_info(bmp_info_t *const info, const char *const type, const char *const version, const char *const serial)
+{
+	const size_t serial_len = MIN(strlen(serial), sizeof(info->serial) - 1U);
+	memcpy(info->serial, serial, serial_len);
+	info->serial[serial_len] = '\0';
+
+	const size_t version_len = MIN(strlen(version), sizeof(info->version) - 1U);
+	memcpy(info->version, version, version_len);
+	info->version[version_len] = '\0';
+
+	const int result = snprintf(info->manufacturer, sizeof(info->manufacturer), "Black Magic Probe (%s)", type);
+	if (result)
+		DEBUG_WARN("snprintf() overflowed while generating manfacturer string\n");
 }
 
 int find_debuggers(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
@@ -226,65 +287,72 @@ int find_debuggers(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
 	DIR *dir = opendir(DEVICE_BY_ID);
 	if (!dir) /* No serial device connected!*/
 		return 0;
-	size_t found_bmps = 0;
-	struct dirent *dp;
-	size_t i = 0;
-	while ((dp = readdir(dir)) != NULL) {
-		if ((strstr(dp->d_name, BMP_IDSTRING_BLACKMAGIC) || strstr(dp->d_name, BMP_IDSTRING_BLACKSPHERE) ||
-				strstr(dp->d_name, BMP_IDSTRING_1BITSQUARED)) &&
-			(strstr(dp->d_name, "-if00"))) {
-			i++;
-			char type[256], version[256], serial[256];
-			if (scan_linux_id(dp->d_name, type, version, serial)) {
-				DEBUG_WARN("Unexpected device name found \"%s\"\n", dp->d_name);
-			}
+	size_t total = 0;
+	while (true) {
+		const struct dirent *const entry = readdir(dir);
+		if (entry == NULL)
+			break;
+		if (device_is_bmp_gdb_port(entry->d_name)) {
+			++total;
+			char *type = NULL;
+			char *version = NULL;
+			char *serial = NULL;
+			if (scan_linux_id(entry->d_name, &type, &version, &serial))
+				DEBUG_WARN("Unexpected device name found \"%s\"\n", entry->d_name);
+
+			/* If either the (partial) serial matches, or the device is in the right position in the detection order */
 			if ((cl_opts->opt_serial && strstr(serial, cl_opts->opt_serial)) ||
-				(cl_opts->opt_position && cl_opts->opt_position == i)) {
-				/* With serial number given and partial match, we are done!*/
-				strncpy(info->serial, serial, sizeof(info->serial));
-				int res = snprintf(info->manufacturer, sizeof(info->manufacturer), "Black Magic Probe (%s)", type);
-				if (res)
-					DEBUG_WARN("Overflow\n");
-				strncpy(info->version, version, sizeof(info->version));
-				found_bmps = 1;
+				(cl_opts->opt_position && cl_opts->opt_position == total)) {
+				copy_to_info(info, type, version, serial);
+				total = 1;
+				free(type);
+				free(version);
+				free(serial);
 				break;
-			} else {
-				found_bmps++;
 			}
+			free(type);
+			free(version);
+			free(serial);
 		}
 	}
 	closedir(dir);
-	if (found_bmps < 1) {
+	if (!total) {
 		DEBUG_WARN("No BMP probe found\n");
 		return -1;
-	} else if ((found_bmps > 1) || cl_opts->opt_list_only) {
-		DEBUG_WARN("Available Probes:\n");
 	}
+	if (total > 1 || cl_opts->opt_list_only)
+		DEBUG_WARN("Available Probes:\n");
 	dir = opendir(DEVICE_BY_ID);
-	i = 0;
-	while ((dp = readdir(dir)) != NULL) {
-		if ((strstr(dp->d_name, BMP_IDSTRING_BLACKMAGIC) || strstr(dp->d_name, BMP_IDSTRING_BLACKSPHERE) ||
-				strstr(dp->d_name, BMP_IDSTRING_1BITSQUARED)) &&
-			(strstr(dp->d_name, "-if00"))) {
-			i++;
-			char type[256], version[256], serial[256];
-			if (scan_linux_id(dp->d_name, type, version, serial)) {
-				DEBUG_WARN("Unexpected device name found \"%s\"\n", dp->d_name);
-			} else if ((found_bmps == 1) && (!cl_opts->opt_list_only)) {
-				strncpy(info->serial, serial, sizeof(info->serial));
-				found_bmps = 1;
-				strncpy(info->serial, serial, sizeof(info->serial));
-				snprintf(info->manufacturer, sizeof(info->manufacturer), "Black Magic Probe (%s)", type);
-				strncpy(info->version, version, sizeof(info->version));
+	size_t i = 0;
+	while (true) {
+		const struct dirent *const entry = readdir(dir);
+		if (entry == NULL)
+			break;
+		if (device_is_bmp_gdb_port(entry->d_name)) {
+			++i;
+			char *type = NULL;
+			char *version = NULL;
+			char *serial = NULL;
+			if (scan_linux_id(entry->d_name, &type, &version, &serial)) {
+				DEBUG_WARN("Unexpected device name found \"%s\"\n", entry->d_name);
+			} else if (total == 1 && !cl_opts->opt_list_only) {
+				copy_to_info(info, type, version, serial);
+				total = 1;
+				free(type);
+				free(version);
+				free(serial);
 				break;
-			} else if (found_bmps > 0) {
+			} else if (total > 0) {
 				DEBUG_WARN("%2d: %s, Black Magic Debug, Black Magic "
 						   "Probe (%s), %s\n",
 					i, serial, type, version);
 			}
+			free(type);
+			free(version);
+			free(serial);
 		}
 	}
 	closedir(dir);
-	return (found_bmps == 1 && !cl_opts->opt_list_only) ? 0 : 1;
+	return (total == 1 && !cl_opts->opt_list_only) ? 0 : 1;
 }
 #endif

--- a/src/platforms/hosted/cli.h
+++ b/src/platforms/hosted/cli.h
@@ -72,7 +72,7 @@ typedef struct BMP_CL_OPTIONS_s {
 
 void cl_init(BMP_CL_OPTIONS_t *opt, int argc, char **argv);
 int cl_execute(BMP_CL_OPTIONS_t *opt);
-int serial_open(BMP_CL_OPTIONS_t *opt, const char *serial);
+int serial_open(const BMP_CL_OPTIONS_t *opt, const char *serial);
 void serial_close(void);
 
 #endif /* PLATFORMS_HOSTED_CLI_H */

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "general.h"
+
 #include <sys/stat.h>
 #include <sys/select.h>
 #include <dirent.h>
@@ -26,8 +26,10 @@
 #include <termios.h>
 #include <unistd.h>
 
+#include "general.h"
 #include "remote.h"
 #include "bmp_hosted.h"
+#include "utils.h"
 #include "cortexm.h"
 
 static int fd; /* File descriptor for connection to GDB remote */
@@ -99,39 +101,6 @@ int serial_open(BMP_CL_OPTIONS_t *cl_opts, char *serial)
 #define BMP_IDSTRING_BLACKMAGIC  "usb-Black_Magic_Debug_Black_Magic_Probe"
 #define BMP_IDSTRING_1BITSQUARED "usb-1BitSquared_Black_Magic_Probe"
 #define DEVICE_BY_ID             "/dev/serial/by-id/"
-
-static bool begins_with(const char *const str, const size_t str_length, const char *const value)
-{
-	const size_t value_length = strlen(value);
-	if (str_length < value_length)
-		return false;
-	return memcmp(str, value, value_length) == 0;
-}
-
-static bool ends_with(const char *const str, const size_t str_length, const char *const value)
-{
-	const size_t value_length = strlen(value);
-	if (str_length < value_length)
-		return false;
-	const size_t offset = str_length - value_length;
-	return memcmp(str + offset, value, value_length) == 0;
-}
-
-static bool constains_substring(
-	const char *const str, const size_t str_len, const char *const search)
-{
-	const size_t search_len = strlen(search);
-	if (str_len < search_len)
-		return false;
-	/* For each possible valid offset */
-	for (size_t offset = 0; offset <= str_len - search_len; ++offset) {
-		/* If we have a match, we're done */
-		if (memcmp(str + offset, search, search_len) == 0)
-			return true;
-	}
-	/* We failed to find a match */
-	return false;
-}
 
 bool device_is_bmp_gdb_port(const char *const device)
 {

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -72,7 +72,7 @@ static int set_interface_attribs(void)
 }
 
 #ifdef __APPLE__
-int serial_open(BMP_CL_OPTIONS_t *cl_opts, char *serial)
+int serial_open(const BMP_CL_OPTIONS_t *cl_opts, char *serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {
@@ -126,7 +126,7 @@ static bool match_serial(const char *const device, const char *const serial)
 	return constains_substring(begin, end - begin, serial);
 }
 
-int serial_open(BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
+int serial_open(const BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -117,14 +117,44 @@ static bool ends_with(const char *const str, const size_t str_length, const char
 	return memcmp(str + offset, value, value_length) == 0;
 }
 
-bool device_is_bmp_gdb_port(const char *const name)
+static bool constains_substring(
+	const char *const str, const size_t str_len, const char *const search)
 {
-	const size_t length = strlen(name);
-	if (begins_with(name, length, BMP_IDSTRING_BLACKSPHERE) || begins_with(name, length, BMP_IDSTRING_BLACKMAGIC) ||
-		begins_with(name, length, BMP_IDSTRING_1BITSQUARED)) {
-		return ends_with(name, length, "-if00");
+	const size_t search_len = strlen(search);
+	if (str_len < search_len)
+		return false;
+	/* For each possible valid offset */
+	for (size_t offset = 0; offset <= str_len - search_len; ++offset) {
+		/* If we have a match, we're done */
+		if (memcmp(str + offset, search, search_len) == 0)
+			return true;
+	}
+	/* We failed to find a match */
+	return false;
+}
+
+bool device_is_bmp_gdb_port(const char *const device)
+{
+	const size_t length = strlen(device);
+	if (begins_with(device, length, BMP_IDSTRING_BLACKSPHERE) || begins_with(device, length, BMP_IDSTRING_BLACKMAGIC) ||
+		begins_with(device, length, BMP_IDSTRING_1BITSQUARED)) {
+		return ends_with(device, length, "-if00");
 	}
 	return false;
+}
+
+static bool match_serial(const char *const device, const char *const serial)
+{
+	const char *const last_underscore = strrchr(device, '_');
+	/* Fail the match if we can't find the _ just before the serial string. */
+	if (!last_underscore)
+		return false;
+	/* This represents the first byte of the serial number string */
+	const char *const begin = last_underscore + 1;
+	/* This represents one past the last byte of the serial number string */
+	const char *const end = device + strlen(device) - 5;
+	/* Try to match the (partial) serial string in the correct part of the device string */
+	return constains_substring(begin, end - begin, serial);
 }
 
 int serial_open(BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
@@ -145,7 +175,7 @@ int serial_open(BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
 				break;
 			if (device_is_bmp_gdb_port(entry->d_name)) {
 				++total;
-				if (serial && strstr(entry->d_name, serial) == 0)
+				if (serial && !match_serial(entry->d_name, serial))
 					continue;
 				++matches;
 				const size_t path_len = sizeof(DEVICE_BY_ID) - 1U;

--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -164,7 +164,7 @@ static char *find_bmp_device(const BMP_CL_OPTIONS_t *const cl_opts, const char *
 	return result;
 }
 
-int serial_open(BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
+int serial_open(const BMP_CL_OPTIONS_t *const cl_opts, const char *const serial)
 {
 	char *const device = find_bmp_device(cl_opts, serial);
 	if (!device) {

--- a/src/platforms/hosted/utils.c
+++ b/src/platforms/hosted/utils.c
@@ -24,9 +24,12 @@
 /* This file deduplicates codes used in several pc-hosted platforms
  */
 
-#include <stdint.h>
+#include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
+
+#include "general.h"
+#include "timing.h"
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 #warning "This vasprintf() is dubious!"
@@ -60,4 +63,36 @@ uint32_t platform_time_ms(void)
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
 	return (tv.tv_sec * 1000) + (tv.tv_usec / 1000);
+}
+
+bool begins_with(const char *const str, const size_t str_length, const char *const value)
+{
+	const size_t value_length = strlen(value);
+	if (str_length < value_length)
+		return false;
+	return memcmp(str, value, value_length) == 0;
+}
+
+bool ends_with(const char *const str, const size_t str_length, const char *const value)
+{
+	const size_t value_length = strlen(value);
+	if (str_length < value_length)
+		return false;
+	const size_t offset = str_length - value_length;
+	return memcmp(str + offset, value, value_length) == 0;
+}
+
+bool constains_substring(const char *const str, const size_t str_len, const char *const search)
+{
+	const size_t search_len = strlen(search);
+	if (str_len < search_len)
+		return false;
+	/* For each possible valid offset */
+	for (size_t offset = 0; offset <= str_len - search_len; ++offset) {
+		/* If we have a match, we're done */
+		if (memcmp(str + offset, search, search_len) == 0)
+			return true;
+	}
+	/* We failed to find a match */
+	return false;
 }

--- a/src/platforms/hosted/utils.h
+++ b/src/platforms/hosted/utils.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORMS_HOSTED_UTILS_H
+#define PLATFORMS_HOSTED_UTILS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+bool begins_with(const char *str, size_t str_length, const char *value);
+bool ends_with(const char *str, size_t str_length, const char *value);
+bool constains_substring(const char *str, size_t str_len, const char *search);
+
+#endif /* PLATFORMS_HOSTED_UTILS_H */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses several shortcomings of the string handling code in BMDA that lead to several possible exploits and general badness. This also fixes the Linux `HOSTED_BMP_ONLY=1` handling of devices as this severely broke in v1.8.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
