### PR TITLE
crc32 fixup: missing return type change

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -138,7 +138,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 	}
 	DEBUG_WARN("%" PRIu32 " ms\n", platform_time_ms() - start_time);
 	*crc_res = crc;
-	return 0;
+	return true;
 }
 #else
 #include <libopencm3/stm32/crc.h>


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

in #1286 a return type change was introduced in the crc32 routines (17c4f1fe19efeb88bbd37ed0b1e054ae59ab22cd) but one return was missed and it borked crc32 calculation results in BMDA and non-stm32 probes.

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability (change tested by @zyp, reported on discord)
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
