### PR TITLE
Fix: Cortex-M SWD attach regression

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,7 @@ int main(int argc, char **argv)
 		if (e.type) {
 			gdb_putpacketz("EFF");
 			target_list_free();
+			gdb_outf("Uncaught exception: %s\n", e.msg);
 			morse("TARGET LOST.", true);
 		}
 	}

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -64,8 +64,8 @@ ifneq ($(HOSTED_BMP_ONLY), 1)
 endif
 
 ifneq ($(HOSTED_BMP_ONLY), 1)
-    CFLAGS  +=  -DCMSIS_DAP
-    SRC += cmsis_dap.c dap.c
+    CFLAGS += -DCMSIS_DAP
+    SRC += cmsis_dap.c dap.c dap_command.c
     ifneq ($(shell pkg-config --exists $(HIDAPILIB); echo $$?), 0)
         $(error Please install $(HIDAPILIB) dependency or set HOSTED_BMP_ONLY to 1)
     endif

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -586,7 +586,10 @@ int dap_swdptap_init(adiv5_debug_port_s *dp)
 		dp->dp_low_write = dap_dp_low_write;
 	else
 		dp->dp_low_write = NULL;
+	dp->seq_in = dap_swdptap_seq_in;
+	dp->seq_in_parity = dap_swdptap_seq_in_parity;
 	dp->seq_out = dap_swdptap_seq_out;
+	dp->seq_out_parity = dap_swdptap_seq_out_parity;
 	dp->dp_read = dap_dp_read_reg;
 	/* For error() use the TARGETID switching firmware_swdp_error */
 	dp->low_access = dap_dp_low_access;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -372,15 +372,16 @@ ssize_t dbg_dap_cmd_bulk(uint8_t *const data, const size_t request_length)
 	return transferred;
 }
 
