### PR TITLE
check argc

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -498,7 +498,7 @@ static const char *on_or_off(const bool value)
 static bool cmd_rtt(target_s *t, int argc, const char **argv)
 {
 	(void)t;
-	const size_t command_len = strlen(argv[1]);
+	const size_t command_len = argc > 1 ? strlen(argv[1]) : 0;
 	if (argc == 1 || (argc == 2 && strncmp(argv[1], "enabled", command_len) == 0)) {
 		rtt_enabled = true;
 		rtt_found = false;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

if the user types "mon rtt" there is only one argument, argv[1] is undefined, and strlen(argv[1]) can cause a null pointer ref.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
