### PR TITLE
hosted/dap: Fixed dap_jtagtap_tdi_tdo_seq() crashing when ticks is 0 and final_tms is true

### DIFF
--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -599,6 +599,8 @@ void dap_jtagtap_tdi_tdo_seq(
 	const uint8_t *din = data_in;
 	uint8_t *dout = data_out;
 	if (!tms) {
+		if (!ticks)
+			return;
 		int last_byte = last_byte = (ticks - 1U) >> 3U;
 		int last_bit = (ticks - 1U) & 7U;
 		if (final_tms)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address a crash in the CMSIS-DAP code triggered when IR post-scan for a device is 0, causing `dap_jtagtap_tdi_tdo_seq` to be called with ticks = 0, final_tms = true. This prevents the crash but is not guaranteed to leave things in a good state (though it should)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