-int dbg_dap_cmd(uint8_t *data, int response_length, int request_length)
+int dbg_dap_cmd(uint8_t *data, int response_length, const size_t request_length)
 {
 	char cmd = data[0];
 	int res = -1;
 
-	DEBUG_WIRE("cmd :   ");
-	for (int i = 0; (i < request_length + 1); i++)
-		DEBUG_WIRE("%02x.", data[i]);
+	DEBUG_WIRE(" command: ");
+	for (size_t i = 0; i < request_length; ++i)
+		DEBUG_WIRE("%02x ", data[i]);
 	DEBUG_WIRE("\n");
+
 	if (type == CMSIS_TYPE_HID)
 		res = dbg_dap_cmd_hid(data, request_length);
 	else if (type == CMSIS_TYPE_BULK)

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -441,10 +441,8 @@ static void dap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size
 			unsigned int transfersize = blocksize;
 			if (transfersize > max_size)
 				transfersize = max_size;
-			unsigned int res = dap_read_block(ap, dest, src, transfersize, align);
-			if (res) {
-				DEBUG_WIRE("mem_read failed %02x\n", res);
-				ap->dp->fault = 1;
+			if (!dap_read_block(ap, dest, src, transfersize, align)) {
+				DEBUG_WIRE("mem_read failed: %u\n", ap->dp->fault);
 				return;
 			}
 			blocksize -= transfersize;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -313,14 +313,13 @@ static uint32_t dap_swd_dp_error(adiv5_debug_port_s *dp, const bool protocol_rec
 
 static uint32_t dap_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
 {
-	bool APnDP = addr & ADIV5_APnDP;
+	const bool APnDP = addr & ADIV5_APnDP;
 	uint32_t res = 0;
-	uint8_t reg = (addr & 0xcU) | ((APnDP) ? 1 : 0);
-	if (RnW) {
+	const uint8_t reg = (addr & 0xcU) | (APnDP ? 1 : 0);
+	if (RnW)
 		res = dap_read_reg(dp, reg);
-	} else {
+	else
 		dap_write_reg(dp, reg, value);
-	}
 	return res;
 }
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -372,10 +372,8 @@ ssize_t dbg_dap_cmd_bulk(uint8_t *const data, const size_t request_length)
 	return transferred;
 }
 
-ssize_t dbg_dap_cmd(uint8_t *data, int response_length, const size_t request_length)
+ssize_t dbg_dap_cmd(uint8_t *const data, const size_t response_length, const size_t request_length)
 {
-	char cmd = data[0];
-
 	DEBUG_WIRE(" command: ");
 	for (size_t i = 0; i < request_length; ++i)
 		DEBUG_WIRE("%02x ", data[i]);
@@ -395,12 +393,13 @@ ssize_t dbg_dap_cmd(uint8_t *data, int response_length, const size_t request_len
 		DEBUG_WIRE("%02x ", buffer[i]);
 	DEBUG_WIRE("\n");
 
-	if (buffer[0] != cmd) {
-		DEBUG_WARN("cmd %02x not implemented\n", cmd);
+	if (buffer[0] != data[0]) {
+		DEBUG_WARN("command %02x not implemented\n", data[0]);
 		buffer[1] = 0xff /*DAP_ERROR*/;
 	}
+
 	if (response_length)
-		memcpy(data, &buffer[1], (response_length < res) ? response_length : res);
+		memcpy(data, buffer + 1, MIN(response_length, result));
 	return res;
 }
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -404,11 +404,12 @@ static ssize_t dap_run_cmd_raw(const uint8_t *const request_data, const size_t r
 	return response;
 }
 
-bool dap_run_cmd(const uint8_t *const request_data, const size_t request_length, uint8_t *const response_data,
+bool dap_run_cmd(const void *const request_data, const size_t request_length, void *const response_data,
 	const size_t response_length)
 {
 	/* This substracts one off the result to account for the command byte that gets stripped above */
-	const ssize_t result = dap_run_cmd_raw(request_data, request_length, response_data, response_length) - 1U;
+	const ssize_t result =
+		dap_run_cmd_raw((const uint8_t *)request_data, request_length, (uint8_t *)response_data, response_length) - 1U;
 	return (size_t)result == response_length;
 }
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -92,8 +92,8 @@ static libusb_device_handle *usb_handle = NULL;
 static uint8_t in_ep;
 static uint8_t out_ep;
 static hid_device *handle = NULL;
-static uint8_t buffer[1024U + 1U];
-static int report_size = 64 + 1; // TODO: read actual report size
+static uint8_t buffer[1024U];
+static size_t report_size = 64U + 1U; // TODO: read actual report size
 static bool has_swd_sequence = false;
 
 static size_t mbslen(const char *str)

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -255,9 +255,11 @@ static void dap_dp_abort(adiv5_debug_port_s *dp, uint32_t abort)
 	dap_write_reg(dp, ADIV5_DP_ABORT, abort);
 }
 
-static uint32_t dap_dp_error(adiv5_debug_port_s *dp)
+/* JTAG DP error recovery function */
+static uint32_t dap_dp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
-	/* Not used for SWD debugging, so no TARGETID switch needed!*/
+	(void)protocol_recovery;
+	/* XXX: This seems entirely wrong considering adiv5_jtagdp.c adiv5_jtagdp_error */
 	uint32_t ctrlstat = dap_read_reg(dp, ADIV5_DP_CTRLSTAT);
 	uint32_t err = ctrlstat &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -372,27 +372,29 @@ ssize_t dbg_dap_cmd_bulk(uint8_t *const data, const size_t request_length)
 	return transferred;
 }
 
-int dbg_dap_cmd(uint8_t *data, int response_length, const size_t request_length)
+ssize_t dbg_dap_cmd(uint8_t *data, int response_length, const size_t request_length)
 {
 	char cmd = data[0];
-	int res = -1;
 
 	DEBUG_WIRE(" command: ");
 	for (size_t i = 0; i < request_length; ++i)
 		DEBUG_WIRE("%02x ", data[i]);
 	DEBUG_WIRE("\n");
 
+	ssize_t res = -1;
 	if (type == CMSIS_TYPE_HID)
 		res = dbg_dap_cmd_hid(data, request_length);
 	else if (type == CMSIS_TYPE_BULK)
 		res = dbg_dap_cmd_bulk(data, request_length);
 	if (res < 0)
 		return res;
+	const size_t result = (size_t)res;
 
-	DEBUG_WIRE("cmd res:");
-	for (int i = 0; i < res; i++)
-		DEBUG_WIRE("%02x.", buffer[i]);
+	DEBUG_WIRE("response: ");
+	for (size_t i = 0; i < result; i++)
+		DEBUG_WIRE("%02x ", buffer[i]);
 	DEBUG_WIRE("\n");
+
 	if (buffer[0] != cmd) {
 		DEBUG_WARN("cmd %02x not implemented\n", cmd);
 		buffer[1] = 0xff /*DAP_ERROR*/;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -356,7 +356,7 @@ ssize_t dbg_dap_cmd_bulk(uint8_t *const data, const size_t request_length)
 	const int result =
 		libusb_bulk_transfer(usb_handle, out_ep, data, request_length, &transferred, TRANSFER_TIMEOUT_MS);
 	if (result < 0) {
-		DEBUG_WARN("CMSIS-DAP write error: %d\n", result);
+		DEBUG_WARN("CMSIS-DAP write error: %s (%d)\n", libusb_strerror(result), result);
 		return result;
 	}
 
@@ -365,7 +365,7 @@ ssize_t dbg_dap_cmd_bulk(uint8_t *const data, const size_t request_length)
 		const int result =
 			libusb_bulk_transfer(usb_handle, in_ep, buffer, report_size, &transferred, TRANSFER_TIMEOUT_MS);
 		if (result < 0) {
-			DEBUG_WARN("CMSIS-DAP read error: %d\n", result);
+			DEBUG_WARN("CMSIS-DAP read error: %s (%d)\n", libusb_strerror(result), result);
 			return result;
 		}
 	} while (buffer[0] != data[0]);

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -257,7 +257,7 @@ static void dap_dp_abort(adiv5_debug_port_s *dp, uint32_t abort)
 }
 
 /* JTAG DP error recovery function */
-static uint32_t dap_dp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
+static uint32_t dap_jtag_dp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
 	(void)protocol_recovery;
 	/* XXX: This seems entirely wrong considering adiv5_jtagdp.c adiv5_jtagdp_error */
@@ -523,7 +523,7 @@ static void dap_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const vo
 
 void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
-	if ((mode == DAP_CAP_JTAG) && dap_jtag_configure())
+	if (mode == DAP_CAP_JTAG && dap_jtag_configure())
 		return;
 	dp->ap_read = dap_ap_read;
 	dp->ap_write = dap_ap_write;
@@ -588,7 +588,7 @@ int cmsis_dap_jtagtap_init(jtag_proc_s *jtag_proc)
 int dap_jtag_dp_init(adiv5_debug_port_s *dp)
 {
 	dp->dp_read = dap_dp_read_reg;
-	dp->error = dap_dp_error;
+	dp->error = dap_jtag_dp_error;
 	dp->low_access = dap_dp_low_access;
 	dp->abort = dap_dp_abort;
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -314,11 +314,6 @@ void dap_exit_function(void)
 	}
 }
 
-int dbg_get_report_size(void)
-{
-	return report_size;
-}
-
 ssize_t dbg_dap_cmd_hid(const uint8_t *const request_data, const size_t request_length, uint8_t *const response_data,
 	const size_t response_length)
 {

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -318,8 +318,7 @@ int dbg_get_report_size(void)
 	return report_size;
 }
 
-int dbg_dap_cmd(uint8_t *data, int size, int rsize)
-
+int dbg_dap_cmd(uint8_t *data, int response_length, int request_length)
 {
 	char cmd = data[0];
 	int res = -1;
@@ -327,10 +326,10 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 	memset(buffer, 0xff, report_size + 1);
 
 	buffer[0] = 0x00; // Report ID??
-	memcpy(&buffer[1], data, rsize);
+	memcpy(&buffer[1], data, request_length);
 
 	DEBUG_WIRE("cmd :   ");
-	for (int i = (type == CMSIS_TYPE_HID) ? 0 : 1; (i < rsize + 1); i++)
+	for (int i = (type == CMSIS_TYPE_HID) ? 0 : 1; (i < request_length + 1); i++)
 		DEBUG_WIRE("%02x.", buffer[i]);
 	DEBUG_WIRE("\n");
 	if (type == CMSIS_TYPE_HID) {
@@ -352,7 +351,7 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 	} else if (type == CMSIS_TYPE_BULK) {
 		int transferred = 0;
 
-		res = libusb_bulk_transfer(usb_handle, out_ep, data, rsize, &transferred, TRANSFER_TIMEOUT_MS);
+		res = libusb_bulk_transfer(usb_handle, out_ep, data, request_length, &transferred, TRANSFER_TIMEOUT_MS);
 		if (res < 0) {
 			DEBUG_WARN("OUT error: %d\n", res);
 			return res;
@@ -376,8 +375,8 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 		DEBUG_WARN("cmd %02x not implemented\n", cmd);
 		buffer[1] = 0xff /*DAP_ERROR*/;
 	}
-	if (size)
-		memcpy(data, &buffer[1], (size < res) ? size : res);
+	if (response_length)
+		memcpy(data, &buffer[1], (response_length < res) ? response_length : res);
 	return res;
 }
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -404,6 +404,14 @@ static ssize_t dap_run_cmd_raw(const uint8_t *const request_data, const size_t r
 	return response;
 }
 
+bool dap_run_cmd(const uint8_t *const request_data, const size_t request_length, uint8_t *const response_data,
+	const size_t response_length)
+{
+	/* This substracts one off the result to account for the command byte that gets stripped above */
+	const ssize_t result = dap_run_cmd_raw(request_data, request_length, response_data, response_length) - 1U;
+	return (size_t)result == response_length;
+}
+
 ssize_t dbg_dap_cmd(uint8_t *const data, const size_t response_length, const size_t request_length)
 {
 	return dap_run_cmd_raw(data, request_length, data, response_length);

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -282,7 +282,7 @@ void dap_trst_reset(void)
 	dbg_dap_cmd(buf, sizeof(buf), 7);
 }
 
-static void dap_line_reset(void)
+void dap_line_reset(void)
 {
 	const uint8_t data[8] = {
 		0xffU,

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -34,6 +34,7 @@
 #include <general.h>
 #include "exception.h"
 #include "dap.h"
+#include "dap_command.h"
 #include "jtag_scan.h"
 
 /*- Definitions -------------------------------------------------------------*/
@@ -721,34 +722,26 @@ int dap_jtag_configure(void)
 
 void dap_swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles)
 {
-	uint8_t buf[6] = {
-		ID_DAP_SWJ_SEQUENCE,
-		clock_cycles,
+	uint8_t data[4] = {
 		(tms_states >> 0U) & 0xffU,
 		(tms_states >> 8U) & 0xffU,
 		(tms_states >> 16U) & 0xffU,
 		(tms_states >> 24U) & 0xffU,
 	};
-	const size_t sequence_bytes = (clock_cycles + 7U) >> 3U;
-	dbg_dap_cmd(buf, 1U, 2U + sequence_bytes);
-	if (buf[0])
+	if (!perform_dap_swj_sequence(clock_cycles, data))
 		DEBUG_WARN("dap_swdptap_seq_out error\n");
 }
 
 void dap_swdptap_seq_out_parity(const uint32_t tms_states, const size_t clock_cycles)
 {
-	uint8_t buf[7] = {
-		ID_DAP_SWJ_SEQUENCE,
-		clock_cycles + 1U,
+	uint8_t data[5] = {
 		(tms_states >> 0U) & 0xffU,
 		(tms_states >> 8U) & 0xffU,
 		(tms_states >> 16U) & 0xffU,
 		(tms_states >> 24U) & 0xffU,
 		__builtin_parity(tms_states),
 	};
-	const size_t sequence_bytes = (clock_cycles + 8U) >> 3U;
-	dbg_dap_cmd(buf, 1, 2U + sequence_bytes);
-	if (buf[0])
+	if (!perform_dap_swj_sequence(clock_cycles + 1U, data))
 		DEBUG_WARN("dap_swdptap_seq_out_parity error\n");
 }
 

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -735,22 +735,21 @@ void dap_swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles)
 		DEBUG_WARN("dap_swdptap_seq_out error\n");
 }
 
-void dap_swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
+void dap_swdptap_seq_out_parity(const uint32_t tms_states, const size_t clock_cycles)
 {
-	/* clang-format off */
-	uint8_t buf[] = {
+	uint8_t buf[7] = {
 		ID_DAP_SWJ_SEQUENCE,
 		clock_cycles + 1U,
 		(tms_states >> 0U) & 0xffU,
 		(tms_states >> 8U) & 0xffU,
 		(tms_states >> 16U) & 0xffU,
 		(tms_states >> 24U) & 0xffU,
-		__builtin_parity(tms_states)
+		__builtin_parity(tms_states),
 	};
-	/* clang-format on */
-	dbg_dap_cmd(buf, 1, sizeof(buf));
+	const size_t sequence_bytes = (clock_cycles + 8U) >> 3U;
+	dbg_dap_cmd(buf, 1, 2U + sequence_bytes);
 	if (buf[0])
-		DEBUG_WARN("dap_swdptap_seq_out error\n");
+		DEBUG_WARN("dap_swdptap_seq_out_parity error\n");
 }
 
 #define SWD_SEQUENCE_IN 0x80U

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -282,9 +282,17 @@ void dap_trst_reset(void)
 
 static void dap_line_reset(void)
 {
-	uint8_t buf[] = {ID_DAP_SWJ_SEQUENCE, 64, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0};
-	dbg_dap_cmd(buf, sizeof(buf), 10);
-	if (buf[0])
+	const uint8_t data[8] = {
+		0xffU,
+		0xffU,
+		0xffU,
+		0xffU,
+		0xffU,
+		0xffU,
+		0xffU,
+		0x0fU,
+	};
+	if (!perform_dap_swj_sequence(64, data))
 		DEBUG_WARN("line reset failed\n");
 }
 

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -298,13 +298,13 @@ void dap_line_reset(void)
 		DEBUG_WARN("line reset failed\n");
 }
 
-static uint32_t wait_word(uint8_t *buf, int size, int len, uint8_t *dp_fault)
+static uint32_t wait_word(uint8_t *buf, size_t response_length, size_t request_length, uint8_t *dp_fault)
 {
-	uint8_t cmd_copy[len];
-	memcpy(cmd_copy, buf, len);
+	uint8_t cmd_copy[request_length];
+	memcpy(cmd_copy, buf, request_length);
 	do {
-		memcpy(buf, cmd_copy, len);
-		dbg_dap_cmd(buf, size, len);
+		memcpy(buf, cmd_copy, request_length);
+		dbg_dap_cmd(buf, response_length, request_length);
 		if (buf[1] < DAP_TRANSFER_WAIT)
 			break;
 	} while (buf[1] == DAP_TRANSFER_WAIT);

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -719,19 +719,18 @@ int dap_jtag_configure(void)
 	return 0;
 }
 
-void dap_swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
+void dap_swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles)
 {
-	/* clang-format off */
-	uint8_t buf[64] = {
+	uint8_t buf[6] = {
 		ID_DAP_SWJ_SEQUENCE,
 		clock_cycles,
 		(tms_states >> 0U) & 0xffU,
 		(tms_states >> 8U) & 0xffU,
 		(tms_states >> 16U) & 0xffU,
-		(tms_states >> 24U) & 0xffU
+		(tms_states >> 24U) & 0xffU,
 	};
-	/* clang-format on */
-	dbg_dap_cmd(buf, 64, 2U + ((clock_cycles + 7U) >> 3U));
+	const size_t sequence_bytes = (clock_cycles + 7U) >> 3U;
+	dbg_dap_cmd(buf, 1U, 2U + sequence_bytes);
 	if (buf[0])
 		DEBUG_WARN("dap_swdptap_seq_out error\n");
 }

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -383,7 +383,7 @@ bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t le
 		memcpy(dest, data, len);
 	else {
 		for (size_t i = 0; i < blocks; ++i) {
-			dest = extract(dest, src, data[i], align);
+			dest = adiv5_unpack_data(dest, src, data[i], align);
 			src += (1U << align);
 		}
 	}
@@ -590,7 +590,7 @@ void dap_read_single(adiv5_access_port_s *ap, void *dest, uint32_t src, align_e 
 		return;
 	}
 	/* Pull out the data. AP_DRW access implies an RDBUFF in CMSIS-DAP, so this is safe */
-	extract(dest, src, result, align);
+	adiv5_unpack_data(dest, src, result, align);
 }
 
 void dap_write_single(adiv5_access_port_s *ap, uint32_t dest, const void *src, align_e align)

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -30,8 +30,8 @@
  * Copyright (c) 2020-21 Uwe Bonnes bon@elektron.ikp.physik.tu-darmstadt.de
  */
 
-/*- Includes ----------------------------------------------------------------*/
-#include <general.h>
+#include <string.h>
+#include "general.h"
 #include "exception.h"
 #include "dap.h"
 #include "dap_command.h"

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -81,6 +81,7 @@ void dap_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 void dap_read_single(adiv5_access_port_s *ap, void *dest, uint32_t src, align_e align);
 void dap_write_single(adiv5_access_port_s *ap, uint32_t dest, const void *src, align_e align);
 ssize_t dbg_dap_cmd(uint8_t *data, size_t response_length, size_t request_length);
+bool dap_run_cmd(const uint8_t *request_data, size_t request_length, uint8_t *response_data, size_t response_length);
 void dap_jtagtap_tdi_tdo_seq(
 	uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -81,7 +81,7 @@ void dap_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 void dap_read_single(adiv5_access_port_s *ap, void *dest, uint32_t src, align_e align);
 void dap_write_single(adiv5_access_port_s *ap, uint32_t dest, const void *src, align_e align);
 ssize_t dbg_dap_cmd(uint8_t *data, size_t response_length, size_t request_length);
-bool dap_run_cmd(const uint8_t *request_data, size_t request_length, uint8_t *response_data, size_t response_length);
+bool dap_run_cmd(const void *request_data, size_t request_length, void *response_data, size_t response_length);
 void dap_jtagtap_tdi_tdo_seq(
 	uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -73,7 +73,7 @@ uint32_t dap_read_reg(adiv5_debug_port_s *dp, uint8_t reg);
 void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data);
 void dap_reset_link(bool jtag);
 uint32_t dap_read_idcode(adiv5_debug_port_s *dp);
-unsigned int dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align);
+bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align);
 unsigned int dap_write_block(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
 void dap_ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align);
 uint32_t dap_ap_read(adiv5_access_port_s *ap, uint16_t addr);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -80,7 +80,7 @@ uint32_t dap_ap_read(adiv5_access_port_s *ap, uint16_t addr);
 void dap_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 void dap_read_single(adiv5_access_port_s *ap, void *dest, uint32_t src, align_e align);
 void dap_write_single(adiv5_access_port_s *ap, uint32_t dest, const void *src, align_e align);
-int dbg_dap_cmd(uint8_t *data, int size, int rsize);
+int dbg_dap_cmd(uint8_t *data, int response_length, size_t request_length);
 void dap_jtagtap_tdi_tdo_seq(
 	uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -80,7 +80,7 @@ uint32_t dap_ap_read(adiv5_access_port_s *ap, uint16_t addr);
 void dap_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 void dap_read_single(adiv5_access_port_s *ap, void *dest, uint32_t src, align_e align);
 void dap_write_single(adiv5_access_port_s *ap, uint32_t dest, const void *src, align_e align);
-ssize_t dbg_dap_cmd(uint8_t *data, int response_length, size_t request_length);
+ssize_t dbg_dap_cmd(uint8_t *data, size_t response_length, size_t request_length);
 void dap_jtagtap_tdi_tdo_seq(
 	uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -69,6 +69,7 @@ void dap_nrst_set_val(bool assert);
 void dap_trst_reset(void);
 void dap_reset_target_hw(int state);
 void dap_reset_pin(int state);
+void dap_line_reset(void);
 uint32_t dap_read_reg(adiv5_debug_port_s *dp, uint8_t reg);
 void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data);
 void dap_reset_link(bool jtag);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -86,7 +86,7 @@ void dap_jtagtap_tdi_tdo_seq(
 int dap_jtag_configure(void);
 
 uint32_t dap_swdptap_seq_in(size_t clock_cycles);
-bool dap_swdptap_seq_in_parity(uint32_t *ret, size_t clock_cycles);
+bool dap_swdptap_seq_in_parity(uint32_t *result, size_t clock_cycles);
 void dap_swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 void dap_swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -74,7 +74,7 @@ void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data);
 void dap_reset_link(bool jtag);
 uint32_t dap_read_idcode(adiv5_debug_port_s *dp);
 bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align);
-unsigned int dap_write_block(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
+bool dap_write_block(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
 void dap_ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align);
 uint32_t dap_ap_read(adiv5_access_port_s *ap, uint16_t addr);
 void dap_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -80,7 +80,7 @@ uint32_t dap_ap_read(adiv5_access_port_s *ap, uint16_t addr);
 void dap_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 void dap_read_single(adiv5_access_port_s *ap, void *dest, uint32_t src, align_e align);
 void dap_write_single(adiv5_access_port_s *ap, uint32_t dest, const void *src, align_e align);
-int dbg_dap_cmd(uint8_t *data, int response_length, size_t request_length);
+ssize_t dbg_dap_cmd(uint8_t *data, int response_length, size_t request_length);
 void dap_jtagtap_tdi_tdo_seq(
 	uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -84,6 +84,9 @@ ssize_t dbg_dap_cmd(uint8_t *data, size_t response_length, size_t request_length
 void dap_jtagtap_tdi_tdo_seq(
 	uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
 int dap_jtag_configure(void);
+
+uint32_t dap_swdptap_seq_in(size_t clock_cycles);
+bool dap_swdptap_seq_in_parity(uint32_t *ret, size_t clock_cycles);
 void dap_swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 void dap_swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 

--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -142,6 +142,19 @@ bool perform_dap_transfer(adiv5_debug_port_s *const dp, const dap_transfer_reque
 	return false;
 }
 
+bool perform_dap_transfer_recoverable(adiv5_debug_port_s *const dp,
+	const dap_transfer_request_s *const transfer_requests, const size_t requests, uint32_t *const response_data,
+	const size_t responses)
+{
+	const bool result = perform_dap_transfer(dp, transfer_requests, requests, response_data, responses);
+	/* If all went well, or we can't recover, we get to early return */
+	if (result || dp->fault != DAP_TRANSFER_NO_RESPONSE)
+		return result;
+	/* Otherwise clear the error and try again as our best and final answer */
+	dp->error(dp, true);
+	return perform_dap_transfer(dp, transfer_requests, requests, response_data, responses);
+}
+
 bool perform_dap_transfer_block_read(
 	adiv5_debug_port_s *const dp, const uint8_t reg, const uint16_t block_count, uint32_t *const blocks)
 {

--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include "dap.h"
+#include "dap_command.h"
+
+bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data)
+{
+	/* Validate that clock_cycles is in range for the request (spec limits it to 256) */
+	if (clock_cycles > 256)
+		return false;
+
+	DEBUG_PROBE("-> dap_swj_sequence (%zu cycles)\n", clock_cycles);
+	/* Construct the request buffer */
+	uint8_t request[34] = {
+		DAP_SWJ_SEQUENCE,
+		(uint8_t)clock_cycles,
+	};
+	/* Calculate the number of bytes needed to represent the requeted number of clock cycles */
+	const size_t bytes = (clock_cycles + 7U) >> 3U;
+	/* And copy the data into the buffer */
+	memcpy(request + 2, data, bytes);
+
+	/* Sequence response is a single byte */
+	uint8_t response = DAP_RESPONSE_OK;
+	/* Run the request */
+	if (!dap_run_cmd(request, 2U + bytes, &response, 1U))
+		return false;
+	/* And check that it succeeded */
+	return response == DAP_RESPONSE_OK;
+}

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -41,6 +41,7 @@
 
 typedef enum dap_command {
 	DAP_TRANSFER = 0x05U,
+	DAP_TRANSFER_BLOCK = 0x06U,
 	DAP_SWJ_SEQUENCE = 0x12U,
 } dap_command_e;
 
@@ -67,8 +68,15 @@ typedef struct dap_transfer_response {
 	uint8_t data[12][4];
 } dap_transfer_response_s;
 
+typedef struct dap_transfer_block_response {
+	uint8_t count[2];
+	uint8_t status;
+	uint8_t data[256][4];
+} dap_transfer_block_response_s;
+
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
 bool perform_dap_transfer(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t requests,
 	uint32_t *response_data, size_t responses);
+bool perform_dap_transfer_block_read(adiv5_debug_port_s *dp, uint8_t reg, uint16_t block_count, uint32_t *blocks);
 
 #endif /*PLATFORMS_HOSTED_DAP_COMMAND_H*/

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -97,6 +97,8 @@ typedef struct dap_transfer_block_response_write {
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
 bool perform_dap_transfer(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t requests,
 	uint32_t *response_data, size_t responses);
+bool perform_dap_transfer_recoverable(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests,
+	size_t requests, uint32_t *response_data, size_t responses);
 bool perform_dap_transfer_block_read(adiv5_debug_port_s *dp, uint8_t reg, uint16_t block_count, uint32_t *blocks);
 bool perform_dap_transfer_block_write(
 	adiv5_debug_port_s *dp, uint8_t reg, uint16_t block_count, const uint32_t *blocks);

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -37,9 +37,10 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include "adiv5.h"
 
-typedef enum dap_command
-{
+typedef enum dap_command {
+	DAP_TRANSFER = 0x05U,
 	DAP_SWJ_SEQUENCE = 0x12U,
 } dap_command_e;
 
@@ -48,11 +49,24 @@ typedef enum dap_response_status {
 	DAP_RESPOSE_ERROR = 0xffU,
 } dap_response_status_e;
 
+typedef enum dap_transfer_status {
+	DAP_TRANSFER_OK = 0x01U,
+	DAP_TRANSFER_WAIT = 0x02U,
+	DAP_TRANSFER_FAULT = 0x04U,
+	DAP_TRANSFER_NO_RESPONSE = 0x07U,
+} dap_transfer_status_e;
+
 typedef struct dap_transfer_request {
 	uint8_t request;
 	uint32_t data;
 } dap_transfer_request_s;
 
+typedef struct dap_transfer_response {
+	uint8_t processed;
+	uint8_t status;
+} dap_transfer_response_s;
+
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
+bool perform_dap_transfer(const adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t count);
 
 #endif /*PLATFORMS_HOSTED_DAP_COMMAND_H*/

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -64,9 +64,11 @@ typedef struct dap_transfer_request {
 typedef struct dap_transfer_response {
 	uint8_t processed;
 	uint8_t status;
+	uint8_t data[12][4];
 } dap_transfer_response_s;
 
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
-bool perform_dap_transfer(const adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t count);
+bool perform_dap_transfer(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t requests,
+	uint32_t *response_data, size_t responses);
 
 #endif /*PLATFORMS_HOSTED_DAP_COMMAND_H*/

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -48,6 +48,11 @@ typedef enum dap_response_status {
 	DAP_RESPOSE_ERROR = 0xffU,
 } dap_response_status_e;
 
+typedef struct dap_transfer_request {
+	uint8_t request;
+	uint32_t data;
+} dap_transfer_request_s;
+
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
 
 #endif /*PLATFORMS_HOSTED_DAP_COMMAND_H*/

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORMS_HOSTED_DAP_COMMAND_H
+#define PLATFORMS_HOSTED_DAP_COMMAND_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef enum dap_command
+{
+	DAP_SWJ_SEQUENCE = 0x12U,
+} dap_command_e;
+
+typedef enum dap_response_status {
+	DAP_RESPONSE_OK = 0x00U,
+	DAP_RESPOSE_ERROR = 0xffU,
+} dap_response_status_e;
+
+bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
+
+#endif /*PLATFORMS_HOSTED_DAP_COMMAND_H*/

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -68,11 +68,18 @@ typedef struct dap_transfer_response {
 	uint8_t data[12][4];
 } dap_transfer_response_s;
 
-typedef struct dap_transfer_block_response {
+typedef struct dap_transfer_block_request_read {
+	uint8_t command;
+	uint8_t index;
+	uint8_t block_count[2];
+	uint8_t request;
+} dap_transfer_block_request_read_s;
+
+typedef struct dap_transfer_block_response_read {
 	uint8_t count[2];
 	uint8_t status;
 	uint8_t data[256][4];
-} dap_transfer_block_response_s;
+} dap_transfer_block_response_read_s;
 
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
 bool perform_dap_transfer(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t requests,

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -75,15 +75,30 @@ typedef struct dap_transfer_block_request_read {
 	uint8_t request;
 } dap_transfer_block_request_read_s;
 
+typedef struct dap_transfer_block_request_write {
+	uint8_t command;
+	uint8_t index;
+	uint8_t block_count[2];
+	uint8_t request;
+	uint8_t data[256][4];
+} dap_transfer_block_request_write_s;
+
 typedef struct dap_transfer_block_response_read {
 	uint8_t count[2];
 	uint8_t status;
 	uint8_t data[256][4];
 } dap_transfer_block_response_read_s;
 
+typedef struct dap_transfer_block_response_write {
+	uint8_t count[2];
+	uint8_t status;
+} dap_transfer_block_response_write_s;
+
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
 bool perform_dap_transfer(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t requests,
 	uint32_t *response_data, size_t responses);
 bool perform_dap_transfer_block_read(adiv5_debug_port_s *dp, uint8_t reg, uint16_t block_count, uint32_t *blocks);
+bool perform_dap_transfer_block_write(
+	adiv5_debug_port_s *dp, uint8_t reg, uint16_t block_count, const uint32_t *blocks);
 
 #endif /*PLATFORMS_HOSTED_DAP_COMMAND_H*/

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -32,7 +32,7 @@
 #include "cli.h"
 
 static uint32_t jlink_adiv5_swdp_read(adiv5_debug_port_s *dp, uint16_t addr);
-static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *dp);
+static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 static uint32_t jlink_adiv5_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
 static void jlink_adiv5_swdp_abort(adiv5_debug_port_s *dp, uint32_t abort);
 
@@ -126,7 +126,7 @@ uint32_t jlink_swdp_scan(bmp_info_s *const info)
 	dp->low_access = jlink_adiv5_swdp_low_access;
 	dp->abort = jlink_adiv5_swdp_abort;
 
-	jlink_adiv5_swdp_error(dp);
+	adiv5_dp_error(dp);
 	adiv5_dp_init(dp, 0);
 	return target_list ? 1U : 0U;
 }
@@ -140,8 +140,9 @@ static uint32_t jlink_adiv5_swdp_read(adiv5_debug_port_s *const dp, const uint16
 	return jlink_adiv5_swdp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 }
 
-static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *const dp)
+static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *const dp, const bool protocol_recovery)
 {
+	(void)protocol_recovery;
 	uint32_t err = jlink_adiv5_swdp_read(dp, ADIV5_DP_CTRLSTAT);
 	err &= (ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 		ADIV5_DP_CTRLSTAT_WDATAERR);

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -211,7 +211,11 @@ static uint32_t jlink_adiv5_swdp_read_nocheck(const uint16_t addr)
 
 static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *const dp, const bool protocol_recovery)
 {
-	(void)protocol_recovery;
+	if (dp->version >= 2 || protocol_recovery) {
+		line_reset(&info);
+		jlink_adiv5_swdp_read_nocheck(ADIV5_DP_DPIDR);
+		dp->dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+	}
 	uint32_t err = jlink_adiv5_swdp_read_nocheck(ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 			ADIV5_DP_CTRLSTAT_WDATAERR);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -605,7 +605,7 @@ uint32_t adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 
 uint32_t adiv5_dp_error(adiv5_debug_port_s *dp)
 {
-	uint32_t ret = dp->error(dp);
+	uint32_t ret = dp->error(dp, false);
 	DEBUG_TARGET("DP Error 0x%08" PRIx32 "\n", ret);
 	return ret;
 }

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -703,9 +703,12 @@ static uint32_t stlink_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 	return stlink_dp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 }
 
-uint32_t stlink_dp_error(adiv5_debug_port_s *dp)
+uint32_t stlink_dp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
-	uint32_t err = stlink_dp_read(dp, ADIV5_DP_CTRLSTAT) &
+	/* XXX: This should perform a line reset for protocol recovery.. */
+	(void)protocol_recovery;
+
+	uint32_t err = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 			ADIV5_DP_CTRLSTAT_WDATAERR);
 
@@ -1108,7 +1111,7 @@ uint32_t stlink_swdp_scan(bmp_info_s *info)
 	dp->low_access = stlink_dp_low_access;
 	dp->abort = stlink_dp_abort;
 
-	stlink_dp_error(dp);
+	adiv5_dp_error(dp);
 
 	adiv5_dp_init(dp, 0);
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -694,15 +694,6 @@ static size_t stlink_read_idcodes(bmp_info_s *info, uint32_t *idcodes)
 
 uint32_t stlink_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
 
-static uint32_t stlink_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
-{
-	if (addr & ADIV5_APnDP) {
-		stlink_dp_low_access(dp, ADIV5_LOW_READ, addr, 0);
-		return stlink_dp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
-	}
-	return stlink_dp_low_access(dp, ADIV5_LOW_READ, addr, 0);
-}
-
 uint32_t stlink_dp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
 	/* XXX: This should perform a line reset for protocol recovery.. */
@@ -1061,7 +1052,7 @@ uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens)
 
 int stlink_jtag_dp_init(adiv5_debug_port_s *dp)
 {
-	dp->dp_read = stlink_dp_read;
+	dp->dp_read = firmware_swdp_read;
 	dp->error = stlink_dp_error;
 	dp->low_access = stlink_dp_low_access;
 	dp->abort = stlink_dp_abort;
@@ -1106,7 +1097,7 @@ uint32_t stlink_swdp_scan(bmp_info_s *info)
 		return 0;
 	}
 
-	dp->dp_read = stlink_dp_read;
+	dp->dp_read = firmware_swdp_read;
 	dp->error = stlink_dp_error;
 	dp->low_access = stlink_dp_low_access;
 	dp->abort = stlink_dp_abort;

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -1026,14 +1026,16 @@ void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void
 
 void firmware_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 {
-	adiv5_dp_write(ap->dp, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | (addr & 0xf0U));
+	adiv5_dp_recoverable_access(
+		ap->dp, ADIV5_LOW_WRITE, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | (addr & 0xf0U));
 	adiv5_dp_write(ap->dp, addr, value);
 }
 
 uint32_t firmware_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 {
 	uint32_t ret;
-	adiv5_dp_write(ap->dp, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | (addr & 0xf0U));
+	adiv5_dp_recoverable_access(
+		ap->dp, ADIV5_LOW_WRITE, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | (addr & 0xf0U));
 	ret = adiv5_dp_read(ap->dp, addr);
 	return ret;
 }

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -944,7 +944,7 @@ static void ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e 
 }
 
 /* Unpack data from the source uint32_t value based on data alignment and source address */
-void *extract(void *dest, uint32_t src, uint32_t data, align_e align)
+void *adiv5_unpack_data(void *const dest, const uint32_t src, const uint32_t data, const align_e align)
 {
 	switch (align) {
 	case ALIGN_BYTE: {
@@ -993,7 +993,7 @@ void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t
 	adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_AP_DRW, 0);
 	while (--len) {
 		tmp = adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_AP_DRW, 0);
-		dest = extract(dest, src, tmp, align);
+		dest = adiv5_unpack_data(dest, src, tmp, align);
 
 		src += (1U << align);
 		/* Check for 10 bit address overflow */
@@ -1004,7 +1004,7 @@ void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t
 		}
 	}
 	tmp = adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
-	extract(dest, src, tmp, align);
+	adiv5_unpack_data(dest, src, tmp, align);
 }
 
 void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -172,9 +172,10 @@
 #define ADIV5_LOW_WRITE 0
 #define ADIV5_LOW_READ  1
 
-#define SWDP_ACK_OK    0x01U
-#define SWDP_ACK_WAIT  0x02U
-#define SWDP_ACK_FAULT 0x04U
+#define SWDP_ACK_OK          0x01U
+#define SWDP_ACK_WAIT        0x02U
+#define SWDP_ACK_FAULT       0x04U
+#define SWDP_ACK_NO_RESPONSE 0x07U
 
 /* JEP-106 code list
  * JEP-106 is a JEDEC standard assigning IDs to different manufacturers

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -399,7 +399,7 @@ int swdptap_init(adiv5_debug_port_s *dp);
 void adiv5_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len);
 uint64_t adiv5_ap_read_pidr(adiv5_access_port_s *ap, uint32_t addr);
 void *adiv5_unpack_data(void *dest, uint32_t src, uint32_t val, align_e align);
-void *extract(void *dest, uint32_t src, uint32_t val, align_e align);
+const void *adiv5_pack_data(uint32_t dest, const void *src, uint32_t *data, align_e align);
 
 void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
 void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -398,6 +398,7 @@ int swdptap_init(adiv5_debug_port_s *dp);
 
 void adiv5_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len);
 uint64_t adiv5_ap_read_pidr(adiv5_access_port_s *ap, uint32_t addr);
+void *adiv5_unpack_data(void *dest, uint32_t src, uint32_t val, align_e align);
 void *extract(void *dest, uint32_t src, uint32_t val, align_e align);
 
 void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -251,7 +251,7 @@ struct adiv5_debug_port {
 	/* dp_low_write returns true if no OK resonse, but ignores errors */
 	bool (*dp_low_write)(adiv5_debug_port_s *dp, uint16_t addr, const uint32_t data);
 	uint32_t (*dp_read)(adiv5_debug_port_s *dp, uint16_t addr);
-	uint32_t (*error)(adiv5_debug_port_s *dp);
+	uint32_t (*error)(adiv5_debug_port_s *dp, bool protocol_recovery);
 	uint32_t (*low_access)(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
 	void (*abort)(adiv5_debug_port_s *dp, uint32_t abort);
 
@@ -317,7 +317,7 @@ static inline uint32_t adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 
 static inline uint32_t adiv5_dp_error(adiv5_debug_port_s *dp)
 {
-	return dp->error(dp);
+	return dp->error(dp, false);
 }
 
 static inline uint32_t adiv5_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
@@ -393,7 +393,7 @@ uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_
 uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 
-uint32_t firmware_swdp_error(adiv5_debug_port_s *dp);
+uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 
 void firmware_swdp_abort(adiv5_debug_port_s *dp, uint32_t abort);
 void adiv5_jtagdp_abort(adiv5_debug_port_s *dp, uint32_t abort);

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -37,7 +37,7 @@
 #define IR_DPACC 0xaU
 #define IR_APACC 0xbU
 
-static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp);
+static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 
 void adiv5_jtag_dp_handler(uint8_t jd_index)
 {
@@ -65,9 +65,11 @@ uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 	return fw_adiv5_jtagdp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
 }
 
-static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp)
+static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
+	(void)protocol_recovery;
 	const uint32_t status = fw_adiv5_jtagdp_read(dp, ADIV5_DP_CTRLSTAT) & ADIV5_DP_CTRLSTAT_ERRMASK;
+	dp->fault = 0;
 	return fw_adiv5_jtagdp_low_access(dp, ADIV5_LOW_WRITE, ADIV5_DP_CTRLSTAT, status) & 0x32U;
 }
 

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -49,7 +49,7 @@ void adiv5_jtag_dp_handler(uint8_t jd_index)
 
 	dp->dp_jd_index = jd_index;
 
