### PR TITLE
Fix: DPv2+ SWD regression

### DIFF
--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -74,8 +74,8 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 
 	*res = remotehston(-1, (char *)&construct[1]);
 	DEBUG_PROBE("swdptap_seq_in_parity  %2d clock_cycles: %08" PRIx32 " %s\n", clock_cycles, *res,
-		(construct[0] != REMOTE_RESP_OK) ? "ERR" : "OK");
-	return (construct[0] != REMOTE_RESP_OK);
+		construct[0] != REMOTE_RESP_OK ? "ERR" : "OK");
+	return construct[0] != REMOTE_RESP_OK;
 }
 
 static uint32_t swdptap_seq_in(size_t clock_cycles)

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -52,10 +52,6 @@ int remote_swdptap_init(adiv5_debug_port_s *dp)
 	dp->seq_in_parity = swdptap_seq_in_parity;
 	dp->seq_out = swdptap_seq_out;
 	dp->seq_out_parity = swdptap_seq_out_parity;
-	dp->dp_read = firmware_swdp_read;
-	dp->error = firmware_swdp_error;
-	dp->low_access = firmware_swdp_low_access;
-	dp->abort = firmware_swdp_abort;
 	return 0;
 }
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -313,6 +313,9 @@ static void remote_packet_process_general(unsigned i, char *packet)
 #define PLATFORM_IDENT() BOARD_IDENT
 #endif
 	case REMOTE_START:
+#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+		debug_bmp = true;
+#endif
 		remote_respond_string(REMOTE_RESP_OK, PLATFORM_IDENT "" FIRMWARE_VERSION);
 		break;
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -1012,7 +1012,6 @@ const void *adiv5_pack_data(const uint32_t dest, const void *const src, uint32_t
 
 void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
 {
-	uint32_t tmp;
 	uint32_t osrc = src;
 	const align_e align = MIN(ALIGNOF(src), ALIGNOF(len));
 
@@ -1023,8 +1022,8 @@ void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t
 	ap_mem_access_setup(ap, src, align);
 	adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_AP_DRW, 0);
 	while (--len) {
-		tmp = adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_AP_DRW, 0);
-		dest = adiv5_unpack_data(dest, src, tmp, align);
+		const uint32_t value = adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_AP_DRW, 0);
+		dest = adiv5_unpack_data(dest, src, value, align);
 
 		src += (1U << align);
 		/* Check for 10 bit address overflow */
@@ -1034,8 +1033,8 @@ void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t
 			adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_AP_DRW, 0);
 		}
 	}
-	tmp = adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
-	adiv5_unpack_data(dest, src, tmp, align);
+	const uint32_t value = adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
+	adiv5_unpack_data(dest, src, value, align);
 }
 
 void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -159,11 +159,12 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 		}
 	}
 
+#if PC_HOSTED == 1
 	if (!initial_dp->dp_low_write) {
-		DEBUG_WARN("CMSIS_DAP < V1.2 can not handle multi-drop!\n");
-		/* E.g. CMSIS_DAP < V1.2 can not handle multi-drop!*/
+		DEBUG_WARN("CMSIS_DAP < v1.2 can not handle multi-drop, disabling\n");
 		scan_multidrop = false;
 	}
+#endif
 
 	DEBUG_WARN("scan_multidrop: %s\n", scan_multidrop ? "true" : "false");
 

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -167,7 +167,7 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 
 	DEBUG_WARN("scan_multidrop: %s\n", scan_multidrop ? "true" : "false");
 
-	const volatile size_t max_dp = (scan_multidrop) ? 16U : 1U;
+	const volatile size_t max_dp = scan_multidrop ? 16U : 1U;
 	for (volatile size_t i = 0; i < max_dp; i++) {
 		if (scan_multidrop) {
 			dp_line_reset(initial_dp);

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -213,8 +213,9 @@ uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, const bool protocol_recover
 		 * With DP Change, another target needs selection.
 		 * => Reselect with right target! */
 		dp_line_reset(dp);
+		if (dp->version >= 2)
+			firmware_dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
 		firmware_dp_low_read(dp, ADIV5_DP_DPIDR);
-		dp->dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
 		/* Exception here is unexpected, so do not catch */
 	}
 	const uint32_t err = firmware_dp_low_read(dp, ADIV5_DP_CTRLSTAT) &

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -60,16 +60,17 @@ static void dp_line_reset(adiv5_debug_port_s *dp)
 
 bool firmware_dp_low_write(adiv5_debug_port_s *dp, const uint16_t addr, const uint32_t data)
 {
-	const uint8_t request = make_packet_request(ADIV5_LOW_WRITE, addr & 0xfU);
+	const uint8_t request = make_packet_request(ADIV5_LOW_WRITE, addr);
 	dp->seq_out(request, 8);
 	const uint8_t res = dp->seq_in(3);
 	dp->seq_out_parity(data, 32);
+	dp->seq_out(0, 8);
 	return res != SWDP_ACK_OK;
 }
 
 uint32_t firmware_dp_low_read(adiv5_debug_port_s *dp, const uint16_t addr)
 {
-	const uint8_t request = make_packet_request(ADIV5_LOW_READ, addr & 0xfU);
+	const uint8_t request = make_packet_request(ADIV5_LOW_READ, addr);
 	dp->seq_out(request, 8);
 	const uint8_t res = dp->seq_in(3);
 	uint32_t data = 0;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the SWD regression identified in https://github.com/blackmagic-debug/blackmagic/issues/1359 which was caused by the protocol recovery addition in https://github.com/blackmagic-debug/blackmagic/pulls/1331 exposing the DPv2+ protocol recovery being incorrect and scan not setting the DP version field so causing recovery to progress incorrectly (post-recovery the device had DP#0 reselected in the multi-drop chain making things work when they shouldn't).

After this change, discovery and recovery both work correctly and reliably for DPv0, DPv1 and DPv2 SWD devices.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1359
