### PR TITLE
Feature: clean BMDA shutdown

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -75,6 +75,9 @@ static bool cmd_rtt(target_s *t, int argc, const char **argv);
 #if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
 static bool cmd_debug_bmp(target_s *t, int argc, const char **argv);
 #endif
+#if PC_HOSTED == 1
+static bool cmd_shutdown_bmda(target_s *t, int argc, const char **argv);
+#endif
 
 const command_s cmd_list[] = {
 	{"version", cmd_version, "Display firmware version info"},
@@ -106,6 +109,9 @@ const command_s cmd_list[] = {
 	{"heapinfo", cmd_heapinfo, "Set semihosting heapinfo"},
 #if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
 	{"debug_bmp", cmd_debug_bmp, "Output BMP \"debug\" strings to the second vcom: (enable|disable)"},
+#endif
+#if PC_HOSTED == 1
+	{"shutdown_bmda", cmd_shutdown_bmda, "Tell the BMDA server to shut down when the GDB connection closes"},
 #endif
 	{NULL, NULL, NULL},
 };
@@ -643,6 +649,17 @@ static bool cmd_debug_bmp(target_s *t, int argc, const char **argv)
 	}
 
 	gdb_outf("Debug mode is %s\n", debug_bmp ? "enabled" : "disabled");
+	return true;
+}
+#endif
+
+#if PC_HOSTED == 1
+static bool cmd_shutdown_bmda(target_s *t, int argc, const char **argv)
+{
+	(void)t;
+	(void)argc;
+	(void)argv;
+	shutdown_bmda = true;
 	return true;
 }
 #endif

--- a/src/command.c
+++ b/src/command.c
@@ -72,7 +72,7 @@ static bool cmd_heapinfo(target_s *t, int argc, const char **argv);
 #ifdef ENABLE_RTT
 static bool cmd_rtt(target_s *t, int argc, const char **argv);
 #endif
-#if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
+#if defined(PLATFORM_HAS_DEBUG) && PC_HOSTED == 0
 static bool cmd_debug_bmp(target_s *t, int argc, const char **argv);
 #endif
 #if PC_HOSTED == 1
@@ -107,7 +107,7 @@ const command_s cmd_list[] = {
 #endif
 #endif
 	{"heapinfo", cmd_heapinfo, "Set semihosting heapinfo"},
-#if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
+#if defined(PLATFORM_HAS_DEBUG) && PC_HOSTED == 0
 	{"debug_bmp", cmd_debug_bmp, "Output BMP \"debug\" strings to the second vcom: (enable|disable)"},
 #endif
 #if PC_HOSTED == 1
@@ -117,7 +117,7 @@ const command_s cmd_list[] = {
 };
 
 bool connect_assert_nrst;
-#if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
+#if defined(PLATFORM_HAS_DEBUG) && PC_HOSTED == 0
 bool debug_bmp;
 #endif
 unsigned cortexm_wait_timeout = 2000; /* Timeout to wait for Cortex to react on halt command. */
@@ -636,7 +636,7 @@ static bool cmd_traceswo(target_s *t, int argc, const char **argv)
 }
 #endif
 