-	if ((PC_HOSTED == 0) || (!platform_jtag_dp_init(dp))) {
+	if (PC_HOSTED == 0 || !platform_jtag_dp_init(dp)) {
 		dp->dp_read = fw_adiv5_jtagdp_read;
 		dp->error = adiv5_jtagdp_error;
 		dp->low_access = fw_adiv5_jtagdp_low_access;

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -263,12 +263,15 @@ uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t 
 		return 0;
 	}
 
-	if (ack != SWDP_ACK_OK)
+	if (ack != SWDP_ACK_OK) {
+		DEBUG_WARN("SWD access has invalid ack %x\n", ack);
 		raise_exception(EXCEPTION_ERROR, "SWD invalid ACK");
+	}
 
 	if (RnW) {
 		if (dp->seq_in_parity(&response, 32)) { /* Give up on parity error */
 			dp->fault = 1;
+			DEBUG_WARN("SWD access resulted in parity error\n");
 			raise_exception(EXCEPTION_ERROR, "SWD parity error");
 		}
 	} else {

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -236,16 +236,15 @@ uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, const bool protocol_recover
 	return err;
 }
 
-uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
+uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, const uint8_t RnW, const uint16_t addr, const uint32_t value)
 {
-	uint8_t request = make_packet_request(RnW, addr);
-	uint32_t response = 0;
-	uint8_t ack = SWDP_ACK_WAIT;
-	platform_timeout_s timeout;
-
 	if ((addr & ADIV5_APnDP) && dp->fault)
 		return 0;
 
+	const uint8_t request = make_packet_request(RnW, addr);
+	uint32_t response = 0;
+	uint8_t ack = SWDP_ACK_WAIT;
+	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 250);
 	do {
 		dp->seq_out(request, 8);

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -230,7 +230,7 @@ uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t 
 {
 	uint8_t request = make_packet_request(RnW, addr);
 	uint32_t response = 0;
-	uint32_t ack = SWDP_ACK_WAIT;
+	uint8_t ack = SWDP_ACK_WAIT;
 	platform_timeout_s timeout;
 
 	if ((addr & ADIV5_APnDP) && dp->fault)
@@ -264,12 +264,12 @@ uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t 
 	}
 
 	if (ack != SWDP_ACK_OK)
-		raise_exception(EXCEPTION_ERROR, "SWDP invalid ACK");
+		raise_exception(EXCEPTION_ERROR, "SWD invalid ACK");
 
 	if (RnW) {
 		if (dp->seq_in_parity(&response, 32)) { /* Give up on parity error */
 			dp->fault = 1;
-			raise_exception(EXCEPTION_ERROR, "SWDP Parity error");
+			raise_exception(EXCEPTION_ERROR, "SWD parity error");
 		}
 	} else {
 		dp->seq_out_parity(value, 32);

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -113,7 +113,7 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 
 		dp_line_reset(initial_dp);
 
-		volatile uint32_t dp_dpidr;
+		volatile uint32_t dp_dpidr = 0;
 		TRY_CATCH (e, EXCEPTION_ALL) {
 			dp_dpidr = initial_dp->dp_read(initial_dp, ADIV5_DP_DPIDR);
 		}
@@ -191,8 +191,8 @@ uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 	if (addr & ADIV5_APnDP) {
 		adiv5_dp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 		return adiv5_dp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
-	} else
-		return firmware_swdp_low_access(dp, ADIV5_LOW_READ, addr, 0);
+	}
+	return firmware_swdp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 }
 
 uint32_t firmware_swdp_error(adiv5_debug_port_s *dp)
