### PR TITLE
Fix: BMDA's CMSIS-DAP protocol recovery

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -292,7 +292,7 @@ static uint32_t dap_swd_dp_error(adiv5_debug_port_s *dp, const bool protocol_rec
 		 */
 		dap_line_reset();
 		if (dp->version >= 2)
-			dap_write_reg(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+			dap_write_reg_no_check(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
 		dap_read_reg(dp, ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */
 	}

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -338,26 +338,24 @@ uint32_t dap_read_reg(adiv5_debug_port_s *dp, uint8_t reg)
 //-----------------------------------------------------------------------------
 void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
 {
-	uint8_t buf[8];
 	DEBUG_PROBE("\tdap_write_reg %02x %08x\n", reg, data);
 
-	buf[0] = ID_DAP_TRANSFER;
-	uint8_t dap_index = 0;
-	dap_index = dp->dp_jd_index;
-	buf[1] = dap_index;
-	buf[2] = 0x01; // Request size
-	buf[3] = reg & ~DAP_TRANSFER_RnW;
-	buf[4] = data & 0xffU;
-	buf[5] = (data >> 8U) & 0xffU;
-	buf[6] = (data >> 16U) & 0xffU;
-	buf[7] = (data >> 24U) & 0xffU;
+	uint8_t buf[8] = {
+		ID_DAP_TRANSFER,
+		dp->dp_jd_index,
+		0x01, // Request size
+		reg & ~DAP_TRANSFER_RnW,
+		data & 0xffU,
+		(data >> 8U) & 0xffU,
+		(data >> 16U) & 0xffU,
+		(data >> 24U) & 0xffU,
+	};
+
 	uint8_t cmd_copy[8];
 	memcpy(cmd_copy, buf, 8);
 	do {
 		memcpy(buf, cmd_copy, 8);
 		dbg_dap_cmd(buf, sizeof(buf), 8);
-		if (buf[1] < DAP_TRANSFER_WAIT)
-			break;
 	} while (buf[1] == DAP_TRANSFER_WAIT);
 
 	if (buf[1] > DAP_TRANSFER_WAIT) {

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -364,7 +364,7 @@ void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
 	}
 	if (buf[1] == DAP_TRANSFER_ERROR) {
 		DEBUG_WARN("dap_write_reg %02x data %08x: protocol error\n", reg, data);
-		dap_line_reset();
+		dp->fault = 7;
 	}
 }
 

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -370,6 +370,24 @@ void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
 	}
 }
 
+bool dap_write_reg_no_check(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
+{
+	DEBUG_PROBE("\tdap_write_reg %02x %08x\n", reg, data);
+
+	uint8_t buf[8] = {
+		ID_DAP_TRANSFER,
+		dp->dp_jd_index,
+		0x01, // Request size
+		reg & ~DAP_TRANSFER_RnW,
+		data & 0xffU,
+		(data >> 8U) & 0xffU,
+		(data >> 16U) & 0xffU,
+		(data >> 24U) & 0xffU,
+	};
+	dbg_dap_cmd(buf, sizeof(buf), 8);
+	return buf[1] != DAP_TRANSFER_OK;
+}
+
 bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align)
 {
 	const size_t blocks = len >> MAX(align, 2U);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -72,6 +72,7 @@ void dap_reset_pin(int state);
 void dap_line_reset(void);
 uint32_t dap_read_reg(adiv5_debug_port_s *dp, uint8_t reg);
 void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data);
+bool dap_write_reg_no_check(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data);
 void dap_reset_link(bool jtag);
 uint32_t dap_read_idcode(adiv5_debug_port_s *dp);
 bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Due to some code duplication in BMDA (which itself needs addressing but will be taken care of in v1.10), a second instance of #1359 was laying in wait in the CMSIS-DAP implementation. This PR addresses this second copy of the buggy protocol recovery code.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes: #1370
