### PR TITLE
fix: USB serial DTR handling and resulting USB packet sent on the wrong endpoint regression

### DIFF
--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -95,7 +95,8 @@ static usbd_request_return_codes_e gdb_serial_control_request(usbd_device *dev, 
 
 	switch (req->bRequest) {
 	case USB_CDC_REQ_SET_CONTROL_LINE_STATE:
-		usb_serial_set_state(dev, req->wIndex, CDCACM_GDB_ENDPOINT);
+		/* Send a notification back on the notification endpoint */
+		usb_serial_set_state(dev, req->wIndex, CDCACM_GDB_ENDPOINT + 1U);
 		gdb_serial_dtr = req->wValue & 1U;
 		return USBD_REQ_HANDLED;
 	case USB_CDC_REQ_SET_LINE_CODING:
@@ -121,7 +122,8 @@ static usbd_request_return_codes_e debug_serial_control_request(usbd_device *dev
 
 	switch (req->bRequest) {
 	case USB_CDC_REQ_SET_CONTROL_LINE_STATE:
-		usb_serial_set_state(dev, req->wIndex, CDCACM_UART_ENDPOINT);
+		/* Send a notification back on the notification endpoint */
+		usb_serial_set_state(dev, req->wIndex, CDCACM_UART_ENDPOINT + 1U);
 #ifdef USBUSART_DTR_PIN
 		gpio_set_val(USBUSART_PORT, USBUSART_DTR_PIN, !(req->wValue & 1U));
 #endif


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Fixed a regression caused in #1190 that puts the CDC notification replies out over the wrong endpoint.

The effect of this regression is that BMP erroneously replies to state change requests, like asking for DTR to be set, over the wrong endpoint channel - using the serial data IN endpoint rather than the notification endpoint.

Many thanks to @compuphase for the data in their bug report allowing us to so quickly pinpoint this.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1310