### PR TITLE
BMDA: Fix build on OSX

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,16 +3,21 @@ PLATFORM_DIR = platforms/$(PROBE_HOST)
 VPATH += $(PLATFORM_DIR) target
 ENABLE_DEBUG ?=
 
+SYS = $(shell $(CC) -dumpmachine)
+
 ifneq ($(V), 1)
 MAKEFLAGS += --no-print-dir
 Q := @
 endif
 
-CFLAGS += -Wall -Wextra -Werror -Wmaybe-uninitialized \
-	-Wreturn-type -Wstringop-overflow -Wunsafe-loop-optimizations \
+CFLAGS += -Wall -Wextra -Werror -Wreturn-type \
 	-Wno-char-subscripts \
 	-std=c11 -g3 -MD -I./target \
 	-I. -Iinclude -I$(PLATFORM_DIR)
+
+ifeq (filter, macosx darwin, $(SYS))
+CFLAGS += -Wmaybe-uninitialized -Wstringop-overflow -Wunsafe-loop-optimizations 
+endif
 
 ifeq ($(ENABLE_DEBUG), 1)
 CFLAGS += -DENABLE_DEBUG

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -72,7 +72,7 @@ static int set_interface_attribs(void)
 }
 
 #ifdef __APPLE__
-int serial_open(const bmda_cli_options_s *cl_opts, char *serial)
+int serial_open(const bmda_cli_options_s *cl_opts, const char *serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

Fixes BMDA build issues on OSX:

(i) Adds certain compiler flags if not OSX (-Wmaybe-uninitialized -Wstringop-overflow -Wunsafe-loop-optimizations)
(ii) Add 'const' to serial_open declaration on OSX

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
