### PR TITLE
stm32f1: Fixed a regression in the identification of STM32F0 parts

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -121,7 +121,7 @@ static void stm32f1_add_flash(target_s *t, uint32_t addr, size_t length, size_t 
 
 static uint16_t stm32f1_read_idcode(target_s *const t)
 {
-	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
+	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M0 || (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
 		return target_mem_read32(t, DBGMCU_IDCODE_F0) & 0xfffU;
 	return target_mem_read32(t, DBGMCU_IDCODE) & 0xfffU;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address a regression in the identification of STM32F0 parts. This was caused in 661d3ccf (#1291) when trying to refactor the part identification code common between GD32 parts and genuine STM32 parts.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
