### PR TITLE
Fix: STM32W device IDs

### DIFF
--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -25,15 +25,23 @@
  * On L4, flash and options are written in DWORDs (8-Byte) only.
  *
  * References:
- * RM0351 STM32L4x5 and STM32L4x6 advanced ARM®-based 32-bit MCUs Rev. 5
+ * RM0351 STM32L4x5 and STM32L4x6 advanced ARM®-based 32-bit MCUs Rev 9
  * - https://www.st.com/resource/en/reference_manual/rm0351-stm32l47xxx-stm32l48xxx-stm32l49xxx-and-stm32l4axxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
- * RM0394 STM32L43xxx STM32L44xxx STM32L45xxx STM32L46xxxx advanced
- *  ARM®-based 32-bit MCUs Rev.3
- * RM0432 STM32L4Rxxx and STM32L4Sxxx advanced Arm®-based 32-bit MCU. Rev 1
- * RM0440 STM32G4 Series advanced Arm®-based 32-bit MCU. Rev 6
+ * RM0394 STM32L43xxx STM32L44xxx STM32L45xxx STM32L46xxxx advanced ARM®-based 32-bit MCUs Rev.4
+ * - https://www.st.com/resource/en/reference_manual/dm00151940-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * RM0432 STM32L4Rxxx and STM32L4Sxxx advanced Arm®-based 32-bit MCU. Rev 9
+ * - https://www.st.com/resource/en/reference_manual/rm0432-stm32l4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * RM0440 STM32G4 Series advanced Arm®-based 32-bit MCU. Rev 7
+ * - https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * RM0438 STM32L552xx and STM32L562xx advanced Arm®-based 32-bit MCUs Rev 7
+ * - https://www.st.com/resource/en/reference_manual/dm00346336-stm32l552xx-and-stm32l562xx-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf
+ * RM0453 STM32WL5x advanced Arm®-based 32-bit MCUs with sub-GHz radio solution Rev 3
+ * - https://www.st.com/resource/en/reference_manual/rm0453-stm32wl5x-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf
+ * RM0461 STM32WLEx advanced Arm®-based 32-bit MCUs with sub-GHz radio solution Rev 5
+ * - https://www.st.com/resource/en/reference_manual/rm0461-stm32wlex-advanced-armbased-32bit-mcus-with-subghz-radio-solution-stmicroelectronics.pdf
  * RM0434 Multiprotocol wireless 32-bit MCU Arm®-based Cortex®-M4 with
