### PR TITLE
Fix: adiv5 sticky error handling

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -550,12 +550,12 @@ static void adiv5_component_probe(
 		DEBUG_INFO("ROM: Table BASE=0x%" PRIx32 " SYSMEM=0x%08" PRIx32 ", Manufacturer %3x Partno %3x\n", addr, memtype,
 			designer_code, part_number);
 #endif
-		for (size_t i = 0; i < 960; i++) {
+		for (uint32_t i = 0; i < 960; i++) {
 			adiv5_dp_error(ap->dp);
 
 			uint32_t entry = adiv5_mem_read32(ap, addr + i * 4);
 			if (adiv5_dp_error(ap->dp)) {
-				DEBUG_WARN("%sFault reading ROM table entry %d\n", indent, i);
+				DEBUG_WARN("%sFault reading ROM table entry %" PRIu32 "\n", indent, i);
 				break;
 			}
 
@@ -563,7 +563,7 @@ static void adiv5_component_probe(
 				break;
 
 			if (!(entry & ADIV5_ROM_ROMENTRY_PRESENT)) {
-				DEBUG_INFO("%s%d Entry 0x%" PRIx32 " -> Not present\n", indent, i, entry);
+				DEBUG_INFO("%s%" PRIu32 " Entry 0x%" PRIx32 " -> Not present\n", indent, i, entry);
 				continue;
 			}
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -876,6 +876,8 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 		ap = adiv5_new_ap(dp, i);
 #endif
 		if (ap == NULL) {
+			/* Clear sticky errors in case scanning for this AP triggered any */
+			adiv5_dp_clear_sticky_errors(dp);
 #if PC_HOSTED == 1
 			if (dp->ap_cleanup)
 				dp->ap_cleanup(i);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -703,11 +703,9 @@ static void adiv5_dp_clear_sticky_errors(adiv5_debug_port_s *dp)
 	 */
 	if (dp->version)
 		adiv5_dp_abort(dp, ADIV5_DP_ABORT_STKERRCLR);
-	else {
-		const uint32_t status = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
-		/* If any of the sticky bits are set, simply writing back to this register will clear them */
-		adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, status);
-	}
+	else
+		/* For JTAG-DPs (which all DPv0 DPs are), use the adiv5_jtagdp_error routine */
+		adiv5_dp_error(dp);
 }
 
 void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -829,7 +829,7 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 201);
 	/* Write request for system and debug power up */
-	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ctrlstat |= ADIV5_DP_CTRLSTAT_CSYSPWRUPREQ | ADIV5_DP_CTRLSTAT_CDBGPWRUPREQ);
+	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ctrlstat | ADIV5_DP_CTRLSTAT_CSYSPWRUPREQ | ADIV5_DP_CTRLSTAT_CDBGPWRUPREQ);
 	/* Wait for acknowledge */
 	while (true) {
 		ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
@@ -848,7 +848,7 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 	 * so we have a timeout mechanism in addition to the sensing one. */
 	platform_timeout_set(&timeout, 200);
 	/* Write request for debug reset */
-	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ctrlstat |= ADIV5_DP_CTRLSTAT_CDBGRSTREQ);
+	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ctrlstat | ADIV5_DP_CTRLSTAT_CDBGRSTREQ);
 	/* Wait for acknowledge */
 	while (true) {
 		ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
@@ -862,7 +862,7 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 		}
 	}
 	/* Write request for debug reset release */
-	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ctrlstat &= ~ADIV5_DP_CTRLSTAT_CDBGRSTREQ);
+	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ctrlstat & ~ADIV5_DP_CTRLSTAT_CDBGRSTREQ);
 
 	/* Probe for APs on this DP */
 	size_t invalid_aps = 0;

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -86,11 +86,12 @@
 
 /* AP Abort Register (ABORT) */
 /* Bits 31:5 - Reserved */
+/* Bits 5:1 - DPv1+, reserved in DPv0 */
 #define ADIV5_DP_ABORT_ORUNERRCLR (1U << 4U)
 #define ADIV5_DP_ABORT_WDERRCLR   (1U << 3U)
 #define ADIV5_DP_ABORT_STKERRCLR  (1U << 2U)
 #define ADIV5_DP_ABORT_STKCMPCLR  (1U << 1U)
-/* Bits 5:1 - SW-DP only, reserved in JTAG-DP */
+/* Bit 1 is always defined as DAP Abort. */
 #define ADIV5_DP_ABORT_DAPABORT (1U << 0U)
 
 /* Control/Status Register (CTRLSTAT) */

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -114,6 +114,8 @@
 #define ADIV5_DP_CTRLSTAT_TRNMODE_MASK (3U << 2U)
 #define ADIV5_DP_CTRLSTAT_STICKYORUN   (1U << 1U)
 #define ADIV5_DP_CTRLSTAT_ORUNDETECT   (1U << 0U)
+/* Mask for bits: sticky overrun, sticky cmp, sticky error, and the system + debug powerup bits */
+#define ADIV5_DP_CTRLSTAT_ERRMASK 0xf0000032U
 
 /* ADIv5 MEM-AP Registers */
 #define ADIV5_AP_CSW ADIV5_AP_REG(0x00U)

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -67,8 +67,8 @@ uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 
 static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp)
 {
-	fw_adiv5_jtagdp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_CTRLSTAT, 0);
-	return fw_adiv5_jtagdp_low_access(dp, ADIV5_LOW_WRITE, ADIV5_DP_CTRLSTAT, 0xf0000032U) & 0x32U;
+	const uint32_t status = fw_adiv5_jtagdp_read(dp, ADIV5_DP_CTRLSTAT) & ADIV5_DP_CTRLSTAT_ERRMASK;
+	return fw_adiv5_jtagdp_low_access(dp, ADIV5_LOW_WRITE, ADIV5_DP_CTRLSTAT, status) & 0x32U;
 }
 
 uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Currently BMP gets "stuck" if trying to evaluate an ARM micro with a DP that has the sticky error bit set and declares it a lost cause. This PR addresses this by adding sticky bit reset sequences just after the DP is discovered, and just after a failed AP scan, which should allow normal scan to proceed on otherwise scuffed targets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes: #1288
