### PR TITLE
Fix/bmda ftdi cleanup

### DIFF
--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -371,11 +371,11 @@ int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
 	/* If swd_(read|write) is not given for the selected cable and
 	   the 'e' command line argument is give, assume resistor SWD
 	   connection.*/
-	if (cl_opts->external_resistor_swd && (active_cable->mpsse_swd_read.set_data_low == 0) &&
-		(active_cable->mpsse_swd_read.clr_data_low == 0) && (active_cable->mpsse_swd_read.set_data_high == 0) &&
-		(active_cable->mpsse_swd_read.clr_data_high == 0) && (active_cable->mpsse_swd_write.set_data_low == 0) &&
-		(active_cable->mpsse_swd_write.clr_data_low == 0) && (active_cable->mpsse_swd_write.set_data_high == 0) &&
-		(active_cable->mpsse_swd_write.clr_data_high == 0)) {
+	if (cl_opts->external_resistor_swd && active_cable->mpsse_swd_read.set_data_low == 0 &&
+		active_cable->mpsse_swd_read.clr_data_low == 0 && active_cable->mpsse_swd_read.set_data_high == 0 &&
+		active_cable->mpsse_swd_read.clr_data_high == 0 && active_cable->mpsse_swd_write.set_data_low == 0 &&
+		active_cable->mpsse_swd_write.clr_data_low == 0 && active_cable->mpsse_swd_write.set_data_high == 0 &&
+		active_cable->mpsse_swd_write.clr_data_high == 0) {
 		DEBUG_INFO("Using external resistor SWD\n");
 		active_cable->mpsse_swd_read.set_data_low = MPSSE_DO;
 		active_cable->mpsse_swd_write.set_data_low = MPSSE_DO;
@@ -388,30 +388,35 @@ int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
 		ftdi_free(ftdic);
 		ftdic = NULL;
 	}
-	if ((ftdic = ftdi_new()) == NULL) {
+	ftdic = ftdi_new();
+	if (ftdic == NULL) {
 		DEBUG_WARN("ftdi_new: %s\n", ftdi_get_error_string(ftdic));
 		abort();
 	}
 	info->ftdic = ftdic;
-	if ((err = ftdi_set_interface(ftdic, active_cable->interface)) != 0) {
+	err = ftdi_set_interface(ftdic, active_cable->interface);
+	if (err != 0) {
 		DEBUG_WARN("ftdi_set_interface: %d: %s\n", err, ftdi_get_error_string(ftdic));
 		goto error_1;
 	}
-	if ((err = ftdi_usb_open_desc(ftdic, active_cable->vendor, active_cable->product, active_cable->description,
-			 cl_opts->opt_serial)) != 0) {
+	err = ftdi_usb_open_desc(
+		ftdic, active_cable->vendor, active_cable->product, active_cable->description, cl_opts->opt_serial);
+	if (err != 0) {
 		DEBUG_WARN("unable to open ftdi device: %d (%s)\n", err, ftdi_get_error_string(ftdic));
 		goto error_1;
 	}
-
-	if ((err = ftdi_set_latency_timer(ftdic, 1)) != 0) {
+	err = ftdi_set_latency_timer(ftdic, 1);
+	if (err != 0) {
 		DEBUG_WARN("ftdi_set_latency_timer: %d: %s\n", err, ftdi_get_error_string(ftdic));
 		goto error_2;
 	}
-	if ((err = ftdi_set_baudrate(ftdic, 1000000)) != 0) {
+	err = ftdi_set_baudrate(ftdic, 1000000);
+	if (err != 0) {
 		DEBUG_WARN("ftdi_set_baudrate: %d: %s\n", err, ftdi_get_error_string(ftdic));
 		goto error_2;
 	}
-	if ((err = ftdi_write_data_set_chunksize(ftdic, BUF_SIZE)) != 0) {
+	err = ftdi_write_data_set_chunksize(ftdic, BUF_SIZE);
+	if (err != 0) {
 		DEBUG_WARN("ftdi_write_data_set_chunksize: %d: %s\n", err, ftdi_get_error_string(ftdic));
 		goto error_2;
 	}
@@ -446,7 +451,7 @@ int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
 			DEBUG_WARN(" %02x", ftdi_init[i]);
 		DEBUG_WARN("\n");
 	}
-	int index = 0;
+	size_t index = 0;
 	ftdi_init[index++] = LOOPBACK_END; /* FT2232D gets upset otherwise*/
 	switch (ftdic->type) {
 	case TYPE_2232H:

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -379,7 +379,7 @@ int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
 		DEBUG_INFO("Using external resistor SWD\n");
 		active_cable->mpsse_swd_read.set_data_low = MPSSE_DO;
 		active_cable->mpsse_swd_write.set_data_low = MPSSE_DO;
-	} else if (!libftdi_swd_possible(NULL, NULL) && cl_opts->opt_scanmode != BMP_SCAN_JTAG) {
+	} else if (!libftdi_swd_possible() && cl_opts->opt_scanmode != BMP_SCAN_JTAG) {
 		DEBUG_WARN("SWD with cable not possible, trying JTAG\n");
 		cl_opts->opt_scanmode = BMP_SCAN_JTAG;
 	}

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -513,29 +513,29 @@ error_1:
 static void libftdi_set_data(data_desc_t *data)
 {
 	uint8_t cmd[6];
-	int index = 0;
-	if ((data->data_low) || (data->ddr_low)) {
+	size_t index = 0;
+	if (data->data_low || data->ddr_low) {
 		if (data->data_low > 0)
-			active_state.data_low |= (data->data_low & 0xff);
+			active_state.data_low |= data->data_low & 0xffU;
 		else if (data->data_low < 0)
-			active_state.data_low &= (data->data_low & 0xff);
+			active_state.data_low &= data->data_low & 0xffU;
 		if (data->ddr_low > 0)
-			active_state.ddr_low |= (data->ddr_low & 0xff);
+			active_state.ddr_low |= data->ddr_low & 0xffU;
 		else if (data->ddr_low < 0)
-			active_state.ddr_low &= (data->ddr_low & 0xff);
+			active_state.ddr_low &= data->ddr_low & 0xffU;
 		cmd[index++] = SET_BITS_LOW;
 		cmd[index++] = active_state.data_low;
 		cmd[index++] = active_state.ddr_low;
 	}
-	if ((data->data_high) || (data->ddr_high)) {
+	if (data->data_high || data->ddr_high) {
 		if (data->data_high > 0)
-			active_state.data_high |= (data->data_high & 0xff);
+			active_state.data_high |= data->data_high & 0xffU;
 		else if (data->data_high < 0)
-			active_state.data_high &= (data->data_high & 0xff);
+			active_state.data_high &= data->data_high & 0xffU;
 		if (data->ddr_high > 0)
-			active_state.ddr_high |= (data->ddr_high & 0xff);
+			active_state.ddr_high |= data->ddr_high & 0xffU;
 		else if (data->ddr_high < 0)
-			active_state.ddr_high &= (data->ddr_high & 0xff);
+			active_state.ddr_high &= data->ddr_high & 0xffU;
 		cmd[index++] = SET_BITS_HIGH;
 		cmd[index++] = active_state.data_high;
 		cmd[index++] = active_state.ddr_high;

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -752,9 +752,9 @@ uint32_t libftdi_max_frequency_get(void)
 {
 	uint32_t clock;
 	if (ftdic->type == TYPE_2232C)
-		clock = 12 * 1000 * 1000;
+		clock = 12U * 1000U * 1000U;
 	else
 		/* Undivided clock set during startup*/
-		clock = 60 * 1000 * 1000;
-	return clock / (2 * (divisor + 1));
+		clock = 60U * 1000U * 1000U;
+	return clock / (2U * (divisor + 1U));
 }

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -624,50 +624,52 @@ size_t libftdi_buffer_read(uint8_t *data, size_t size)
 	return size;
 }
 
-void libftdi_jtagtap_tdi_tdo_seq(uint8_t *DO, const bool final_tms, const uint8_t *DI, size_t ticks)
+void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t ticks)
 {
-	int rsize, rticks;
-
 	if (!ticks)
 		return;
-	if (!DI && !DO)
+	if (!data_in && !data_out)
 		return;
 
-	DEBUG_WIRE(
-		"libftdi_jtagtap_tdi_tdo_seq %s ticks: %d\n", (DI && DO) ? "read/write" : ((DI) ? "write" : "read"), ticks);
+	DEBUG_WIRE("libftdi_jtagtap_tdi_tdo_seq %s ticks: %d\n",
+		data_in && data_out ? "read/write"
+			: data_in       ? "write"
+							: "read",
+		ticks);
 	if (final_tms)
 		--ticks;
-	rticks = ticks & 7;
+	uint8_t rticks = ticks & 7U;
 	ticks >>= 3;
 	uint8_t data[8];
-	uint8_t cmd = ((DO) ? MPSSE_DO_READ : 0) | ((DI) ? (MPSSE_DO_WRITE | MPSSE_WRITE_NEG) : 0) | MPSSE_LSB;
-	rsize = ticks;
+	uint8_t cmd = ((data_out) ? MPSSE_DO_READ : 0) | ((data_in) ? (MPSSE_DO_WRITE | MPSSE_WRITE_NEG) : 0) | MPSSE_LSB;
+	size_t rsize = ticks;
 	if (ticks) {
 		data[0] = cmd;
 		data[1] = ticks - 1;
 		data[2] = 0;
 		libftdi_buffer_write(data, 3);
-		if (DI)
-			libftdi_buffer_write(DI, ticks);
+		if (data_in)
+			libftdi_buffer_write(data_in, ticks);
 	}
 	int index = 0;
 	if (rticks) {
 		rsize++;
 		data[index++] = cmd | MPSSE_BITMODE;
 		data[index++] = rticks - 1;
-		if (DI)
-			data[index++] = DI[ticks];
+		if (data_in)
+			data[index++] = data_in[ticks];
 	}
 	if (final_tms) {
 		rsize++;
-		data[index++] = MPSSE_WRITE_TMS | ((DO) ? MPSSE_DO_READ : 0) | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG;
+		data[index++] =
+			MPSSE_WRITE_TMS | ((data_out) ? MPSSE_DO_READ : 0) | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG;
 		data[index++] = 0;
-		if (DI)
-			data[index++] = (DI[ticks] & (1 << rticks)) ? 0x81 : 0x01;
+		if (data_in)
+			data[index++] = (data_in[ticks] & (1 << rticks)) ? 0x81 : 0x01;
 	}
 	if (index)
 		libftdi_buffer_write(data, index);
-	if (DO) {
+	if (data_out) {
 		int index = 0;
 		uint8_t *tmp = alloca(rsize);
 		libftdi_buffer_read(tmp, rsize);
@@ -675,19 +677,19 @@ void libftdi_jtagtap_tdi_tdo_seq(uint8_t *DO, const bool final_tms, const uint8_
 			rsize--;
 
 		while (rsize--)
-			*DO++ = tmp[index++];
+			*data_out++ = tmp[index++];
 		if (rticks == 0)
-			*DO++ = 0;
+			*data_out++ = 0;
 
 		if (final_tms) {
 			rticks++;
-			*(--DO) >>= 1;
-			*DO |= tmp[index] & 0x80;
+			*(--data_out) >>= 1;
+			*data_out |= tmp[index] & 0x80;
 		} else
-			--DO;
+			--data_out;
 
 		if (rticks)
-			*DO >>= (8 - rticks);
+			*data_out >>= (8 - rticks);
 	}
 }
 

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -592,7 +592,7 @@ size_t libftdi_buffer_write(const uint8_t *data, size_t size)
 	return size;
 }
 
-int libftdi_buffer_read(uint8_t *data, int size)
+size_t libftdi_buffer_read(uint8_t *data, size_t size)
 {
 #if defined(USE_USB_VERSION_BIT)
 	struct ftdi_transfer_control *tc;
@@ -601,17 +601,17 @@ int libftdi_buffer_read(uint8_t *data, int size)
 	tc = ftdi_read_data_submit(ftdic, data, size);
 	ftdi_transfer_data_done(tc);
 #else
-	int index = 0;
+	size_t index = 0;
 	const uint8_t cmd[1] = {SEND_IMMEDIATE};
 	libftdi_buffer_write(cmd, 1);
 	libftdi_buffer_flush();
-	while ((index += ftdi_read_data(ftdic, data + index, size - index)) != size)
-		;
+	for (size_t index = 0; index != size; )
+		index += ftdi_read_data(ftdic, data + index, size - index);
 #endif
 	DEBUG_WIRE("Read  %d bytes:", size);
-	for (int i = 0; i < size; i++) {
+	for (size_t i = 0; i < size; i++) {
 		DEBUG_WIRE(" %02x", data[i]);
-		if (i && (i & 0xf) == 0xf)
+		if ((i & 0xfU) == 0xfU)
 			DEBUG_WIRE("\n\t");
 	}
 	DEBUG_WIRE("\n");

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -556,28 +556,28 @@ void libftdi_nrst_set_val(bool assert)
 
 bool libftdi_nrst_get_val(void)
 {
-	uint8_t cmd[1] = {0};
+	uint8_t cmd;
 	uint8_t pin = 0;
 	if (active_cable->nrst_get_port_cmd && active_cable->nrst_get_pin) {
-		cmd[0] = active_cable->nrst_get_port_cmd;
+		cmd = active_cable->nrst_get_port_cmd;
 		pin = active_cable->nrst_get_pin;
 	} else if (active_cable->assert_nrst.data_low && active_cable->assert_nrst.ddr_low) {
-		cmd[0] = GET_BITS_LOW;
+		cmd = GET_BITS_LOW;
 		pin = active_cable->assert_nrst.data_low;
 	} else if (active_cable->assert_nrst.data_high && active_cable->assert_nrst.ddr_high) {
-		cmd[0] = GET_BITS_HIGH;
+		cmd = GET_BITS_HIGH;
 		pin = active_cable->assert_nrst.data_high;
-	} else {
+	} else
 		return false;
-	}
-	libftdi_buffer_write(cmd, 1);
-	uint8_t data[1];
-	libftdi_buffer_read(data, 1);
+
+	uint8_t data;
+	libftdi_buffer_write_val(cmd);
+	libftdi_buffer_read_val(data);
 	bool res = false;
-	if (pin < 0x7f || pin == PIN7)
-		res = data[0] & pin;
+	if (pin < 0x7fU || pin == PIN7)
+		res = data & pin;
 	else
-		res = !(data[0] & ~pin);
+		res = !(data & ~pin);
 	return res;
 }
 
@@ -605,7 +605,7 @@ size_t libftdi_buffer_write(const uint8_t *data, size_t size)
 	DEBUG_WIRE("Write %d bytes:", size);
 	for (size_t i = 0; i < size; i++) {
 		DEBUG_WIRE(" %02x", data[i]);
-		if (i && (i & 0xf) == 0xf)
+		if (i && (i & 0xfU) == 0xfU)
 			DEBUG_WIRE("\n\t");
 	}
 	DEBUG_WIRE("\n");

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -654,38 +654,37 @@ void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const 
 	if (final_tms)
 		--ticks;
 	uint8_t rticks = ticks & 7U;
-	ticks >>= 3;
+	ticks >>= 3U;
 	uint8_t data[8];
-	uint8_t cmd = ((data_out) ? MPSSE_DO_READ : 0) | ((data_in) ? (MPSSE_DO_WRITE | MPSSE_WRITE_NEG) : 0) | MPSSE_LSB;
+	uint8_t cmd = (data_out ? MPSSE_DO_READ : 0U) | (data_in ? (MPSSE_DO_WRITE | MPSSE_WRITE_NEG) : 0U) | MPSSE_LSB;
 	size_t rsize = ticks;
 	if (ticks) {
 		data[0] = cmd;
-		data[1] = ticks - 1;
+		data[1] = ticks - 1U;
 		data[2] = 0;
-		libftdi_buffer_write(data, 3);
+		libftdi_buffer_write(data, 3U);
 		if (data_in)
 			libftdi_buffer_write(data_in, ticks);
 	}
-	int index = 0;
+	size_t index = 0;
 	if (rticks) {
 		rsize++;
 		data[index++] = cmd | MPSSE_BITMODE;
-		data[index++] = rticks - 1;
+		data[index++] = rticks - 1U;
 		if (data_in)
 			data[index++] = data_in[ticks];
 	}
 	if (final_tms) {
 		rsize++;
-		data[index++] =
-			MPSSE_WRITE_TMS | ((data_out) ? MPSSE_DO_READ : 0) | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG;
+		data[index++] = MPSSE_WRITE_TMS | (data_out ? MPSSE_DO_READ : 0) | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG;
 		data[index++] = 0;
 		if (data_in)
-			data[index++] = (data_in[ticks] & (1 << rticks)) ? 0x81 : 0x01;
+			data[index++] = (data_in[ticks] & (1U << rticks)) ? 0x81U : 0x01U;
 	}
 	if (index)
 		libftdi_buffer_write(data, index);
 	if (data_out) {
-		int index = 0;
+		size_t index = 0;
 		uint8_t *tmp = alloca(rsize);
 		libftdi_buffer_read(tmp, rsize);
 		if (final_tms)
@@ -699,12 +698,12 @@ void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const 
 		if (final_tms) {
 			rticks++;
 			*(--data_out) >>= 1;
-			*data_out |= tmp[index] & 0x80;
+			*data_out |= tmp[index] & 0x80U;
 		} else
 			--data_out;
 
 		if (rticks)
-			*data_out >>= (8 - rticks);
+			*data_out >>= (8U - rticks);
 	}
 }
 

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -368,9 +368,11 @@ int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info)
 
 	active_cable = cable;
 	memcpy(&active_state, &active_cable->init, sizeof(data_desc_t));
-	/* If swd_(read|write) is not given for the selected cable and
-	   the 'e' command line argument is give, assume resistor SWD
-	   connection.*/
+	/*
+	 * If swd_(read|write) is not given for the selected cable and
+	 * the 'e' command line argument is give, assume resistor SWD
+	 * connection.
+	 */
 	if (cl_opts->external_resistor_swd && active_cable->mpsse_swd_read.set_data_low == 0 &&
 		active_cable->mpsse_swd_read.clr_data_low == 0 && active_cable->mpsse_swd_read.set_data_high == 0 &&
 		active_cable->mpsse_swd_read.clr_data_high == 0 && active_cable->mpsse_swd_write.set_data_low == 0 &&
@@ -606,11 +608,10 @@ size_t libftdi_buffer_read(uint8_t *data, size_t size)
 	tc = ftdi_read_data_submit(ftdic, data, size);
 	ftdi_transfer_data_done(tc);
 #else
-	size_t index = 0;
-	const uint8_t cmd[1] = {SEND_IMMEDIATE};
-	libftdi_buffer_write(cmd, 1);
+	const uint8_t cmd = SEND_IMMEDIATE;
+	libftdi_buffer_write(&cmd, 1);
 	libftdi_buffer_flush();
-	for (size_t index = 0; index != size; )
+	for (size_t index = 0; index < size;)
 		index += ftdi_read_data(ftdic, data + index, size - index);
 #endif
 	DEBUG_WIRE("Read  %d bytes:", size);
@@ -704,8 +705,7 @@ const char *libftdi_target_voltage(void)
 			res = !(data[0] & ~pin);
 		if (res)
 			return "Present";
-		else
-			return "Absent";
+		return "Absent";
 	}
 	return NULL;
 }

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -732,19 +732,20 @@ void libftdi_max_frequency_set(uint32_t freq)
 {
 	uint32_t clock;
 	if (ftdic->type == TYPE_2232C)
-		clock = 12 * 1000 * 1000;
+		clock = 12U * 1000U * 1000U;
 	else
 		/* Undivided clock set during startup*/
-		clock = 60 * 1000 * 1000;
-	uint32_t div = (clock + 2 * freq - 1) / freq;
-	if (div < 4 && ftdic->type == TYPE_2232C)
-		div = 4; /* Avoid bad unsymetrict FT2232C clock at 6 MHz*/
-	divisor = div / 2 - 1;
+		clock = 60U * 1000U * 1000U;
+
+	uint32_t div = (clock + 2U * freq - 1U) / freq;
+	if (div < 4U && ftdic->type == TYPE_2232C)
+		div = 4U; /* Avoid bad asymetric FT2232C clock at 6 MHz*/
+	divisor = div / 2U - 1U;
 	uint8_t buf[3];
 	buf[0] = TCK_DIVISOR;
-	buf[1] = divisor & 0xff;
-	buf[2] = (divisor >> 8) & 0xff;
-	libftdi_buffer_write(buf, 3);
+	buf[1] = divisor & 0xffU;
+	buf[2] = (divisor >> 8U) & 0xffU;
+	libftdi_buffer_write_arr(buf);
 }
 
 uint32_t libftdi_max_frequency_get(void)

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -40,11 +40,12 @@ data_desc_t active_state;
 
 cable_desc_t cable_desc[] = {
 	{
-		/* Direct connection from FTDI to Jtag/Swd.
+		/*
+		 * Direct connection from FTDI to JTAG/SWD.
 		 * Pin 6 direct connected to RST.
 		 */
-		.vendor = 0x0403,
-		.product = 0x6014,
+		.vendor = 0x0403U,
+		.product = 0x6014U,
 		.interface = INTERFACE_A,
 		// No explicit reset
 		.bb_swdio_in_port_cmd = GET_BITS_LOW,
@@ -53,11 +54,12 @@ cable_desc_t cable_desc[] = {
 		.name = "um232h",
 	},
 	{
-		/* Direct connection from FTDI to Jtag/Swd.
+		/*
+		 * Direct connection from FTDI to JTAG/SWD.
 		 * Pin 6 direct connected to RST.
 		 */
-		.vendor = 0x0403,
-		.product = 0x6010,
+		.vendor = 0x0403U,
+		.product = 0x6010U,
 		.interface = INTERFACE_A,
 		.init.data_low = PIN6, /* PULL nRST high*/
 		.bb_swdio_in_port_cmd = GET_BITS_LOW,
@@ -70,7 +72,8 @@ cable_desc_t cable_desc[] = {
 		.name = "flossjtag",
 	},
 	{
-		/* MPSSE_SK (DB0) ----------- SWDCK/JTCK
+		/*
+		 * MPSSE_SK (DB0) ----------- SWDCK/JTCK
 		 * MPSSE-DO (DB1) -- 470 R -- SWDIO/JTMS
 		 * MPSSE-DI (DB2) ----------- SWDIO/JTMS
 		 * DO is tristated with SWD read, so
@@ -79,8 +82,8 @@ cable_desc_t cable_desc[] = {
 		 * JTAG not possible
 		 * PIN6     (DB6) ----------- NRST
 		 */
-		.vendor = 0x0403,
-		.product = 0x6010, /*FT2232H*/
+		.vendor = 0x0403U,
+		.product = 0x6010U, /*FT2232H*/
 		.interface = INTERFACE_B,
 		.init.data_low = PIN4, /* Pull up pin 4 */
 		.init.ddr_low = PIN4,  /* Pull up pin 4 */
@@ -96,7 +99,8 @@ cable_desc_t cable_desc[] = {
 		.name = "usbmate",
 	},
 	{
-		/* MPSSE_SK (DB0) ----------- SWDCK/JTCK
+		/*
+		 * MPSSE_SK (DB0) ----------- SWDCK/JTCK
 		 * MPSSE-DO (DB1) -- 470 R -- SWDIO/JTMS
 		 * MPSSE-DI (DB2) ----------- SWDIO/JTMS
 		 * DO is tristated with SWD read, so
@@ -104,25 +108,26 @@ cable_desc_t cable_desc[] = {
 		 * from contentions in case of errors.
 		 * JTAG not possible.
 		 */
-		.vendor = 0x0403,
-		.product = 0x6014, /*FT232H*/
+		.vendor = 0x0403U,
+		.product = 0x6014U, /*FT232H*/
 		.interface = INTERFACE_A,
 		.mpsse_swd_read.set_data_low = MPSSE_DO,
 		.mpsse_swd_write.set_data_low = MPSSE_DO,
 		.name = "ft232h_resistor_swd",
 	},
 	{
-		/* Buffered connection from FTDI to Jtag/Swd.
-		 * TCK and TMS not independant switchable!
-		 * SWD not possible.
+		/*
+		 * Buffered connection from FTDI to JTAG/SWD.
+		 * TCK and TMS are not independantly switchable.
+		 * => SWD is not possible.
 		 * PIN4 low enables buffers
 		 * PIN5 Low indicates VRef applied
 		 * PIN6 reads back nRST
 		 * CBUS PIN1 Sets nRST
 		 * CBUS PIN2 low drives nRST
 		 */
-		.vendor = 0x0403,
-		.product = 0x6010,
+		.vendor = 0x0403U,
+		.product = 0x6010U,
 		.interface = INTERFACE_A,
 		.init.ddr_low = PIN4,
 		.init.data_high = PIN4 | PIN3 | PIN2,
@@ -135,22 +140,23 @@ cable_desc_t cable_desc[] = {
 		.name = "ftdijtag",
 	},
 	{
-		/* UART/SWO on Interface A
+		/*
+		 * UART/SWO on Interface A
 		 * JTAG and control on INTERFACE_B
 		 * Bit 5 high selects SWD-WRITE (TMS routed to MPSSE_DI)
 		 * Bit 6 high selects JTAG vs SWD (TMS routed to MPSSE_CS)
 		 * BCBUS 1 (Output) N_RST
-		 * BCBUS 2 (Input/ Internal Pull Up) V_ISO available
+		 * BCBUS 2 (Input/Internal pull-up) V_ISO available
 		 *
 		 * For bitbanged SWD, set Bit 5 low and select SWD read with
 		 * Bit 6 low. Read Connector TMS as MPSSE_DI.
 		 *
-		 * TDO is routed to Interface 0 RXD as SWO or with Uart
+		 * TDO is routed to Interface 0 RXD as SWO or with UART
 		 * Connector pin 10 pulled to ground will connect Interface 0 RXD
 		 * to UART connector RXD
 		 */
-		.vendor = 0x0403,
-		.product = 0x6010,
+		.vendor = 0x0403U,
+		.product = 0x6010U,
 		.interface = INTERFACE_B,
 		.init.data_low = PIN6 | PIN5,
 		.init.ddr_low = PIN6 | PIN5,
@@ -169,23 +175,24 @@ cable_desc_t cable_desc[] = {
 		.description = "FTDISWD",
 	},
 	{
-		.vendor = 0x15b1,
-		.product = 0x0003,
+		.vendor = 0x15b1U,
+		.product = 0x0003U,
 		.interface = INTERFACE_A,
 		.init.ddr_low = PIN5,
 		.name = "olimex",
 	},
 	{
-		/* Buffered connection from FTDI to Jtag/Swd.
-		 * TCK and TMS not independant switchable!
-		 * => SWD not possible.
+		/*
+		 * Buffered connection from FTDI to JTAG/SWD.
+		 * TCK and TMS are not independantly switchable.
+		 * => SWD is not possible.
 		 * DBUS PIN4 / JTAGOE low enables buffers
 		 * DBUS PIN5 / TRST high drives nTRST low OC
 		 * DBUS PIN6 / RST high drives nRST low OC
 		 * CBUS PIN0 reads back nRST
 		 */
-		.vendor = 0x0403,
-		.product = 0xbdc8,
+		.vendor = 0x0403U,
+		.product = 0xbdc8U,
 		.interface = INTERFACE_A,
 		/* Drive low to activate JTAGOE and deassert TRST/RST.*/
 		.init.data_low = 0,
@@ -199,20 +206,21 @@ cable_desc_t cable_desc[] = {
 		.description = "Turtelizer JTAG/RS232 Adapter",
 	},
 	{
-		/* https://reference.digilentinc.com/jtag_hs1/jtag_hs1
+		/*
+		 * https://reference.digilentinc.com/jtag_hs1/jtag_hs1
 		 * No schmeatics available.
-		 * Buffered from FTDI to Jtag/Swd announced
+		 * Buffered from FTDI to JTAG/SWD announced
 		 * Independant switch for TMS not known
 		 * => SWD not possible. */
-		.vendor = 0x0403,
-		.product = 0xbdc8,
+		.vendor = 0x0403U,
+		.product = 0xbdc8U,
 		.interface = INTERFACE_A,
 		.name = "jtaghs1",
 	},
 	{
-		/* Direct connection from FTDI to Jtag/Swd assumed.*/
-		.vendor = 0x0403,
-		.product = 0xbdc8,
+		/* Direct connection from FTDI to JTAG/SWD assumed.*/
+		.vendor = 0x0403U,
+		.product = 0xbdc8U,
 		.interface = INTERFACE_A,
 		.init.data_low = MPSSE_CS | MPSSE_DO | MPSSE_DI,
 		.init.ddr_low = MPSSE_CS | MPSSE_DO | MPSSE_SK,
@@ -222,8 +230,8 @@ cable_desc_t cable_desc[] = {
 	},
 	{
 		/* Product name not unique! Assume SWD not possible.*/
-		.vendor = 0x0403,
-		.product = 0x6014,
+		.vendor = 0x0403U,
+		.product = 0x6014U,
 		.interface = INTERFACE_A,
 		.init.data_low = PIN7,
 		.init.ddr_low = PIN7,
@@ -232,9 +240,9 @@ cable_desc_t cable_desc[] = {
 		.name = "digilent",
 	},
 	{
-		/* Direct connection from FTDI to Jtag/Swd assumed.*/
-		.vendor = 0x0403,
-		.product = 0x6014,
+		/* Direct connection from FTDI to JTAG/SWD assumed.*/
+		.vendor = 0x0403U,
+		.product = 0x6014U,
 		.interface = INTERFACE_A,
 		.init.data_low = MPSSE_CS | MPSSE_DO | MPSSE_DI,
 		.init.ddr_low = MPSSE_CS | MPSSE_DO | MPSSE_SK,
@@ -243,13 +251,14 @@ cable_desc_t cable_desc[] = {
 		.name = "ft232h",
 	},
 	{
-		/* MPSSE-SK (AD0) ----------- SWCLK/JTCK
+		/*
+		 * MPSSE-SK (AD0) ----------- SWCLK/JTCK
 		 * MPSSE-DO (AD1) ----------- SWDIO/JTMS
 		 * MPSSE-DI (AD2) -- 330 R -- SWDIO/JTMS
 		 *                  (470 R or similar also fine)
 		 */
-		.vendor = 0x0403,
-		.product = 0x6011,
+		.vendor = 0x0403U,
+		.product = 0x6011U,
 		.interface = INTERFACE_A,
 		.mpsse_swd_read.set_data_low = MPSSE_DI,
 		.mpsse_swd_write.set_data_low = MPSSE_DO,
@@ -257,12 +266,14 @@ cable_desc_t cable_desc[] = {
 		.name = "ft4232h",
 	},
 	{
-		/* http://www.olimex.com/dev/pdf/ARM-USB-OCD.pdf.
+		/*
+		 * http://www.olimex.com/dev/pdf/ARM-USB-OCD.pdf.
 		 * DBUS 4 global enables JTAG Buffer.
-		 * => TCK and TMS not independant switchable!
-		 * => SWD not possible. */
-		.vendor = 0x15ba,
-		.product = 0x002b,
+		 * TCK and TMS are not independantly switchable.
+		 * => SWD is not possible.
+		 */
+		.vendor = 0x15baU,
+		.product = 0x002bU,
 		.interface = INTERFACE_A,
 		.init.ddr_low = PIN4,
 		.init.data_high = PIN3 | PIN1 | PIN0,
@@ -270,24 +281,25 @@ cable_desc_t cable_desc[] = {
 		.name = "arm-usb-ocd-h",
 	},
 	{
-		/* ESP Prog:
-		 *
+		/*
 		 * JTAG buffered on Interface A -> No SWD
 		 * Standard VID/PID/Product
 		 * No nRST on the 10 pin connectors
 		 *
+		 * This device has no explicit reset.
+		 * => SWD is not possible.
+		 *
 		 * JTAG enabled by default, ESP_EN pulled up,
 		 * inverted by U4 and enabling JTAG by U5
 		 */
-		.vendor = 0x0403,
-		.product = 0x6010,
+		.vendor = 0x0403U,
+		.product = 0x6010U,
 		.interface = INTERFACE_A,
 		.name = "esp-prog",
-		// No explicit reset
-		// SWD not possible
 	},
 	{
-		/* MPSSE_SK (DB0) ----------- SWDCK/JTCK
+		/*
+		 * MPSSE_SK (DB0) ----------- SWDCK/JTCK
 		 * Mode-Switch 1-2/4-5: JTAG
 		 * MPSSE-DO (DB1) ----------- JTAG/TDI
 		 * MPSSE-DI (DB2) ----------- JTAG/TDO
@@ -299,9 +311,10 @@ cable_desc_t cable_desc[] = {
 		 * TRST is Push/Pull, not OD!
 		 * PIN4     (DB5) ----------- TRST
 		 * nRST is Push/Pull, not OD! Keep DDR set.
-		 * PIN5     (DB5) ----------- NRST */
-		.vendor = 0x0403,
-		.product = 0x6010, /*FT2232H*/
+		 * PIN5     (DB5) ----------- NRST
+		 */
+		.vendor = 0x0403U,
+		.product = 0x6010U, /*FT2232H*/
 		.interface = INTERFACE_B,
 		.init.data_high = PIN4 | PIN5, /* High   on PIN4/5 */
 		.init.ddr_high = PIN4 | PIN5,  /* Output on PIN4/5 */
@@ -314,13 +327,14 @@ cable_desc_t cable_desc[] = {
 		.name = "tigard",
 	},
 	{
-		/* https://sifive.cdn.prismic.io/sifive/b5c95ddd-22af-4be0-8021-50327e186b07_hifive1-a-schematics.pdf
-		 * Direct Connection on Interface-A
-		 * Reset on PIN5, Open-Drain, pulled up tp 3.3 Volt
+		/*
+		 * https://sifive.cdn.prismic.io/sifive/b5c95ddd-22af-4be0-8021-50327e186b07_hifive1-a-schematics.pdf
+		 * Direct connection on Interface-A
+		 * Reset on PIN5, Open-Drain, pulled up to 3.3V
 		 * and decoupled from FE310 reset voa Schottky
 		 */
-		.vendor = 0x0403,
-		.product = 0x6010,
+		.vendor = 0x0403U,
+		.product = 0x6010U,
 		.interface = INTERFACE_A,
 		.assert_nrst.data_low = ~PIN5,
 		.assert_nrst.ddr_low = PIN5,
@@ -331,12 +345,13 @@ cable_desc_t cable_desc[] = {
 		.name = "hifive1",
 	},
 	{
-		/* https://www.olimex.com/Products/ARM/JTAG/ARM-USB-TINY-H/
+		/*
+		 * https://www.olimex.com/Products/ARM/JTAG/ARM-USB-TINY-H/
 		 *
 		 * schematics not available
 		 */
-		.vendor = 0x15b1,
-		.product = 0x002a,
+		.vendor = 0x15b1U,
+		.product = 0x002aU,
 		.interface = INTERFACE_A,
 		.init.data_low = PIN4,
 		.init.ddr_low = PIN4 | PIN5,

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -117,9 +117,9 @@ int libftdi_swdptap_init(ADIv5_DP_t *dp)
 	return -1;
 }
 
-int libftdi_jtagtap_init(void)
+bool libftdi_jtagtap_init(void)
 {
-	return 0;
+	return false;
 }
 
 void libftdi_buffer_flush(void)
@@ -179,7 +179,7 @@ extern data_desc_t active_state;
 
 int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info);
 int libftdi_swdptap_init(ADIv5_DP_t *dp);
-int libftdi_jtagtap_init(void);
+bool libftdi_jtagtap_init(void);
 void libftdi_buffer_flush(void);
 size_t libftdi_buffer_write(const uint8_t *data, size_t size);
 size_t libftdi_buffer_read(uint8_t *data, size_t size);

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -99,6 +99,10 @@ typedef struct cable_desc_s {
 	char *name;
 } cable_desc_t;
 
+#define libftdi_buffer_write_arr(array) libftdi_buffer_write(array, sizeof(array))
+#define libftdi_buffer_read_arr(array)  libftdi_buffer_read(array, sizeof(array))
+#define libftdi_buffer_read_val(value)  libftdi_buffer_read(&(value), sizeof(value))
+
 #if HOSTED_BMP_ONLY == 1
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -127,7 +131,7 @@ size_t libftdi_buffer_write(const uint8_t *data, size_t size)
 	return size;
 }
 
-int libftdi_buffer_read(uint8_t *data, int size)
+size_t libftdi_buffer_read(uint8_t *data, size_t size)
 {
 	return size;
 }
@@ -178,7 +182,7 @@ int libftdi_swdptap_init(ADIv5_DP_t *dp);
 int libftdi_jtagtap_init(jtag_proc_t *jtag_proc);
 void libftdi_buffer_flush(void);
 size_t libftdi_buffer_write(const uint8_t *data, size_t size);
-int libftdi_buffer_read(uint8_t *data, int size);
+size_t libftdi_buffer_read(uint8_t *data, size_t size);
 const char *libftdi_target_voltage(void);
 void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t ticks);
 bool libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd);

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -117,7 +117,7 @@ int libftdi_swdptap_init(ADIv5_DP_t *dp)
 	return -1;
 }
 
-int libftdi_jtagtap_init(jtag_proc_t *jtag_proc)
+int libftdi_jtagtap_init(void)
 {
 	return 0;
 }
@@ -179,7 +179,7 @@ extern data_desc_t active_state;
 
 int ftdi_bmp_init(BMP_CL_OPTIONS_t *cl_opts, bmp_info_t *info);
 int libftdi_swdptap_init(ADIv5_DP_t *dp);
-int libftdi_jtagtap_init(jtag_proc_t *jtag_proc);
+int libftdi_jtagtap_init(void);
 void libftdi_buffer_flush(void);
 size_t libftdi_buffer_write(const uint8_t *data, size_t size);
 size_t libftdi_buffer_read(uint8_t *data, size_t size);

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -146,7 +146,7 @@ void libftdi_jtagtap_tdi_tdo_seq(
 {
 }
 
-bool libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd)
+bool libftdi_swd_possible(void)
 {
 	return false;
 }
@@ -185,7 +185,7 @@ size_t libftdi_buffer_write(const uint8_t *data, size_t size);
 size_t libftdi_buffer_read(uint8_t *data, size_t size);
 const char *libftdi_target_voltage(void);
 void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t ticks);
-bool libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd);
+bool libftdi_swd_possible(void);
 void libftdi_max_frequency_set(uint32_t freq);
 uint32_t libftdi_max_frequency_get(void);
 void libftdi_nrst_set_val(bool assert);

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -100,6 +100,7 @@ typedef struct cable_desc_s {
 } cable_desc_t;
 
 #define libftdi_buffer_write_arr(array) libftdi_buffer_write(array, sizeof(array))
+#define libftdi_buffer_write_val(value) libftdi_buffer_write(&(value), sizeof(value))
 #define libftdi_buffer_read_arr(array)  libftdi_buffer_read(array, sizeof(array))
 #define libftdi_buffer_read_val(value)  libftdi_buffer_read(&(value), sizeof(value))
 

--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -33,7 +33,7 @@ extern struct ftdi_context *ftdic;
 
 static void jtagtap_reset(void);
 static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks);
-static void jtagtap_tdi_seq(bool final_tms, const uint8_t *DI, size_t ticks);
+static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jtagtap_next(bool tms, bool tdi);
 
 int libftdi_jtagtap_init(jtag_proc_t *jtag_proc)
@@ -106,9 +106,9 @@ static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks)
 	}
 }
 
-static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *DI, size_t ticks)
+static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
-	return libftdi_jtagtap_tdi_tdo_seq(NULL, final_tms, DI, ticks);
+	return libftdi_jtagtap_tdi_tdo_seq(NULL, final_tms, data_in, clock_cycles);
 }
 
 static bool jtagtap_next(bool tms, bool tdi)

--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -32,7 +32,7 @@ extern cable_desc_t *active_cable;
 extern struct ftdi_context *ftdic;
 
 static void jtagtap_reset(void);
-static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks);
+static void jtagtap_tms_seq(uint32_t tms_states, size_t clock_cycles);
 static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jtagtap_next(bool tms, bool tdi);
 
@@ -90,19 +90,16 @@ static void jtagtap_reset(void)
 	jtagtap_soft_reset();
 }
 
-static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks)
+static void jtagtap_tms_seq(uint32_t tms_states, const size_t clock_cycles)
 {
-	uint8_t tmp[3] = {MPSSE_WRITE_TMS | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG, 0, 0};
-	while (ticks > 0) {
-		tmp[1] = ticks < 7 ? ticks - 1 : 6;
-		tmp[2] = 0x80 | (tms_states & 0x7F);
-
-		libftdi_buffer_write(tmp, 3);
-		tms_states >>= 7;
-		if (ticks < 7)
-			ticks = 0;
-		else
-			ticks -= 7;
+	for (size_t cycle = 0U; cycle < clock_cycles; cycle += 7U) {
+		const uint8_t cmd[3U] = {
+			MPSSE_WRITE_TMS | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG,
+			MIN(7U, clock_cycles - cycle) - 1U,
+			0x80U | (tms_states & 0x7FU),
+		};
+		tms_states >>= 7U;
+		libftdi_buffer_write_arr(cmd);
 	}
 }
 

--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -18,8 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Low level JTAG implementation using FT2232 with libftdi.
- *
+/*
+ * Low level JTAG implementation using FT2232 with libftdi.
  */
 
 #include "general.h"
@@ -28,60 +28,64 @@
 #include <ftdi.h>
 #include "ftdi_bmp.h"
 
-extern cable_desc_t *active_cable;
-extern struct ftdi_context *ftdic;
-
 static void jtagtap_reset(void);
 static void jtagtap_tms_seq(uint32_t tms_states, size_t clock_cycles);
 static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jtagtap_next(bool tms, bool tdi);
 
-int libftdi_jtagtap_init(jtag_proc_t *jtag_proc)
+void libftdi_drain_potential_garbage(void)
 {
-	if ((active_cable->mpsse_swd_read.set_data_low == MPSSE_DO) &&
-		(active_cable->mpsse_swd_write.set_data_low == MPSSE_DO)) {
-		printf("Jtag not possible with resistor SWD!\n");
+	uint8_t data[16];
+	int garbage = ftdi_read_data(ftdic, data, sizeof(data));
+	if (garbage > 0) {
+		DEBUG_WARN("FTDI JTAG init got garbage:");
+		for (int i = 0; i < garbage; i++)
+			DEBUG_WARN(" %02x", data[i]);
+		DEBUG_WARN("\n");
+	}
+}
+
+int libftdi_jtagtap_init(void)
+{
+	if (active_cable->mpsse_swd_read.set_data_low == MPSSE_DO &&
+		active_cable->mpsse_swd_write.set_data_low == MPSSE_DO) {
+		DEBUG_WARN("JTAG not possible with resistor SWD!\n");
 		return -1;
 	}
-	jtag_proc->jtagtap_reset = jtagtap_reset;
-	jtag_proc->jtagtap_next = jtagtap_next;
-	jtag_proc->jtagtap_tms_seq = jtagtap_tms_seq;
-	jtag_proc->jtagtap_tdi_tdo_seq = libftdi_jtagtap_tdi_tdo_seq;
-	jtag_proc->jtagtap_tdi_seq = jtagtap_tdi_seq;
+
+	jtag_proc.jtagtap_reset = jtagtap_reset;
+	jtag_proc.jtagtap_next = jtagtap_next;
+	jtag_proc.jtagtap_tms_seq = jtagtap_tms_seq;
+	jtag_proc.jtagtap_tdi_tdo_seq = libftdi_jtagtap_tdi_tdo_seq;
+	jtag_proc.jtagtap_tdi_seq = jtagtap_tdi_seq;
 
 	active_state.data_low |= active_cable->jtag.set_data_low | MPSSE_CS | MPSSE_DI | MPSSE_DO;
 	active_state.data_low &= ~(active_cable->jtag.clr_data_low | MPSSE_SK);
 	active_state.ddr_low |= MPSSE_CS | MPSSE_DO | MPSSE_SK;
-	active_state.ddr_low &= ~(MPSSE_DI);
+	active_state.ddr_low &= ~MPSSE_DI;
 	active_state.data_high |= active_cable->jtag.set_data_high;
-	active_state.data_high &= ~(active_cable->jtag.clr_data_high);
-	uint8_t gab[16];
-	int garbage = ftdi_read_data(ftdic, gab, sizeof(gab));
-	if (garbage > 0) {
-		DEBUG_WARN("FTDI JTAG init got garbage:");
-		for (int i = 0; i < garbage; i++)
-			DEBUG_WARN(" %02x", gab[i]);
-		DEBUG_WARN("\n");
-	}
-	uint8_t cmd_write[16] = {SET_BITS_LOW, active_state.data_low, active_state.ddr_low, SET_BITS_HIGH,
-		active_state.data_high, active_state.ddr_high};
-	libftdi_buffer_write(cmd_write, 6);
+	active_state.data_high &= ~active_cable->jtag.clr_data_high;
+	libftdi_drain_potential_garbage();
+
+	const uint8_t cmd[6] = {
+		SET_BITS_LOW,
+		active_state.data_low,
+		active_state.ddr_low,
+		SET_BITS_HIGH,
+		active_state.data_high,
+		active_state.ddr_high,
+	};
+	libftdi_buffer_write_arr(cmd);
 	libftdi_buffer_flush();
 	/* Write out start condition and pull garbage from read buffer.
 	 * FT2232D otherwise misbehaves on runs follwoing the first run.*/
-	garbage = ftdi_read_data(ftdic, cmd_write, sizeof(cmd_write));
-	if (garbage > 0) {
-		DEBUG_WARN("FTDI JTAG end init got garbage:");
-		for (int i = 0; i < garbage; i++)
-			DEBUG_WARN(" %02x", cmd_write[i]);
-		DEBUG_WARN("\n");
-	}
-	/* Go to JTAG mode for SWJ-DP */
-	for (int i = 0; i <= 50; i++)
-		jtag_proc->jtagtap_next(1, 0);      /* Reset SW-DP */
-	jtag_proc->jtagtap_tms_seq(0xE73C, 16); /* SWD to JTAG sequence */
-	jtag_proc->jtagtap_tms_seq(0x1F, 6);
+	libftdi_drain_potential_garbage();
 
+	/* Ensure we're in JTAG mode */
+	for (size_t i = 0; i <= 50U; ++i)
+		jtagtap_next(true, false); /* 50 idle cycles for SWD reset */
+	jtagtap_tms_seq(0xe73cU, 16);  /* SWD to JTAG sequence */
+	jtagtap_soft_reset();
 	return 0;
 }
 

--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -33,6 +33,26 @@ static void jtagtap_tms_seq(uint32_t tms_states, size_t clock_cycles);
 static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jtagtap_next(bool tms, bool tdi);
 
+/*
+ * Throughout this file you will see command buffers being built which have the following basic form:
+ *
+ * The command block (3 bytes):
+ * ┌─────────┬─────────────┬───────────┐
+ * │    0    │      1      │     2     │
+ * ├─────────┼─────────────┼───────────┤
+ * │ Command │ Cycle count │ Data bits │
+ * │         │     (-1)    │    LBE    │
+ * └─────────┴─────────────┴───────────┘
+ * where LBE == Little Bit Endian.
+ *
+ * These are then sequenced into command buffers:
+ * ┌─────────────────┬─────┐
+ * │ Command block 0 │ ... │
+ * └─────────────────┴─────┘
+ *
+ * Each command block is allowed to handle at most 7 clock cycles - why not 8 is undocumented.
+ */
+
 void libftdi_drain_potential_garbage(void)
 {
 	uint8_t data[16];

--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -45,12 +45,12 @@ void libftdi_drain_potential_garbage(void)
 	}
 }
 
-int libftdi_jtagtap_init(void)
+bool libftdi_jtagtap_init(void)
 {
 	if (active_cable->mpsse_swd_read.set_data_low == MPSSE_DO &&
 		active_cable->mpsse_swd_write.set_data_low == MPSSE_DO) {
 		DEBUG_WARN("JTAG not possible with resistor SWD!\n");
-		return -1;
+		return false;
 	}
 
 	jtag_proc.jtagtap_reset = jtagtap_reset;
@@ -86,7 +86,7 @@ int libftdi_jtagtap_init(void)
 		jtagtap_next(true, false); /* 50 idle cycles for SWD reset */
 	jtagtap_tms_seq(0xe73cU, 16);  /* SWD to JTAG sequence */
 	jtagtap_soft_reset();
-	return 0;
+	return true;
 }
 
 static void jtagtap_reset(void)

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -257,14 +257,19 @@ void swdptap_bit_out(bool val)
 {
 	swdptap_turnaround(SWDIO_STATUS_DRIVE);
 	if (do_mpsse) {
-		uint8_t cmd[3] = {MPSSE_TDO_SHIFT, 0, (val) ? 1 : 0};
-		libftdi_buffer_write(cmd, sizeof(cmd));
+		const uint8_t cmd[3] = {
+			MPSSE_TDO_SHIFT,
+			0,
+			val ? 1 : 0,
+		};
+		libftdi_buffer_write_arr(cmd);
 	} else {
-		uint8_t cmd[3];
-		cmd[0] = MPSSE_TMS_SHIFT;
-		cmd[1] = 0;
-		cmd[2] = (val) ? 1 : 0;
-		libftdi_buffer_write(cmd, sizeof(cmd));
+		const uint8_t cmd[3] = {
+			MPSSE_TMS_SHIFT,
+			0,
+			val ? 1 : 0,
+		};
+		libftdi_buffer_write_arr(cmd);
 	}
 }
 

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -74,10 +74,10 @@ int libftdi_swdptap_init(ADIv5_DP_t *dp)
 		DEBUG_WARN("SWD not possible or missing item in cable description.\n");
 		return -1;
 	}
+	active_state.data_low &= ~MPSSE_SK;
 	active_state.data_low |= MPSSE_CS | MPSSE_DI | MPSSE_DO;
-	active_state.data_low &= MPSSE_SK;
-	active_state.ddr_low |= MPSSE_SK;
 	active_state.ddr_low &= ~(MPSSE_CS | MPSSE_DI | MPSSE_DO);
+	active_state.ddr_low |= MPSSE_SK;
 	if (do_mpsse) {
 		DEBUG_INFO("Using genuine MPSSE for SWD.\n");
 		active_state.data_low |= active_cable->mpsse_swd_read.set_data_low;

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -320,42 +320,48 @@ static bool swdptap_seq_in_parity(uint32_t *const result, const size_t clock_cyc
 	return swdptap_seq_in_parity_raw(result, clock_cycles);
 }
 
-static uint32_t swdptap_seq_in(size_t clock_cycles)
+static uint32_t swdptap_seq_in_mpsse(const size_t clock_cycles)
 {
-	if (!clock_cycles)
-		return 0;
-	uint32_t result = 0;
-	swdptap_turnaround(SWDIO_STATUS_FLOAT);
-	if (do_mpsse) {
-		uint8_t DO[4];
-		libftdi_jtagtap_tdi_tdo_seq(DO, 0, NULL, clock_cycles);
-		int bytes = clock_cycles >> 3;
-		if (clock_cycles & 7)
-			bytes++;
-		for (int i = 0; i < bytes; i++) {
-			result |= DO[i] << (8 * i);
-		}
-	} else {
-		size_t index = clock_cycles;
-		uint8_t cmd[4];
+	uint8_t data_out[4];
+	libftdi_jtagtap_tdi_tdo_seq(data_out, false, NULL, clock_cycles);
+	size_t bytes = clock_cycles >> 3U;
+	if (clock_cycles & 7U)
+		bytes++;
+	uint32_t result = 0U;
+	for (size_t i = 0U; i < bytes; i++)
+		result |= data_out[i] << (8U * i);
+	return result;
+}
 
-		cmd[0] = active_cable->bb_swdio_in_port_cmd;
-		cmd[1] = MPSSE_TMS_SHIFT;
-		cmd[2] = 0;
-		cmd[3] = 0;
+static uint32_t swdptap_seq_in_raw(const size_t clock_cycles)
+{
+	const uint8_t cmd[4] = {
+		active_cable->bb_swdio_in_port_cmd,
+		MPSSE_TMS_SHIFT,
+		0U,
+		0U,
+	};
+	for (size_t clock_cycle = 0U; clock_cycle < clock_cycles; ++clock_cycle)
+		libftdi_buffer_write_arr(cmd);
 
-		while (index--) {
-			libftdi_buffer_write(cmd, sizeof(cmd));
-		}
-		uint8_t data[32];
-		libftdi_buffer_read(data, clock_cycles);
-		index = clock_cycles;
-		while (index--) {
-			if (data[index] & active_cable->bb_swdio_in_pin)
-				result |= (1 << index);
-		}
+	uint8_t data[32];
+	libftdi_buffer_read(data, clock_cycles);
+	uint32_t result = 0U;
+	for (size_t clock_cycle = 0U; clock_cycle < clock_cycles; ++clock_cycle) {
+		if (data[clock_cycle] & active_cable->bb_swdio_in_pin)
+			result |= (1U << clock_cycle);
 	}
 	return result;
+}
+
+static uint32_t swdptap_seq_in(size_t clock_cycles)
+{
+	if (!clock_cycles || clock_cycles > 32U)
+		return 0;
+	swdptap_turnaround(SWDIO_STATUS_FLOAT);
+	if (do_mpsse)
+		return swdptap_seq_in_mpsse(clock_cycles);
+	return swdptap_seq_in_raw(clock_cycles);
 }
 
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -23,6 +23,7 @@
 
 #include "general.h"
 #include <assert.h>
+#include <stdlib.h>
 
 #include <ftdi.h>
 #include "ftdi_bmp.h"
@@ -399,48 +400,82 @@ static void swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles
 		swdptap_seq_out_raw(tms_states, clock_cycles);
 }
 
-/* ARM Debug Interface Architecture Specification ADIv5.0 to ADIv5.2
- * tells to clock the data through SW-DP to either :
- * - immediate start a new transaction
+/*
+ * The ADI Specification v5.0 through v5.2 states that when clocking data
+ * in SWD mode, when we finish we must either:
+ * - immediately start a new transaction
  * - continue to drive idle cycles
- * - or clock at least 8 idle cycles
+ * - or clock at least 8 idle cycles to complete the transaction.
  *
- * Implement last option to favour correctness over
- *   slight speed decrease
+ * We implement the last option to favour correctness over a slight speed decrease
  */
+
+static void swdptap_seq_out_parity_mpsse(const uint32_t tms_states, const uint8_t parity, const size_t clock_cycles)
+{
+	uint8_t data_in[6] = {
+		tms_states & 0xffU,
+		(tms_states >> 8U) & 0xffU,
+		(tms_states >> 16U) & 0xffU,
+		(tms_states >> 24U) & 0xffU,
+		0,
+		0,
+	};
+	/* Figure out which byte we should write the parity to */
+	const size_t parity_offset = clock_cycles >> 3U;
+	/* Then which bit in that byte */
+	const size_t parity_shift = clock_cycles & 7U;
+	data_in[parity_offset] = parity << parity_shift;
+	/*
+	 * This clocks out the requested number of clock cycles,
+	 * then an additional 1 for the parity, and finally
+	 * 8 more to complete the idle cycles.
+	 */
+	libftdi_jtagtap_tdi_tdo_seq(NULL, false, data_in, clock_cycles + 9U);
+}
+
+static void swdptap_seq_out_parity_raw(const uint32_t tms_states, const uint8_t parity, const size_t clock_cycles)
+{
+	uint8_t cmd[18] = {};
+	size_t offset = 0;
+	for (size_t cycle = 0U; cycle < clock_cycles; cycle += 7U, offset += 3U) {
+		const size_t cycles = MIN(7U, clock_cycles - cycle);
+		cmd[offset] = MPSSE_TMS_SHIFT;
+		cmd[offset + 1U] = cycles - 1U;
+		cmd[offset + 2U] = tms_states & 0x7fU;
+	}
+	/* Calculate which command block the parity goes in */
+	const div_t parity_index = div(clock_cycles, 7U);
+	const size_t parity_offset = parity_index.quot * 3U;
+	cmd[parity_offset] = MPSSE_TMS_SHIFT;
+	cmd[parity_offset + 1U] = 6U;                            /* Increase that block's cycle count to 7 cycles */
+	cmd[parity_offset + 2U] |= (parity << parity_index.rem); /* And write the parity bit in */
+	size_t idle_remaining = parity_index.rem + 2U;
+	/* clock_cycles is not allowed to exceed 32, so the next step is always safe. */
+	/* First, we put together a packet for up to 7 idle cycles */
+	const size_t idle_cycles = MIN(7U, idle_remaining);
+	cmd[offset] = MPSSE_TMS_SHIFT;
+	cmd[offset + 1U] = idle_cycles - 1U;
+	cmd[offset + 2U] = 0U;
+	offset += 3U;
+	/* Then, if idle_remaining was actually 8 (the remainder of the division was 6) */
+	if (idle_remaining == 8U) {
+		/* Deal with the single missing idle cycle */
+		cmd[offset] = MPSSE_TMS_SHIFT;
+		cmd[offset + 1U] = 0U;
+		cmd[offset + 2U] = 0U;
+		offset += 3U;
+	}
+	libftdi_buffer_write(cmd, offset);
+}
+
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 {
-	(void)clock_cycles;
-	int parity = __builtin_parity(tms_states) & 1;
-	size_t index = 0;
+	if (clock_cycles > 32U)
+		return;
+	const uint8_t parity = __builtin_parity(tms_states) & 1U;
 	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	if (do_mpsse) {
-		uint8_t DI[8];
-		DI[0] = (tms_states >> 0) & 0xff;
-		DI[1] = (tms_states >> 8) & 0xff;
-		DI[2] = (tms_states >> 16) & 0xff;
-		DI[3] = (tms_states >> 24) & 0xff;
-		DI[4] = parity;
-		DI[5] = 0;
-		libftdi_jtagtap_tdi_tdo_seq(NULL, 0, DI, 32 + 1 + 8);
-	} else {
-		uint8_t cmd[32];
-		size_t steps = clock_cycles;
-		while (steps) {
-			cmd[index++] = MPSSE_TMS_SHIFT;
-			cmd[index++] = 6;
-			if (steps >= 7) {
-				cmd[index++] = tms_states & 0x7f;
-				tms_states >>= 7;
-				steps -= 7;
-			} else {
-				cmd[index++] = (tms_states & 0x7f) | (parity << 4);
-				steps = 0;
-			}
-		}
-		cmd[index++] = MPSSE_TMS_SHIFT;
-		cmd[index++] = 4;
-		cmd[index++] = 0;
-		libftdi_buffer_write(cmd, index);
-	}
+	if (do_mpsse)
+		swdptap_seq_out_parity_mpsse(tms_states, parity, clock_cycles);
+	else
+		swdptap_seq_out_parity_raw(tms_states, parity, clock_cycles);
 }

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -219,30 +219,38 @@ static void swdptap_turnaround(const swdio_status_e dir)
 		swdptap_turnaround_raw(dir);
 }
 
+bool swdptap_bit_in_mpsse(void)
+{
+	const uint8_t cmd[2] = {
+		MPSSE_DO_READ | MPSSE_LSB | MPSSE_BITMODE,
+		0,
+	};
+	libftdi_buffer_write_arr(cmd);
+	uint8_t data;
+	libftdi_buffer_read_val(data);
+	return data & 0x80U;
+}
+
+bool swdptap_bit_in_raw(void)
+{
+	const uint8_t cmd[4] = {
+		active_cable->bb_swdio_in_port_cmd,
+		MPSSE_TMS_SHIFT,
+		0,
+		0,
+	};
+	libftdi_buffer_write_arr(cmd);
+	uint8_t data;
+	libftdi_buffer_read_val(data);
+	return data & active_cable->bb_swdio_in_pin;
+}
+
 bool swdptap_bit_in(void)
 {
 	swdptap_turnaround(SWDIO_STATUS_FLOAT);
-	uint8_t cmd[4];
-	int index = 0;
-	bool result = false;
-
-	if (do_mpsse) {
-		uint8_t cmd[2] = {MPSSE_DO_READ | MPSSE_LSB | MPSSE_BITMODE, 0};
-		libftdi_buffer_write(cmd, sizeof(cmd));
-		uint8_t data[1];
-		libftdi_buffer_read(data, sizeof(data));
-		result = (data[0] & 0x80);
-	} else {
-		cmd[index++] = active_cable->bb_swdio_in_port_cmd;
-		cmd[index++] = MPSSE_TMS_SHIFT;
-		cmd[index++] = 0;
-		cmd[index++] = 0;
-		libftdi_buffer_write(cmd, index);
-		uint8_t data[1];
-		libftdi_buffer_read(data, sizeof(data));
-		result = (data[0] &= active_cable->bb_swdio_in_pin);
-	}
-	return result;
+	if (do_mpsse)
+		return swdptap_bit_in_mpsse();
+	return swdptap_bit_in_raw();
 }
 
 void swdptap_bit_out(bool val)

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -41,6 +41,86 @@ static bool direct_bb_swd;
 #define MPSSE_TMS_SHIFT (MPSSE_WRITE_TMS | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG)
 #define MPSSE_TDO_SHIFT (MPSSE_DO_WRITE | MPSSE_LSB | MPSSE_BITMODE | MPSSE_WRITE_NEG)
 
+static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles);
+static uint32_t swdptap_seq_in(size_t clock_cycles);
+static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
+static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
+
+bool libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd)
+{
+	const bool swd_read = active_cable->mpsse_swd_read.set_data_low || active_cable->mpsse_swd_read.clr_data_low ||
+		active_cable->mpsse_swd_read.set_data_high || active_cable->mpsse_swd_read.clr_data_high;
+	const bool swd_write = active_cable->mpsse_swd_write.set_data_low || active_cable->mpsse_swd_write.clr_data_low ||
+		active_cable->mpsse_swd_write.set_data_high || active_cable->mpsse_swd_write.clr_data_high;
+	const bool mpsse = swd_read && swd_write;
+	if (do_mpsse)
+		*do_mpsse = mpsse;
+	if (!mpsse) {
+		const bool bb_swd_read = active_cable->bb_swd_read.set_data_low || active_cable->bb_swd_read.clr_data_low ||
+			active_cable->bb_swd_read.set_data_high || active_cable->bb_swd_read.clr_data_high;
+		const bool bb_swd_write = active_cable->bb_swd_write.set_data_low || active_cable->bb_swd_write.clr_data_low ||
+			active_cable->bb_swd_write.set_data_high || active_cable->bb_swd_write.clr_data_high;
+		const bool bb_direct_possible =
+			active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW && active_cable->bb_swdio_in_pin == MPSSE_CS;
+		if (!bb_swd_read && !bb_swd_write) {
+			if (!bb_direct_possible)
+				return false;
+		}
+		if (direct_bb_swd)
+			*direct_bb_swd = true;
+	}
+	return true;
+}
+
+int libftdi_swdptap_init(ADIv5_DP_t *dp)
+{
+	if (!libftdi_swd_possible(&do_mpsse, &direct_bb_swd)) {
+		DEBUG_WARN("SWD not possible or missing item in cable description.\n");
+		return -1;
+	}
+	active_state.data_low |= MPSSE_CS | MPSSE_DI | MPSSE_DO;
+	active_state.data_low &= MPSSE_SK;
+	active_state.ddr_low |= MPSSE_SK;
+	active_state.ddr_low &= ~(MPSSE_CS | MPSSE_DI | MPSSE_DO);
+	if (do_mpsse) {
+		DEBUG_INFO("Using genuine MPSSE for SWD.\n");
+		active_state.data_low |= active_cable->mpsse_swd_read.set_data_low;
+		active_state.data_low &= ~(active_cable->mpsse_swd_read.clr_data_low);
+		active_state.data_high |= active_cable->mpsse_swd_read.set_data_high;
+		active_state.data_high &= ~(active_cable->mpsse_swd_read.clr_data_high);
+	} else if (direct_bb_swd) {
+		DEBUG_INFO("Using direct bitbang with SWDIO %cBUS%d.\n",
+			(active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW) ? 'C' : 'D',
+			__builtin_ctz(active_cable->bb_swdio_in_pin));
+	} else {
+		DEBUG_INFO("Using switched bitbang for SWD.\n");
+		active_state.data_low |= active_cable->bb_swd_read.set_data_low;
+		active_state.data_low &= ~(active_cable->bb_swd_read.clr_data_low);
+		active_state.data_high |= active_cable->bb_swd_read.set_data_high;
+		active_state.data_high &= ~(active_cable->bb_swd_read.clr_data_high);
+		active_state.ddr_low |= MPSSE_CS;
+		if (active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW)
+			active_state.ddr_low &= ~active_cable->bb_swdio_in_pin;
+		else if (active_cable->bb_swdio_in_port_cmd == GET_BITS_HIGH)
+			active_state.ddr_high &= ~active_cable->bb_swdio_in_pin;
+	}
+	uint8_t cmd_write[6] = {SET_BITS_LOW, active_state.data_low, active_state.ddr_low, SET_BITS_HIGH,
+		active_state.data_high, active_state.ddr_high};
+	libftdi_buffer_write(cmd_write, 6);
+	libftdi_buffer_flush();
+	olddir = SWDIO_STATUS_FLOAT;
+
+	dp->seq_in = swdptap_seq_in;
+	dp->seq_in_parity = swdptap_seq_in_parity;
+	dp->seq_out = swdptap_seq_out;
+	dp->seq_out_parity = swdptap_seq_out_parity;
+	dp->dp_read = firmware_swdp_read;
+	dp->error = firmware_swdp_error;
+	dp->low_access = firmware_swdp_low_access;
+	dp->abort = firmware_swdp_abort;
+	return 0;
+}
+
 static void swdptap_turnaround_mpsse(const swdio_status_e dir)
 {
 	if (dir == SWDIO_STATUS_FLOAT) { /* SWDIO goes to input */
@@ -141,86 +221,6 @@ static void swdptap_turnaround(const swdio_status_e dir)
 		swdptap_turnaround_mpsse(dir);
 	else
 		swdptap_turnaround_raw(dir);
-}
-
-static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles);
-static uint32_t swdptap_seq_in(size_t clock_cycles);
-static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
-static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
-
-bool libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd)
-{
-	const bool swd_read = active_cable->mpsse_swd_read.set_data_low || active_cable->mpsse_swd_read.clr_data_low ||
-		active_cable->mpsse_swd_read.set_data_high || active_cable->mpsse_swd_read.clr_data_high;
-	const bool swd_write = active_cable->mpsse_swd_write.set_data_low || active_cable->mpsse_swd_write.clr_data_low ||
-		active_cable->mpsse_swd_write.set_data_high || active_cable->mpsse_swd_write.clr_data_high;
-	const bool mpsse = swd_read && swd_write;
-	if (do_mpsse)
-		*do_mpsse = mpsse;
-	if (!mpsse) {
-		const bool bb_swd_read = active_cable->bb_swd_read.set_data_low || active_cable->bb_swd_read.clr_data_low ||
-			active_cable->bb_swd_read.set_data_high || active_cable->bb_swd_read.clr_data_high;
-		const bool bb_swd_write = active_cable->bb_swd_write.set_data_low || active_cable->bb_swd_write.clr_data_low ||
-			active_cable->bb_swd_write.set_data_high || active_cable->bb_swd_write.clr_data_high;
-		const bool bb_direct_possible =
-			active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW && active_cable->bb_swdio_in_pin == MPSSE_CS;
-		if (!bb_swd_read && !bb_swd_write) {
-			if (!bb_direct_possible)
-				return false;
-		}
-		if (direct_bb_swd)
-			*direct_bb_swd = true;
-	}
-	return true;
-}
-
-int libftdi_swdptap_init(ADIv5_DP_t *dp)
-{
-	if (!libftdi_swd_possible(&do_mpsse, &direct_bb_swd)) {
-		DEBUG_WARN("SWD not possible or missing item in cable description.\n");
-		return -1;
-	}
-	active_state.data_low |= MPSSE_CS | MPSSE_DI | MPSSE_DO;
-	active_state.data_low &= MPSSE_SK;
-	active_state.ddr_low |= MPSSE_SK;
-	active_state.ddr_low &= ~(MPSSE_CS | MPSSE_DI | MPSSE_DO);
-	if (do_mpsse) {
-		DEBUG_INFO("Using genuine MPSSE for SWD.\n");
-		active_state.data_low |= active_cable->mpsse_swd_read.set_data_low;
-		active_state.data_low &= ~(active_cable->mpsse_swd_read.clr_data_low);
-		active_state.data_high |= active_cable->mpsse_swd_read.set_data_high;
-		active_state.data_high &= ~(active_cable->mpsse_swd_read.clr_data_high);
-	} else if (direct_bb_swd) {
-		DEBUG_INFO("Using direct bitbang with SWDIO %cBUS%d.\n",
-			(active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW) ? 'C' : 'D',
-			__builtin_ctz(active_cable->bb_swdio_in_pin));
-	} else {
-		DEBUG_INFO("Using switched bitbang for SWD.\n");
-		active_state.data_low |= active_cable->bb_swd_read.set_data_low;
-		active_state.data_low &= ~(active_cable->bb_swd_read.clr_data_low);
-		active_state.data_high |= active_cable->bb_swd_read.set_data_high;
-		active_state.data_high &= ~(active_cable->bb_swd_read.clr_data_high);
-		active_state.ddr_low |= MPSSE_CS;
-		if (active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW)
-			active_state.ddr_low &= ~active_cable->bb_swdio_in_pin;
-		else if (active_cable->bb_swdio_in_port_cmd == GET_BITS_HIGH)
-			active_state.ddr_high &= ~active_cable->bb_swdio_in_pin;
-	}
-	uint8_t cmd_write[6] = {SET_BITS_LOW, active_state.data_low, active_state.ddr_low, SET_BITS_HIGH,
-		active_state.data_high, active_state.ddr_high};
-	libftdi_buffer_write(cmd_write, 6);
-	libftdi_buffer_flush();
-	olddir = SWDIO_STATUS_FLOAT;
-
-	dp->seq_in = swdptap_seq_in;
-	dp->seq_in_parity = swdptap_seq_in_parity;
-	dp->seq_out = swdptap_seq_out;
-	dp->seq_out_parity = swdptap_seq_out_parity;
-	dp->dp_read = firmware_swdp_read;
-	dp->error = firmware_swdp_error;
-	dp->low_access = firmware_swdp_low_access;
-	dp->abort = firmware_swdp_abort;
-	return 0;
 }
 
 bool swdptap_bit_in(void)

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -364,36 +364,39 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 	return swdptap_seq_in_raw(clock_cycles);
 }
 
-static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
+static void swdptap_seq_out_mpsse(const uint32_t tms_states, const size_t clock_cycles)
 {
-	if (!clock_cycles)
+	const uint8_t data_in[4] = {
+		tms_states & 0xffU,
+		(tms_states >> 8U) & 0xffU,
+		(tms_states >> 16U) & 0xffU,
+		(tms_states >> 24U) & 0xffU,
+	};
+	libftdi_jtagtap_tdi_tdo_seq(NULL, false, data_in, clock_cycles);
+}
+
+static void swdptap_seq_out_raw(uint32_t tms_states, const size_t clock_cycles)
+{
+	uint8_t cmd[15] = {};
+	size_t offset = 0U;
+	for (size_t cycle = 0U; cycle < clock_cycles; cycle += 7U, offset += 3U) {
+		const size_t cycles = MIN(7U, clock_cycles - cycle);
+		cmd[offset] = MPSSE_TMS_SHIFT;
+		cmd[offset + 1U] = cycles - 1U;
+		cmd[offset + 2U] = tms_states & 0x7fU;
+	}
+	libftdi_buffer_write(cmd, offset);
+}
+
+static void swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles)
+{
+	if (!clock_cycles || clock_cycles > 32U)
 		return;
 	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	if (do_mpsse) {
-		uint8_t DI[4];
-		DI[0] = (tms_states >> 0) & 0xff;
-		DI[1] = (tms_states >> 8) & 0xff;
-		DI[2] = (tms_states >> 16) & 0xff;
-		DI[3] = (tms_states >> 24) & 0xff;
-		libftdi_jtagtap_tdi_tdo_seq(NULL, 0, DI, clock_cycles);
-	} else {
-		uint8_t cmd[16];
-		size_t index = 0;
-		while (clock_cycles) {
-			cmd[index++] = MPSSE_TMS_SHIFT;
-			if (clock_cycles >= 7) {
-				cmd[index++] = 6;
-				cmd[index++] = tms_states & 0x7f;
-				tms_states >>= 7;
-				clock_cycles -= 7;
-			} else {
-				cmd[index++] = clock_cycles - 1;
-				cmd[index++] = tms_states & 0x7f;
-				clock_cycles = 0;
-			}
-		}
-		libftdi_buffer_write(cmd, index);
-	}
+	if (do_mpsse)
+		swdptap_seq_out_mpsse(tms_states, clock_cycles);
+	else
+		swdptap_seq_out_raw(tms_states, clock_cycles);
 }
 
 /* ARM Debug Interface Architecture Specification ADIv5.0 to ADIv5.2

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -46,35 +46,31 @@ static uint32_t swdptap_seq_in(size_t clock_cycles);
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
-bool libftdi_swd_possible(bool *do_mpsse, bool *direct_bb_swd)
+bool libftdi_swd_possible(void)
 {
 	const bool swd_read = active_cable->mpsse_swd_read.set_data_low || active_cable->mpsse_swd_read.clr_data_low ||
 		active_cable->mpsse_swd_read.set_data_high || active_cable->mpsse_swd_read.clr_data_high;
 	const bool swd_write = active_cable->mpsse_swd_write.set_data_low || active_cable->mpsse_swd_write.clr_data_low ||
 		active_cable->mpsse_swd_write.set_data_high || active_cable->mpsse_swd_write.clr_data_high;
-	const bool mpsse = swd_read && swd_write;
+	do_mpsse = swd_read && swd_write;
 	if (do_mpsse)
-		*do_mpsse = mpsse;
-	if (!mpsse) {
-		const bool bb_swd_read = active_cable->bb_swd_read.set_data_low || active_cable->bb_swd_read.clr_data_low ||
-			active_cable->bb_swd_read.set_data_high || active_cable->bb_swd_read.clr_data_high;
-		const bool bb_swd_write = active_cable->bb_swd_write.set_data_low || active_cable->bb_swd_write.clr_data_low ||
-			active_cable->bb_swd_write.set_data_high || active_cable->bb_swd_write.clr_data_high;
-		const bool bb_direct_possible =
-			active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW && active_cable->bb_swdio_in_pin == MPSSE_CS;
-		if (!bb_swd_read && !bb_swd_write) {
-			if (!bb_direct_possible)
-				return false;
-		}
-		if (direct_bb_swd)
-			*direct_bb_swd = true;
-	}
+		return true;
+
+	const bool bb_swd_read = active_cable->bb_swd_read.set_data_low || active_cable->bb_swd_read.clr_data_low ||
+		active_cable->bb_swd_read.set_data_high || active_cable->bb_swd_read.clr_data_high;
+	const bool bb_swd_write = active_cable->bb_swd_write.set_data_low || active_cable->bb_swd_write.clr_data_low ||
+		active_cable->bb_swd_write.set_data_high || active_cable->bb_swd_write.clr_data_high;
+	const bool bb_direct_possible =
+		active_cable->bb_swdio_in_port_cmd == GET_BITS_LOW && active_cable->bb_swdio_in_pin == MPSSE_CS;
+	if (!bb_swd_read && !bb_swd_write && !bb_direct_possible)
+		return false;
+	direct_bb_swd = true;
 	return true;
 }
 
 int libftdi_swdptap_init(ADIv5_DP_t *dp)
 {
-	if (!libftdi_swd_possible(&do_mpsse, &direct_bb_swd)) {
+	if (!libftdi_swd_possible()) {
 		DEBUG_WARN("SWD not possible or missing item in cable description.\n");
 		return -1;
 	}

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -216,7 +216,7 @@ int platform_jtagtap_init(void)
 		return 0;
 
 	case BMP_TYPE_LIBFTDI:
-		return libftdi_jtagtap_init(&jtag_proc);
+		return libftdi_jtagtap_init();
 
 	case BMP_TYPE_JLINK:
 		return jlink_jtagtap_init(&info, &jtag_proc);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -216,7 +216,7 @@ int platform_jtagtap_init(void)
 		return 0;
 
 	case BMP_TYPE_LIBFTDI:
-		return libftdi_jtagtap_init();
+		return libftdi_jtagtap_init() ? 0 : -1;
 
 	case BMP_TYPE_JLINK:
 		return jlink_jtagtap_init(&info, &jtag_proc);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the code quality, and conformity, of the BMDA FTDI code. This fixes a considerable amount of undefined behaviour and brings the code style into line with the rest of the code base as best as we could manage.

There is an outstanding work item to address `send_recv()` and its incorrect parameter types and a couple of structural issues found, but this will be done as follow-up in v1.10 because that involves less superficial changes across BMDA to achieve.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
