### PR TITLE
Fix: JTAG timings

### DIFF
--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -120,7 +120,10 @@ static void jtagtap_tms_seq_no_delay(uint32_t tms_states, const size_t clock_cyc
 		const bool state = tms_states & 1U;
 		gpio_set_val(TMS_PORT, TMS_PIN, state);
 		gpio_set(TCK_PORT, TCK_PIN);
+		/* Block the compiler from re-ordering the TMS states calculation to preserve timings */
+		__asm__ volatile("" ::: "memory");
 		tms_states >>= 1U;
+		__asm__("nop");
 		__asm__("nop");
 		__asm__("nop");
 		gpio_clear(TCK_PORT, TCK_PIN);

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -30,8 +30,8 @@ jtag_proc_s jtag_proc;
 
 static void jtagtap_reset(void);
 static void jtagtap_tms_seq(uint32_t tms_states, size_t ticks);
-static void jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t ticks);
-static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t ticks);
+static void jtagtap_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t clock_cycles);
+static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jtagtap_next(bool tms, bool tdi);
 static void jtagtap_cycle(bool tms, bool tdi, size_t clock_cycles);
 

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -116,14 +116,14 @@ static void jtagtap_tms_seq_swd_delay(uint32_t tms_states, const size_t clock_cy
 
 static void jtagtap_tms_seq_no_delay(uint32_t tms_states, const size_t clock_cycles)
 {
+	bool state = tms_states & 1U;
 	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
-		const bool state = tms_states & 1U;
 		gpio_set_val(TMS_PORT, TMS_PIN, state);
 		gpio_set(TCK_PORT, TCK_PIN);
 		/* Block the compiler from re-ordering the TMS states calculation to preserve timings */
 		__asm__ volatile("" ::: "memory");
 		tms_states >>= 1U;
-		__asm__("nop");
+		state = tms_states & 1U;
 		__asm__("nop");
 		__asm__("nop");
 		gpio_clear(TCK_PORT, TCK_PIN);

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -62,7 +62,7 @@ static void jtagtap_reset(void)
 	if (platform_hwversion() == 0) {
 		gpio_clear(TRST_PORT, TRST_PIN);
 		for (volatile size_t i = 0; i < 10000U; i++)
-			__asm__("nop");
+			continue;
 		gpio_set(TRST_PORT, TRST_PIN);
 	}
 #endif


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the JTAG timing issues that the earlier refactor in #1118 accidentally introduced. These timings issues impact the ability for the JTAG-PDI branch to function, and made the timings for ARM parts marginal. The timings issues occur while doing TMS sequences.

The following captures show the before-and-after of this timing fix:

![image](https://user-images.githubusercontent.com/691140/204147254-5870ff8a-7853-4609-beac-4fddc68aecf0.png)

![image](https://user-images.githubusercontent.com/691140/204147661-df5cff61-184a-4045-a170-9a02490f8056.png)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
