### PR TITLE
hosted/dap: Fixed error in link reset pointer math.

### DIFF
--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -449,7 +449,7 @@ void dap_reset_link(bool jtag)
 		*p++ = 0x3c;
 		*p++ = 0xe7;
 		*p++ = 0x1f;
-		buf[1] = ((p - buf + 2U) * 8U) - 2U;
+		buf[1] = ((p - (buf + 2U)) * 8U) - 2U;
 	} else {
 		*p++ = 0x9e;
 		*p++ = 0xe7;
@@ -461,7 +461,7 @@ void dap_reset_link(bool jtag)
 		*p++ = 0xff;
 		*p++ = 0xff;
 		*p++ = 0x00;
-		buf[1] = (p - buf + 2U) * 8U;
+		buf[1] = (p - (buf + 2U)) * 8U;
 	}
 	dbg_dap_cmd(buf, sizeof(buf), p - buf);
 


### PR DESCRIPTION
This fixes a regression introduced in 52cad38.

## Detailed description

52cad38 rewrote the pointer math and forgot brackets, unintentionally changing the sign of the 2-offset, leading to the command requesting to shift 32 bits more than it provided.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
