### PR TITLE
Fix/bmda jlink cleanup

### DIFF
--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -48,11 +48,12 @@ struct trans_ctx {
 	volatile unsigned long flags;
 };
 
-typedef struct usb_link_s {
+typedef struct usb_link {
 	libusb_context *ul_libusb_ctx;
 	libusb_device_handle *ul_libusb_device_handle;
-	unsigned char ep_tx;
-	unsigned char ep_rx;
+	uint8_t interface;
+	uint8_t ep_tx;
+	uint8_t ep_rx;
 	struct libusb_transfer *req_trans;
 	struct libusb_transfer *rep_trans;
 	void *priv;

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -131,7 +131,7 @@ static bool claim_jlink_interface(bmp_info_t *info, libusb_device *dev)
 	const struct libusb_interface_descriptor *descriptor = NULL;
 	for (size_t i = 0; i < config->bNumInterfaces; ++i) {
 		const struct libusb_interface *const interface = &config->interface[i];
-		// XXX: This fails to handle multile alt-modes being present correctly.
+		// XXX: This fails to handle multiple alt-modes being present correctly.
 		const struct libusb_interface_descriptor *const interface_desc = &interface->altsetting[0];
 		if (interface_desc->bInterfaceClass == LIBUSB_CLASS_VENDOR_SPEC &&
 			interface_desc->bInterfaceSubClass == LIBUSB_CLASS_VENDOR_SPEC && interface_desc->bNumEndpoints > 1) {

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -29,6 +29,7 @@
 #include <signal.h>
 #include <ctype.h>
 #include <sys/time.h>
+#include <libusb.h>
 
 #include "cli.h"
 #include "jlink.h"
@@ -41,7 +42,7 @@
 #define USB_PID_SEGGER_1020 0x1020U
 
 static uint32_t emu_caps;
-static uint32_t emu_speed_kHz;
+static uint32_t emu_speed_khz;
 static uint16_t emu_min_divisor;
 static uint16_t emu_current_divisor;
 
@@ -65,9 +66,9 @@ static void jlink_print_speed(bmp_info_t *const info)
 	uint8_t cmd = CMD_GET_SPEEDS;
 	uint8_t res[6];
 	send_recv(info->usb_link, &cmd, 1, res, sizeof(res));
-	emu_speed_kHz = (res[0] | (res[1] << 8) | (res[2] << 16) | (res[3] << 24)) / 1000U;
+	emu_speed_khz = (res[0] | (res[1] << 8) | (res[2] << 16) | (res[3] << 24)) / 1000U;
 	emu_min_divisor = res[4] | (res[5] << 8);
-	DEBUG_INFO("Emulator speed %ukHz, minimum divisor %u%s\n", emu_speed_kHz, emu_min_divisor,
+	DEBUG_INFO("Emulator speed %ukHz, minimum divisor %u%s\n", emu_speed_khz, emu_min_divisor,
 		(emu_caps & JLINK_CAP_GET_SPEEDS) ? "" : ", fixed");
 }
 
@@ -227,56 +228,57 @@ bool jlink_init(bmp_info_t *const info)
 	return true;
 }
 
-const char *jlink_target_voltage(bmp_info_t *info)
+const char *jlink_target_voltage(bmp_info_t *const info)
 {
-	uint8_t cmd[1] = {CMD_GET_HW_STATUS};
-	uint8_t res[8];
-	send_recv(info->usb_link, cmd, 1, res, sizeof(res));
-	uint16_t mVolt = res[0] | (res[1] << 8);
 	static char ret[7];
-	sprintf(ret, "%2d.%03d", mVolt / 1000, mVolt % 1000);
+	uint8_t cmd = CMD_GET_HW_STATUS;
+	uint8_t res[8];
+	send_recv(info->usb_link, &cmd, 1, res, sizeof(res));
+	const uint16_t millivolts = res[0] | (res[1] << 8);
+	snprintf(ret, sizeof(ret), "%2u.%03u", millivolts / 1000U, millivolts % 1000U);
 	return ret;
 }
 
-static bool nrst_status = false;
-
-void jlink_nrst_set_val(bmp_info_t *info, bool assert)
+void jlink_nrst_set_val(bmp_info_t *const info, const bool assert)
 {
-	uint8_t cmd[1];
-	cmd[0] = (assert) ? CMD_HW_RESET0 : CMD_HW_RESET1;
-	send_recv(info->usb_link, cmd, 1, NULL, 0);
+	uint8_t cmd = assert ? CMD_HW_RESET0 : CMD_HW_RESET1;
+	send_recv(info->usb_link, &cmd, 1, NULL, 0);
 	platform_delay(2);
-	nrst_status = assert;
 }
 
-bool jlink_nrst_get_val(bmp_info_t *info)
+bool jlink_nrst_get_val(bmp_info_t *const info)
 {
 	uint8_t cmd[1] = {CMD_GET_HW_STATUS};
 	uint8_t res[8];
 	send_recv(info->usb_link, cmd, 1, res, sizeof(res));
-	return !(res[6]);
+	return res[6] == 0;
 }
 
-void jlink_max_frequency_set(bmp_info_t *info, uint32_t freq)
+void jlink_max_frequency_set(bmp_info_t *const info, const uint32_t freq)
 {
 	if (!(emu_caps & JLINK_CAP_GET_SPEEDS))
 		return;
 	if (!info->is_jtag)
 		return;
-	uint16_t freq_kHz = freq / 1000;
-	uint16_t divisor = (emu_speed_kHz + freq_kHz - 1) / freq_kHz;
-	if (divisor < emu_min_divisor)
-		divisor = emu_min_divisor;
-	emu_current_divisor = divisor;
-	uint16_t speed_kHz = emu_speed_kHz / divisor;
-	uint8_t cmd[3] = {CMD_SET_SPEED, speed_kHz & 0xff, speed_kHz >> 8};
-	DEBUG_WARN("Set Speed %d\n", speed_kHz);
+	const uint16_t freq_khz = freq / 1000;
+	const uint16_t divisor = (emu_speed_khz + freq_khz - 1U) / freq_khz;
+	if (divisor > emu_min_divisor)
+		emu_current_divisor = divisor;
+	else
+		emu_current_divisor = emu_min_divisor;
+	const uint16_t speed_khz = emu_speed_khz / emu_current_divisor;
+	uint8_t cmd[3] = {
+		CMD_SET_SPEED,
+		speed_khz & 0xffU,
+		speed_khz >> 8U,
+	};
+	DEBUG_WARN("Set Speed %d\n", speed_khz);
 	send_recv(info->usb_link, cmd, 3, NULL, 0);
 }
 
-uint32_t jlink_max_frequency_get(bmp_info_t *info)
+uint32_t jlink_max_frequency_get(bmp_info_t *const info)
 {
-	if ((emu_caps & JLINK_CAP_GET_SPEEDS) && (info->is_jtag))
-		return (emu_speed_kHz * 1000L) / emu_current_divisor;
+	if ((emu_caps & JLINK_CAP_GET_SPEEDS) && info->is_jtag)
+		return (emu_speed_khz * 1000U) / emu_current_divisor;
 	return FREQ_FIXED;
 }

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -33,71 +33,80 @@
 #include "cli.h"
 #include "jlink.h"
 
-#define USB_VID_SEGGER 0x1366
+#define USB_VID_SEGGER 0x1366U
 
-#define USB_PID_SEGGER_0101 0x0101
-#define USB_PID_SEGGER_0105 0x0105
-#define USB_PID_SEGGER_1015 0x1015
-#define USB_PID_SEGGER_1020 0x1020
+#define USB_PID_SEGGER_0101 0x0101U
+#define USB_PID_SEGGER_0105 0x0105U
+#define USB_PID_SEGGER_1015 0x1015U
+#define USB_PID_SEGGER_1020 0x1020U
 
 static uint32_t emu_caps;
 static uint32_t emu_speed_kHz;
 static uint16_t emu_min_divisor;
 static uint16_t emu_current_divisor;
 
-static void jlink_print_caps(bmp_info_t *info)
+static void jlink_print_caps(bmp_info_t *const info)
 {
-	uint8_t cmd[1] = {CMD_GET_CAPS};
+	uint8_t cmd = CMD_GET_CAPS;
 	uint8_t res[4];
-	send_recv(info->usb_link, cmd, 1, res, sizeof(res));
+	send_recv(info->usb_link, &cmd, 1, res, sizeof(res));
 	emu_caps = res[0] | (res[1] << 8) | (res[2] << 16) | (res[3] << 24);
 	DEBUG_INFO("Caps %" PRIx32 "\n", emu_caps);
 	if (emu_caps & JLINK_CAP_GET_HW_VERSION) {
-		uint8_t cmd[1] = {CMD_GET_HW_VERSION};
-		send_recv(info->usb_link, cmd, 1, NULL, 0);
+		uint8_t cmd = CMD_GET_HW_VERSION;
+		send_recv(info->usb_link, &cmd, 1, NULL, 0);
 		send_recv(info->usb_link, NULL, 0, res, sizeof(res));
-		DEBUG_INFO("HW: Type %d, Major %d, Minor %d, Rev %d\n", res[3], res[2], res[1], res[0]);
+		DEBUG_INFO("HW: Type %u, Major %u, Minor %u, Rev %u\n", res[3], res[2], res[1], res[0]);
 	}
 }
 
-static void jlink_print_speed(bmp_info_t *info)
+static void jlink_print_speed(bmp_info_t *const info)
 {
-	uint8_t cmd[1] = {CMD_GET_SPEEDS};
+	uint8_t cmd = CMD_GET_SPEEDS;
 	uint8_t res[6];
-	send_recv(info->usb_link, cmd, 1, res, sizeof(res));
-	emu_speed_kHz = (res[0] | (res[1] << 8) | (res[2] << 16) | (res[3] << 24)) / 1000;
+	send_recv(info->usb_link, &cmd, 1, res, sizeof(res));
+	emu_speed_kHz = (res[0] | (res[1] << 8) | (res[2] << 16) | (res[3] << 24)) / 1000U;
 	emu_min_divisor = res[4] | (res[5] << 8);
-	DEBUG_INFO("Emulator speed %d kHz, Mindiv %d%s\n", emu_speed_kHz, emu_min_divisor,
+	DEBUG_INFO("Emulator speed %ukHz, minimum divisor %u%s\n", emu_speed_kHz, emu_min_divisor,
 		(emu_caps & JLINK_CAP_GET_SPEEDS) ? "" : ", fixed");
 }
 
-static void jlink_print_version(bmp_info_t *info)
+static void jlink_print_version(bmp_info_t *const info)
 {
-	uint8_t cmd[1] = {CMD_GET_VERSION};
+	uint8_t cmd = CMD_GET_VERSION;
 	uint8_t len_str[2];
-	send_recv(info->usb_link, cmd, 1, len_str, sizeof(len_str));
+	send_recv(info->usb_link, &cmd, 1, len_str, sizeof(len_str));
 	uint8_t version[0x70];
 	send_recv(info->usb_link, NULL, 0, version, sizeof(version));
+	version[0x6F] = '\0';
 	DEBUG_INFO("%s\n", version);
 }
 
-static void jlink_print_interfaces(bmp_info_t *info)
+static void jlink_print_interfaces(bmp_info_t *const info)
 {
-	uint8_t cmd[2] = {CMD_GET_SELECT_IF, JLINK_IF_GET_ACTIVE};
-	uint8_t res[4];
-	send_recv(info->usb_link, cmd, 2, res, sizeof(res));
+	uint8_t cmd[2] = {
+		CMD_GET_SELECT_IF,
+		JLINK_IF_GET_ACTIVE,
+	};
+	uint8_t selected_if[4];
+	send_recv(info->usb_link, cmd, 2, selected_if, sizeof(selected_if));
 	cmd[1] = JLINK_IF_GET_AVAILABLE;
-	uint8_t res1[4];
-	send_recv(info->usb_link, cmd, 2, res1, sizeof(res1));
-	DEBUG_INFO("%s active", (res[0] == SELECT_IF_SWD) ? "SWD" : (res[0] == SELECT_IF_JTAG) ? "JTAG" : "NONE");
-	uint8_t other_interface = res1[0] - (res[0] + 1);
-	if (other_interface)
-		DEBUG_INFO(", %s available\n", (other_interface == JLINK_IF_SWD) ? "SWD" : "JTAG");
+	uint8_t available_ifs[4];
+	send_recv(info->usb_link, cmd, 2, available_ifs, sizeof(available_ifs));
+	if (selected_if[0] == SELECT_IF_SWD)
+		DEBUG_INFO("SWD active");
+	else if (selected_if[0] == SELECT_IF_JTAG)
+		DEBUG_INFO("JTAG active");
 	else
-		DEBUG_INFO(", %s not available\n", ((res[0] + 1) == JLINK_IF_SWD) ? "JTAG" : "SWD");
+		DEBUG_INFO("No interfaces active");
+	const uint8_t other_interface = available_ifs[0] - (selected_if[0] + 1U);
+	if (other_interface)
+		DEBUG_INFO(", %s available\n", other_interface == JLINK_IF_SWD ? "SWD" : "JTAG");
+	else
+		DEBUG_INFO(", %s not available\n", selected_if[0] + 1U == JLINK_IF_SWD ? "JTAG" : "SWD");
 }
 
-static void jlink_info(bmp_info_t *info)
+static void jlink_info(bmp_info_t *const info)
 {
 	jlink_print_version(info);
 	jlink_print_caps(info);
@@ -153,7 +162,7 @@ static int initialize_handle(bmp_info_t *info, libusb_device *dev)
 /* Return 0 if single J-Link device connected or
  * serial given matches one of several J-Link devices.
  */
-int jlink_init(bmp_info_t *info)
+int jlink_init(bmp_info_t *const info)
 {
 	usb_link_t *jl = calloc(1, sizeof(usb_link_t));
 	if (!jl)

--- a/src/platforms/hosted/jlink.h
+++ b/src/platforms/hosted/jlink.h
@@ -22,28 +22,27 @@
 
 #include <stdbool.h>
 #include "bmp_hosted.h"
-#include "jtagtap.h"
 
 /** @cond PRIVATE */
-#define CMD_GET_VERSION    0x01
-#define CMD_SET_SPEED      0x05
-#define CMD_GET_HW_STATUS  0x07
-#define CMD_GET_SPEEDS     0xc0
-#define CMD_GET_SELECT_IF  0xc7
-#define CMD_HW_JTAG3       0xcf
-#define CMD_HW_RESET0      0xdc
-#define CMD_HW_RESET1      0xdd
-#define CMD_GET_CAPS       0xe8
-#define CMD_GET_EXT_CAPS   0xed
-#define CMD_GET_HW_VERSION 0xf0
+#define CMD_GET_VERSION    0x01U
+#define CMD_SET_SPEED      0x05U
+#define CMD_GET_HW_STATUS  0x07U
+#define CMD_GET_SPEEDS     0xc0U
+#define CMD_GET_SELECT_IF  0xc7U
+#define CMD_HW_JTAG3       0xcfU
+#define CMD_HW_RESET0      0xdcU
+#define CMD_HW_RESET1      0xddU
+#define CMD_GET_CAPS       0xe8U
+#define CMD_GET_EXT_CAPS   0xedU
+#define CMD_GET_HW_VERSION 0xf0U
 
-#define JLINK_IF_GET_ACTIVE    0xfe
-#define JLINK_IF_GET_AVAILABLE 0xff
+#define JLINK_IF_GET_ACTIVE    0xfeU
+#define JLINK_IF_GET_AVAILABLE 0xffU
 
-#define JLINK_CAP_GET_SPEEDS     (1 << 9)
-#define JLINK_CAP_GET_HW_VERSION (1 << 1)
-#define JLINK_IF_JTAG            1
-#define JLINK_IF_SWD             2
+#define JLINK_CAP_GET_SPEEDS     (1U << 9U)
+#define JLINK_CAP_GET_HW_VERSION (1U << 1U)
+#define JLINK_IF_JTAG            1U
+#define JLINK_IF_SWD             2U
 
 #define SELECT_IF_JTAG 0
 #define SELECT_IF_SWD  1
@@ -62,9 +61,9 @@ uint32_t jlink_swdp_scan(bmp_info_t *info)
 	return 0;
 }
 
-int jlink_jtagtap_init(bmp_info_t *info, jtag_proc_t *jtag_proc)
+bool jlink_jtagtap_init(bmp_info_t *info)
 {
-	return 0;
+	return false;
 }
 
 const char *jlink_target_voltage(bmp_info_t *info)
@@ -130,7 +129,7 @@ enum jaylink_device_capability {
 
 bool jlink_init(bmp_info_t *info);
 uint32_t jlink_swdp_scan(bmp_info_t *info);
-int jlink_jtagtap_init(bmp_info_t *info, jtag_proc_t *jtag_proc);
+bool jlink_jtagtap_init(bmp_info_t *info);
 const char *jlink_target_voltage(bmp_info_t *info);
 void jlink_nrst_set_val(bmp_info_t *info, bool assert);
 bool jlink_nrst_get_val(bmp_info_t *info);

--- a/src/platforms/hosted/jlink.h
+++ b/src/platforms/hosted/jlink.h
@@ -20,6 +20,7 @@
 #ifndef PLATFORMS_HOSTED_JLINK_H
 #define PLATFORMS_HOSTED_JLINK_H
 
+#include <stdbool.h>
 #include "bmp_hosted.h"
 #include "jtagtap.h"
 
@@ -51,9 +52,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-int jlink_init(bmp_info_t *info)
+bool jlink_init(bmp_info_t *info)
 {
-	return -1;
+	return false;
 }
 
 uint32_t jlink_swdp_scan(bmp_info_t *info)
@@ -127,7 +128,7 @@ enum jaylink_device_capability {
 	JAYLINK_DEV_CAP_ETHERNET = 38
 };
 
-int jlink_init(bmp_info_t *info);
+bool jlink_init(bmp_info_t *info);
 uint32_t jlink_swdp_scan(bmp_info_t *info);
 int jlink_jtagtap_init(bmp_info_t *info, jtag_proc_t *jtag_proc);
 const char *jlink_target_voltage(bmp_info_t *info);

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -41,33 +41,34 @@ enum {
 	SWDIO_READ
 };
 
-/* Write at least 50 bits high, two bits low and read DP_IDR and put
-*  idle cyccles at the end*/
-static int line_reset(bmp_info_t *info)
+/*
+ * Write at least 50 bits high, two bits low and read DP_IDR and put
+ * idle cycles at the end
+ */
+static bool line_reset(bmp_info_t *info)
 {
 	uint8_t cmd[44];
 	memset(cmd, 0, sizeof(cmd));
 
 	cmd[0] = CMD_HW_JTAG3;
-	/* write 19 Bytes.*/
+	/* write 19 bytes */
 	cmd[2] = 19 * 8;
-	uint8_t *direction = cmd + 4;
-	memset(direction + 5, 0xffU, 9);
-	direction[18] = 0xe0;
-	uint8_t *data = direction + 19;
-	memset(data + 5, 0xffU, 7);
-	data[13] = 0xa5;
+	uint8_t *const direction = cmd + 4U;
+	memset(direction + 5U, 0xffU, 9U);
+	direction[18] = 0xe0U;
+	uint8_t *const data = direction + 19U;
+	memset(data + 5U, 0xffU, 7U);
+	data[13] = 0xa5U;
 
 	uint8_t res[19];
-	send_recv(info->usb_link, cmd, 42, res, 19);
-	send_recv(info->usb_link, NULL, 0, res, 1);
+	send_recv(info->usb_link, cmd, 42U, res, 19U);
+	send_recv(info->usb_link, NULL, 0U, res, 1U);
 
 	if (res[0] != 0) {
 		DEBUG_WARN("Line reset failed\n");
-		return -1;
+		return false;
 	}
-
-	return 0;
+	return true;
 }
 
 static bool jlink_swdptap_init(bmp_info_t *info)

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -169,46 +169,90 @@ static uint32_t jlink_adiv5_swdp_error(ADIv5_DP_t *const dp)
 	return err;
 }
 
-static uint32_t jlink_adiv5_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW, uint16_t addr, uint32_t value)
+static uint32_t jlink_adiv5_swdp_low_read(void)
 {
-	uint8_t request = make_packet_request(RnW, addr);
-	bool APnDP = addr & ADIV5_APnDP;
-	uint32_t response = 0;
-	uint8_t ack;
-	platform_timeout timeout;
+	uint8_t cmd[14];
+	uint8_t result[6];
+	memset(cmd, 0, sizeof(cmd));
+	cmd[0] = CMD_HW_JTAG3;
+	cmd[2] = 33 + 2; /* 2 idle cycles */
+	cmd[8] = 0xfe;
+	send_recv(info.usb_link, cmd, 14, result, 5);
+	send_recv(info.usb_link, NULL, 0, result + 5, 1);
 
-	if (APnDP && dp->fault)
+	if (result[5] != 0)
+		raise_exception(EXCEPTION_ERROR, "Low access read failed");
+
+	const uint32_t response = result[0] | result[1] << 8U | result[2] << 16U | result[3] << 24U;
+
+	const uint8_t parity = result[4] & 1;
+	const uint32_t bit_count = __builtin_popcount(response) + parity;
+	if (bit_count & 1) /* Give up on parity error */
+		raise_exception(EXCEPTION_ERROR, "SWDP Parity error");
+	return response;
+}
+
+static void jlink_adiv5_swdp_low_write(const uint32_t value)
+{
+	uint8_t cmd[16];
+	uint8_t result[6];
+	memset(cmd, 0, sizeof(cmd));
+	cmd[2] = 33 + 8; /* 8 idle cycle  to move data through SW-DP */
+	memset(cmd + 4, 0xffU, 6);
+	cmd[10] = value & 0xffU;
+	cmd[11] = (value >> 8U) & 0xffU;
+	cmd[12] = (value >> 16U) & 0xffU;
+	cmd[13] = (value >> 24U) & 0xffU;
+	const uint8_t bit_count = __builtin_popcount(value);
+	cmd[14] = bit_count & 1;
+	cmd[15] = 0;
+
+	send_recv(info.usb_link, cmd, 16, result, 6);
+	send_recv(info.usb_link, NULL, 0, result, 1);
+
+	if (result[0] != 0)
+		raise_exception(EXCEPTION_ERROR, "Low access write failed");
+}
+
+static uint32_t jlink_adiv5_swdp_low_access(
+	ADIv5_DP_t *const dp, const uint8_t RnW, const uint16_t addr, const uint32_t value)
+{
+	if ((addr & ADIV5_APnDP) && dp->fault)
 		return 0;
 
 	uint8_t cmd[16];
 	memset(cmd, 0, sizeof(cmd));
-
-	uint8_t res[8];
 	cmd[0] = CMD_HW_JTAG3;
 
-	/* It seems, JLINK samples read data at end of previous clock.
-	 * So target data read must start at the 12'th clock, while
-	 * write starts as expected at the 14'th clock (8 cmd, 3 response,
-	 * 2 turn around.
+	/*
+	 * It seems that JLink samples the data to read at the end of the
+	 * previous clock cycle, so reading target data must start at the
+	 * 12th clock cycle, while writing starts as expected at the 14th
+	 * clock cycle (8 cmd, 3 response, 2 turn around).
 	 */
 	cmd[2] = RnW ? 11 : 13;
 
-	cmd[4] = 0xff; /* 8 bits command OUT */
-	cmd[5] = 0xf0; /* one IN bit to turn around to read, read 2
-					  (read) or 3 (write) IN bits for response and
-					  and one OUT bit to turn around to write on write*/
-	cmd[6] = request;
+	cmd[4] = 0xffU; /* 8 bits command OUT */
+	/*
+	 * one IN bit to turn around to read, read 2
+	 * (read) or 3 (write) IN bits for response and
+	 * and one OUT bit to turn around to write on write
+	 */
+	cmd[5] = 0xf0U;
+	cmd[6] = make_packet_request(RnW, addr);
 
+	uint8_t res[8];
+	platform_timeout timeout;
 	platform_timeout_set(&timeout, 2000);
-	do {
-		send_recv(info.usb_link, cmd, 8, res, 2);
-		send_recv(info.usb_link, NULL, 0, res + 2, 1);
+	uint8_t ack = SWDP_ACK_WAIT;
+	while (ack == SWDP_ACK_WAIT && !platform_timeout_is_expired(&timeout)) {
+		send_recv(info.usb_link, cmd, 8U, res, 2U);
+		send_recv(info.usb_link, NULL, 0U, res + 2, 1U);
 
 		if (res[2] != 0)
 			raise_exception(EXCEPTION_ERROR, "Low access setup failed");
-
-		ack = res[1] & 7;
-	} while (ack == SWDP_ACK_WAIT && !platform_timeout_is_expired(&timeout));
+		ack = res[1] & 7U;
+	};
 
 	if (ack == SWDP_ACK_WAIT)
 		raise_exception(EXCEPTION_TIMEOUT, "SWDP ACK timeout");
@@ -227,41 +271,11 @@ static uint32_t jlink_adiv5_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW, uint16_
 		return 0;
 	}
 
-	/* Always append 8 idle cycle (SWDIO = 0)!*/
-	if (RnW) {
-		memset(cmd + 4, 0, 10);
-		cmd[2] = 33 + 2; /* 2 idle cycles */
-		cmd[8] = 0xfe;
-		send_recv(info.usb_link, cmd, 14, res, 5);
-		send_recv(info.usb_link, NULL, 0, res + 5, 1);
-
-		if (res[5] != 0)
-			raise_exception(EXCEPTION_ERROR, "Low access read failed");
-
-		response = res[0] | res[1] << 8U | res[2] << 16U | res[3] << 24U;
-
-		const unsigned int parity = res[4] & 1;
-		const unsigned int bit_count = __builtin_popcount(response) + parity;
-		if (bit_count & 1) /* Give up on parity error */
-			raise_exception(EXCEPTION_ERROR, "SWDP Parity error");
-	} else {
-		cmd[2] = 33 + 8; /* 8 idle cycle  to move data through SW-DP */
-		memset(cmd + 4, 0xffU, 6);
-		cmd[10] = ((value >> 0U) & 0xffU);
-		cmd[11] = ((value >> 8U) & 0xffU);
-		cmd[12] = ((value >> 16U) & 0xffU);
-		cmd[13] = ((value >> 24U) & 0xffU);
-		const unsigned int bit_count = __builtin_popcount(value);
-		cmd[14] = bit_count & 1;
-		cmd[15] = 0;
-
-		send_recv(info.usb_link, cmd, 16, res, 6);
-		send_recv(info.usb_link, NULL, 0, res, 1);
-
-		if (res[0] != 0)
-			raise_exception(EXCEPTION_ERROR, "Low access write failed");
-	}
-	return response;
+	/* Always append 8 idle cycles (SWDIO = 0)! */
+	if (RnW)
+		return jlink_adiv5_swdp_low_read();
+	jlink_adiv5_swdp_low_write(value);
+	return 0;
 }
 
 static void jlink_adiv5_swdp_abort(ADIv5_DP_t *const dp, const uint32_t abort)

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -45,14 +45,14 @@ enum {
  * Write at least 50 bits high, two bits low and read DP_IDR and put
  * idle cycles at the end
  */
-static bool line_reset(bmp_info_t *info)
+static bool line_reset(bmp_info_t *const info)
 {
 	uint8_t cmd[44];
 	memset(cmd, 0, sizeof(cmd));
 
 	cmd[0] = CMD_HW_JTAG3;
 	/* write 19 bytes */
-	cmd[2] = 19 * 8;
+	cmd[2] = 19U * 8U;
 	uint8_t *const direction = cmd + 4U;
 	memset(direction + 5U, 0xffU, 9U);
 	direction[18] = 0xe0U;
@@ -71,9 +71,12 @@ static bool line_reset(bmp_info_t *info)
 	return true;
 }
 
-static bool jlink_swdptap_init(bmp_info_t *info)
+static bool jlink_swdptap_init(bmp_info_t *const info)
 {
-	uint8_t cmd[2] = {CMD_GET_SELECT_IF, JLINK_IF_GET_AVAILABLE};
+	uint8_t cmd[2] = {
+		CMD_GET_SELECT_IF,
+		JLINK_IF_GET_AVAILABLE,
+	};
 	uint8_t res[4];
 	send_recv(info->usb_link, cmd, 2, res, sizeof(res));
 
@@ -84,16 +87,13 @@ static bool jlink_swdptap_init(bmp_info_t *info)
 	send_recv(info->usb_link, cmd, 2, res, sizeof(res));
 
 	platform_delay(10);
-
 	/* SWD speed is fixed. Do not set it here*/
-
 	return true;
 }
 
-uint32_t jlink_swdp_scan(bmp_info_t *info)
+uint32_t jlink_swdp_scan(bmp_info_t *const info)
 {
 	target_list_free();
-
 	if (!jlink_swdptap_init(info))
 		return 0;
 
@@ -103,17 +103,17 @@ uint32_t jlink_swdp_scan(bmp_info_t *info)
 	cmd[0] = CMD_HW_JTAG3;
 	/* write 18 Bytes.*/
 	cmd[2] = 17U * 8U;
-	uint8_t *direction = cmd + 4;
-	memset(direction, 0xffU, 17);
-	uint8_t *data = direction + 17;
-	memset(data, 0xffU, 7);
-	data[7] = 0x9e;
-	data[8] = 0xe7;
-	memset(data + 9, 0xffU, 6);
+	uint8_t *direction = cmd + 4U;
+	memset(direction, 0xffU, 17U);
+	uint8_t *data = direction + 17U;
+	memset(data, 0xffU, 7U);
+	data[7] = 0x9eU;
+	data[8] = 0xe7U;
+	memset(data + 9U, 0xffU, 6U);
 
 	uint8_t res[18];
-	send_recv(info->usb_link, cmd, 38, res, 17);
-	send_recv(info->usb_link, NULL, 0, res, 1);
+	send_recv(info->usb_link, cmd, 38U, res, 17U);
+	send_recv(info->usb_link, NULL, 0U, res, 1U);
 
 	if (res[0] != 0) {
 		DEBUG_WARN("Line reset failed\n");
@@ -132,28 +132,25 @@ uint32_t jlink_swdp_scan(bmp_info_t *info)
 	dp->abort = jlink_adiv5_swdp_abort;
 
 	jlink_adiv5_swdp_error(dp);
-
 	adiv5_dp_init(dp, 0);
-
 	return target_list ? 1U : 0U;
 }
 
-static uint32_t jlink_adiv5_swdp_read(ADIv5_DP_t *dp, uint16_t addr)
+static uint32_t jlink_adiv5_swdp_read(ADIv5_DP_t *const dp, const uint16_t addr)
 {
 	if (addr & ADIV5_APnDP) {
 		adiv5_dp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 		return adiv5_dp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
-	} else {
-		return jlink_adiv5_swdp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 	}
+	return jlink_adiv5_swdp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 }
 
-static uint32_t jlink_adiv5_swdp_error(ADIv5_DP_t *dp)
+static uint32_t jlink_adiv5_swdp_error(ADIv5_DP_t *const dp)
 {
-	uint32_t err, clr = 0;
-	err = jlink_adiv5_swdp_read(dp, ADIV5_DP_CTRLSTAT) &
-		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
-			ADIV5_DP_CTRLSTAT_WDATAERR);
+	uint32_t err = jlink_adiv5_swdp_read(dp, ADIV5_DP_CTRLSTAT);
+	err &= (ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
+		ADIV5_DP_CTRLSTAT_WDATAERR);
+	uint32_t clr = 0;
 
 	if (err & ADIV5_DP_CTRLSTAT_STICKYORUN)
 		clr |= ADIV5_DP_ABORT_ORUNERRCLR;
@@ -267,7 +264,7 @@ static uint32_t jlink_adiv5_swdp_low_access(ADIv5_DP_t *dp, uint8_t RnW, uint16_
 	return response;
 }
 
-static void jlink_adiv5_swdp_abort(ADIv5_DP_t *dp, uint32_t abort)
+static void jlink_adiv5_swdp_abort(ADIv5_DP_t *const dp, const uint32_t abort)
 {
 	adiv5_dp_write(dp, ADIV5_DP_ABORT, abort);
 }

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -81,15 +81,13 @@ bool jlink_jtagtap_init(bmp_info_t *const info)
 	};
 	send_recv(info->usb_link, jtag_speed, 3, NULL, 0);
 	uint8_t cmd[22];
+	memset(cmd, 0, 22);
 	cmd[0] = CMD_HW_JTAG3;
-	cmd[1] = 0;
-	/* write 8 Bytes.*/
+	/* write 9 bytes */
 	cmd[2] = 9 * 8;
-	cmd[3] = 0;
 	memset(cmd + 4, 0xffU, 7);
 	cmd[11] = 0x3c;
 	cmd[12] = 0xe7;
-	memset(cmd + 13, 0, 9);
 	send_recv(info->usb_link, cmd, 22, cmd, 9);
 	send_recv(info->usb_link, NULL, 0, res, 1);
 

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -24,6 +24,7 @@
 #include "general.h"
 #include <unistd.h>
 #include <assert.h>
+#include <memory.h>
 
 #include "exception.h"
 #include "jtagtap.h"
@@ -60,23 +61,17 @@ bool jlink_jtagtap_init(bmp_info_t *const info)
 		speed >> 8U,
 	};
 	send_recv(info->usb_link, jtag_speed, 3, NULL, 0);
-	uint8_t cmd[44];
+	uint8_t cmd[22];
 	cmd[0] = CMD_HW_JTAG3;
 	cmd[1] = 0;
 	/* write 8 Bytes.*/
 	cmd[2] = 9 * 8;
 	cmd[3] = 0;
-	uint8_t *tms = cmd + 4;
-	tms[0] = 0xff;
-	tms[1] = 0xff;
-	tms[2] = 0xff;
-	tms[3] = 0xff;
-	tms[4] = 0xff;
-	tms[5] = 0xff;
-	tms[6] = 0xff;
-	tms[7] = 0x3c;
-	tms[8] = 0xe7;
-	send_recv(info->usb_link, cmd, 4 + 2 * 9, cmd, 9);
+	memset(cmd + 4, 0xffU, 7);
+	cmd[11] = 0x3c;
+	cmd[12] = 0xe7;
+	memset(cmd + 13, 0, 9);
+	send_recv(info->usb_link, cmd, 22, cmd, 9);
 	send_recv(info->usb_link, NULL, 0, res, 1);
 
 	if (res[0] != 0) {

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -149,21 +149,21 @@ static void jtagtap_tdi_tdo_seq(
 		raise_exception(EXCEPTION_ERROR, "jtagtap_tdi_tdi failed");
 }
 
-static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *data_in, size_t ticks)
+static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
 	if (cl_debuglevel & BMP_DEBUG_PROBE) {
-		DEBUG_PROBE("jtagtap_tdi_seq %s:", (final_tms) ? "final_tms" : "");
-		const uint8_t *p = data_in;
-		unsigned int i = (ticks & 7) & ~7;
-		if (i > 16)
-			i = 16;
-		while (i--)
-			DEBUG_PROBE(" %02x", *p++);
-		if (ticks > (16 * 8))
-			DEBUG_PROBE(" ...");
+		DEBUG_PROBE("jtagtap_tdi_seq final tms: %u, data_in: ", final_tms ? 1 : 0);
+		for (size_t cycle = 0; cycle < clock_cycles; cycle += 8) {
+			const size_t chunk = cycle >> 3U;
+			if (chunk > 16) {
+				DEBUG_PROBE(" ...");
+				break;
+			}
+			DEBUG_PROBE(" %02x", data_in[chunk]);
+		}
 		DEBUG_PROBE("\n");
 	}
-	return jtagtap_tdi_tdo_seq(NULL, final_tms, data_in, ticks);
+	return jtagtap_tdi_tdo_seq(NULL, final_tms, data_in, clock_cycles);
 }
 
 static bool jtagtap_next(bool tms, bool tdi)

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -38,6 +38,24 @@ static void jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t
 static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jtagtap_next(bool tms, bool tdi);
 
+/*
+ * In this file, command buffers with the command code CMD_HW_JTAG3 are built.
+ * These have the following format:
+ * ┌─────────┬─────────┬───────────────┬─────────┐
+ * │    0    │    1    │       2       │    3    │
+ * ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+ * │ Command │ Unknown │  Cycle count  │ Unknown │
+ * ├─────────┼─────────┼───────────────┼─────────┤
+ * │    4    │    …    │ 4 + tms_bytes │    …    │
+ * ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+ * │  TMS data bytes…  │     TDI data bytes…     │
+ * └─────────┴─────────┴───────────────┴─────────┘
+ * where the byte counts for each of TDI and TMS are defined by:
+ * count = ⌈cycle_count / 8⌉
+ *
+ * ⌈⌉ is defined as the ceiling function.
+ */
+
 bool jlink_jtagtap_init(bmp_info_t *const info)
 {
 	DEBUG_PROBE("jtap_init\n");

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -33,7 +33,7 @@
 
 static void jtagtap_reset(void);
 static void jtagtap_tms_seq(uint32_t tms_states, size_t clock_cycles);
-static void jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t clock_cycles);
+static void jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jtagtap_next(bool tms, bool tdi);
 
@@ -114,39 +114,38 @@ static void jtagtap_tms_seq(const uint32_t tms_states, const size_t clock_cycles
 		raise_exception(EXCEPTION_ERROR, "tagtap_tms_seq failed");
 }
 
-static void jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const uint8_t *data_in, size_t ticks)
+static void jtagtap_tdi_tdo_seq(
+	uint8_t *const data_out, const bool final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
-	if (!ticks)
+	if (!clock_cycles)
 		return;
-	int len = (ticks + 7) / 8;
+	const size_t total_chunks = (clock_cycles >> 3U) + ((clock_cycles & 7U) ? 1U : 0U);
 	if (cl_debuglevel & BMP_DEBUG_PROBE) {
-		DEBUG_PROBE("jtagtap_tdi_tdo %s, ticks %d, data_in: ", (final_tms) ? "Final TMS" : "", ticks);
-		for (int i = 0; i < len; i++) {
+		DEBUG_PROBE("jtagtap_tdi_tdo final tms: %u, clock cycles: %u, data_in: ", final_tms ? 1 : 0, clock_cycles);
+		for (size_t i = 0; i < total_chunks; ++i)
 			DEBUG_PROBE("%02x", data_in[i]);
-		}
 		DEBUG_PROBE("\n");
 	}
-	uint8_t *cmd = alloca(4 + 2 * len);
+	const size_t cmd_len = 4 + (total_chunks * 2U);
+	uint8_t *cmd = calloc(1, cmd_len);
 	cmd[0] = CMD_HW_JTAG3;
-	cmd[1] = 0;
-	cmd[2] = ticks;
-	cmd[3] = 0;
-	uint8_t *tms = cmd + 4;
-	for (int i = 0; i < len; i++)
-		*tms++ = 0;
-	if (final_tms)
-		cmd[4 + (ticks - 1) / 8] |= (1 << ((ticks - 1) % 8));
-	uint8_t *tdi = tms;
-	if (data_in)
-		for (int i = 0; i < len; i++)
-			*tdi++ = data_in[i];
-	if (data_out)
-		send_recv(info.usb_link, cmd, 4 + 2 * len, data_out, len);
-	else
-		send_recv(info.usb_link, cmd, 4 + 2 * len, cmd, len);
-	uint8_t res[1];
-	send_recv(info.usb_link, NULL, 0, res, 1);
-	if (res[0] != 0)
+	cmd[2] = clock_cycles;
+	if (final_tms) {
+		const size_t bit_offset = (clock_cycles - 1U) & 7U;
+		cmd[4 + total_chunks - 1U] |= 1U << bit_offset;
+	}
+	if (data_in) {
+		for (size_t cycle = 0; cycle < clock_cycles; cycle += 8) {
+			const size_t chunk = cycle >> 3U;
+			const size_t index = 4 + total_chunks + chunk;
+			cmd[index] = data_in[chunk];
+		}
+	}
+	uint8_t result[4];
+	send_recv(info.usb_link, cmd, cmd_len, data_out ? data_out : result, total_chunks);
+	send_recv(info.usb_link, NULL, 0, result, 1);
+	free(cmd);
+	if (result[0] != 0)
 		raise_exception(EXCEPTION_ERROR, "jtagtap_tdi_tdi failed");
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -115,7 +115,7 @@ void platform_init(int argc, char **argv)
 		break;
 
 	case BMP_TYPE_JLINK:
-		if (jlink_init(&info))
+		if (!jlink_init(&info))
 			exit(-1);
 		break;
 
@@ -131,7 +131,6 @@ void platform_init(int argc, char **argv)
 #ifdef ENABLE_RTT
 		rtt_if_init();
 #endif
-		return;
 	}
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -218,7 +218,7 @@ int platform_jtagtap_init(void)
 		return libftdi_jtagtap_init(&jtag_proc);
 
 	case BMP_TYPE_JLINK:
-		return jlink_jtagtap_init(&info, &jtag_proc);
+		return jlink_jtagtap_init(&info) ? 0 : -1;
 
 	case BMP_TYPE_CMSIS_DAP:
 		return cmsis_dap_jtagtap_init(&jtag_proc);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the code quality, and conformity, of the BMDA JLink code. This fixes a considerable amount of undefined behaviour and brings the code style into line with the rest of the code base as best as we could manage.

There is an outstanding work item to address `send_recv()` and its incorrect parameter types and a couple of structural issues found, but this will be done as follow-up in v1.10 because that involves less superficial changes across BMDA to achieve.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
