### PR TITLE
target/stm32f4: correct code used to look up part name

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -231,7 +231,7 @@ bool stm32f4_probe(target_s *t)
 		t->attach = stm32f4_attach;
 		t->detach = stm32f4_detach;
 		t->mass_erase = stm32f4_mass_erase;
-		t->driver = stm32f4_get_chip_name(t->part_id);
+		t->driver = stm32f4_get_chip_name(device_id);
 		t->part_id = device_id;
 		target_add_commands(t, stm32f4_cmd_list, t->driver);
 		return true;


### PR DESCRIPTION
t->part_id was being used, but that code is unlikely to match the idcode used internally by ST leading to a bad look up, use device_id which is read from the internal ST register

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability (see #1328)
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

fixes #1328

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
