### PR TITLE
Fix: target default functions undefined behaviour

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -497,9 +497,9 @@ unsigned int target_part_id(target_s *t)
 
 uint32_t target_mem_read32(target_s *t, uint32_t addr)
 {
-	uint32_t ret;
-	t->mem_read(t, &ret, addr, sizeof(ret));
-	return ret;
+	uint32_t result = 0;
+	t->mem_read(t, &result, addr, sizeof(result));
+	return result;
 }
 
 void target_mem_write32(target_s *t, uint32_t addr, uint32_t value)
@@ -509,9 +509,9 @@ void target_mem_write32(target_s *t, uint32_t addr, uint32_t value)
 
 uint16_t target_mem_read16(target_s *t, uint32_t addr)
 {
-	uint16_t ret;
-	t->mem_read(t, &ret, addr, sizeof(ret));
-	return ret;
+	uint16_t result = 0;
+	t->mem_read(t, &result, addr, sizeof(result));
+	return result;
 }
 
 void target_mem_write16(target_s *t, uint32_t addr, uint16_t value)
@@ -521,9 +521,9 @@ void target_mem_write16(target_s *t, uint32_t addr, uint16_t value)
 
 uint8_t target_mem_read8(target_s *t, uint32_t addr)
 {
-	uint8_t ret;
-	t->mem_read(t, &ret, addr, sizeof(ret));
-	return ret;
+	uint8_t result = 0;
+	t->mem_read(t, &result, addr, sizeof(result));
+	return result;
 }
 
 void target_mem_write8(target_s *t, uint32_t addr, uint8_t value)

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -21,6 +21,9 @@
 #ifndef TARGET_TARGET_INTERNAL_H
 #define TARGET_TARGET_INTERNAL_H
 
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 #include "platform_support.h"
 
 extern target_s *target_list;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the secondary problem encountered by zyp in https://github.com/blackmagic-debug/blackmagic/issues/1353

This issue is caused by the undefined and strictly forbidden casting of incompatible function pointer types to assign to the target structure function pointers as defaults. The net result is that on platforms where this visibly matters, it generates segfaults/crashes. On other platforms it generates unpredictable and unreliable behaviour.

This has been fixed by introducing a couple more no-op functions with the correct return types to use, and assigning suitable ones (without cast, where possible) to the various function pointers.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
