### PR TITLE
Fix: nrf52 probe memory exhaustion

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -126,6 +126,7 @@ bool nrf51_probe(target_s *t)
 	if (page_size == 0xffffffffU || code_size == 0xffffffffU || page_size == 0 || code_size == 0 ||
 		page_size > 0x10000U || code_size > 0x10000U)
 		return false;
+	DEBUG_INFO("nRF51/52: code page size: %" PRIu32 ", code size: %" PRIu32 "\n", page_size, code_size);
 	/* Check that device identifier makes sense */
 	uint32_t uid0 = target_mem_read32(t, NRF51_FICR_DEVICEID_LOW);
 	uint32_t uid1 = target_mem_read32(t, NRF51_FICR_DEVICEID_HIGH);

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -136,7 +136,6 @@ bool nrf51_probe(target_s *t)
 	uint32_t uid1 = target_mem_read32(t, NRF51_FICR_DEVICEID_HIGH);
 	if (uid0 == 0xffffffffU || uid1 == 0xffffffffU || uid0 == 0 || uid1 == 0)
 		return false;
-	t->mass_erase = nrf51_mass_erase;
 	/* Test for NRF52 device */
 	uint32_t info_part = target_mem_read32(t, NRF52_PART_INFO);
 	if (info_part != 0xffffffffU && info_part != 0 && (info_part & 0x00ff000U) == 0x52000U) {
@@ -159,6 +158,7 @@ bool nrf51_probe(target_s *t)
 		nrf51_add_flash(t, NRF51_UICR, page_size, page_size);
 		target_add_commands(t, nrf51_cmd_list, "nRF51");
 	}
+	t->mass_erase = nrf51_mass_erase;
 	return true;
 }
 

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -113,6 +113,8 @@ static void nrf51_add_flash(target_s *t, uint32_t addr, size_t length, size_t er
 	f->start = addr;
 	f->length = length;
 	f->blocksize = erasesize;
+	/* Limit the write buffer size to 1k to help prevent probe memory exhaustion */
+	f->writesize = MIN(erasesize, 1024);
 	f->erase = nrf51_flash_erase;
 	f->write = nrf51_flash_write;
 	f->done = nrf51_flash_done;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Thanks to the Discord user dsmullen (@drspangle), we were informed that nRF52 devices were still triggering memory issues in the firmware. In this case, the device they were trying to Flash was after a 4kiB write buffer and this was running their probe out of memory.

With their kind help for testing, we have capped the maximum write buffer size for nRF targets to 1kiB, and applied some cleanup to the Flash routines as suggested by Perigoso which have also reduced Flash usage a small amount more. This has all been tested working.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
