### PR TITLE
Fix: ADIv5 SWD fault handling

### DIFF
--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -643,41 +643,31 @@ void adiv5_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t le
 {
 	ap->dp->mem_read(ap, dest, src, len);
 	if (cl_debuglevel & BMP_DEBUG_TARGET) {
-		fprintf(stderr, "ap_memread @ %" PRIx32 " len %" PRIx32 ":", src, (uint32_t)len);
-		uint8_t *p = (uint8_t *)dest;
-		unsigned int i = len;
-
-		if (i > 16)
-			i = 16;
-
-		while (i--)
-			fprintf(stderr, " %02x", *p++);
-
+		fprintf(stderr, "ap_memread @ %" PRIx32 " len %zu:", src, len);
+		const uint8_t *const data = (const uint8_t *)dest;
+		for (size_t offset = 0; offset < len; ++offset) {
+			if (offset == 16)
+				break;
+			fprintf(stderr, " %02x", data[offset]);
+		}
 		if (len > 16)
 			fprintf(stderr, " ...");
-
 		fprintf(stderr, "\n");
 	}
-	return;
 }
 
 void adiv5_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
 	if (cl_debuglevel & BMP_DEBUG_TARGET) {
-		fprintf(stderr, "ap_mem_write_sized @ %" PRIx32 " len %" PRIx32 ", align %d:", dest, (uint32_t)len, 1 << align);
-
-		uint8_t *p = (uint8_t *)src;
-		unsigned int i = len;
-
-		if (i > 16)
-			i = 16;
-
-		while (i--)
-			fprintf(stderr, " %02x", *p++);
-
+		fprintf(stderr, "ap_mem_write_sized @ %" PRIx32 " len %zu, align %d:", dest, len, 1 << align);
+		const uint8_t *const data = (const uint8_t *)src;
+		for (size_t offset = 0; offset < len; ++offset) {
+			if (offset == 16)
+				break;
+			fprintf(stderr, " %02x", data[offset]);
+		}
 		if (len > 16)
 			fprintf(stderr, " ...");
-
 		fprintf(stderr, "\n");
 	}
 	return ap->dp->mem_write_sized(ap, dest, src, len, align);

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -210,7 +210,8 @@ int platform_buffer_write(const uint8_t *data, int size)
 	DEBUG_WIRE("%s\n", data);
 	const int written = write(fd, data, size);
 	if (written < 0) {
-		DEBUG_WARN("Failed to write\n");
+		const int error = errno;
+		DEBUG_WARN("Failed to write (%d): %s\n", errno, strerror(error));
 		exit(-2);
 	}
 	return size;
@@ -242,7 +243,8 @@ int platform_buffer_read(uint8_t *data, int maxsize)
 			return -4;
 		}
 		if (read(fd, &response, 1) != 1) {
-			DEBUG_WARN("Failed to read response\n");
+			const int error = errno;
+			DEBUG_WARN("Failed to read response (%d): %s\n", error, strerror(error));
 			return -6;
 		}
 	}
@@ -261,7 +263,8 @@ int platform_buffer_read(uint8_t *data, int maxsize)
 			return -5;
 		}
 		if (read(fd, data + offset, 1) != 1) {
-			DEBUG_WARN("Failed to read response\n");
+			const int error = errno;
+			DEBUG_WARN("Failed to read response (%d): %s\n", error, strerror(error));
 			return -6;
 		}
 		if (data[offset] == REMOTE_EOM) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a regression caused in #1001. While that PR did fix a real bug, use of dp->error(dp) in the SWD DP access function causes BMP to misbehave and behave badly. In reality this is most likely because an exception is getting throw and not getting caught, but we have no real way to find out and be sure. To solve this, we instead use adiv5_dp_write() directly so we don't go through a read cycle on the control/status DP register (and a series of traversals through the DP access routine) to write the abort DP register (which still requires traversals through the DP access routine, but which ADIv5 guarantees won't fail).

This fixes the behaviour where a user would see
```
Calling lmi_probe
Timeout while waiting for BMP response
remote_ap_mem_read error -4 around 0x400fe000
ap_memread @ 400fe000 len 4: 80 0a 01 00
Timeout while waiting for BMP response
remote_ap_mem_read error -4 around 0x400fe004
ap_memread @ 400fe004 len 4: 80 0a 01 00
Timeout while waiting for BMP response
remote_adiv5_dp_read error -4
Read  CTRL/STAT: 0x00ff001d
Write DP_ABORT : 0x00000002
Timeout while waiting for BMP response
remote_adiv5_low_access error -4
DP Error 0x00000010
```
on the console from BMDA repeatedly and be unable to do any further scans.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
