### PR TITLE
Feature: Initial LPC55 support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -48,6 +48,7 @@ SRC =              \
 	lpc15xx.c      \
 	lpc43xx.c      \
 	lpc546xx.c     \
+	lpc55xx.c      \
 	kinetis.c      \
 	main.c         \
 	morse.c        \

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -659,7 +659,9 @@ adiv5_access_port_s *adiv5_new_ap(adiv5_debug_port_s *dp, uint8_t apsel)
 
 	if (!tmpap.idr) /* IDR Invalid */
 		return NULL;
-	tmpap.csw = adiv5_ap_read(&tmpap, ADIV5_AP_CSW) & ~(ADIV5_AP_CSW_SIZE_MASK | ADIV5_AP_CSW_ADDRINC_MASK);
+	tmpap.csw = adiv5_ap_read(&tmpap, ADIV5_AP_CSW);
+	tmpap.csw &= ~(ADIV5_AP_CSW_SIZE_MASK | ADIV5_AP_CSW_ADDRINC_MASK);
+	tmpap.csw |= ADIV5_AP_CSW_DBGSWENABLE;
 
 	if (tmpap.csw & ADIV5_AP_CSW_TRINPROG) {
 		DEBUG_WARN("AP %d: Transaction in progress. AP is not usable!\n", apsel);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -857,6 +857,9 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 	/* Write request for debug reset release */
 	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ctrlstat & ~ADIV5_DP_CTRLSTAT_CDBGRSTREQ);
 
+	if (dp->target_designer_code == JEP106_MANUFACTURER_NXP)
+		lpc55_dp_prepare(dp);
+
 	/* Probe for APs on this DP */
 	size_t invalid_aps = 0;
 	dp->refcnt++;
@@ -887,6 +890,7 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 		kinetis_mdm_probe(ap);
 		nrf51_mdm_probe(ap);
 		efm32_aap_probe(ap);
+		lpc55_dmap_probe(ap);
 
 		/* Halt the device and release from reset if reset is active! */
 		if (!ap->apsel && (ap->idr & 0xfU) == ARM_AP_TYPE_AHB)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -698,6 +698,12 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 	case JEP106_MANUFACTURER_RENESAS:
 		PROBE(renesas_probe);
 		break;
+	case JEP106_MANUFACTURER_NXP:
+		if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M33)
+			PROBE(lpc55xx_probe);
+		else
+			DEBUG_WARN("Unhandled NXP device\n");
+		break;
 	case JEP106_MANUFACTURER_ARM_CHINA:
 		PROBE(mm32f3xx_probe); /* MindMotion Star-MC1 */
 		break;

--- a/src/target/jep106.h
+++ b/src/target/jep106.h
@@ -54,6 +54,7 @@
 
 #define JEP106_MANUFACTURER_ARM          0x43bU /* ARM Ltd. */
 #define JEP106_MANUFACTURER_FREESCALE    0x00eU /* Freescale */
+#define JEP106_MANUFACTURER_NXP          0x015U /* NXP */
 #define JEP106_MANUFACTURER_TEXAS        0x017U /* Texas Instruments */
 #define JEP106_MANUFACTURER_ATMEL        0x01fU /* Atmel */
 #define JEP106_MANUFACTURER_STM          0x020U /* STMicroelectronics */

--- a/src/target/lpc55xx.c
+++ b/src/target/lpc55xx.c
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * Based on prior work by Uwe Bones <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "general.h"
+#include "target.h"
+#include "target_internal.h"
+#include "cortexm.h"
+
+#define LPC55xx_CHIPID 0x50000ff8U
+
+bool lpc55xx_probe(target_s *const target)
+{
+	adiv5_access_port_s *const ap = cortexm_ap(target);
+	if (ap->apsel == 1)
+		return false;
+#ifdef ENABLE_DEBUG
+	const uint32_t chipid = target_mem_read32(target, LPC55xx_CHIPID);
+	DEBUG_WARN("Chip ID: %08" PRIx32 "\n", chipid);
+#endif
+
+	target_add_ram(target, 0x20000000, 0x44000);
+	target->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
+	switch (target->cpuid & CPUID_PATCH_MASK) {
+	case 3:
+		target->driver = "LPC55";
+		break;
+	case 4:
+		target->driver = "LPC551x";
+		break;
+	}
+	return true;
+}

--- a/src/target/lpc55xx.c
+++ b/src/target/lpc55xx.c
@@ -38,6 +38,9 @@
 #include "cortexm.h"
 
 #define LPC55xx_CHIPID 0x50000ff8U
+#define LPC55_DMAP_IDR 0x002a0000U
+
+static void lpc55_dmap_ap_free(void *priv);
 
 bool lpc55xx_probe(target_s *const target)
 {
@@ -60,4 +63,28 @@ bool lpc55xx_probe(target_s *const target)
 		break;
 	}
 	return true;
