### PR TITLE
Fix: Target registers description crash

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -470,7 +470,9 @@ size_t target_regs_size(target_s *t)
  */
 const char *target_regs_description(target_s *t)
 {
-	return t->regs_description(t);
+	if (t->regs_description)
+		return t->regs_description(t);
+	return NULL;
 }
 
 const char *target_driver_name(target_s *t)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses the issue reported in https://github.com/blackmagic-debug/blackmagic/issues/1353 which causes a crash due to calling a NULL pointer in `target_regs_description`. This occurs because not all targets set the t->regs_description member. This fix restores the previous behaviour that was changed in 2c52af6 and improves robustness.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes: #1353