@@ -206,10 +206,10 @@ uint32_t firmware_swdp_error(adiv5_debug_port_s *dp)
 		dp->dp_read(dp, ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */
 	}
-	uint32_t err, clr = 0;
-	err = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT) &
+	const uint32_t err = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 			ADIV5_DP_CTRLSTAT_WDATAERR);
+	uint32_t clr = 0;
 
 	if (err & ADIV5_DP_CTRLSTAT_STICKYORUN)
 		clr |= ADIV5_DP_ABORT_ORUNERRCLR;

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -207,16 +207,17 @@ uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 
 uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
-	if (dp->version >= 2 && dp->dp_low_write) {
+	if ((dp->version >= 2 && dp->dp_low_write) || protocol_recovery) {
 		/* On protocol error target gets deselected.
 		 * With DP Change, another target needs selection.
 		 * => Reselect with right target! */
 		dp_line_reset(dp);
-		dp->dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
-		dp->dp_read(dp, ADIV5_DP_DPIDR);
+		firmware_dp_low_read(dp, ADIV5_DP_DPIDR);
+		if (dp->dp_low_write)
+			dp->dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
 		/* Exception here is unexpected, so do not catch */
 	}
-	const uint32_t err = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT) &
+	const uint32_t err = firmware_dp_low_read(dp, ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 			ADIV5_DP_CTRLSTAT_WDATAERR);
 	uint32_t clr = 0;