+}
+
+bool lpc55_dmap_probe(adiv5_access_port_s *ap)
+{
+	if (ap->idr != LPC55_DMAP_IDR)
+		return false;
+
+	target_s *target = target_new();
+	if (!target)
+		return false;
+
+	adiv5_ap_ref(ap);
+	target->priv = ap;
+	target->priv_free = lpc55_dmap_ap_free;
+
+	target->driver = "LPC55 Debug Mailbox";
+	target->regs_size = 0;
+
+	return true;
+}
+
+static void lpc55_dmap_ap_free(void *priv)
+{
+	adiv5_ap_unref(priv);
 }

--- a/src/target/lpc55xx.c
+++ b/src/target/lpc55xx.c
@@ -40,8 +40,10 @@
 #define LPC55xx_CHIPID 0x50000ff8U
 #define LPC55_DMAP_IDR 0x002a0000U
 
-static bool lpc55_dmap_cmd(adiv5_access_port_s *ap, uint32_t cmd);
+#define LPC55_DMAP_BULK_ERASE 0x02U
 
+static bool lpc55_dmap_cmd(adiv5_access_port_s *ap, uint32_t cmd);
+static bool lpc55_dmap_mass_erase(target_s *target);
 static void lpc55_dmap_ap_free(void *priv);
 
 bool lpc55xx_probe(target_s *const target)
@@ -82,6 +84,7 @@ bool lpc55_dmap_probe(adiv5_access_port_s *ap)
 
 	target->driver = "LPC55 Debug Mailbox";
 	target->regs_size = 0;
+	target->mass_erase = lpc55_dmap_mass_erase;
 
 	return true;
 }
@@ -115,4 +118,9 @@ static bool lpc55_dmap_cmd(adiv5_access_port_s *const ap, const uint32_t cmd)
 			return false;
 		}
 	}
+}
+
+static bool lpc55_dmap_mass_erase(target_s *target)
+{
+	return lpc55_dmap_cmd(cortexm_ap(target), LPC55_DMAP_BULK_ERASE);
 }

--- a/src/target/lpc55xx.c
+++ b/src/target/lpc55xx.c
@@ -40,6 +40,8 @@
 #define LPC55xx_CHIPID 0x50000ff8U
 #define LPC55_DMAP_IDR 0x002a0000U
 
+static bool lpc55_dmap_cmd(adiv5_access_port_s *ap, uint32_t cmd);
+
 static void lpc55_dmap_ap_free(void *priv);
 
 bool lpc55xx_probe(target_s *const target)
@@ -87,4 +89,30 @@ bool lpc55_dmap_probe(adiv5_access_port_s *ap)
 static void lpc55_dmap_ap_free(void *priv)
 {
 	adiv5_ap_unref(priv);
+}
+
+static bool lpc55_dmap_cmd(adiv5_access_port_s *const ap, const uint32_t cmd)
+{
+	platform_timeout_s timeout;
+	platform_timeout_set(&timeout, 20);
+	while (true) {
+		const uint32_t csw = adiv5_ap_read(ap, ADIV5_AP_CSW);
+		if (csw == 0)
+			break;
+		if (platform_timeout_is_expired(&timeout))
+			return false;
+	}
+
+	adiv5_ap_write(ap, ADIV5_AP_TAR, cmd);
+
+	platform_timeout_set(&timeout, 20);
+	while (true) {
+		const uint16_t value = (uint16_t)adiv5_ap_read(ap, ADIV5_AP_DRW);
+		if (value == 0)
+			return true;
+		if (platform_timeout_is_expired(&timeout)) {
+			DEBUG_WARN("LPC55 cmd %" PRIx32 " failed\n", cmd);
+			return false;
+		}
+	}
 }

--- a/src/target/target_probe.c
+++ b/src/target/target_probe.c
@@ -26,10 +26,11 @@
 #define DO_PRAGMA_(x) _Pragma(#x)
 #define DO_PRAGMA(x)  DO_PRAGMA_(x)
 // __attribute__((alias)) is not supported in AppleClang.
-#define weak_alias(name, aliasname)  DO_PRAGMA(weak name = aliasname)
-#define CORTEXA_PROBE_WEAK_NOP(name) weak_alias(name, cortexa_probe_nop)
-#define CORTEXM_PROBE_WEAK_NOP(name) weak_alias(name, cortexm_probe_nop)
-#define TARGET_PROBE_WEAK_NOP(name)  weak_alias(name, target_probe_nop)
+#define weak_alias(name, aliasname)     DO_PRAGMA(weak name = aliasname)
+#define CORTEXA_PROBE_WEAK_NOP(name)    weak_alias(name, cortexa_probe_nop)
+#define CORTEXM_PROBE_WEAK_NOP(name)    weak_alias(name, cortexm_probe_nop)
+#define TARGET_PROBE_WEAK_NOP(name)     weak_alias(name, target_probe_nop)
+#define LPC55_DP_PREPARE_WEAK_NOP(name) weak_alias(name, lpc55_dp_prepare_nop)
 #else
 #define APPLE_STATIC static inline
 #define CORTEXA_PROBE_WEAK_NOP(name) \
