### PR TITLE
Fix: udev symlinks when multiple probes are attached to one host

### DIFF
--- a/driver/99-blackmagic-plugdev.rules
+++ b/driver/99-blackmagic-plugdev.rules
@@ -5,6 +5,8 @@
 ACTION!="add|change", GOTO="blackmagic_rules_end"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg"
+SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb%E{ID_SERIAL_SHORT}"
+SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg%E{ID_SERIAL_SHORT}"
 SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6017", MODE="0666", GROUP="plugdev", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6018", MODE="0666", GROUP="plugdev", TAG+="uaccess"
 LABEL="blackmagic_rules_end"

--- a/driver/99-blackmagic-uucp.rules
+++ b/driver/99-blackmagic-uucp.rules
@@ -5,6 +5,8 @@
 ACTION!="add|change", GOTO="blackmagic_rules_end"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg"
+SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb%E{ID_SERIAL_SHORT}"
+SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg%E{ID_SERIAL_SHORT}"
 SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6017", MODE="0666", GROUP="uucp", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6018", MODE="0666", GROUP="uucp", TAG+="uaccess"
 LABEL="blackmagic_rules_end"


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Added a second set of symlinks so the friendly names continue to work using the probe serials even when a user plugs multiple BMPs into one host machine.

Before this change, a machine with any number of BMPs plugged in would have a /dev that looks like:
```
❯ ls /dev/ttyBmp*
/dev/ttyBmpGdb  /dev/ttyBmpTarg
```

After, the same /dev now looks like:
```
❯ ls /dev/ttyBmp*
/dev/ttyBmpGdb  /dev/ttyBmpGdb8BB20695  /dev/ttyBmpGdbBFC590F5  /dev/ttyBmpTarg  /dev/ttyBmpTarg8BB20695  /dev/ttyBmpTargBFC590F5
```

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
