### PR TITLE
Fix: BMDA probe info

### DIFF
--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -73,7 +73,7 @@ ifneq ($(HOSTED_BMP_ONLY), 1)
     LDFLAGS += $(shell pkg-config --libs $(HIDAPILIB))
 endif
 
-SRC += timing.c cli.c utils.c
+SRC += timing.c cli.c utils.c probe_info.c
 SRC += bmp_remote.c remote_swdptap.c remote_jtagtap.c
 ifneq ($(HOSTED_BMP_ONLY), 1)
     SRC += bmp_libusb.c stlinkv2.c

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -82,8 +82,8 @@ typedef struct bmp_info {
 	libusb_context *libusb_ctx;
 	ftdi_context_s *ftdic;
 	usb_link_s *usb_link;
-	unsigned int vid;
-	unsigned int pid;
+	uint16_t vid;
+	uint16_t pid;
 	uint8_t interface_num;
 	uint8_t in_ep;
 	uint8_t out_ep;

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -169,6 +169,7 @@ print_probes_info:
 #define BMP_IDSTRING_BLACKMAGIC  "usb-Black_Magic_Debug_Black_Magic_Probe"
 #define BMP_IDSTRING_1BITSQUARED "usb-1BitSquared_Black_Magic_Probe"
 #define DEVICE_BY_ID             "/dev/serial/by-id"
+#define BMP_PRODUCT_STRING       "Black Magic Probe"
 #define MFR_FORMAT_STRING        "Black Magic Probe (%s)"
 
 typedef struct dirent dirent_s;
@@ -245,12 +246,18 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 
 	/* Now we know where everything is, start by extracting the serial string on the end. */
 	char *const serial = extract_serial(name, name_len);
-	if (!*serial)
+	if (!serial)
 		return probe_list;
 
 	/* Now extract the underlying probe type and versioning information */
 	char *version = NULL;
 	char *type = NULL;
+	char *product = strdup(BMP_PRODUCT_STRING);
+
+	if (!product) {
+		free(serial);
+		return probe_list;
+	}
 
 	/* If the device name has no underscores after the prefix, it's an original BMP */
 	if (underscores == 0) {
@@ -281,6 +288,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 		free(serial);
 		free(version);
 		free(type);
+		free(product);
 		return probe_list;
 	}
 
@@ -291,12 +299,13 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 		free(serial);
 		free(version);
 		free(type);
+		free(product);
 		return probe_list;
 	}
 
 	snprintf(mfr, mfr_length, MFR_FORMAT_STRING, type);
 	free(type);
-	return probe_info_add(probe_list, BMP_TYPE_BMP, mfr, NULL, serial, version);
+	return probe_info_add(probe_list, BMP_TYPE_BMP, mfr, product, serial, version);
 }
 
 static const probe_info_s *scan_for_devices(void)

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -296,7 +296,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 
 	snprintf(mfr, mfr_length, MFR_FORMAT_STRING, type);
 	free(type);
-	return probe_info_add(probe_list, BMP_TYPE_BMP, mfr, serial, version);
+	return probe_info_add(probe_list, BMP_TYPE_BMP, mfr, NULL, serial, version);
 }
 
 static const probe_info_s *scan_for_devices(void)

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -170,7 +170,6 @@ print_probes_info:
 #define BMP_IDSTRING_1BITSQUARED "usb-1BitSquared_Black_Magic_Probe"
 #define DEVICE_BY_ID             "/dev/serial/by-id"
 #define BMP_PRODUCT_STRING       "Black Magic Probe"
-#define MFR_FORMAT_STRING        "Black Magic Probe (%s)"
 
 typedef struct dirent dirent_s;
 
@@ -292,20 +291,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 		return probe_list;
 	}
 
