### PR TITLE
Fix: STM32F1 option bytes regression

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -544,7 +544,7 @@ static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const u
 
 	uint16_t opt_val[8];
 	/* Retrieve old values */
-	for (size_t i = 0; i < 16; i += 4) {
+	for (size_t i = 0U; i < 16U; i += 4U) {
 		const size_t offset = i >> 1U;
 		uint32_t val = target_mem_read32(t, FLASH_OBP_RDP + i);
 		opt_val[offset] = val & 0xffffU;
@@ -563,8 +563,8 @@ static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const u
 	 * Write changed values, taking into account if we can use 32- or have to use 16-bit writes.
 	 * GD32E230 is a special case as target_mem_write16 does not work
 	 */
-	const bool write16_broken = t->part_id == 0x410 && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
-	for (size_t i = 0; i < 8; i++) {
+	const bool write16_broken = t->part_id == 0x410U && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
+	for (size_t i = 0U; i < 8U; ++i) {
 		if (!stm32f1_option_write_erased(t, FLASH_OBP_RDP + (i * 2U), opt_val[i], write16_broken))
 			return false;
 	}
@@ -601,7 +601,7 @@ static bool stm32f1_cmd_option(target_s *t, int argc, const char **argv)
 		 * Write OBD RDP key, taking into account if we can use 32- or have to use 16-bit writes.
 		 * GD32E230 is a special case as target_mem_write16 does not work
 		 */
-		const bool write16_broken = t->part_id == 0x410 && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
+		const bool write16_broken = t->part_id == 0x410U && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
 		stm32f1_option_write_erased(t, FLASH_OBP_RDP, flash_obp_rdp_key, write16_broken);
 	} else if (rdprt) {
 		tc_printf(t, "Device is Read Protected\nUse `monitor option erase` to unprotect and erase device\n");
@@ -613,11 +613,11 @@ static bool stm32f1_cmd_option(target_s *t, int argc, const char **argv)
 	} else
 		tc_printf(t, "usage: monitor option erase\nusage: monitor option <addr> <value>\n");
 
-	for (size_t i = 0; i < 16; i += 4) {
+	for (size_t i = 0U; i < 16U; i += 4U) {
 		const uint32_t addr = FLASH_OBP_RDP + i;
 		const uint32_t val = target_mem_read32(t, addr);
-		tc_printf(t, "0x%08X: 0x%04X\n", addr, val & 0xFFFF);
-		tc_printf(t, "0x%08X: 0x%04X\n", addr + 2, val >> 16);
+		tc_printf(t, "0x%08X: 0x%04X\n", addr, val & 0xffffU);
+		tc_printf(t, "0x%08X: 0x%04X\n", addr + 2, val >> 16U);
 	}
 
 	return true;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -564,9 +564,10 @@ static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const u
 	 * GD32E230 is a special case as target_mem_write16 does not work
 	 */
 	const bool write16_broken = t->part_id == 0x410 && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
-	for (size_t i = 0; i < 8; i++)
+	for (size_t i = 0; i < 8; i++) {
 		if (!stm32f1_option_write_erased(t, FLASH_OBP_RDP + (i * 2U), opt_val[i], write16_broken))
 			return false;
+	}
 
 	return true;
 }

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -512,7 +512,7 @@ static bool stm32f1_option_erase(target_s *t)
 	target_mem_write32(t, FLASH_CR, FLASH_CR_STRT | FLASH_CR_OPTER | FLASH_CR_OPTWRE);
 
 	/* Wait for completion or an error */
-	return stm32f1_flash_busy_wait(t, 0, NULL);
+	return stm32f1_flash_busy_wait(t, FLASH_BANK1_OFFSET, NULL);
 }
 
 static bool stm32f1_option_write_erased(
@@ -532,7 +532,7 @@ static bool stm32f1_option_write_erased(
 		target_mem_write16(t, addr, value);
 
 	/* Wait for completion or an error */
-	return stm32f1_flash_busy_wait(t, 0, NULL);
+	return stm32f1_flash_busy_wait(t, FLASH_BANK1_OFFSET, NULL);
 }
 
 static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const uint16_t value)

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -565,7 +565,7 @@ static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const u
 	 */
 	const bool write16_broken = t->part_id == 0x410U && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
 	for (size_t i = 0U; i < 8U; ++i) {
-		if (!stm32f1_option_write_erased(t, FLASH_OBP_RDP + (i * 2U), opt_val[i], write16_broken))
+		if (!stm32f1_option_write_erased(t, FLASH_OBP_RDP + (i * 2U), opt_val[i], write16_broken) && i != 0)
 			return false;
 	}
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the option bytes write regression for STM32F1 as GD32F1 which was privately reported. As it turns out, because 0x5aa5 is the erased state for the first option byte, this fails the erased state check at the top of `stm32f1_option_write_erased()` and results in the code writing this first byte, which is not erased and the write aborts with an error (`FLASH_SR`'s `PGERR` bit being set). Because `stm32f1_flash_busy_wait()` checks for this error on the way out, it returns false, this then causes the write control loop in `stm32f1_option_write()` to abort.

In this regression fix we test if `i != 0` in that control loop as a second condition before aborting the write. In the future a map of the erased option bytes should be written per-part supported, and this used as the erased state check at the top of `stm32f1_option_write_erased()`, but this is an item for v1.10.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