@@ -37,6 +38,8 @@
 #define CORTEXM_PROBE_WEAK_NOP(name) \
 	extern bool name(adiv5_access_port_s *) __attribute__((weak, alias("cortexm_probe_nop")));
 #define TARGET_PROBE_WEAK_NOP(name) extern bool name(target_s *) __attribute__((weak, alias("target_probe_nop")));
+#define LPC55_DP_PREPARE_WEAK_NOP(name) \
+	extern void name(adiv5_debug_port_s *) __attribute__((weak, alias("lpc55_dp_prepare_nop")));
 #endif
 
 APPLE_STATIC bool cortexa_probe_nop(adiv5_access_port_s *apb, uint32_t debug_base)
@@ -46,16 +49,21 @@ APPLE_STATIC bool cortexa_probe_nop(adiv5_access_port_s *apb, uint32_t debug_bas
 	return false;
 }
 
-APPLE_STATIC bool cortexm_probe_nop(adiv5_access_port_s *ap)
+APPLE_STATIC bool cortexm_probe_nop(adiv5_access_port_s *access_port)
 {
-	(void)ap;
+	(void)access_port;
 	return false;
 }
 
-APPLE_STATIC bool target_probe_nop(target_s *t)
+APPLE_STATIC bool target_probe_nop(target_s *target)
 {
-	(void)t;
+	(void)target;
 	return false;
+}
+
+APPLE_STATIC void lpc55_dp_prepare_nop(adiv5_debug_port_s *debug_port)
+{
+	(void)debug_port;
 }
 
 /*
@@ -71,6 +79,7 @@ CORTEXM_PROBE_WEAK_NOP(kinetis_mdm_probe)
 CORTEXM_PROBE_WEAK_NOP(nrf51_mdm_probe)
 CORTEXM_PROBE_WEAK_NOP(efm32_aap_probe)
 CORTEXM_PROBE_WEAK_NOP(rp_rescue_probe)
+CORTEXM_PROBE_WEAK_NOP(lpc55_dmap_probe)
 
 TARGET_PROBE_WEAK_NOP(ch32f1_probe)
 TARGET_PROBE_WEAK_NOP(gd32f1_probe)
@@ -89,6 +98,7 @@ TARGET_PROBE_WEAK_NOP(lpc15xx_probe)
 TARGET_PROBE_WEAK_NOP(lpc17xx_probe)
 TARGET_PROBE_WEAK_NOP(lpc43xx_probe)
 TARGET_PROBE_WEAK_NOP(lpc546xx_probe)
+TARGET_PROBE_WEAK_NOP(lpc55xx_probe)
 TARGET_PROBE_WEAK_NOP(samx7x_probe)
 TARGET_PROBE_WEAK_NOP(sam3x_probe)
 TARGET_PROBE_WEAK_NOP(sam4l_probe)
@@ -103,3 +113,5 @@ TARGET_PROBE_WEAK_NOP(rp_probe)
 TARGET_PROBE_WEAK_NOP(renesas_probe)
 TARGET_PROBE_WEAK_NOP(mm32l0xx_probe)
 TARGET_PROBE_WEAK_NOP(mm32f3xx_probe)
+
+LPC55_DP_PREPARE_WEAK_NOP(lpc55_dp_prepare)

--- a/src/target/target_probe.h
+++ b/src/target/target_probe.h
@@ -36,6 +36,7 @@ bool kinetis_mdm_probe(adiv5_access_port_s *ap);
 bool nrf51_mdm_probe(adiv5_access_port_s *ap);
 bool efm32_aap_probe(adiv5_access_port_s *ap);
 bool rp_rescue_probe(adiv5_access_port_s *ap);
+bool lpc55_dmap_probe(adiv5_access_port_s *ap);
 
 bool ch32f1_probe(target_s *t);  // will catch all the clones
 bool at32fxx_probe(target_s *t); // STM32 clones from Artery
@@ -56,6 +57,7 @@ bool lpc15xx_probe(target_s *t);
 bool lpc17xx_probe(target_s *t);
 bool lpc43xx_probe(target_s *t);
 bool lpc546xx_probe(target_s *t);
+bool lpc55xx_probe(target_s *t);
 bool samx7x_probe(target_s *t);
 bool sam3x_probe(target_s *t);
 bool sam4l_probe(target_s *t);
@@ -68,5 +70,7 @@ bool msp432_probe(target_s *t);
 bool ke04_probe(target_s *t);
 bool rp_probe(target_s *t);
 bool renesas_probe(target_s *t);
+
+void lpc55_dp_prepare(adiv5_debug_port_s *dp);
 
 #endif /* TARGET_TARGET_PROBE_H */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR is a revamp of #861 to meet the current code base standards and contribution guidelines, and replaces that PR. This provides initial basic support for LPC55 targets which will then be supplemented by #1189 which expands this considerably to provide full target support.

This basic support provides detection, "debug mailbox" recovery support, and recovery-mode mass erase.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #736