- *        FPU, Bluetooth® Low-Energy and 802.15.4 radio solution
- * RM0453 STM32WL5x advanced Arm®-based 32-bit MCUswith sub-GHz radio solution
+ *        FPU, Bluetooth® Low-Energy and 802.15.4 radio solution Rev 10
+ * - https://www.st.com/resource/en/reference_manual/rm0434-multiprotocol-wireless-32bit-mcu-armbased-cortexm4-with-fpu-bluetooth-lowenergy-and-802154-radio-solution-stmicroelectronics.pdf
  */
 
 #include <limits.h>

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -140,18 +140,26 @@ const command_s stm32l4_cmd_list[] = {
 #define RAM_COUNT_MSK 0x07U
 
 typedef enum stm32l4_device_id {
-	ID_STM32L41 = 0x464U,  /* RM0394, Rev.4 */
-	ID_STM32L43 = 0x435U,  /* RM0394, Rev.4 */
-	ID_STM32L45 = 0x462U,  /* RM0394, Rev.4 */
-	ID_STM32L47 = 0x415U,  /* RM0351, Rev.5 */
-	ID_STM32L49 = 0x461U,  /* RM0351, Rev.5 */
-	ID_STM32L4R = 0x470U,  /* RM0432, Rev.5 */
-	ID_STM32G43 = 0x468U,  /* RM0440, Rev.1 */
-	ID_STM32G47 = 0x469U,  /* RM0440, Rev.1 */
-	ID_STM32G49 = 0x479U,  /* RM0440, Rev.6 */
-	ID_STM32L55 = 0x472U,  /* RM0438, Rev.4 */
-	ID_STM32WLXX = 0x497U, /* RM0461, Rev.3, RM453, Rev.1 */
-	ID_STM32WBXX = 0x495U, /* RM0434, Rev.9 */
+	/* This first block of devices uses an ID code register located in the DBG_MCU block at 0xe0042000 */
+	ID_STM32L41 = 0x464U, /* RM0394, Rev.4 §46.6.1 MCU device ID code */
+	ID_STM32L43 = 0x435U, /* RM0394, Rev.4 §46.6.1 MCU device ID code */
+	ID_STM32L45 = 0x462U, /* RM0394, Rev.4 §46.6.1 MCU device ID code */
+	ID_STM32L47 = 0x415U, /* RM0351, Rev.9 §48.6.1 MCU device ID code */
+	ID_STM32L49 = 0x461U, /* RM0351, Rev.9 §48.6.1 MCU device ID code */
+	ID_STM32L4R = 0x470U, /* RM0432, Rev.9 §57.6.1 MCU device ID code */
+	ID_STM32L4P = 0x471U, /* RM0432, Rev.9 §57.6.1 MCU device ID code */
+	ID_STM32G43 = 0x468U, /* RM0440, Rev.7 §47.6.1 MCU device ID code Cat 2 */
+	ID_STM32G47 = 0x469U, /* RM0440, Rev.7 §47.6.1 MCU device ID code Cat 3 */
+	ID_STM32G49 = 0x479U, /* RM0440, Rev.7 §47.6.1 MCU device ID code Cat 4 */
+	/* This part is a bit funky to identify as it's both DPv1 (JTAG) and DPv2 (SWD) */
+	ID_STM32L55 = 0x0472U, /* RM0438, Rev.7 §52.2.10 for DPv2, §52.4.1 (MCU ROM table PIDR) for DPv1 */
+	/*
+	 * The following are all DPv2 parts which are then identified using their "DP target identification register"
+	 * which is ADIv5 DP register TARGETID in bank 2 from the ADIv5.2 spec §B2.2.10.
+	 * The references after the values are the sections to look at in the respective reference manuals.
+	 */
+	ID_STM32WLXX = 0x4970U, /* from RM0461, Rev.5 §36.4.5, and RM0453, Rev.3 §38.4.5 */
+	ID_STM32WBXX = 0x4950U, /* from RM0434, Rev.10 §41.4.8 */
 } stm32l4_device_id_e;
 
 typedef enum stm32l4_family {

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -505,18 +505,11 @@ static uint32_t stm32l4_main_sram_length(const target_s *const t)
 bool stm32l4_probe(target_s *const t)
 {
 	adiv5_access_port_s *ap = cortexm_ap(t);
-	uint32_t device_id;
-	if (ap->dp->version >= 2 && ap->dp->target_partno > 1) /* STM32L552 has invalid TARGETID 1 */
-		/* FIXME: ids likely no longer match and need fixing */
-		device_id = ap->dp->target_partno;
-	else {
-		uint32_t idcode_addr = STM32L4_DBGMCU_IDCODE_PHYS;
-		/* FIXME: we probaly want to check if this is a C-M33 via cpuid */
-		if (ap->dp->partno == 0xbe)
-			idcode_addr = STM32L5_DBGMCU_IDCODE_PHYS;
-		device_id = target_mem_read32(t, idcode_addr) & 0xfffU;
-		DEBUG_INFO("IDCode %08" PRIx32 "\n", device_id);
-	}
+	uint32_t device_id = ap->dp->version >= 2 ? ap->dp->target_partno : ap->partno;
+	/* If the part is DPv0 or DPv1, we must use the L4 ID register, except if we've already identified an L5 part */
+	if (ap->dp->version < 2 && device_id != ID_STM32L55)
+		device_id = target_mem_read32(t, STM32L4_DBGMCU_IDCODE_PHYS) & 0xfffU;
+	DEBUG_INFO("ID Code: %08" PRIx32 "\n", device_id);
 
 	const stm32l4_device_info_s *device = stm32l4_get_device_info(device_id);
 	/* If the call returned the sentinel, it's not a supported L4 device */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR seeks to address the STM32W part ID regression caused by the improved ADIv5 implementation correctness. This also redresses the work-around at the top of the probe routine for the STM32L4/L5/G4/W parts as the reference manuals for this part series indicates it is unnecessary (though reading the special part ID register is still required for L4 and G4 parts).

Unfortunately we don't have any STM32L55 parts (in particular) to test against, so this is untested, however it is based on the prior work by Uwe to address this same problem so should be OK.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