@@ -230,9 +231,8 @@ uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, const bool protocol_recover
 	if (err & ADIV5_DP_CTRLSTAT_WDATAERR)
 		clr |= ADIV5_DP_ABORT_WDERRCLR;
 
-	adiv5_dp_write(dp, ADIV5_DP_ABORT, clr);
+	firmware_dp_low_write(dp, ADIV5_DP_ABORT, clr);
 	dp->fault = 0;
-
 	return err;
 }
 

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -253,13 +253,19 @@ uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t 
 	if (ack == SWDP_ACK_WAIT) {
 		DEBUG_WARN("SWD access resulted in wait, aborting\n");
 		dp->abort(dp, ADIV5_DP_ABORT_DAPABORT);
-		dp->fault = 1;
+		dp->fault = ack;
 		return 0;
 	}
 
 	if (ack == SWDP_ACK_FAULT) {
 		DEBUG_WARN("SWD access resulted in fault\n");
-		dp->fault = 1;
+		dp->fault = ack;
+		return 0;
+	}
+
+	if (ack == SWDP_ACK_NO_RESPONSE) {
+		DEBUG_WARN("SWD access resulted in no response\n");
+		dp->fault = ack;
 		return 0;
 	}
 

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -195,7 +195,7 @@ uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 	return firmware_swdp_low_access(dp, ADIV5_LOW_READ, addr, 0);
 }
 
