### PR TITLE
Fix memory leaking of t->tdesc

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -122,6 +122,8 @@ void target_list_free(void)
 {
 	while (target_list) {
 		target_s *t = target_list->next;
+		if (target_list->attached)
+			target_detach(target_list);
 		if (target_list->tc && target_list->tc->destroy_callback)
 			target_list->tc->destroy_callback(target_list->tc, target_list);
 		if (target_list->priv)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Fixing issue when **target_detach** not called in **target_list_free**

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

#1327  