### PR TITLE
Fix: RP2040 blank flash bringup

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -208,10 +208,10 @@ static uint32_t rp_get_flash_length(target_s *t);
 static bool rp_mass_erase(target_s *t);
 
 // Our own implementation of bootloader functions for handling flash chip
-static void rp_flash_exit_xip(target_s *const t);
-static void rp_flash_enter_xip(target_s *const t);
-static void rp_flash_connect_internal(target_s *const t);
-static void rp_flash_flush_cache(target_s *const t);
+static void rp_flash_exit_xip(target_s *t);
+static void rp_flash_enter_xip(target_s *t);
+static void rp_flash_connect_internal(target_s *t);
+static void rp_flash_flush_cache(target_s *t);
 
 static void rp_spi_read_sfdp(target_s *const t, const uint32_t address, void *const buffer, const size_t length)
 {

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -249,7 +249,7 @@ static void rp_add_flash(target_s *t)
 		rp_flash_flush_cache(t);
 	rp_flash_enter_xip(t);
 
-	DEBUG_INFO("Flash size: %uMiB\n", spi_parameters.capacity / (1024U * 1024U));
+	DEBUG_INFO("Flash size: %" PRIu32 "MiB\n", (uint32_t)spi_parameters.capacity / (1024U * 1024U));
 
 	target_flash_s *const f = &flash->f;
 	f->start = RP_XIP_FLASH_BASE;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -52,7 +52,7 @@
 #define RP_ID                 "Raspberry RP2040"
 #define RP_MAX_TABLE_SIZE     0x80U
 #define BOOTROM_MAGIC_ADDR    0x00000010U
-#define BOOTROM_MAGIC         ((unsigned)'M' | ((unsigned)'u' << 8U) | (1U << 16U))
+#define BOOTROM_MAGIC         ((uint32_t)'M' | ((uint32_t)'u' << 8U) | (1U << 16U))
 #define BOOTROM_MAGIC_MASK    0x00ffffffU
 #define BOOTROM_VERSION_SHIFT 24U
 #define RP_XIP_FLASH_BASE     0x10000000U

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -210,10 +210,8 @@ static bool rp_mass_erase(target_s *t);
 // Our own implementation of bootloader functions for handling flash chip
 static void rp_flash_exit_xip(target_s *const t);
 static void rp_flash_enter_xip(target_s *const t);
-#if 0
 static void rp_flash_connect_internal(target_s *const t);
 static void rp_flash_flush_cache(target_s *const t);
-#endif
 
 static void rp_spi_read_sfdp(target_s *const t, const uint32_t address, void *const buffer, const size_t length)
 {
@@ -228,6 +226,7 @@ static void rp_add_flash(target_s *t)
 		return;
 	}
 
+	rp_flash_connect_internal(t);
 	rp_flash_exit_xip(t);
 
 	spi_parameters_s spi_parameters;
@@ -239,6 +238,7 @@ static void rp_add_flash(target_s *t)
 		spi_parameters.sector_erase_opcode = SPI_FLASH_CMD_SECTOR_ERASE;
 	}
 
+	rp_flash_flush_cache(t);
 	rp_flash_enter_xip(t);
 
 	DEBUG_INFO("Flash size: %uMiB\n", spi_parameters.capacity / (1024U * 1024U));
@@ -615,7 +615,6 @@ static void rp_spi_read(
 	target_mem_write32(t, RP_SSI_ENABLE, ssi_enabled);
 }
 
-#if 0
 // Connect the XIP controller to the flash pads
 static void rp_flash_connect_internal(target_s *const t)
 {
@@ -637,7 +636,6 @@ static void rp_flash_connect_internal(target_s *const t)
 	target_mem_write32(t, RP_GPIO_QSPI_SD2_CTRL, 0);
 	target_mem_write32(t, RP_GPIO_QSPI_SD3_CTRL, 0);
 }
-#endif
 
 // Set up the SSI controller for standard SPI mode,i.e. for every byte sent we get one back
 // This is only called by flash_exit_xip(), not by any of the other functions.
@@ -773,7 +771,6 @@ static void rp_flash_exit_xip(target_s *const t)
 	target_mem_write32(t, RP_GPIO_QSPI_CS_CTRL, 0);
 }
 
-#if 0
 // This is a hook for steps to be taken in between programming the flash and
 // doing cached XIP reads from the flash. Called by the bootrom before
 // entering flash second stage, and called by the debugger after flash
@@ -788,7 +785,6 @@ static void rp_flash_flush_cache(target_s *const t)
 	target_mem_write32(t, RP_XIP_CTRL, ctrl | RP_XIP_CTRL_ENABLE);
 	rp_spi_chip_select(t, RP_GPIO_QSPI_CS_DRIVE_NORMAL);
 }
-#endif
 
 // Put the SSI into a mode where XIP accesses translate to standard
 // serial 03h read commands. The flash remains in its default serial command


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the issues around how the RP2040 boot ROMs handle when the attached Flash is blank, as the ROMs leave the controllers involved in a state where we cannot access the Flash. This is characterised by seeing something like this when using BMDA run as `src/blackmagic -tv 1`:

```
8 byte SFDP read at 0x0:
        00 00 00 00 00 00 00 00
Flash device ID: 00 00 00
```

After this fix, the result is a reliable working SFDP readout:

```
RP2040 Flash controller in POR state, reconfiguring
8 byte SFDP read at 0x0:
        53 46 44 50 05 01 00 ff
8 byte SFDP read at 0x8:
        00 05 01 10 80 00 00 ff
Flash size: 2MiB
```

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
