### PR TITLE
Fix: Bootloader compilation regression on some ARM GCC toolchains

### DIFF
--- a/src/platforms/stm32/dfu_f1.c
+++ b/src/platforms/stm32/dfu_f1.c
@@ -116,7 +116,7 @@ void dfu_jump_app_if_valid(void)
 		__asm__(
 			"msr msp, %1\n"     /* Load the system stack register with the new stack pointer */
 			"ldr pc, [%0, 4]\n" /* Jump to application */
-			: : "g"(app_address), "g"(stack_pointer) : "r0"
+			: : "l"(app_address), "l"(stack_pointer) : "r0"
 		);
 		/* clang-format on */
 

--- a/src/platforms/stm32/dfu_f4.c
+++ b/src/platforms/stm32/dfu_f4.c
@@ -126,7 +126,7 @@ void dfu_jump_app_if_valid(void)
 		__asm__(
 			"msr msp, %1\n"     /* Load the system stack register with the new stack pointer */
 			"ldr pc, [%0, 4]\n" /* Jump to application */
-			: : "g"(app_address), "g"(stack_pointer) : "r0"
+			: : "l"(app_address), "l"(stack_pointer) : "r0"
 		);
 		/* clang-format on */
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address a mistake we made when reworking the DFU bootloaders, resulting in non-compilation on some toolchains.

This switches the constraints on the asm blocks controlling jumping to the firmware to using the "l" constraint from "g", which stops the compiler locating the firmware Flash address in an unusable register or in a constant that cannot be used in the required manner.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