-uint32_t firmware_swdp_error(adiv5_debug_port_s *dp)
+uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
 	if (dp->version >= 2 && dp->dp_low_write) {
 		/* On protocol error target gets deselected.

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -199,10 +199,10 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 {
 	if (addr & ADIV5_APnDP) {
-		adiv5_dp_low_access(dp, ADIV5_LOW_READ, addr, 0);
+		adiv5_dp_recoverable_access(dp, ADIV5_LOW_READ, addr, 0);
 		return adiv5_dp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
 	}
-	return firmware_swdp_low_access(dp, ADIV5_LOW_READ, addr, 0);
+	return adiv5_dp_recoverable_access(dp, ADIV5_LOW_READ, addr, 0);
 }
 
 uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -58,13 +58,13 @@ static void dp_line_reset(adiv5_debug_port_s *dp)
 	dp->seq_out(0x0fffffffU, 32U);
 }
 
-bool firmware_dp_low_write(adiv5_debug_port_s *dp, uint16_t addr, const uint32_t data)
+bool firmware_dp_low_write(adiv5_debug_port_s *dp, const uint16_t addr, const uint32_t data)
 {
-	unsigned int request = make_packet_request(ADIV5_LOW_WRITE, addr & 0xfU);
+	const uint8_t request = make_packet_request(ADIV5_LOW_WRITE, addr & 0xfU);
 	dp->seq_out(request, 8);
-	int res = dp->seq_in(3);
+	const uint8_t res = dp->seq_in(3);
 	dp->seq_out_parity(data, 32);
-	return (res != 1);
+	return res != SWDP_ACK_OK;
 }
 
 /* Try first the dormant to SWD procedure.

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -67,6 +67,16 @@ bool firmware_dp_low_write(adiv5_debug_port_s *dp, const uint16_t addr, const ui
 	return res != SWDP_ACK_OK;
 }
 
+uint32_t firmware_dp_low_read(adiv5_debug_port_s *dp, const uint16_t addr)
+{
+	const uint8_t request = make_packet_request(ADIV5_LOW_READ, addr & 0xfU);
+	dp->seq_out(request, 8);
+	const uint8_t res = dp->seq_in(3);
+	uint32_t data = 0;
+	dp->seq_in_parity(&data, 32);
+	return res == SWDP_ACK_OK ? data : 0;
+}
+
 /* Try first the dormant to SWD procedure.
  * If target id given, scan DPs 0 .. 15 on that device and return.
  * Otherwise


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses the issue reported in https://github.com/blackmagic-debug/blackmagic/issues/1319 and on Discord where a user trying to attach to various Cortex-M cores via SWD would get an attach failure from the firmware, the remote protocol going non-responsive (BMDA connected to BMF), or have the debug server abort (BMDA via ST-Link, JLink, CMSIS-DAP). This would happen only if there was a delay between scan and attach.

The underlying issue causing this (something happening on the bus that causes the target to go into the protocol error state defined by ADIv5.2 §B1.2 subtitle "Protocol errors (SW-DP only)", and §B4.2.5) remains unchanged, however this PR gives BMP proper handling for the no-response answer used to indicate this state and a proper error recovery mechanism which means the target ends up happily back in a usable state and we continue on successfully as before.

A follow-up PR for v1.10 will be needed to address this underlying issue.

Tested on native hardware against STM32F4, Tiva-C and other targets. Tested via BMDA using the BMP remote protocol, ST-Link and CMSIS-DAP.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1319 
