### PR TITLE
Fix: not handling ERROR_SUCCESS return code from RegGetValue

### DIFF
--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -98,7 +98,7 @@ static char *read_key_from_path(const char *const subpath, const char *const key
 
 	DWORD value_len = 0;
 	const LSTATUS result = RegGetValue(key_path_handle, NULL, key_name, RRF_RT_REG_SZ, NULL, NULL, &value_len);
-	if (result != ERROR_MORE_DATA) {
+	if (result != ERROR_SUCCESS && result != ERROR_MORE_DATA) {
 		display_error(result, "retrieving value for key", key_name);
 		RegCloseKey(key_path_handle);
 		return NULL;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

Previously I would get this error while trying to run hosted blackmagic:

```
$ ./src/blackmagic.exe -jtv 31
Black Magic Debug App (for BMP only) v1.9.0-rc0-4-g5e3f0084-dirty
Using:
 BMP  98B69BC2
Error retrieving value for key ParentIdPrefix, got error 00000000: The operation completed successfully.

Unexpected problems finding the device!
```

This PR handles the case where `RegGetValue` can return `ERROR_SUCCESS`, fixing this issue 

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