-#if defined(PLATFORM_HAS_DEBUG) && (PC_HOSTED == 0)
+#if defined(PLATFORM_HAS_DEBUG) && PC_HOSTED == 0
 static bool cmd_debug_bmp(target_s *t, int argc, const char **argv)
 {
 	(void)t;

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -124,7 +124,7 @@ int gdb_main_loop(target_controller_s *tc, bool in_syscall)
 		SET_IDLE_STATE(1);
 		size_t size = gdb_getpacket(pbuf, BUF_SIZE);
 		// If port closed and target detached, stay idle
-		if ((pbuf[0] != '\x04') || cur_target) {
+		if (pbuf[0] != '\x04' || cur_target) {
 			SET_IDLE_STATE(0);
 		}
 		switch (pbuf[0]) {

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -306,6 +306,10 @@ int gdb_main_loop(target_controller_s *tc, bool in_syscall)
 
 		case '\x04':
 		case 'D': /* GDB 'detach' command. */
+#if PC_HOSTED == 1
+			if (shutdown_bmda)
+				return 0;
+#endif
 			if (cur_target) {
 				SET_RUN_STATE(true);
 				target_detach(cur_target);

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -46,7 +46,7 @@ size_t gdb_getpacket(char *const packet, const size_t size)
 			 */
 			do {
 				/* Smells like bad code */
-				packet[0] = (char)gdb_if_getchar();
+				packet[0] = gdb_if_getchar();
 				if (packet[0] == '\x04')
 					return 1;
 			} while (packet[0] != '$' && packet[0] != REMOTE_SOM);
@@ -57,7 +57,7 @@ size_t gdb_getpacket(char *const packet, const size_t size)
 				bool getting_remote_packet = true;
 				while (getting_remote_packet) {
 					/* Smells like bad code */
-					const char c = (char)gdb_if_getchar();
+					const char c = gdb_if_getchar();
 					switch (c) {
 					case REMOTE_SOM: /* Oh dear, packet restarts */
 						offset = 0;
@@ -99,7 +99,7 @@ size_t gdb_getpacket(char *const packet, const size_t size)
 		char c = '\0';
 		/* Capture packet data into buffer */
 		while (c != '#') {
-			c = (char)gdb_if_getchar();
+			c = gdb_if_getchar();
 			if (c == '#')
 				break;
 			/* If we run out of buffer space, exit early */
@@ -120,8 +120,8 @@ size_t gdb_getpacket(char *const packet, const size_t size)
 			csum += c;
 			packet[offset++] = c;
 		}
-		recv_csum[0] = (char)gdb_if_getchar();
-		recv_csum[1] = (char)gdb_if_getchar();
+		recv_csum[0] = gdb_if_getchar();
+		recv_csum[1] = gdb_if_getchar();
 		recv_csum[2] = 0;
 
 		/* Return packet if checksum matches */

--- a/src/include/command.h
+++ b/src/include/command.h
@@ -35,4 +35,8 @@ int command_process(target_s *t, char *cmd);
  */
 bool parse_enable_or_disable(const char *s, bool *out);
 
+#if PC_HOSTED == 1
+extern bool shutdown_bmda;
+#endif
+
 #endif /* INCLUDE_COMMAND_H */

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@
 #include "exception.h"
 #include "gdb_packet.h"
 #include "morse.h"
+#include "command.h"
 
 int main(int argc, char **argv)
 {
@@ -49,8 +50,12 @@ int main(int argc, char **argv)
 			gdb_outf("Uncaught exception: %s\n", e.msg);
 			morse("TARGET LOST.", true);
 		}
+#if PC_HOSTED == 1
+		if (shutdown_bmda)
+			break;
+#endif
 	}
 
-	/* Should never get here */
+	target_list_free();
 	return 0;
 }

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -47,6 +47,7 @@
 
 #include "gdb_if.h"
 #include "bmp_hosted.h"
+#include "command.h"
 
 static const uint16_t default_port = 2000U;
 static const uint16_t max_port = default_port + 4U;
@@ -66,6 +67,7 @@ static inline int closesocket(const int s)
 
 static int gdb_if_serv = -1;
 static int gdb_if_conn = -1;
+bool shutdown_bmda = false;
 
 #define GDB_BUFFER_LEN 2048U
 static size_t gdb_buffer_used = 0U;

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -248,6 +248,8 @@ int gdb_if_init(void)
 char gdb_if_getchar(void)
 {
 	if (gdb_if_conn == -1) {
+		if (shutdown_bmda)
+			return '\x04';
 		const int flags = socket_get_flags(gdb_if_serv);
 		socket_set_flags(gdb_if_serv, flags | O_NONBLOCK);
 		gdb_if_conn = -1;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we implement a feature to allow BMDA to be cleanly shut down rather than having to always signal it.

This has been done for two reasons.
The first more minor one is to help with users scripting GDB/BMDA wishing to shut the server back down after completing a GDB script.
The second reason is to make ASAN, LSAN and friends more useful - leak sanitizer can only act after a clean non-signalled shutdown of the program so this provides a mechanism to allow the program to exit normally and trigger LSAN processing. Likewise this allows testing with other sanitizers with this restriction in the future.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
