### PR TITLE
Fix: LPC17xx detection reliability/issues

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: 'bugprone-*,cert-*,clang-analyzer-*,misc-*,modernize-*,portability-*,performance-*,readability-*,-readability-magic-numbers,-readability-braces-around-statements,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
+Checks: 'bugprone-*,cert-*,clang-analyzer-*,misc-*,modernize-*,portability-*,performance-*,readability-*,-readability-magic-numbers,-readability-braces-around-statements,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-modernize-macro-to-enum,-bugprone-easily-swappable-parameters'
 FormatStyle: 'none'
 HeaderFilterRegex: '(src|upgrade)/.+'
 AnalyzeTemporaryDtors: false

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -175,22 +175,27 @@ static bool lpc17xx_exit_flash_mode(target_s *const target)
 static bool lpc17xx_mass_erase(target_s *target)
 {
 	iap_result_s result;
+	lpc17xx_enter_flash_mode(target);
 
 	if (lpc17xx_iap_call(target, &result, IAP_CMD_PREPARE, 0, FLASH_NUM_SECTOR - 1U)) {
+		lpc17xx_exit_flash_mode(target);
 		DEBUG_WARN("lpc17xx_cmd_erase: prepare failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 
 	if (lpc17xx_iap_call(target, &result, IAP_CMD_ERASE, 0, FLASH_NUM_SECTOR - 1U, CPU_CLK_KHZ)) {
+		lpc17xx_exit_flash_mode(target);
 		DEBUG_WARN("lpc17xx_cmd_erase: erase failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 
 	if (lpc17xx_iap_call(target, &result, IAP_CMD_BLANKCHECK, 0, FLASH_NUM_SECTOR - 1U)) {
+		lpc17xx_exit_flash_mode(target);
 		DEBUG_WARN("lpc17xx_cmd_erase: blankcheck failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 
+	lpc17xx_exit_flash_mode(target);
 	tc_printf(target, "Erase OK.\n");
 	return true;
 }

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -39,7 +39,8 @@
 #define IAP_ENTRYPOINT 0x1fff1ff1U
 #define IAP_RAM_BASE   0x10000000U
 
-#define MEMMAP           0x400fc040U
+#define LPC17xx_MEMMAP UINT32_C(0x400fc040)
+
 #define FLASH_NUM_SECTOR 30U
 
 typedef struct iap_config {
@@ -150,8 +151,12 @@ static bool lpc17xx_mass_erase(target_s *target)
  */
 static void lpc17xx_extended_reset(target_s *target)
 {
-	/* From §33.6 Debug memory re-mapping (Page 643) UM10360.pdf (Rev 2) */
-	target_mem_write32(target, MEMMAP, 1);
+	/*
+	 * Transition the memory map to user mode (if it wasn't already) to ensure
+	 * the correct environment is seen by the user
+	 * See §33.6 Debug memory re-mapping, pg655 of UM10360 for more details.
+	 */
+	target_mem_write32(target, LPC17xx_MEMMAP, 1);
 }
 
 static size_t lpc17xx_iap_params(const iap_cmd_e cmd)

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -211,6 +211,10 @@ iap_status_e lpc17xx_iap_call(target_s *target, iap_result_s *result, iap_cmd_e 
 	while (!target_halt_poll(target, NULL)) {
 		if (cmd == IAP_CMD_ERASE)
 			target_print_progress(&timeout);
+		else if (cmd == IAP_CMD_PARTID && platform_timeout_is_expired(&timeout)) {
+			target_halt_request(target);
+			return IAP_STATUS_INVALID_COMMAND;
+		}
 	}
 
 	/* Copy back just the results */

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -88,7 +88,7 @@ bool lpc17xx_probe(target_s *target)
 		/* Read the Part ID */
 		iap_result_s result;
 		lpc17xx_iap_call(target, &result, IAP_CMD_PARTID);
-		target_halt_resume(target, 0);
+		target_halt_resume(target, false);
 
 		if (result.return_code)
 			return false;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the LPC17xx detection reliability and issues cause by the support being very rudimentary and written with some assumption that don't really hold. These assumptions being that nobody uses the MPU, that the IAP ROM disables the MPU if needed while making IAP calls, and that doing UB stack reads as part of varargs couldn't backfire horribly.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes https://github.com/blackmagic-debug/blackmagic/issues/1366
