### PR TITLE
Fix: Flashing from the hosted CLI on macOS/*nix

### DIFF
--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -62,11 +62,11 @@ static target_controller_s cl_controller = {
 typedef struct mmap_data {
 	void *data;
 	size_t size;
-	size_t real_size;
 #if defined(_WIN32) || defined(__CYGWIN__)
 	HANDLE hFile;
 	HANDLE hMapFile;
 #else
+	size_t real_size;
 	int fd;
 #endif
 } mmap_data_s;
@@ -122,7 +122,7 @@ static void bmp_munmap(mmap_data_s *map)
 	CloseHandle(map->hMapFile);
 	CloseHandle(map->hFile);
 #else
-	/* Use the untainted 'real_size' not 'size' here otherwise we don't unmap the entire file */
+	/* Use the untainted 'real_size' here, 'size' may have been bounded to the flash size and we want to unmap the whole file */
 	munmap(map->data, map->real_size);
 #endif
 }

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -109,6 +109,7 @@ static bool bmp_mmap(char *file, mmap_data_s *map)
 	if (fstat(map->fd, &stat))
 		return false;
 	map->real_size = stat.st_size;
+	map->size = stat.st_size;
 	map->data = mmap(NULL, map->real_size, PROT_READ, MAP_PRIVATE, map->fd, 0);
 #endif
 	return true;


### PR DESCRIPTION
Using the hosted CLI on macOS, I found I was not able to flash my target. It would say the flash succeeded having written zero bytes.

I tracked this down to the way the file is loaded in, where the size is captured improperly during the mmap.

I also cleaned up that structure, as the `real_size` variable was not necessary on Windows platforms.

With this change, I'm able to flash successfully.

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
