### PR TITLE
Fix: target register description allocation induced memory exhaustion

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -206,8 +206,10 @@ int gdb_main_loop(target_controller_s *tc, bool in_syscall)
 			single_step = false;
 			/* fall through */
 		case '?': { /* '?': Request reason for target halt */
-			/* This packet isn't documented as being mandatory,
-			 * but GDB doesn't work without it. */
+			/*
+			 * This packet isn't documented as being mandatory,
+			 * but GDB doesn't work without it.
+			 */
 
 			if (!cur_target) {
 				/* Report "target exited" if no target */

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -44,6 +44,7 @@
 #else
 #include <alloca.h>
 #endif
+#include <stdlib.h>
 
 typedef enum gdb_signal {
 	GDB_SIGINT = 2,
@@ -454,15 +455,17 @@ static void exec_q_feature_read(const char *packet, const size_t length)
 {
 	(void)length;
 	/* Read target description */
-	if ((!cur_target) && last_target) {
+	if (!cur_target && last_target)
 		/* Attach to last target if detached. */
 		cur_target = target_attach(last_target, &gdb_controller);
-	}
+
 	if (!cur_target) {
 		gdb_putpacketz("E01");
 		return;
 	}
-	handle_q_string_reply(target_tdesc(cur_target), packet);
+	const char *const description = target_regs_description(cur_target);
+	handle_q_string_reply(description ? description : "", packet);
+	free((void *)description);
 }
 
 static void exec_q_crc(const char *packet, const size_t length)

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -400,8 +400,11 @@ static void exec_q_rcmd(const char *packet, const size_t length)
 		gdb_putpacketz("");
 	else if (c == 0)
 		gdb_putpacketz("OK");
-	else
-		gdb_putpacket(hexify(pbuf, "Failed\n", strlen("Failed\n")), 2 * strlen("Failed\n"));
+	else {
+		const char *const response = "Failed\n";
+		const size_t length = strlen(response);
+		gdb_putpacket(hexify(pbuf, response, length), 2 * length);
+	}
 }
 
 static void handle_q_string_reply(const char *reply, const char *param)

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -66,7 +66,7 @@ bool target_flash_complete(target_s *t);
 
 /* Register access functions */
 size_t target_regs_size(target_s *t);
-const char *target_tdesc(target_s *t);
+const char *target_regs_description(target_s *t);
 void target_regs_read(target_s *t, void *data);
 void target_regs_write(target_s *t, const void *data);
 ssize_t target_reg_read(target_s *t, int reg, void *data, size_t max);

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -463,9 +463,7 @@ const char *cortexa_regs_description(target_s *t)
 
 bool cortexa_probe(adiv5_access_port_s *apb, uint32_t debug_base)
 {
-	target_s *t;
-
-	t = target_new();
+	target_s *t = target_new();
 	if (!t) {
 		return false;
 	}
@@ -519,7 +517,6 @@ bool cortexa_probe(adiv5_access_port_s *apb, uint32_t debug_base)
 bool cortexa_attach(target_s *t)
 {
 	cortexa_priv_s *priv = t->priv;
-	int tries;
 
 	/* Clear any pending fault condition */
 	target_check_error(t);
@@ -532,7 +529,7 @@ bool cortexa_attach(target_s *t)
 	DEBUG_INFO("DBGDSCR = 0x%08" PRIx32 "\n", dbgdscr);
 
 	target_halt_request(t);
-	tries = 10;
+	size_t tries = 10;
 	while (!platform_nrst_get_val() && !target_halt_poll(t, NULL) && --tries)
 		platform_delay(200);
 	if (!tries)
@@ -555,9 +552,8 @@ void cortexa_detach(target_s *t)
 	cortexa_priv_s *priv = t->priv;
 
 	/* Clear any stale breakpoints */
-	for (unsigned i = 0; i < priv->hw_breakpoint_max; i++) {
+	for (size_t i = 0; i < priv->hw_breakpoint_max; i++)
 		apb_write(t, DBGBCR(i), 0);
-	}
 
 	/* Restore any clobbered registers */
 	cortexa_regs_write_internal(t);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -554,9 +554,7 @@ const char *cortexm_regs_description(target_s *t)
 
 bool cortexm_probe(adiv5_access_port_s *ap)
 {
-	target_s *t;
-
-	t = target_new();
+	target_s *t = target_new();
 	if (!t)
 		return false;
 
@@ -593,12 +591,10 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 	t->detach = cortexm_detach;
 
 	/* Probe for FP extension. */
-	bool is_cortexmf = false;
 	uint32_t cpacr = target_mem_read32(t, CORTEXM_CPACR);
 	cpacr |= 0x00f00000U; /* CP10 = 0b11, CP11 = 0b11 */
 	target_mem_write32(t, CORTEXM_CPACR, cpacr);
-	if (target_mem_read32(t, CORTEXM_CPACR) == cpacr)
-		is_cortexmf = true;
+	bool is_cortexmf = target_mem_read32(t, CORTEXM_CPACR) == cpacr;
 
 	/* Should probe here to make sure it's Cortex-M3 */
 
@@ -821,14 +817,13 @@ bool cortexm_attach(target_s *t)
 void cortexm_detach(target_s *t)
 {
 	cortexm_priv_s *priv = t->priv;
-	unsigned i;
 
 	/* Clear any stale breakpoints */
-	for (i = 0; i < priv->hw_breakpoint_max; i++)
+	for (size_t i = 0; i < priv->hw_breakpoint_max; i++)
 		target_mem_write32(t, CORTEXM_FPB_COMP(i), 0);
 
 	/* Clear any stale watchpoints */
-	for (i = 0; i < priv->hw_watchpoint_max; i++)
+	for (size_t i = 0; i < priv->hw_watchpoint_max; i++)
 		target_mem_write32(t, CORTEXM_DWT_FUNC(i), 0);
 
 	/* Restort DEMCR*/

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -396,11 +396,10 @@ static size_t create_tdesc_cortex_mf(char *buffer, size_t max_len)
 	// has static inputs and shouldn't ever return a value large enough for casting it to a
 	// signed int to change its value, and if it does, then again there's something wrong that
 	// we can't really do anything about.
-	int total = 0;
 
 	// The first part of the target description for the Cortex-MF is identical to the Cortex-M
 	// target description.
-	total = (int)create_tdesc_cortex_m(buffer, max_len);
+	int total = (int)create_tdesc_cortex_m(buffer, max_len);
 
 	// We can't just repeatedly pass max_len to snprintf, because we keep changing the start
 	// of buffer (effectively changing its size), so we have to repeatedly compute the size

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -315,28 +315,28 @@ bool stm32f1_probe(target_s *t)
 		target_add_commands(t, stm32f1_cmd_list, "STM32F3");
 		return true;
 
-	case 0x444U: /* STM32F03 RM0091 Rev.7, STM32F030x[4|6] RM0360 Rev. 4*/
+	case 0x444U: /* STM32F03 RM0091 Rev. 7, STM32F030x[4|6] RM0360 Rev. 4 */
 		t->driver = "STM32F03";
 		flash_size = 0x8000;
 		break;
 
-	case 0x445U: /* STM32F04 RM0091 Rev.7, STM32F070x6 RM0360 Rev. 4*/
+	case 0x445U: /* STM32F04 RM0091 Rev. 7, STM32F070x6 RM0360 Rev. 4 */
 		t->driver = "STM32F04/F070x6";
 		flash_size = 0x8000;
 		break;
 
-	case 0x440U: /* STM32F05 RM0091 Rev.7, STM32F030x8 RM0360 Rev. 4*/
+	case 0x440U: /* STM32F05 RM0091 Rev. 7, STM32F030x8 RM0360 Rev. 4 */
 		t->driver = "STM32F05/F030x8";
 		flash_size = 0x10000;
 		break;
 
-	case 0x448U: /* STM32F07 RM0091 Rev.7, STM32F070xb RM0360 Rev. 4*/
+	case 0x448U: /* STM32F07 RM0091 Rev. 7, STM32F070xb RM0360 Rev. 4 */
 		t->driver = "STM32F07";
 		flash_size = 0x20000;
 		block_size = 0x800;
 		break;
 
-	case 0x442U: /* STM32F09 RM0091 Rev.7, STM32F030xc RM0360 Rev. 4*/
+	case 0x442U: /* STM32F09 RM0091 Rev. 7, STM32F030xc RM0360 Rev. 4 */
 		t->driver = "STM32F09/F030xc";
 		flash_size = 0x40000;
 		block_size = 0x800;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -463,9 +463,14 @@ size_t target_regs_size(target_s *t)
 	return t->regs_size;
 }
 
-const char *target_tdesc(target_s *t)
+/*
+ * Get an XML description of the target's registers. Called during the attach phase when
+ * GDB supplies request `qXfer:features:read:target.xml:`. The pointer returned by this call
+ * must be passed to `free()` on conclusion of its use.
+ */
+const char *target_regs_description(target_s *t)
 {
-	return t->tdesc ? t->tdesc : "";
+	return t->regs_description(t);
 }
 
 const char *target_driver_name(target_s *t)

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -104,7 +104,7 @@ struct target {
 
 	/* Register access functions */
 	size_t regs_size;
-	char *tdesc;
+	const char *(*regs_description)(target_s *t);
 	void (*regs_read)(target_s *t, void *data);
 	void (*regs_write)(target_s *t, const void *data);
 	ssize_t (*reg_read)(target_s *t, int reg, void *data, size_t max);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

On some probes with little SRAM or for targets with large Flash buffer allocations, the allocation of a large buffer to hold the target register description induces a heap memory exhaustion, seen as crashes and freeze-ups. This PR seeks to address this by limiting this large SRAM allocation to just the duration of the GDB request during which it is required, sacrificing a little speed for reduced memory pressure.

Many thanks to Aqz2 for providing the traces and information to allow us to isolate this as being the cause of several recent issues. This PR replaces https://github.com/blackmagic-debug/blackmagic/pull/1334

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes https://github.com/blackmagic-debug/blackmagic/pull/1327