### PR TITLE
blackpillv2: semihosting debug output redirection to usb-uart port

### DIFF
--- a/src/platforms/blackpillv2/platform.h
+++ b/src/platforms/blackpillv2/platform.h
@@ -29,6 +29,7 @@
 
 #include <setjmp.h>
 
+#define PLATFORM_HAS_USBUART
 #define PLATFORM_HAS_TRACESWO
 #define PLATFORM_IDENT "(BlackPillV2) "
 /*


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Semihosting output on usb uart "monitor redirect_stdout enable" was not enabled on the blackpillv2 platform.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