-	const size_t mfr_length = strlen(type) + sizeof(MFR_FORMAT_STRING) - 2U;
-	char *const mfr = malloc(mfr_length);
-	if (!mfr) {
-		DEBUG_WARN("Failed to allocate space for manufacturer string");
-		free(serial);
-		free(version);
-		free(type);
-		free(product);
-		return probe_list;
-	}
-
-	snprintf(mfr, mfr_length, MFR_FORMAT_STRING, type);
-	free(type);
-	return probe_info_add(probe_list, BMP_TYPE_BMP, mfr, product, serial, version);
+	return probe_info_add(probe_list, BMP_TYPE_BMP, type, product, serial, version);
 }
 
 static const probe_info_s *scan_for_devices(void)

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -291,7 +291,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 		return probe_list;
 	}
 
-	return probe_info_add(probe_list, BMP_TYPE_BMP, type, product, serial, version);
+	return probe_info_add_by_serial(probe_list, BMP_TYPE_BMP, type, product, serial, version);
 }
 
 static const probe_info_s *scan_for_devices(void)
@@ -306,7 +306,7 @@ static const probe_info_s *scan_for_devices(void)
 			break;
 		if (device_is_bmp_gdb_port(entry->d_name)) {
 			probe_info_s *probe_info = parse_device_node(entry->d_name, probe_list);
-			/* If the operation would have succeeded but probe_info_add fails, we exhausted memory. */
+			/* If the operation would have succeeded but probe_info_add_by_serial fails, we exhausted memory. */
 			if (!probe_info) {
 				probe_info_list_free(probe_list);
 				probe_list = NULL;

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include "general.h"
 #include "bmp_hosted.h"
+#include "probe_info.h"
 #include "utils.h"
 #include "version.h"
 
@@ -168,6 +169,7 @@ print_probes_info:
 #define BMP_IDSTRING_BLACKMAGIC  "usb-Black_Magic_Debug_Black_Magic_Probe"
 #define BMP_IDSTRING_1BITSQUARED "usb-1BitSquared_Black_Magic_Probe"
 #define DEVICE_BY_ID             "/dev/serial/by-id"
+#define MFR_FORMAT_STRING        "Black Magic Probe (%s)"
 
 typedef struct dirent dirent_s;
 
@@ -205,14 +207,9 @@ char *extract_serial(const char *const device, const size_t length)
 	return result;
 }
 
-/*
- * Extract type, version and serial from /dev/serial/by_id
- * Return 0 on success
- *
- * Old versions have different strings. Try to cope!
- */
-static bool scan_linux_id(const char *name, char **const type, char **const version, char **const serial)
+static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_list)
 {
+	/* Starting with a string such as 'usb-Black_Magic_Debug_Black_Magic_Probe_v1.8.0-650-g829308db_8BB20695-if00' */
 	const size_t name_len = strlen(name) + 1U;
 	/* Find the correct prefix */
 	size_t prefix_length = find_prefix_length(name, name_len);
@@ -221,9 +218,11 @@ static bool scan_linux_id(const char *name, char **const type, char **const vers
 		++prefix_length;
 	if (prefix_length == name_len) {
 		DEBUG_WARN("Unexpected end\n");
-		return false;
+		return probe_list;
 	}
 
+	/* With the remaining string, scan for _'s and index where the string chunks lie either side */
+	/* This operates on a string such as 'v1.8.0-650-g829308db_8BB20695-if00' */
 	size_t offsets[3][2] = {{prefix_length, 0U}, {0U, 0U}};
 	size_t underscores = 0;
 	for (size_t offset = prefix_length; offset < name_len; ++offset) {
@@ -232,7 +231,7 @@ static bool scan_linux_id(const char *name, char **const type, char **const vers
 			++underscores;
 			/* Device paths with more than 2 underscore delimited sections can't be valid BMP strings. */
 			if (underscores > 2U)
-				return false;
+				return probe_list;
 			/* Skip over consecutive strings of underscores */
 			while (name[offset + 1U] == '_' && offset < name_len)
 				++offset;
@@ -244,110 +243,123 @@ static bool scan_linux_id(const char *name, char **const type, char **const vers
 	}
 	offsets[underscores][1] = name_len - offsets[underscores][0];
 
-	*serial = extract_serial(name, name_len);
+	/* Now we know where everything is, start by extracting the serial string on the end. */
+	char *const serial = extract_serial(name, name_len);
 	if (!*serial)
-		return false;
+		return probe_list;
+
+	/* Now extract the underlying probe type and versioning information */
+	char *version = NULL;
+	char *type = NULL;
 
 	/* If the device name has no underscores after the prefix, it's an original BMP */
 	if (underscores == 0) {
-		*version = strdup("Unknown");
-		*type = strdup("Native");
+		version = strdup("Unknown");
+		type = strdup("Native");
 		/*
 		 * If the device name has two underscores delimited sections after the prefix,
 		 * it's a non-native device running the Black Magic Firmware.
 		 */
 	} else if (underscores == 2) {
-		*version = strndup(name + offsets[0][0], offsets[0][1]);
-		*type = strndup(name + offsets[1][0], offsets[1][1]);
+		version = strndup(name + offsets[0][0], offsets[0][1]);
+		type = strndup(name + offsets[1][0], offsets[1][1]);
 		/* Otherwise it's a native BMP */
 	} else {
 		/* The first section should start with a 'v' indicating the version info */
 		if (name[prefix_length] == 'v') {
-			*version = strndup(name + offsets[0][0], offsets[0][1]);
-			*type = strdup("Native");
+			version = strndup(name + offsets[0][0], offsets[0][1]);
+			type = strdup("Native");
 			/* But if not then it's actually a non-native device and has no version string. */
 		} else {
-			*version = strdup("Unknown");
-			*type = strndup(name + offsets[0][0], offsets[0][1]);
+			version = strdup("Unknown");
+			type = strndup(name + offsets[0][0], offsets[0][1]);
 		}
 	}
-	return true;
-}
 
-void copy_to_info(bmp_info_s *const info, const char *const type, const char *const version, const char *const serial)
-{
-	const size_t serial_len = MIN(strlen(serial), sizeof(info->serial) - 1U);
-	memcpy(info->serial, serial, serial_len);
-	info->serial[serial_len] = '\0';
-
-	const size_t version_len = MIN(strlen(version), sizeof(info->version) - 1U);
-	memcpy(info->version, version, version_len);
-	info->version[version_len] = '\0';
-
-	const int result = snprintf(info->manufacturer, sizeof(info->manufacturer), "Black Magic Probe (%s)", type);
-	if (result < 0) {
-		const int error = errno;
-		DEBUG_WARN("sprintf() failed with result %d while generating manufacturer string: %s", error, strerror(error));
+	if (!version || !type) {
+		DEBUG_WARN("Failed to construct version of type string");
+		free(serial);
+		free(version);
+		free(type);
+		return probe_list;
 	}
-	if ((size_t)result >= sizeof(info->manufacturer))
-		DEBUG_WARN("snprintf() overflowed while generating manfacturer string\n");
+
+	const size_t mfr_length = strlen(type) + sizeof(MFR_FORMAT_STRING) - 2U;
+	char *const mfr = malloc(mfr_length);
+	if (!mfr) {
+		DEBUG_WARN("Failed to allocate space for manufacturer string");
+		free(serial);
+		free(version);
+		free(type);
+		return probe_list;
+	}
+
+	snprintf(mfr, mfr_length, MFR_FORMAT_STRING, type);
+	free(type);
+	return probe_info_add(probe_list, BMP_TYPE_BMP, mfr, serial, version);
 }
 
-size_t scan_devices(scan_mode_e mode, bmp_info_s *info, const char *const search_serial, const size_t search_position)
+static const probe_info_s *scan_for_devices(void)
 {
 	DIR *dir = opendir(DEVICE_BY_ID);
 	if (!dir) /* /dev/serial/by-id is unavailable */
-		return false;
-	bool done = false;
-	size_t devices = 0;
-	while (!done) {
+		return NULL;
+	probe_info_s *probe_list = NULL;
+	while (true) {
 		const dirent_s *const entry = readdir(dir);
 		if (entry == NULL)
 			break;
 		if (device_is_bmp_gdb_port(entry->d_name)) {
-			++devices;
-			char *type = NULL;
-			char *version = NULL;
-			char *serial = NULL;
-			if (!scan_linux_id(entry->d_name, &type, &version, &serial)) {
-				DEBUG_WARN("Error parsing device name \"%s\"\n", entry->d_name);
-				continue;
+			probe_info_s *probe_info = parse_device_node(entry->d_name, probe_list);
+			/* If the operation would have succeeded but probe_info_add fails, we exhausted memory. */
+			if (!probe_info) {
+				probe_info_list_free(probe_list);
+				probe_list = NULL;
+				break;
 			}
-
-			if (mode == SCAN_FIND) {
-				if ((search_serial && strstr(serial, search_serial)) ||
-					(search_position && devices == search_position)) {
-					copy_to_info(info, type, version, serial);
-					devices = 1;
-					done = true;
-				}
-			} else if (mode == SCAN_LIST)
-				DEBUG_WARN("%2zu: %s, Black Magic Debug, Black Magic Probe (%s), %s\n", devices, serial, type, version);
-
-			free(type);
-			free(version);
-			free(serial);
+			/* If the operation returned the probe_list unchanged, it failed to parse the node */
+			if (probe_info == probe_list)
+				DEBUG_WARN("Error parsing device name \"%s\"\n", entry->d_name);
+			probe_list = probe_info;
 		}
 	}
 	closedir(dir);
-	return devices;
+	return probe_info_correct_order(probe_list);
 }
 
 int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
 	if (cl_opts->opt_device)
 		return 1;
-	info->bmp_type = BMP_TYPE_BMP;
-	const size_t total = scan_devices(SCAN_FIND, info, cl_opts->opt_serial, cl_opts->opt_position);
-	if (!total) {
+	/* Scan for all possible probes on the system */
+	const probe_info_s *const probe_list = scan_for_devices();
+	if (!probe_list) {
 		DEBUG_WARN("No BMP probe found\n");
 		return -1;
 	}
-	if (total > 1U || cl_opts->opt_list_only) {
+	/* Count up how many were found and filter the list for a match to the program options request */
+	const size_t probes = probe_info_count(probe_list);
+	const probe_info_s *probe = NULL;
+	/* If there's just one probe and we didn't get match critera, pick it */
+	if (probes == 1U && !cl_opts->opt_serial && !cl_opts->opt_position)
+		probe = probe_list;
+	else /* Otherwise filter the list */
+		probe = probe_info_filter(probe_list, cl_opts->opt_serial, cl_opts->opt_position);
+
+	/* If we found no matching probes, or we're in list-only mode */
+	if (!probe || cl_opts->opt_list_only) {
 		DEBUG_WARN("Available Probes:\n");
-		scan_devices(SCAN_LIST, NULL, NULL, 0);
-	} else if (total == 1U && !cl_opts->opt_serial && !cl_opts->opt_position)
-		scan_devices(SCAN_FIND, info, NULL, 1);
-	return total == 1U && !cl_opts->opt_list_only ? 0 : 1;
+		probe = probe_list;
+		for (size_t position = 1U; probe; probe = probe->next, ++position)
+			DEBUG_WARN(
+				"%2zu: %s, Black Magic Debug, %s, %s\n", position, probe->serial, probe->manufacturer, probe->version);
+		probe_info_list_free(probe_list);
+		return 1; // false;
+	}
+
+	/* We found a matching probe, populate bmp_info_s and signal success */
+	probe_info_to_bmp_info(probe, info);
+	probe_info_list_free(probe_list);
+	return 0; // true;
 }
 #endif

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -114,7 +114,14 @@ void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_s *info)
 	memcpy(info->version, probe->version, version_len);
 	info->version[version_len] = '\0';
 
-	const size_t manufacturer_len = MIN(strlen(probe->manufacturer), sizeof(info->manufacturer) - 1U);
-	memcpy(info->manufacturer, probe->manufacturer, manufacturer_len);
-	info->manufacturer[manufacturer_len] = '\0';
+	const size_t product_len = strlen(probe->product);
+	const size_t manufacturer_len = strlen(probe->manufacturer);
+	/* + 4 as we're including two parens, a space and C's NUL character requirement */
+	const size_t descriptor_len = MIN(product_len + manufacturer_len + 4, sizeof(info->manufacturer));
+
+	if (snprintf(info->manufacturer, descriptor_len, "%s (%s)", probe->product, probe->manufacturer) !=
+		(int)descriptor_len - 1) {
+		DEBUG_WARN("Probe descriptor string '%s (%s)' exceeds allowable manufacturer description length\n",
+			probe->product, probe->manufacturer);
+	}
 }

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -1,0 +1,118 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <malloc.h>
+#include "probe_info.h"
+#include "general.h"
+
+probe_info_s *probe_info_add(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
+	const char *const serial, const char *const version)
+{
+	probe_info_s *probe_info = malloc(sizeof(*probe_info));
+	if (!probe_info) {
+		DEBUG_INFO("Fatal: Failed to allocate memory for a probe info structure\n");
+		return NULL;
+	}
+
+	probe_info->type = type;
+	probe_info->manufacturer = mfr;
+	probe_info->serial = serial;
+	probe_info->version = version;
+
+	probe_info->next = list;
+	return probe_info;
+}
+
+size_t probe_info_count(const probe_info_s *const list)
+{
+	size_t probes = 0;
+	for (const probe_info_s *probe_info = list; probe_info; probe_info = probe_info->next)
+		++probes;
+	return probes;
+}
+
+void probe_info_free(probe_info_s *const probe_info)
+{
+	free((void *)probe_info->manufacturer);
+	free((void *)probe_info->serial);
+	free((void *)probe_info->version);
+	free(probe_info);
+}
+
+void probe_info_list_free(const probe_info_s *list)
+{
+	while (list) {
+		probe_info_s *probe_info = (probe_info_s *)list;
+		list = probe_info->next;
+		probe_info_free(probe_info);
+	}
+}
+
+const probe_info_s *probe_info_correct_order(probe_info_s *list)
+{
+	probe_info_s *list_head = NULL;
+	while (list) {
+		probe_info_s *probe_info = list->next;
+		list->next = list_head;
+		list_head = list;
+		list = probe_info;
+	}
+	return list_head;
+}
+
+const probe_info_s *probe_info_filter(const probe_info_s *const list, const char *const serial, const size_t position)
+{
+	const probe_info_s *probe_info = list;
+	for (size_t probe = 0; probe_info; probe_info = probe_info->next, ++probe) {
+		if ((serial && strstr(probe_info->serial, serial)) || (position && probe == position))
+			return probe_info;
+	}
+	return NULL;
+}
+
+void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_t *info)
+{
+	info->bmp_type = probe->type;
+
+	const size_t serial_len = MIN(strlen(probe->serial), sizeof(info->serial) - 1U);
+	memcpy(info->serial, probe->serial, serial_len);
+	info->serial[serial_len] = '\0';
+
+	const size_t version_len = MIN(strlen(probe->version), sizeof(info->version) - 1U);
+	memcpy(info->version, probe->version, version_len);
+	info->version[version_len] = '\0';
+
+	const size_t manufacturer_len = MIN(strlen(probe->manufacturer), sizeof(info->manufacturer) - 1U);
+	memcpy(info->manufacturer, probe->manufacturer, manufacturer_len);
+	info->manufacturer[manufacturer_len] = '\0';
+}

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -36,7 +36,7 @@
 #include "general.h"
 
 probe_info_s *probe_info_add(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
-	const char *const serial, const char *const version)
+	const char *const product, const char *const serial, const char *const version)
 {
 	probe_info_s *probe_info = malloc(sizeof(*probe_info));
 	if (!probe_info) {
@@ -46,6 +46,7 @@ probe_info_s *probe_info_add(probe_info_s *const list, const bmp_type_t type, co
 
 	probe_info->type = type;
 	probe_info->manufacturer = mfr;
+	probe_info->product = product;
 	probe_info->serial = serial;
 	probe_info->version = version;
 
@@ -64,6 +65,7 @@ size_t probe_info_count(const probe_info_s *const list)
 void probe_info_free(probe_info_s *const probe_info)
 {
 	free((void *)probe_info->manufacturer);
+	free((void *)probe_info->product);
 	free((void *)probe_info->serial);
 	free((void *)probe_info->version);
 	free(probe_info);
@@ -100,7 +102,7 @@ const probe_info_s *probe_info_filter(const probe_info_s *const list, const char
 	return NULL;
 }
 
-void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_t *info)
+void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_s *info)
 {
 	info->bmp_type = probe->type;
 

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -102,7 +102,7 @@ const probe_info_s *probe_info_correct_order(probe_info_s *list)
 const probe_info_s *probe_info_filter(const probe_info_s *const list, const char *const serial, const size_t position)
 {
 	const probe_info_s *probe_info = list;
-	for (size_t probe = 0; probe_info; probe_info = probe_info->next, ++probe) {
+	for (size_t probe = 1; probe_info; probe_info = probe_info->next, ++probe) {
 		if ((serial && strstr(probe_info->serial, serial)) || (position && probe == position))
 			return probe_info;
 	}

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -112,7 +112,8 @@ const probe_info_s *probe_info_filter(const probe_info_s *const list, const char
 void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_s *info)
 {
 	info->bmp_type = probe->type;
-
+	info->pid = probe->pid;
+	info->vid = probe->vid;
 	const size_t serial_len = MIN(strlen(probe->serial), sizeof(info->serial) - 1U);
 	memcpy(info->serial, probe->serial, serial_len);
 	info->serial[serial_len] = '\0';

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -38,7 +38,7 @@
 probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
 	const char *const product, const char *const serial, const char *const version)
 {
-	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version) ;
+	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version);
 }
 
 probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
@@ -51,15 +51,16 @@ probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t ty
 	}
 
 	probe_info->type = type;
-	probe_info->vid  = vid ;
-	probe_info->pid = pid ;
+	probe_info->vid = vid;
+	probe_info->pid = pid;
 	probe_info->manufacturer = mfr;
 	probe_info->product = product;
 	probe_info->serial = serial;
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;}
+	return probe_info;
+}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -35,7 +35,7 @@
 #include "probe_info.h"
 #include "general.h"
 
-probe_info_s *probe_info_add(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
+probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
 	const char *const product, const char *const serial, const char *const version)
 {
 	probe_info_s *probe_info = malloc(sizeof(*probe_info));

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -38,6 +38,12 @@
 probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_t type, const char *const mfr,
 	const char *const product, const char *const serial, const char *const version)
 {
+	return probe_info_add_by_id(list, type, 0, 0, mfr, product, serial, version) ;
+}
+
+probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
+	const char *const mfr, const char *const product, const char *const serial, const char *const version)
+{
 	probe_info_s *probe_info = malloc(sizeof(*probe_info));
 	if (!probe_info) {
 		DEBUG_INFO("Fatal: Failed to allocate memory for a probe info structure\n");
@@ -45,14 +51,15 @@ probe_info_s *probe_info_add_by_serial(probe_info_s *const list, const bmp_type_
 	}
 
 	probe_info->type = type;
+	probe_info->vid  = vid ;
+	probe_info->pid = pid ;
 	probe_info->manufacturer = mfr;
 	probe_info->product = product;
 	probe_info->serial = serial;
 	probe_info->version = version;
 
 	probe_info->next = list;
-	return probe_info;
-}
+	return probe_info;}
 
 size_t probe_info_count(const probe_info_s *const list)
 {

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -113,8 +113,10 @@ const probe_info_s *probe_info_filter(const probe_info_s *const list, const char
 void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_s *info)
 {
 	info->bmp_type = probe->type;
+#if HOSTED_BMP_ONLY != 1
 	info->pid = probe->pid;
 	info->vid = probe->vid;
+#endif
 	const size_t serial_len = MIN(strlen(probe->serial), sizeof(info->serial) - 1U);
 	memcpy(info->serial, probe->serial, serial_len);
 	info->serial[serial_len] = '\0';

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -41,6 +41,7 @@
 typedef struct probe_info {
 	bmp_type_t type;
 	const char *manufacturer;
+	const char *product;
 	const char *serial;
 	const char *version;
 

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -49,12 +49,12 @@ typedef struct probe_info {
 } probe_info_s;
 
 probe_info_s *probe_info_add(
-	probe_info_s *list, bmp_type_t type, const char *mfr, const char *serial, const char *version);
+	probe_info_s *list, bmp_type_t type, const char *mfr, const char *product, const char *serial, const char *version);
 size_t probe_info_count(const probe_info_s *list);
 void probe_info_list_free(const probe_info_s *list);
 
 const probe_info_s *probe_info_correct_order(probe_info_s *list);
 const probe_info_s *probe_info_filter(const probe_info_s *list, const char *serial, size_t position);
-void probe_info_to_bmp_info(const probe_info_s *probe, bmp_info_t *info);
+void probe_info_to_bmp_info(const probe_info_s *probe, bmp_info_s *info);
 
 #endif /* PLATFORMS_HOSTED_PROBE_INFO_H */

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORMS_HOSTED_PROBE_INFO_H
+#define PLATFORMS_HOSTED_PROBE_INFO_H
+
+#include <stddef.h>
+#include "platform.h"
+#include "bmp_hosted.h"
+
+typedef struct probe_info {
+	bmp_type_t type;
+	const char *manufacturer;
+	const char *serial;
+	const char *version;
+
+	struct probe_info *next;
+} probe_info_s;
+
+probe_info_s *probe_info_add(
+	probe_info_s *list, bmp_type_t type, const char *mfr, const char *serial, const char *version);
+size_t probe_info_count(const probe_info_s *list);
+void probe_info_list_free(const probe_info_s *list);
+
+const probe_info_s *probe_info_correct_order(probe_info_s *list);
+const probe_info_s *probe_info_filter(const probe_info_s *list, const char *serial, size_t position);
+void probe_info_to_bmp_info(const probe_info_s *probe, bmp_info_t *info);
+
+#endif /* PLATFORMS_HOSTED_PROBE_INFO_H */

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -52,6 +52,8 @@ typedef struct probe_info {
 
 probe_info_s *probe_info_add_by_serial(
 	probe_info_s *list, bmp_type_t type, const char *mfr, const char *product, const char *serial, const char *version);
+probe_info_s *probe_info_add_by_id(probe_info_s *const list, const bmp_type_t type, uint16_t vid, uint16_t pid,
+	const char *const mfr, const char *const product, const char *const serial, const char *const version);
 size_t probe_info_count(const probe_info_s *list);
 void probe_info_list_free(const probe_info_s *list);
 

--- a/src/platforms/hosted/probe_info.h
+++ b/src/platforms/hosted/probe_info.h
@@ -40,6 +40,8 @@
 
 typedef struct probe_info {
 	bmp_type_t type;
+	uint16_t vid;
+	uint16_t pid;
 	const char *manufacturer;
 	const char *product;
 	const char *serial;
@@ -48,7 +50,7 @@ typedef struct probe_info {
 	struct probe_info *next;
 } probe_info_s;
 
-probe_info_s *probe_info_add(
+probe_info_s *probe_info_add_by_serial(
 	probe_info_s *list, bmp_type_t type, const char *mfr, const char *product, const char *serial, const char *version);
 size_t probe_info_count(const probe_info_s *list);
 void probe_info_list_free(const probe_info_s *list);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes the way BMDA handles probe enumeration when built `HOSTED_BMP_ONLY=1` and provides a framework for rebuilding the probe enumeration of the full build BMDA. This forms a basis for the work Sid Price has been doing to try and replace the spaghetti mess that is find_debuggers() and the lack of support of OSX.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
