### PR TITLE
Feature/auto flash write buffer size

### DIFF
--- a/src/target/renesas.c
+++ b/src/target/renesas.c
@@ -622,11 +622,9 @@ static void renesas_add_rv40_flash(target_s *t, target_addr_t addr, size_t lengt
 
 	if (code_flash) {
 		f->blocksize = RV40_CF_REGION1_BLOCK_SIZE;
-		f->writebufsize = RV40_CF_WRITE_SIZE * 8U;
 		f->writesize = RV40_CF_WRITE_SIZE;
 	} else {
 		f->blocksize = RV40_DF_BLOCK_SIZE;
-		f->writebufsize = RV40_DF_BLOCK_SIZE * 8U;
 		f->writesize = RV40_DF_WRITE_SIZE;
 	}
 

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -50,7 +50,7 @@ struct target_flash {
 	size_t length;               /* Flash length */
 	size_t blocksize;            /* Erase block size */
 	size_t writesize;            /* Write operation size, must be <= blocksize/writebufsize */
-	size_t writebufsize;         /* Size of write buffer */
+	size_t writebufsize;         /* Size of write buffer, this is calculated and not set in target code */
 	uint8_t erased;              /* Byte erased state */
 	bool ready;                  /* True if flash is in flash mode/prepared */
 	flash_prepare_func prepare;  /* Prepare for flash operations */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

`writebufsize` is no longer set in the target code, it's now sized automatically up to a ceiling

This reduces overhead and reduces allocation/deallocation count in targets with small `writesize`, while keeping the buffers manageably small

## Detailed description

Targets with `writesize` > `FLASH_WRITE_BUFFER_CEILLING`, use `writesize` as buffer size
Other Targets use a buffer sized to as many `writesize` fit in `FLASH_WRITE_BUFFER_CEILLING`

`FLASH_WRITE_BUFFER_CEILLING` was chosen as `1024` as a fairly arbitrary value, targets with large `writesize` don't benefit much from a multi-write buffer like targets with smaller `writesize`, as the overhead is already comparatively small

This does nothing to bind the max size of the buffer, as it's directly tied to `writesize` and that's not something we can just mess with, to keep that to a reasonable size is a job for correctness in the target implementation. (we might want to ditch the automatic `writesize` to `blocksize` when absent and make that value mandatory for the target)

note: **_this code was not tested!!_** the code logic is trivial, and the target flash code should be ready for this, but nonetheless some testing is definitely welcome

## Your checklist for this pull request

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
