### PR TITLE
Fix: BMDA CLI options structure naming

### DIFF
--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -98,7 +98,7 @@ typedef struct timeval timeval_s;
 
 extern bmp_info_s info;
 void bmp_ident(bmp_info_s *info);
-int find_debuggers(bmp_cli_options_s *cl_opts, bmp_info_s *info);
+int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info);
 void libusb_exit_function(bmp_info_s *info);
 
 #if HOSTED_BMP_ONLY == 1

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -106,7 +106,7 @@ static bmp_type_t find_cmsis_dap_interface(libusb_device *dev, bmp_info_s *info)
 	return type;
 }
 
-int find_debuggers(bmp_cli_options_s *cl_opts, bmp_info_s *info)
+int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
 	libusb_device **devs;
 	int res = libusb_init(&info->libusb_ctx);

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -47,7 +47,7 @@ void libusb_exit_function(bmp_info_s *info)
 };
 
 #ifdef __APPLE__
-int find_debuggers(bmp_cli_options_s *cl_opts, bmp_info_s *info)
+int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
 	DEBUG_WARN("Please implement find_debuggers for MACOS!\n");
 	(void)cl_opts;
@@ -78,7 +78,7 @@ DEFINE_DEVPROPKEY(DEVPKEY_Device_BusReportedDeviceDesc, 0x540b947e, 0x8b40, 0x45
 
 /* List all USB devices with some additional information.
  * Unfortunately, this code is quite ugly. */
-int find_debuggers(bmp_cli_options_s *cl_opts, bmp_info_s *info)
+int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
 	unsigned i;
 	DWORD dwSize;
@@ -333,7 +333,7 @@ size_t scan_devices(scan_mode_e mode, bmp_info_s *info, const char *const search
 	return devices;
 }
 
-int find_debuggers(bmp_cli_options_s *cl_opts, bmp_info_s *info)
+int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
 	if (cl_opts->opt_device)
 		return 1;

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -226,7 +226,7 @@ static const getopt_option_s long_options[] = {
 	{NULL, 0, NULL, 0},
 };
 
-void cl_init(bmp_cli_options_s *opt, int argc, char **argv)
+void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 {
 	int c;
 	opt->opt_target_dev = 1;
@@ -399,7 +399,7 @@ static void display_target(int i, target_s *t, void *context)
 			"*** %2d %c %s %s\n", i, target_attached(t) ? '*' : ' ', target_driver_name(t), core_name ? core_name : "");
 }
 
-int cl_execute(bmp_cli_options_s *opt)
+int cl_execute(bmda_cli_options_s *opt)
 {
 	int num_targets;
 	if (opt->opt_tpwr) {

--- a/src/platforms/hosted/cli.h
+++ b/src/platforms/hosted/cli.h
@@ -70,9 +70,9 @@ typedef struct bmda_cli_options {
 	size_t opt_flash_size;
 } bmda_cli_options_s;
 
-void cl_init(bmp_cli_options_s *opt, int argc, char **argv);
-int cl_execute(bmp_cli_options_s *opt);
-int serial_open(const bmp_cli_options_s *opt, const char *serial);
+void cl_init(bmda_cli_options_s *opt, int argc, char **argv);
+int cl_execute(bmda_cli_options_s *opt);
+int serial_open(const bmda_cli_options_s *opt, const char *serial);
 void serial_close(void);
 
 #endif /* PLATFORMS_HOSTED_CLI_H */

--- a/src/platforms/hosted/cli.h
+++ b/src/platforms/hosted/cli.h
@@ -68,7 +68,7 @@ typedef struct bmda_cli_options {
 	uint32_t opt_flash_start;
 	uint32_t opt_max_swj_frequency;
 	size_t opt_flash_size;
-} bmp_cli_options_s;
+} bmda_cli_options_s;
 
 void cl_init(bmp_cli_options_s *opt, int argc, char **argv);
 int cl_execute(bmp_cli_options_s *opt);

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -371,7 +371,7 @@ const cable_desc_s cable_desc[] = {
 	{},
 };
 
-int ftdi_bmp_init(bmp_cli_options_s *cl_opts, bmp_info_s *info)
+int ftdi_bmp_init(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
 	int err;
 	const cable_desc_s *cable = cable_desc;

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -108,7 +108,7 @@ typedef struct cable_desc {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-int ftdi_bmp_init(bmp_cli_options_s *cl_opts, bmp_info_s *info)
+int ftdi_bmp_init(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
 	return -1;
 }

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -178,7 +178,7 @@ extern cable_desc_s active_cable;
 extern ftdi_context_s *ftdic;
 extern data_desc_s active_state;
 
-int ftdi_bmp_init(bmp_cli_options_s *cl_opts, bmp_info_s *info);
+int ftdi_bmp_init(bmda_cli_options_s *cl_opts, bmp_info_s *info);
 int libftdi_swdptap_init(adiv5_debug_port_s *dp);
 bool libftdi_jtagtap_init(void);
 void libftdi_buffer_flush(void);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -45,7 +45,7 @@ bmp_info_s info;
 
 jtag_proc_s jtag_proc;
 
-static bmp_cli_options_s cl_opts;
+static bmda_cli_options_s cl_opts;
 
 void gdb_ident(char *p, int count)
 {

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -72,7 +72,7 @@ static int set_interface_attribs(void)
 }
 
 #ifdef __APPLE__
-int serial_open(const bmp_cli_options_s *cl_opts, char *serial)
+int serial_open(const bmda_cli_options_s *cl_opts, char *serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {
@@ -128,7 +128,7 @@ static bool match_serial(const char *const device, const char *const serial)
 	return constains_substring(begin, end - begin, serial);
 }
 
-int serial_open(const bmp_cli_options_s *const cl_opts, const char *const serial)
+int serial_open(const bmda_cli_options_s *const cl_opts, const char *const serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {

--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -152,7 +152,7 @@ static char *device_to_path(const char *const device)
 	return path;
 }
 
-static char *find_bmp_device(const bmp_cli_options_s *const cl_opts, const char *const serial)
+static char *find_bmp_device(const bmda_cli_options_s *const cl_opts, const char *const serial)
 {
 	if (cl_opts->opt_device)
 		return device_to_path(cl_opts->opt_device);
@@ -164,7 +164,7 @@ static char *find_bmp_device(const bmp_cli_options_s *const cl_opts, const char 
 	return result;
 }
 
-int serial_open(const bmp_cli_options_s *const cl_opts, const char *const serial)
+int serial_open(const bmda_cli_options_s *const cl_opts, const char *const serial)
 {
 	char *const device = find_bmp_device(cl_opts, serial);
 	if (!device) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As part of his work rebuilding find_debuggers() for BMDA, @sidprice noticed that we'd been a little inconsistent in the naming conformity branch, resulting in this set of naming fixes. We suggest this is applied using a squash commit.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
