### PR TITLE
hosted/cmsis_dap: Fixes CMSIS-DAP adapters connected with USB HID.

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -436,7 +436,7 @@ bool dap_run_cmd(const void *const request_data, const size_t request_length, vo
 	/* This subtracts one off the result to account for the command byte that gets stripped above */
 	const ssize_t result =
 		dap_run_cmd_raw((const uint8_t *)request_data, request_length, (uint8_t *)response_data, response_length) - 1U;
-	return (size_t)result == response_length;
+	return (size_t)result >= response_length;
 }
 
 ssize_t dbg_dap_cmd(uint8_t *const data, const size_t response_length, const size_t request_length)


### PR DESCRIPTION
## Detailed description

When using HID as transport, the responses are always the same length, so we only need to check that the received length is more than or equal that the expected response length.

This fixes debugging with [dap42](https://github.com/devanlai/dap42) adapter, tested with an stm32f103 target.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do
