### PR TITLE
Fix: ADIv5 code duplication

### DIFF
--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -76,7 +76,7 @@ extern jtag_proc_s jtag_proc;
 #if PC_HOSTED == 1
 bool platform_jtagtap_init(void);
 #else
-int jtagtap_init(void);
+void jtagtap_init(void);
 #endif
 
 #endif /* INCLUDE_JTAGTAP_H */

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -74,7 +74,7 @@ extern jtag_proc_s jtag_proc;
 #define jtagtap_return_idle(cycles) jtag_proc.jtagtap_tms_seq(0x01, (cycles) + 1U)
 
 #if PC_HOSTED == 1
-int platform_jtagtap_init(void);
+bool platform_jtagtap_init(void);
 #else
 int jtagtap_init(void);
 #endif

--- a/src/include/swd.h
+++ b/src/include/swd.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef INCLUDE_SWD_H
+#define INCLUDE_SWD_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* Functions interface talking SWD */
+typedef struct swd_proc {
+	/* Perform a clock_cycles read */
+	uint32_t (*seq_in)(size_t clock_cycles);
+	/* Perform a clock_cycles read + parity */
+	bool (*seq_in_parity)(uint32_t *ret, size_t clock_cycles);
+	/* Perform a clock_cycles write with the provided data */
+	void (*seq_out)(uint32_t tms_states, size_t clock_cycles);
+	/* Perform a clock_cycles write + parity with the provided data */
+	void (*seq_out_parity)(uint32_t tms_states, size_t clock_cycles);
+} swd_proc_s;
+
+extern swd_proc_s swd_proc;
+
+#if PC_HOSTED == 1
+int platform_swdptap_init(void);
+#else
+int swdptap_init(void);
+#endif
+
+#endif /*INCLUDE_SWD_H*/

--- a/src/include/swd.h
+++ b/src/include/swd.h
@@ -39,10 +39,6 @@ typedef struct swd_proc {
 
 extern swd_proc_s swd_proc;
 
-#if PC_HOSTED == 1
-int platform_swdptap_init(void);
-#else
-int swdptap_init(void);
-#endif
+void swdptap_init(void);
 
 #endif /*INCLUDE_SWD_H*/

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -34,7 +34,7 @@ static void jtagtap_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock
 static bool jtagtap_next(bool tms, bool tdi);
 static void jtagtap_cycle(bool tms, bool tdi, size_t clock_cycles);
 
-int jtagtap_init()
+void jtagtap_init(void)
 {
 	platform_target_clk_output_enable(true);
 	TMS_SET_MODE();
@@ -52,7 +52,6 @@ int jtagtap_init()
 		jtagtap_next(true, false); /* 50 idle cylces for SWD reset */
 	jtagtap_tms_seq(0xe73cU, 16U); /* SWD to JTAG sequence */
 	jtagtap_soft_reset();
-	return 0;
 }
 
 static void jtagtap_reset(void)

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -24,7 +24,6 @@
 
 #include "general.h"
 #include "jtagtap.h"
-#include "gdb_packet.h"
 
 jtag_proc_s jtag_proc;
 

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -273,7 +273,7 @@ void remote_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->ap_write = remote_adiv5_ap_write;
 	dp->ap_read = remote_adiv5_ap_read;
 	dp->mem_read = remote_ap_mem_read;
-	dp->mem_write_sized = remote_ap_mem_write_sized;
+	dp->mem_write = remote_ap_mem_write_sized;
 }
 
 void remote_add_jtag_dev(uint32_t i, const jtag_dev_s *jtag_dev)

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -31,7 +31,7 @@ int platform_buffer_write(const uint8_t *data, int size);
 int platform_buffer_read(uint8_t *data, int size);
 
 int remote_init(void);
-int remote_swdptap_init(void);
+bool remote_swdptap_init(void);
 int remote_jtagtap_init(void);
 bool remote_target_get_power(void);
 const char *remote_target_voltage(void);

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -31,7 +31,7 @@ int platform_buffer_write(const uint8_t *data, int size);
 int platform_buffer_read(uint8_t *data, int size);
 
 int remote_init(void);
-int remote_swdptap_init(adiv5_debug_port_s *dp);
+int remote_swdptap_init(void);
 int remote_jtagtap_init(jtag_proc_s *jtag_proc);
 bool remote_target_get_power(void);
 const char *remote_target_voltage(void);

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -32,7 +32,7 @@ int platform_buffer_read(uint8_t *data, int size);
 
 int remote_init(void);
 int remote_swdptap_init(void);
-int remote_jtagtap_init(jtag_proc_s *jtag_proc);
+int remote_jtagtap_init(void);
 bool remote_target_get_power(void);
 const char *remote_target_voltage(void);
 bool remote_target_set_power(bool power);

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -32,7 +32,7 @@ int platform_buffer_read(uint8_t *data, int size);
 
 int remote_init(void);
 bool remote_swdptap_init(void);
-int remote_jtagtap_init(void);
+bool remote_jtagtap_init(void);
 bool remote_target_get_power(void);
 const char *remote_target_voltage(void);
 bool remote_target_set_power(bool power);

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -591,14 +591,12 @@ int cmsis_dap_jtagtap_init(jtag_proc_s *jtag_proc)
 	return 0;
 }
 
-int dap_jtag_dp_init(adiv5_debug_port_s *dp)
+void dap_jtag_dp_init(adiv5_debug_port_s *dp)
 {
 	dp->dp_read = dap_dp_read_reg;
 	dp->error = dap_jtag_dp_error;
 	dp->low_access = dap_dp_low_access;
 	dp->abort = dap_dp_abort;
-
-	return true;
 }
 
 #define SWD_SEQUENCE_IN  0x80U

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -574,7 +574,7 @@ static bool cmsis_dap_jtagtap_next(const bool tms, const bool tdi)
 	return tdo;
 }
 
-int cmsis_dap_jtagtap_init(jtag_proc_s *jtag_proc)
+int cmsis_dap_jtagtap_init(void)
 {
 	DEBUG_PROBE("jtap_init\n");
 	if (!(dap_caps & DAP_CAP_JTAG))
@@ -583,11 +583,11 @@ int cmsis_dap_jtagtap_init(jtag_proc_s *jtag_proc)
 	dap_disconnect();
 	dap_connect(true);
 	dap_reset_link(true);
-	jtag_proc->jtagtap_reset = cmsis_dap_jtagtap_reset;
-	jtag_proc->jtagtap_next = cmsis_dap_jtagtap_next;
-	jtag_proc->jtagtap_tms_seq = cmsis_dap_jtagtap_tms_seq;
-	jtag_proc->jtagtap_tdi_tdo_seq = cmsis_dap_jtagtap_tdi_tdo_seq;
-	jtag_proc->jtagtap_tdi_seq = cmsis_dap_jtagtap_tdi_seq;
+	jtag_proc.jtagtap_reset = cmsis_dap_jtagtap_reset;
+	jtag_proc.jtagtap_next = cmsis_dap_jtagtap_next;
+	jtag_proc.jtagtap_tms_seq = cmsis_dap_jtagtap_tms_seq;
+	jtag_proc.jtagtap_tdi_tdo_seq = cmsis_dap_jtagtap_tdi_tdo_seq;
+	jtag_proc.jtagtap_tdi_seq = cmsis_dap_jtagtap_tdi_seq;
 	return 0;
 }
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -574,11 +574,11 @@ static bool cmsis_dap_jtagtap_next(const bool tms, const bool tdi)
 	return tdo;
 }
 
-int cmsis_dap_jtagtap_init(void)
+bool dap_jtagtap_init(void)
 {
 	DEBUG_PROBE("jtap_init\n");
 	if (!(dap_caps & DAP_CAP_JTAG))
-		return -1;
+		return false;
 	mode = DAP_CAP_JTAG;
 	dap_disconnect();
 	dap_connect(true);
@@ -588,7 +588,7 @@ int cmsis_dap_jtagtap_init(void)
 	jtag_proc.jtagtap_tms_seq = cmsis_dap_jtagtap_tms_seq;
 	jtag_proc.jtagtap_tdi_tdo_seq = cmsis_dap_jtagtap_tdi_tdo_seq;
 	jtag_proc.jtagtap_tdi_seq = cmsis_dap_jtagtap_tdi_seq;
-	return 0;
+	return true;
 }
 
 void dap_jtag_dp_init(adiv5_debug_port_s *dp)

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -87,7 +87,7 @@ typedef enum cmsis_type {
 typedef struct hid_device_info hid_device_info_s;
 #endif
 
-static bool dap_dp_low_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t data);
+static bool dap_dp_low_write(uint16_t addr, uint32_t data);
 
 /*- Variables ---------------------------------------------------------------*/
 static cmsis_type_e type;
@@ -294,7 +294,7 @@ static uint32_t dap_swd_dp_error(adiv5_debug_port_s *dp, const bool protocol_rec
 		 */
 		dap_line_reset();
 		if (dp->version >= 2)
-			dap_dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+			dap_dp_low_write(ADIV5_DP_TARGETSEL, dp->targetsel);
 		dap_read_reg(dp, ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */
 	}
@@ -602,10 +602,9 @@ void dap_jtag_dp_init(adiv5_debug_port_s *dp)
 #define SWD_SEQUENCE_IN  0x80U
 #define DAP_SWD_SEQUENCE 0x1dU
 
-static bool dap_dp_low_write(adiv5_debug_port_s *dp, uint16_t addr, const uint32_t data)
+static bool dap_dp_low_write(uint16_t addr, const uint32_t data)
 {
 	DEBUG_PROBE("dap_dp_low_write %08" PRIx32 "\n", data);
-	(void)dp;
 	unsigned int packet_request = make_packet_request(ADIV5_LOW_WRITE, addr);
 	uint8_t buf[32] = {DAP_SWD_SEQUENCE, 5, 8, packet_request,
 		4U + SWD_SEQUENCE_IN, /* one turn-around + read 3 bit ACK */
@@ -635,10 +634,10 @@ int dap_swdptap_init(adiv5_debug_port_s *dp)
 		dp->dp_low_write = dap_dp_low_write;
 	else
 		dp->dp_low_write = NULL;
-	dp->seq_in = dap_swdptap_seq_in;
-	dp->seq_in_parity = dap_swdptap_seq_in_parity;
-	dp->seq_out = dap_swdptap_seq_out;
-	dp->seq_out_parity = dap_swdptap_seq_out_parity;
+	swd_proc.seq_in = dap_swdptap_seq_in;
+	swd_proc.seq_in_parity = dap_swdptap_seq_in_parity;
+	swd_proc.seq_out = dap_swdptap_seq_out;
+	swd_proc.seq_out_parity = dap_swdptap_seq_out_parity;
 	dp->dp_read = dap_dp_read_reg;
 	dp->error = dap_swd_dp_error;
 	dp->low_access = dap_dp_low_access;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -619,10 +619,10 @@ static bool dap_dp_low_write(uint16_t addr, const uint32_t data)
 	return (ack != SWDP_ACK_OK);
 }
 
-int dap_swdptap_init(adiv5_debug_port_s *dp)
+bool dap_swdptap_init(adiv5_debug_port_s *dp)
 {
 	if (!(dap_caps & DAP_CAP_SWD))
-		return 1;
+		return false;
 	mode = DAP_CAP_SWD;
 	dap_transfer_configure(2, 128, 128);
 	dap_swd_configure(0);
@@ -642,5 +642,5 @@ int dap_swdptap_init(adiv5_debug_port_s *dp)
 	dp->error = dap_swd_dp_error;
 	dp->low_access = dap_dp_low_access;
 	dp->abort = dap_dp_abort;
-	return 0;
+	return true;
 }

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -489,7 +489,7 @@ static void dap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size
 	DEBUG_WIRE("dap_mem_read transferred %zu blocks\n", len >> align);
 }
 
-static void dap_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
+static void dap_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
 	if (len == 0)
 		return;
@@ -534,7 +534,7 @@ void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->ap_read = dap_ap_read;
 	dp->ap_write = dap_ap_write;
 	dp->mem_read = dap_mem_read;
-	dp->mem_write_sized = dap_mem_write_sized;
+	dp->mem_write = dap_mem_write;
 }
 
 static void cmsis_dap_jtagtap_reset(void)

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -27,7 +27,7 @@
 int dap_init(bmp_info_s *info);
 void dap_exit_function(void);
 void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp);
-int cmsis_dap_jtagtap_init(void);
+bool dap_jtagtap_init(void);
 bool dap_swdptap_init(adiv5_debug_port_s *dp);
 void dap_jtag_dp_init(adiv5_debug_port_s *dp);
 uint32_t dap_swj_clock(uint32_t clock);
@@ -57,7 +57,7 @@ void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
 }
 
-int cmsis_dap_jtagtap_init(void)
+bool dap_jtagtap_init(void)
 {
 	return -1;
 }

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -28,7 +28,7 @@ int dap_init(bmp_info_s *info);
 void dap_exit_function(void);
 void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp);
 int cmsis_dap_jtagtap_init(void);
-int dap_swdptap_init(adiv5_debug_port_s *dp);
+bool dap_swdptap_init(adiv5_debug_port_s *dp);
 void dap_jtag_dp_init(adiv5_debug_port_s *dp);
 uint32_t dap_swj_clock(uint32_t clock);
 void dap_swd_configure(uint8_t cfg);
@@ -62,9 +62,9 @@ int cmsis_dap_jtagtap_init(void)
 	return -1;
 }
 
-int dap_swdptap_init(adiv5_debug_port_s *dp)
+bool dap_swdptap_init(adiv5_debug_port_s *dp)
 {
-	return -1;
+	return false;
 }
 
 void dap_jtag_dp_init(adiv5_debug_port_s *dp)

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -27,7 +27,7 @@
 int dap_init(bmp_info_s *info);
 void dap_exit_function(void);
 void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp);
-int cmsis_dap_jtagtap_init(jtag_proc_s *jtag_proc);
+int cmsis_dap_jtagtap_init(void);
 int dap_swdptap_init(adiv5_debug_port_s *dp);
 void dap_jtag_dp_init(adiv5_debug_port_s *dp);
 uint32_t dap_swj_clock(uint32_t clock);
@@ -57,7 +57,7 @@ void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
 }
 
-int cmsis_dap_jtagtap_init(jtag_proc_s *jtag_proc)
+int cmsis_dap_jtagtap_init(void)
 {
 	return -1;
 }

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -29,7 +29,7 @@ void dap_exit_function(void);
 void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp);
 int cmsis_dap_jtagtap_init(jtag_proc_s *jtag_proc);
 int dap_swdptap_init(adiv5_debug_port_s *dp);
-int dap_jtag_dp_init(adiv5_debug_port_s *dp);
+void dap_jtag_dp_init(adiv5_debug_port_s *dp);
 uint32_t dap_swj_clock(uint32_t clock);
 void dap_swd_configure(uint8_t cfg);
 void dap_nrst_set_val(bool assert);
@@ -67,9 +67,9 @@ int dap_swdptap_init(adiv5_debug_port_s *dp)
 	return -1;
 }
 
-int dap_jtag_dp_init(adiv5_debug_port_s *dp)
+void dap_jtag_dp_init(adiv5_debug_port_s *dp)
 {
-	return -1;
+	(void)dp;
 }
 
 void dap_swd_configure(uint8_t cfg)

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -113,9 +113,9 @@ int ftdi_bmp_init(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 	return -1;
 }
 
-int libftdi_swdptap_init(void)
+bool libftdi_swdptap_init(void)
 {
-	return -1;
+	return false;
 }
 
 bool libftdi_jtagtap_init(void)
@@ -179,7 +179,7 @@ extern ftdi_context_s *ftdic;
 extern data_desc_s active_state;
 
 int ftdi_bmp_init(bmda_cli_options_s *cl_opts, bmp_info_s *info);
-int libftdi_swdptap_init(void);
+bool libftdi_swdptap_init(void);
 bool libftdi_jtagtap_init(void);
 void libftdi_buffer_flush(void);
 size_t libftdi_buffer_write(const uint8_t *data, size_t size);

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -113,7 +113,7 @@ int ftdi_bmp_init(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 	return -1;
 }
 
-int libftdi_swdptap_init(adiv5_debug_port_s *dp)
+int libftdi_swdptap_init(void)
 {
 	return -1;
 }
@@ -179,7 +179,7 @@ extern ftdi_context_s *ftdic;
 extern data_desc_s active_state;
 
 int ftdi_bmp_init(bmda_cli_options_s *cl_opts, bmp_info_s *info);
-int libftdi_swdptap_init(adiv5_debug_port_s *dp);
+int libftdi_swdptap_init(void);
 bool libftdi_jtagtap_init(void);
 void libftdi_buffer_flush(void);
 size_t libftdi_buffer_write(const uint8_t *data, size_t size);

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -32,7 +32,7 @@
 #include "jlink.h"
 #include "cli.h"
 
-static bool jlink_adiv5_swdp_write_nocheck(adiv5_debug_port_s *dp, uint16_t addr, uint32_t data);
+static bool jlink_adiv5_swdp_write_nocheck(uint16_t addr, uint32_t data);
 static uint32_t jlink_adiv5_swdp_read_nocheck(uint16_t addr);
 static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 static uint32_t jlink_adiv5_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
@@ -159,9 +159,8 @@ static void jlink_adiv5_swdp_make_packet_request(
 	cmd[6] = make_packet_request(RnW, addr);
 }
 
-static bool jlink_adiv5_swdp_write_nocheck(adiv5_debug_port_s *dp, const uint16_t addr, const uint32_t data)
+static bool jlink_adiv5_swdp_write_nocheck(const uint16_t addr, const uint32_t data)
 {
-	(void)dp;
 	uint8_t result[3];
 	uint8_t request[8];
 	jlink_adiv5_swdp_make_packet_request(request, sizeof(request), ADIV5_LOW_WRITE, addr & 0xfU);
@@ -214,7 +213,7 @@ static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *const dp, const bool 
 	if (dp->version >= 2 || protocol_recovery) {
 		line_reset(&info);
 		jlink_adiv5_swdp_read_nocheck(ADIV5_DP_DPIDR);
-		dp->dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+		jlink_adiv5_swdp_write_nocheck(ADIV5_DP_TARGETSEL, dp->targetsel);
 	}
 	uint32_t err = jlink_adiv5_swdp_read_nocheck(ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
@@ -230,7 +229,7 @@ static uint32_t jlink_adiv5_swdp_error(adiv5_debug_port_s *const dp, const bool 
 	if (err & ADIV5_DP_CTRLSTAT_WDATAERR)
 		clr |= ADIV5_DP_ABORT_WDERRCLR;
 
-	jlink_adiv5_swdp_write_nocheck(dp, ADIV5_DP_ABORT, clr);
+	jlink_adiv5_swdp_write_nocheck(ADIV5_DP_ABORT, clr);
 	if (dp->fault)
 		err |= 0x8000U;
 	dp->fault = 0;

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -69,11 +69,11 @@ bool libftdi_swd_possible(void)
 	return true;
 }
 
-int libftdi_swdptap_init(void)
+bool libftdi_swdptap_init(void)
 {
 	if (!libftdi_swd_possible()) {
 		DEBUG_WARN("SWD not possible or missing item in cable description.\n");
-		return -1;
+		return false;
 	}
 	active_state.data_low &= ~MPSSE_SK;
 	active_state.data_low |= MPSSE_CS | MPSSE_DI | MPSSE_DO;
@@ -111,7 +111,7 @@ int libftdi_swdptap_init(void)
 	swd_proc.seq_in_parity = swdptap_seq_in_parity;
 	swd_proc.seq_out = swdptap_seq_out;
 	swd_proc.seq_out_parity = swdptap_seq_out_parity;
-	return 0;
+	return true;
 }
 
 static void swdptap_turnaround_mpsse(const swdio_status_e dir)

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -107,10 +107,10 @@ int libftdi_swdptap_init(adiv5_debug_port_s *dp)
 	libftdi_buffer_flush();
 	olddir = SWDIO_STATUS_FLOAT;
 
-	dp->seq_in = swdptap_seq_in;
-	dp->seq_in_parity = swdptap_seq_in_parity;
-	dp->seq_out = swdptap_seq_out;
-	dp->seq_out_parity = swdptap_seq_out_parity;
+	swd_proc.seq_in = swdptap_seq_in;
+	swd_proc.seq_in_parity = swdptap_seq_in_parity;
+	swd_proc.seq_out = swdptap_seq_out;
+	swd_proc.seq_out_parity = swdptap_seq_out_parity;
 	dp->dp_read = firmware_swdp_read;
 	dp->error = firmware_swdp_error;
 	dp->low_access = firmware_swdp_low_access;

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -69,7 +69,7 @@ bool libftdi_swd_possible(void)
 	return true;
 }
 
-int libftdi_swdptap_init(adiv5_debug_port_s *dp)
+int libftdi_swdptap_init(void)
 {
 	if (!libftdi_swd_possible()) {
 		DEBUG_WARN("SWD not possible or missing item in cable description.\n");
@@ -111,10 +111,6 @@ int libftdi_swdptap_init(adiv5_debug_port_s *dp)
 	swd_proc.seq_in_parity = swdptap_seq_in_parity;
 	swd_proc.seq_out = swdptap_seq_out;
 	swd_proc.seq_out_parity = swdptap_seq_out_parity;
-	dp->dp_read = firmware_swdp_read;
-	dp->error = firmware_swdp_error;
-	dp->low_access = firmware_swdp_low_access;
-	dp->abort = firmware_swdp_abort;
 	return 0;
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -211,7 +211,7 @@ int platform_jtagtap_init(void)
 {
 	switch (info.bmp_type) {
 	case BMP_TYPE_BMP:
-		return remote_jtagtap_init(&jtag_proc);
+		return remote_jtagtap_init();
 
 	case BMP_TYPE_STLINKV2:
 		return 0;
@@ -223,7 +223,7 @@ int platform_jtagtap_init(void)
 		return jlink_jtagtap_init(&info) ? 0 : -1;
 
 	case BMP_TYPE_CMSIS_DAP:
-		return cmsis_dap_jtagtap_init(&jtag_proc);
+		return cmsis_dap_jtagtap_init();
 
 	default:
 		return -1;

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -668,7 +668,7 @@ void adiv5_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *s
 			fprintf(stderr, " ...");
 		fprintf(stderr, "\n");
 	}
-	return ap->dp->mem_write_sized(ap, dest, src, len, align);
+	return ap->dp->mem_write(ap, dest, src, len, align);
 }
 
 void adiv5_dp_abort(adiv5_debug_port_s *dp, uint32_t abort)

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -22,6 +22,7 @@
 
 #include "general.h"
 #include "jtagtap.h"
+#include "swd.h"
 #include "target.h"
 #include "target_internal.h"
 #include "adiv5.h"
@@ -44,6 +45,7 @@
 bmp_info_s info;
 
 jtag_proc_s jtag_proc;
+swd_proc_s swd_proc;
 
 static bmda_cli_options_s cl_opts;
 
@@ -157,11 +159,11 @@ uint32_t platform_adiv5_swdp_scan(uint32_t targetid)
 	}
 }
 
-int swdptap_init(adiv5_debug_port_s *dp)
+int platform_swdptap_init(adiv5_debug_port_s *dp)
 {
 	switch (info.bmp_type) {
 	case BMP_TYPE_BMP:
-		return remote_swdptap_init(dp);
+		return remote_swdptap_init();
 
 	case BMP_TYPE_CMSIS_DAP:
 		return dap_swdptap_init(dp);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -173,7 +173,7 @@ int platform_swdptap_init(adiv5_debug_port_s *dp)
 		return 0;
 
 	case BMP_TYPE_LIBFTDI:
-		return libftdi_swdptap_init(dp);
+		return libftdi_swdptap_init();
 
 	default:
 		return -1;

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -249,22 +249,17 @@ void platform_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	}
 }
 
-int platform_jtag_dp_init(adiv5_debug_port_s *dp)
+void platform_jtag_dp_init(adiv5_debug_port_s *dp)
 {
 	switch (info.bmp_type) {
-	case BMP_TYPE_BMP:
-	case BMP_TYPE_LIBFTDI:
-	case BMP_TYPE_JLINK:
-		return 0;
-
 	case BMP_TYPE_STLINKV2:
-		return stlink_jtag_dp_init(dp);
-
+		stlink_jtag_dp_init(dp);
+		break;
 	case BMP_TYPE_CMSIS_DAP:
-		return dap_jtag_dp_init(dp);
-
+		dap_jtag_dp_init(dp);
+		break;
 	default:
-		return 0;
+		break;
 	}
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -498,7 +498,7 @@ void platform_target_clk_output_enable(const bool enable)
 static void ap_decode_access(uint16_t addr, uint8_t RnW)
 {
 	if (RnW)
-		fprintf(stderr, "Read  ");
+		fprintf(stderr, "Read ");
 	else
 		fprintf(stderr, "Write ");
 
@@ -506,9 +506,9 @@ static void ap_decode_access(uint16_t addr, uint8_t RnW)
 		switch (addr) {
 		case 0x00U:
 			if (RnW)
-				fprintf(stderr, "DP_DPIDR :");
+				fprintf(stderr, "DP_DPIDR:");
 			else
-				fprintf(stderr, "DP_ABORT :");
+				fprintf(stderr, "DP_ABORT:");
 			break;
 
 		case 0x04U:
@@ -517,7 +517,7 @@ static void ap_decode_access(uint16_t addr, uint8_t RnW)
 
 		case 0x08U:
 			if (RnW)
-				fprintf(stderr, "RESEND   :");
+				fprintf(stderr, "RESEND:");
 			else
 				fprintf(stderr, "DP_SELECT:");
 			break;
@@ -527,50 +527,50 @@ static void ap_decode_access(uint16_t addr, uint8_t RnW)
 			break;
 
 		default:
-			fprintf(stderr, "Unknown %02x   :", addr);
+			fprintf(stderr, "Unknown register %02x:", addr);
 		}
 	} else {
-		fprintf(stderr, "AP 0x%02x ", addr >> 8U);
+		fprintf(stderr, "AP %u ", addr >> 8U);
 
 		switch (addr & 0xffU) {
 		case 0x00U:
-			fprintf(stderr, "CSW   :");
+			fprintf(stderr, "CSW:");
 			break;
 
 		case 0x04U:
-			fprintf(stderr, "TAR   :");
+			fprintf(stderr, "TAR:");
 			break;
 
 		case 0x0cU:
-			fprintf(stderr, "DRW   :");
+			fprintf(stderr, "DRW:");
 			break;
 
 		case 0x10U:
-			fprintf(stderr, "DB0   :");
+			fprintf(stderr, "DB0:");
 			break;
 
 		case 0x14U:
-			fprintf(stderr, "DB1   :");
+			fprintf(stderr, "DB1:");
 			break;
 
 		case 0x18U:
-			fprintf(stderr, "DB2   :");
+			fprintf(stderr, "DB2:");
 			break;
 
 		case 0x1cU:
-			fprintf(stderr, "DB3   :");
+			fprintf(stderr, "DB3:");
 			break;
 
 		case 0xf8U:
-			fprintf(stderr, "BASE  :");
+			fprintf(stderr, "BASE:");
 			break;
 
 		case 0xf4U:
-			fprintf(stderr, "CFG   :");
+			fprintf(stderr, "CFG:");
 			break;
 
 		case 0xfcU:
-			fprintf(stderr, "IDR   :");
+			fprintf(stderr, "IDR:");
 			break;
 
 		default:

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -207,7 +207,7 @@ uint32_t platform_jtag_scan(const uint8_t *lrlens)
 	}
 }
 
-int platform_jtagtap_init(void)
+bool platform_jtagtap_init(void)
 {
 	switch (info.bmp_type) {
 	case BMP_TYPE_BMP:
@@ -217,16 +217,16 @@ int platform_jtagtap_init(void)
 		return 0;
 
 	case BMP_TYPE_LIBFTDI:
-		return libftdi_jtagtap_init() ? 0 : -1;
+		return libftdi_jtagtap_init();
 
 	case BMP_TYPE_JLINK:
-		return jlink_jtagtap_init(&info) ? 0 : -1;
+		return jlink_jtagtap_init(&info);
 
 	case BMP_TYPE_CMSIS_DAP:
-		return cmsis_dap_jtagtap_init();
+		return dap_jtagtap_init();
 
 	default:
-		return -1;
+		return false;
 	}
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -230,8 +230,6 @@ int platform_jtagtap_init(void)
 
 void platform_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
-	dp->dp_bmp_type = info.bmp_type;
-
 	switch (info.bmp_type) {
 	case BMP_TYPE_BMP:
 		if (cl_opts.opt_no_hl) {

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -159,7 +159,7 @@ uint32_t platform_adiv5_swdp_scan(uint32_t targetid)
 	}
 }
 
-int platform_swdptap_init(adiv5_debug_port_s *dp)
+bool platform_swdptap_init(adiv5_debug_port_s *dp)
 {
 	switch (info.bmp_type) {
 	case BMP_TYPE_BMP:
@@ -176,7 +176,7 @@ int platform_swdptap_init(adiv5_debug_port_s *dp)
 		return libftdi_swdptap_init();
 
 	default:
-		return -1;
+		return false;
 	}
 }
 

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -48,7 +48,7 @@ static inline unsigned int bool_to_int(const bool value)
 	return value ? 1 : 0;
 }
 
-int remote_jtagtap_init(jtag_proc_s *jtag_proc)
+int remote_jtagtap_init(void)
 {
 	platform_buffer_write((uint8_t *)REMOTE_JTAG_INIT_STR, sizeof(REMOTE_JTAG_INIT_STR));
 
@@ -59,18 +59,18 @@ int remote_jtagtap_init(jtag_proc_s *jtag_proc)
 		exit(-1);
 	}
 
-	jtag_proc->jtagtap_reset = jtagtap_reset;
-	jtag_proc->jtagtap_next = jtagtap_next;
-	jtag_proc->jtagtap_tms_seq = jtagtap_tms_seq;
-	jtag_proc->jtagtap_tdi_tdo_seq = jtagtap_tdi_tdo_seq;
-	jtag_proc->jtagtap_tdi_seq = jtagtap_tdi_seq;
+	jtag_proc.jtagtap_reset = jtagtap_reset;
+	jtag_proc.jtagtap_next = jtagtap_next;
+	jtag_proc.jtagtap_tms_seq = jtagtap_tms_seq;
+	jtag_proc.jtagtap_tdi_tdo_seq = jtagtap_tdi_tdo_seq;
+	jtag_proc.jtagtap_tdi_seq = jtagtap_tdi_seq;
 
 	platform_buffer_write((uint8_t *)REMOTE_HL_CHECK_STR, sizeof(REMOTE_HL_CHECK_STR));
 	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR || buffer[0] == 1)
 		PRINT_INFO("Firmware does not support newer JTAG commands, please update it.");
 	else
-		jtag_proc->jtagtap_cycle = jtagtap_cycle;
+		jtag_proc.jtagtap_cycle = jtagtap_cycle;
 
 	return 0;
 }

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -54,7 +54,7 @@ bool remote_jtagtap_init(void)
 
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	int length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
-	if ((!length) || (buffer[0] == REMOTE_RESP_ERR)) {
+	if (!length || buffer[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("jtagtap_init failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -48,7 +48,7 @@ static inline unsigned int bool_to_int(const bool value)
 	return value ? 1 : 0;
 }
 
-int remote_jtagtap_init(void)
+bool remote_jtagtap_init(void)
 {
 	platform_buffer_write((uint8_t *)REMOTE_JTAG_INIT_STR, sizeof(REMOTE_JTAG_INIT_STR));
 
@@ -72,7 +72,7 @@ int remote_jtagtap_init(void)
 	else
 		jtag_proc.jtagtap_cycle = jtagtap_cycle;
 
-	return 0;
+	return true;
 }
 
 /* See remote.c/.h for protocol information */

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -39,13 +39,12 @@ static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 bool remote_swdptap_init(void)
 {
 	DEBUG_WIRE("remote_swdptap_init\n");
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
-	int s = sprintf((char *)construct, "%s", REMOTE_SWDP_INIT_STR);
-	platform_buffer_write(construct, s);
+	platform_buffer_write((uint8_t *)REMOTE_SWDP_INIT_STR, sizeof(REMOTE_SWDP_INIT_STR));
 
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
+	char construct[REMOTE_MAX_MSG_SIZE];
+	int s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
 	if (!s || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_init failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
+		DEBUG_WARN("swdptap_init failed, error %s\n", s ? construct + 1 : "unknown");
 		exit(-1);
 	}
 
@@ -58,18 +57,18 @@ bool remote_swdptap_init(void)
 
 static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
+	char construct[REMOTE_MAX_MSG_SIZE];
 
-	int s = sprintf((char *)construct, REMOTE_SWDP_IN_PAR_STR, clock_cycles);
-	platform_buffer_write(construct, s);
+	int s = sprintf(construct, REMOTE_SWDP_IN_PAR_STR, clock_cycles);
+	platform_buffer_write((uint8_t *)construct, s);
 
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if ((s < 2) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", s ? (char *)&(construct[1]) : "short response");
+	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (s < 2 || construct[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", s ? &(construct[1]) : "short response");
 		exit(-1);
 	}
 
-	*res = remotehston(-1, (char *)&construct[1]);
+	*res = remotehston(-1, &construct[1]);
 	DEBUG_PROBE("swdptap_seq_in_parity  %2d clock_cycles: %08" PRIx32 " %s\n", clock_cycles, *res,
 		construct[0] != REMOTE_RESP_OK ? "ERR" : "OK");
 	return construct[0] != REMOTE_RESP_OK;
@@ -77,47 +76,47 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 
 static uint32_t swdptap_seq_in(size_t clock_cycles)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
+	char construct[REMOTE_MAX_MSG_SIZE];
 
-	int s = sprintf((char *)construct, REMOTE_SWDP_IN_STR, clock_cycles);
-	platform_buffer_write(construct, s);
+	int s = sprintf(construct, REMOTE_SWDP_IN_STR, clock_cycles);
+	platform_buffer_write((uint8_t *)construct, s);
 
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if ((s < 2) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("swdptap_seq_in failed, error %s\n", s ? (char *)construct + 1 : "short response");
+	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (s < 2 || construct[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_in failed, error %s\n", s ? construct + 1 : "short response");
 		exit(-1);
 	}
-	uint32_t res = remotehston(-1, (char *)&construct[1]);
+	uint32_t res = remotehston(-1, &construct[1]);
 	DEBUG_PROBE("swdptap_seq_in         %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, res);
 	return res;
 }
 
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
+	char construct[REMOTE_MAX_MSG_SIZE];
 
 	DEBUG_PROBE("swdptap_seq_out        %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
-	int s = sprintf((char *)construct, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
-	platform_buffer_write(construct, s);
+	int s = sprintf(construct, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
+	platform_buffer_write((uint8_t *)construct, s);
 
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if ((s < 1) || (construct[0] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("swdptap_seq_out failed, error %s\n", s ? (char *)construct + 1 : "short response");
+	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (s < 1 || construct[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_out failed, error %s\n", s ? construct + 1 : "short response");
 		exit(-1);
 	}
 }
 
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
+	char construct[REMOTE_MAX_MSG_SIZE];
 
 	DEBUG_PROBE("swdptap_seq_out_parity %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
-	int s = sprintf((char *)construct, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
-	platform_buffer_write(construct, s);
+	int s = sprintf(construct, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
+	platform_buffer_write((uint8_t *)construct, s);
 
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if ((s < 1) || (construct[1] == REMOTE_RESP_ERR)) {
-		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", s ? (char *)construct + 2 : "short response");
+	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (s < 1 || construct[1] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", s ? construct + 2 : "short response");
 		exit(-1);
 	}
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -36,7 +36,7 @@ static uint32_t swdptap_seq_in(size_t clock_cycles);
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
-int remote_swdptap_init(void)
+bool remote_swdptap_init(void)
 {
 	DEBUG_WIRE("remote_swdptap_init\n");
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
@@ -44,7 +44,7 @@ int remote_swdptap_init(void)
 	platform_buffer_write(construct, s);
 
 	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if ((!s) || (construct[0] == REMOTE_RESP_ERR)) {
+	if (!s || construct[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("swdptap_init failed, error %s\n", s ? (char *)&(construct[1]) : "unknown");
 		exit(-1);
 	}
@@ -53,7 +53,7 @@ int remote_swdptap_init(void)
 	swd_proc.seq_in_parity = swdptap_seq_in_parity;
 	swd_proc.seq_out = swdptap_seq_out;
 	swd_proc.seq_out_parity = swdptap_seq_out_parity;
-	return 0;
+	return true;
 }
 
 static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -42,9 +42,9 @@ bool remote_swdptap_init(void)
 	platform_buffer_write((uint8_t *)REMOTE_SWDP_INIT_STR, sizeof(REMOTE_SWDP_INIT_STR));
 
 	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (!s || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_init failed, error %s\n", s ? construct + 1 : "unknown");
+	int length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (!length || construct[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_init failed, error %s\n", length ? construct + 1 : "unknown");
 		exit(-1);
 	}
 
@@ -59,12 +59,12 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 {
 	char construct[REMOTE_MAX_MSG_SIZE];
 
-	int s = sprintf(construct, REMOTE_SWDP_IN_PAR_STR, clock_cycles);
-	platform_buffer_write((uint8_t *)construct, s);
+	int length = sprintf(construct, REMOTE_SWDP_IN_PAR_STR, clock_cycles);
+	platform_buffer_write((uint8_t *)construct, length);
 
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 2 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", s ? &(construct[1]) : "short response");
+	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (length < 2 || construct[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", length ? &(construct[1]) : "short response");
 		exit(-1);
 	}
 
@@ -78,12 +78,12 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 {
 	char construct[REMOTE_MAX_MSG_SIZE];
 
-	int s = sprintf(construct, REMOTE_SWDP_IN_STR, clock_cycles);
-	platform_buffer_write((uint8_t *)construct, s);
+	int length = sprintf(construct, REMOTE_SWDP_IN_STR, clock_cycles);
+	platform_buffer_write((uint8_t *)construct, length);
 
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 2 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_in failed, error %s\n", s ? construct + 1 : "short response");
+	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (length < 2 || construct[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_in failed, error %s\n", length ? construct + 1 : "short response");
 		exit(-1);
 	}
 	uint32_t res = remotehston(-1, &construct[1]);
@@ -96,12 +96,12 @@ static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
 	char construct[REMOTE_MAX_MSG_SIZE];
 
 	DEBUG_PROBE("swdptap_seq_out        %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
-	int s = sprintf(construct, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
-	platform_buffer_write((uint8_t *)construct, s);
+	int length = sprintf(construct, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
+	platform_buffer_write((uint8_t *)construct, length);
 
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_out failed, error %s\n", s ? construct + 1 : "short response");
+	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || construct[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_out failed, error %s\n", length ? construct + 1 : "short response");
 		exit(-1);
 	}
 }
@@ -111,12 +111,12 @@ static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 	char construct[REMOTE_MAX_MSG_SIZE];
 
 	DEBUG_PROBE("swdptap_seq_out_parity %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
-	int s = sprintf(construct, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
-	platform_buffer_write((uint8_t *)construct, s);
+	int length = sprintf(construct, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
+	platform_buffer_write((uint8_t *)construct, length);
 
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[1] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", s ? construct + 2 : "short response");
+	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || construct[1] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", length ? construct + 2 : "short response");
 		exit(-1);
 	}
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -23,11 +23,12 @@
  * Speed is sensible.
  */
 
+#include "general.h"
 #include <stdio.h>
 #include <assert.h>
 
-#include "general.h"
 #include "remote.h"
+#include "jtagtap.h"
 #include "bmp_remote.h"
 
 static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles);
@@ -35,7 +36,7 @@ static uint32_t swdptap_seq_in(size_t clock_cycles);
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
-int remote_swdptap_init(adiv5_debug_port_s *dp)
+int remote_swdptap_init(void)
 {
 	DEBUG_WIRE("remote_swdptap_init\n");
 	uint8_t construct[REMOTE_MAX_MSG_SIZE];
@@ -48,10 +49,10 @@ int remote_swdptap_init(adiv5_debug_port_s *dp)
 		exit(-1);
 	}
 
-	dp->seq_in = swdptap_seq_in;
-	dp->seq_in_parity = swdptap_seq_in_parity;
-	dp->seq_out = swdptap_seq_out;
-	dp->seq_out_parity = swdptap_seq_out_parity;
+	swd_proc.seq_in = swdptap_seq_in;
+	swd_proc.seq_in_parity = swdptap_seq_in_parity;
+	swd_proc.seq_out = swdptap_seq_out;
+	swd_proc.seq_out_parity = swdptap_seq_out_parity;
 	return 0;
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1050,14 +1050,11 @@ uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens)
 	return jtag_dev_count;
 }
 
-int stlink_jtag_dp_init(adiv5_debug_port_s *dp)
+void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
 {
-	dp->dp_read = firmware_swdp_read;
 	dp->error = stlink_dp_error;
 	dp->low_access = stlink_dp_low_access;
 	dp->abort = stlink_dp_abort;
-
-	return true;
 }
 
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -838,7 +838,7 @@ static int stlink_usb_get_rw_status(bool verbose)
 	return stlink_usb_error_check(data, verbose);
 }
 
-static void stlink_readmem(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
+static void stlink_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
 {
 	if (len == 0)
 		return;
@@ -876,13 +876,13 @@ static void stlink_readmem(adiv5_access_port_s *ap, void *dest, uint32_t src, si
 		 * Approach taken:
 		 * Fill the memory with some fixed pattern so hopefully
 		 * the caller notices the error*/
-		DEBUG_WARN("stlink_readmem from  %" PRIx32 " to %p, len %zu failed\n", src, dest, len);
+		DEBUG_WARN("stlink_mem_read from  %" PRIx32 " to %p, len %zu failed\n", src, dest, len);
 		memset(dest, 0xff, len);
 	}
-	DEBUG_PROBE("stlink_readmem from %" PRIx32 " to %p, len %zu\n", src, dest, len);
+	DEBUG_PROBE("stlink_mem_read from %" PRIx32 " to %p, len %zu\n", src, dest, len);
 }
 
-static void stlink_writemem8(usb_link_s *link, adiv5_access_port_s *ap, uint32_t addr, size_t len, uint8_t *buffer)
+static void stlink_mem_write8(usb_link_s *link, adiv5_access_port_s *ap, uint32_t addr, size_t len, uint8_t *buffer)
 {
 	while (len) {
 		size_t length;
@@ -910,7 +910,7 @@ static void stlink_writemem8(usb_link_s *link, adiv5_access_port_s *ap, uint32_t
 	}
 }
 
-static void stlink_writemem16(usb_link_s *link, adiv5_access_port_s *ap, uint32_t addr, size_t len, uint16_t *buffer)
+static void stlink_mem_write16(usb_link_s *link, adiv5_access_port_s *ap, uint32_t addr, size_t len, uint16_t *buffer)
 {
 	uint8_t cmd[16];
 	memset(cmd, 0, sizeof(cmd));
@@ -928,7 +928,7 @@ static void stlink_writemem16(usb_link_s *link, adiv5_access_port_s *ap, uint32_
 	stlink_usb_get_rw_status(true);
 }
 
-static void stlink_writemem32(adiv5_access_port_s *ap, uint32_t addr, size_t len, uint32_t *buffer)
+static void stlink_mem_write32(adiv5_access_port_s *ap, uint32_t addr, size_t len, uint32_t *buffer)
 {
 	uint8_t cmd[16];
 	memset(cmd, 0, sizeof(cmd));
@@ -999,14 +999,14 @@ static void stlink_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void 
 	usb_link_s *link = info.usb_link;
 	switch (align) {
 	case ALIGN_BYTE:
-		stlink_writemem8(link, ap, dest, len, (uint8_t *)src);
+		stlink_mem_write8(link, ap, dest, len, (uint8_t *)src);
 		break;
 	case ALIGN_HALFWORD:
-		stlink_writemem16(link, ap, dest, len, (uint16_t *)src);
+		stlink_mem_write16(link, ap, dest, len, (uint16_t *)src);
 		break;
 	case ALIGN_WORD:
 	case ALIGN_DWORD:
-		stlink_writemem32(ap, dest, len, (uint32_t *)src);
+		stlink_mem_write32(ap, dest, len, (uint32_t *)src);
 		break;
 	}
 }
@@ -1069,7 +1069,7 @@ void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->ap_cleanup = stlink_ap_cleanup;
 	dp->ap_write = stlink_ap_write;
 	dp->ap_read = stlink_ap_read;
-	dp->mem_read = stlink_readmem;
+	dp->mem_read = stlink_mem_read;
 	dp->mem_write = stlink_mem_write;
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -992,7 +992,7 @@ static void stlink_reg_write(adiv5_access_port_s *ap, int num, uint32_t val)
 	stlink_usb_error_check(res, true);
 }
 
-static void stlink_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
+static void stlink_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
 	if (len == 0)
 		return;
@@ -1070,7 +1070,7 @@ void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->ap_write = stlink_ap_write;
 	dp->ap_read = stlink_ap_read;
 	dp->mem_read = stlink_readmem;
-	dp->mem_write_sized = stlink_mem_write_sized;
+	dp->mem_write = stlink_mem_write;
 }
 
 uint32_t stlink_swdp_scan(bmp_info_s *info)

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -65,9 +65,9 @@ void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
 }
 
-int stlink_jtag_dp_init(adiv5_debug_port_s *dp)
+void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
 {
-	return false;
+	(void)dp;
 }
 
 uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens)
@@ -97,7 +97,7 @@ void stlink_nrst_set_val(bmp_info_s *info, bool assert);
 bool stlink_nrst_get_val(void);
 uint32_t stlink_swdp_scan(bmp_info_s *info);
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp);
-int stlink_jtag_dp_init(adiv5_debug_port_s *dp);
+void stlink_jtag_dp_init(adiv5_debug_port_s *dp);
 uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens);
 void stlink_exit_function(bmp_info_s *info);
 void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq);

--- a/src/remote.c
+++ b/src/remote.c
@@ -23,6 +23,7 @@
 #include "remote.h"
 #include "gdb_packet.h"
 #include "jtagtap.h"
+#include "swd.h"
 #include "gdb_if.h"
 #include "version.h"
 #include "exception.h"
@@ -129,7 +130,7 @@ static void remote_packet_process_swd(unsigned i, char *packet)
 			remote_dp.dp_read = firmware_swdp_read;
 			remote_dp.low_access = firmware_swdp_low_access;
 			remote_dp.abort = firmware_swdp_abort;
-			swdptap_init(&remote_dp);
+			swdptap_init();
 			remote_respond(REMOTE_RESP_OK, 0);
 		} else {
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
@@ -138,27 +139,27 @@ static void remote_packet_process_swd(unsigned i, char *packet)
 
 	case REMOTE_IN_PAR: /* SI = In parity ============================= */
 		ticks = remotehston(2, &packet[2]);
-		badParity = remote_dp.seq_in_parity(&param, ticks);
+		badParity = swd_proc.seq_in_parity(&param, ticks);
 		remote_respond(badParity ? REMOTE_RESP_PARERR : REMOTE_RESP_OK, param);
 		break;
 
 	case REMOTE_IN: /* Si = In ======================================= */
 		ticks = remotehston(2, &packet[2]);
-		param = remote_dp.seq_in(ticks);
+		param = swd_proc.seq_in(ticks);
 		remote_respond(REMOTE_RESP_OK, param);
 		break;
 
 	case REMOTE_OUT: /* So= Out ====================================== */
 		ticks = remotehston(2, &packet[2]);
 		param = remotehston(-1, &packet[4]);
-		remote_dp.seq_out(param, ticks);
+		swd_proc.seq_out(param, ticks);
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
 
 	case REMOTE_OUT_PAR: /* SO = Out parity ========================== */
 		ticks = remotehston(2, &packet[2]);
 		param = remotehston(-1, &packet[4]);
-		remote_dp.seq_out_parity(param, ticks);
+		swd_proc.seq_out_parity(param, ticks);
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -113,7 +113,7 @@ static void remote_respond_string(char respCode, const char *s)
 static adiv5_debug_port_s remote_dp = {
 	.ap_read = firmware_ap_read,
 	.ap_write = firmware_ap_write,
-	.mem_read = firmware_mem_read,
+	.mem_read = advi5_mem_read_bytes,
 	.mem_write_sized = firmware_mem_write_sized,
 };
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -114,7 +114,7 @@ static adiv5_debug_port_s remote_dp = {
 	.ap_read = firmware_ap_read,
 	.ap_write = firmware_ap_write,
 	.mem_read = advi5_mem_read_bytes,
-	.mem_write_sized = firmware_mem_write_sized,
+	.mem_write_sized = adiv5_mem_write_bytes,
 };
 
 static void remote_packet_process_swd(unsigned i, char *packet)

--- a/src/remote.c
+++ b/src/remote.c
@@ -114,7 +114,7 @@ static adiv5_debug_port_s remote_dp = {
 	.ap_read = firmware_ap_read,
 	.ap_write = firmware_ap_write,
 	.mem_read = advi5_mem_read_bytes,
-	.mem_write_sized = adiv5_mem_write_bytes,
+	.mem_write = adiv5_mem_write_bytes,
 };
 
 static void remote_packet_process_swd(unsigned i, char *packet)

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -413,17 +413,17 @@ static uint32_t cortexm_initial_halt(adiv5_access_port_s *ap)
  */
 static bool cortexm_prepare(adiv5_access_port_s *ap)
 {
-#if ((PC_HOSTED == 1) || (ENABLE_DEBUG == 1))
+#if PC_HOSTED == 1 || ENABLE_DEBUG == 1
 	uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t dhcsr = cortexm_initial_halt(ap);
 	if (!dhcsr) {
-		DEBUG_WARN("Halt via DHCSR: Failure DHCSR %08" PRIx32 " after % " PRId32 "ms\nTry again, evt. with longer "
+		DEBUG_WARN("Halt via DHCSR(%08" PRIx32 "): failure after %" PRId32 "ms\nTry again, evt. with longer "
 				   "timeout or connect under reset\n",
 			adiv5_mem_read32(ap, CORTEXM_DHCSR), platform_time_ms() - start_time);
 		return false;
 	}
-	DEBUG_INFO("Halt via DHCSR: success %08" PRIx32 " after %" PRId32 "ms\n", dhcsr, platform_time_ms() - start_time);
+	DEBUG_INFO("Halt via DHCSR(%08" PRIx32 "): success after %" PRId32 "ms\n", dhcsr, platform_time_ms() - start_time);
 	ap->ap_cortexm_demcr = adiv5_mem_read32(ap, CORTEXM_DEMCR);
 	const uint32_t demcr = CORTEXM_DEMCR_TRCENA | CORTEXM_DEMCR_VC_HARDERR | CORTEXM_DEMCR_VC_CORERESET;
 	adiv5_mem_write(ap, CORTEXM_DEMCR, &demcr, sizeof(demcr));
@@ -636,7 +636,7 @@ static void adiv5_component_probe(
 
 adiv5_access_port_s *adiv5_new_ap(adiv5_debug_port_s *dp, uint8_t apsel)
 {
-	adiv5_access_port_s *ap, tmpap;
+	adiv5_access_port_s tmpap;
 	/* Assume valid and try to read IDR */
 	memset(&tmpap, 0, sizeof(tmpap));
 	tmpap.dp = dp;
@@ -666,7 +666,7 @@ adiv5_access_port_s *adiv5_new_ap(adiv5_debug_port_s *dp, uint8_t apsel)
 	}
 
 	/* It's valid to so create a heap copy */
-	ap = malloc(sizeof(*ap));
+	adiv5_access_port_s *ap = malloc(sizeof(*ap));
 	if (!ap) { /* malloc failed: heap exhaustion */
 		DEBUG_WARN("malloc: failed in %s\n", __func__);
 		return NULL;

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -807,13 +807,13 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 	if (!dp->ap_read)
 		dp->ap_read = firmware_ap_read;
 	if (!dp->mem_read)
-		dp->mem_read = firmware_mem_read;
+		dp->mem_read = advi5_mem_read_bytes;
 	if (!dp->mem_write_sized)
 		dp->mem_write_sized = firmware_mem_write_sized;
 #else
 	dp->ap_write = firmware_ap_write;
 	dp->ap_read = firmware_ap_read;
-	dp->mem_read = firmware_mem_read;
+	dp->mem_read = advi5_mem_read_bytes;
 	dp->mem_write_sized = firmware_mem_write_sized;
 #endif
 
@@ -1010,7 +1010,7 @@ const void *adiv5_pack_data(const uint32_t dest, const void *const src, uint32_t
 	return (const uint8_t *)src + (1 << align);
 }
 
-void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
+void advi5_mem_read_bytes(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
 {
 	uint32_t osrc = src;
 	const align_e align = MIN(ALIGNOF(src), ALIGNOF(len));

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -800,21 +800,12 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 		return;
 	}
 
-#if PC_HOSTED == 1
-	platform_adiv5_dp_defaults(dp);
-	if (!dp->ap_write)
-		dp->ap_write = firmware_ap_write;
-	if (!dp->ap_read)
-		dp->ap_read = firmware_ap_read;
-	if (!dp->mem_read)
-		dp->mem_read = advi5_mem_read_bytes;
-	if (!dp->mem_write_sized)
-		dp->mem_write_sized = adiv5_mem_write_bytes;
-#else
 	dp->ap_write = firmware_ap_write;
 	dp->ap_read = firmware_ap_read;
 	dp->mem_read = advi5_mem_read_bytes;
 	dp->mem_write_sized = adiv5_mem_write_bytes;
+#if PC_HOSTED == 1
+	platform_adiv5_dp_defaults(dp);
 #endif
 
 	volatile uint32_t ctrlstat = 0;

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -803,7 +803,7 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 	dp->ap_write = firmware_ap_write;
 	dp->ap_read = firmware_ap_read;
 	dp->mem_read = advi5_mem_read_bytes;
-	dp->mem_write_sized = adiv5_mem_write_bytes;
+	dp->mem_write = adiv5_mem_write_bytes;
 #if PC_HOSTED == 1
 	platform_adiv5_dp_defaults(dp);
 #endif

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -809,12 +809,12 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 	if (!dp->mem_read)
 		dp->mem_read = advi5_mem_read_bytes;
 	if (!dp->mem_write_sized)
-		dp->mem_write_sized = firmware_mem_write_sized;
+		dp->mem_write_sized = adiv5_mem_write_bytes;
 #else
 	dp->ap_write = firmware_ap_write;
 	dp->ap_read = firmware_ap_read;
 	dp->mem_read = advi5_mem_read_bytes;
-	dp->mem_write_sized = firmware_mem_write_sized;
+	dp->mem_write_sized = adiv5_mem_write_bytes;
 #endif
 
 	volatile uint32_t ctrlstat = 0;
@@ -1037,7 +1037,7 @@ void advi5_mem_read_bytes(adiv5_access_port_s *ap, void *dest, uint32_t src, siz
 	adiv5_unpack_data(dest, src, value, align);
 }
 
-void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
+void adiv5_mem_write_bytes(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
 	uint32_t odest = dest;
 

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -404,7 +404,7 @@ const void *adiv5_pack_data(uint32_t dest, const void *src, uint32_t *data, alig
 
 void ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align);
 void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
-void firmware_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len);
+void advi5_mem_read_bytes(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len);
 void firmware_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 uint32_t firmware_ap_read(adiv5_access_port_s *ap, uint16_t addr);
 uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -258,7 +258,6 @@ struct adiv5_debug_port {
 	void (*abort)(adiv5_debug_port_s *dp, uint32_t abort);
 
 #if PC_HOSTED == 1
-	bmp_type_t dp_bmp_type;
 	bool (*ap_setup)(int i);
 	void (*ap_cleanup)(int i);
 	void (*ap_regs_read)(adiv5_access_port_s *ap, void *data);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -392,7 +392,7 @@ void platform_add_jtag_dev(uint32_t dev_index, const jtag_dev_s *jtag_dev);
 void adiv5_jtag_dp_handler(uint8_t jd_index);
 #if PC_HOSTED == 1
 void platform_jtag_dp_init(adiv5_debug_port_s *dp);
-int platform_swdptap_init(adiv5_debug_port_s *dp);
+bool platform_swdptap_init(adiv5_debug_port_s *dp);
 #endif
 
 void adiv5_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -393,7 +393,7 @@ void adiv5_ap_unref(adiv5_access_port_s *ap);
 void platform_add_jtag_dev(uint32_t dev_index, const jtag_dev_s *jtag_dev);
 
 void adiv5_jtag_dp_handler(uint8_t jd_index);
-int platform_jtag_dp_init(adiv5_debug_port_s *dp);
+void platform_jtag_dp_init(adiv5_debug_port_s *dp);
 int swdptap_init(adiv5_debug_port_s *dp);
 
 void adiv5_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -403,7 +403,7 @@ void *adiv5_unpack_data(void *dest, uint32_t src, uint32_t val, align_e align);
 const void *adiv5_pack_data(uint32_t dest, const void *src, uint32_t *data, align_e align);
 
 void ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align);
-void firmware_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
+void adiv5_mem_write_bytes(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
 void advi5_mem_read_bytes(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len);
 void firmware_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 uint32_t firmware_ap_read(adiv5_access_port_s *ap, uint16_t addr);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -270,7 +270,7 @@ struct adiv5_debug_port {
 	void (*ap_write)(adiv5_access_port_s *ap, uint16_t addr, uint32_t value);
 
 	void (*mem_read)(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len);
-	void (*mem_write_sized)(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
+	void (*mem_write)(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
 	uint8_t dp_jd_index;
 	uint8_t fault;
 
@@ -349,7 +349,7 @@ static inline void adiv5_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t 
 static inline void adiv5_mem_write_sized(
 	adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
-	return ap->dp->mem_write_sized(ap, dest, src, len, align);
+	return ap->dp->mem_write(ap, dest, src, len, align);
 }
 
 static inline void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value)

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -49,12 +49,13 @@ void adiv5_jtag_dp_handler(uint8_t jd_index)
 
 	dp->dp_jd_index = jd_index;
 
-	if (PC_HOSTED == 0 || !platform_jtag_dp_init(dp)) {
-		dp->dp_read = fw_adiv5_jtagdp_read;
-		dp->error = adiv5_jtagdp_error;
-		dp->low_access = fw_adiv5_jtagdp_low_access;
-		dp->abort = adiv5_jtagdp_abort;
-	}
+	dp->dp_read = fw_adiv5_jtagdp_read;
+	dp->error = adiv5_jtagdp_error;
+	dp->low_access = fw_adiv5_jtagdp_low_access;
+	dp->abort = adiv5_jtagdp_abort;
+#if PC_HOSTED == 1
+	platform_jtag_dp_init(dp);
+#endif
 
 	adiv5_dp_init(dp, jtag_devs[jd_index].jd_idcode);
 }

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -101,7 +101,7 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 #if PC_HOSTED == 0
 	swdptap_init();
 #else
-	if (platform_swdptap_init(initial_dp))
+	if (!platform_swdptap_init(initial_dp))
 		return 0;
 #endif
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -853,7 +853,7 @@ static void cortexm_regs_read(target_s *t, void *data)
 	uint32_t *regs = data;
 	adiv5_access_port_s *ap = cortexm_ap(t);
 #if PC_HOSTED == 1
-	if ((ap->dp->ap_reg_read) && (ap->dp->ap_regs_read)) {
+	if (ap->dp->ap_reg_read && ap->dp->ap_regs_read) {
 		uint32_t base_regs[21];
 		ap->dp->ap_regs_read(ap, base_regs);
 		for (size_t i = 0; i < sizeof(regnum_cortex_m) / 4U; i++)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1060,14 +1060,13 @@ static target_halt_reason_e cortexm_halt_poll(target_s *t, target_addr_t *watch)
 		return TARGET_HALT_FAULT;
 
 	/* Remember if we stopped on a breakpoint */
-	priv->on_bkpt = dfsr & (CORTEXM_DFSR_BKPT);
+	priv->on_bkpt = dfsr & CORTEXM_DFSR_BKPT;
 	if (priv->on_bkpt) {
-		/* If we've hit a programmed breakpoint, check for semihosting
-		 * call. */
-		uint32_t pc = cortexm_pc_read(t);
-		uint16_t bkpt_instr;
-		bkpt_instr = target_mem_read16(t, pc);
-		if (bkpt_instr == 0xbeabU) {
+		/* If we've hit a programmed breakpoint, check for semihosting call. */
+		const uint32_t program_counter = cortexm_pc_read(t);
+		const uint16_t instruction = target_mem_read16(t, program_counter);
+		/* 0xbeab encodes the breakpoint instruction used to indicate a semihosting call */
+		if (instruction == 0xbeabU) {
 			if (cortexm_hostio_request(t))
 				return TARGET_HALT_REQUEST;
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -654,10 +654,6 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 	switch (t->designer_code) {
 	case JEP106_MANUFACTURER_FREESCALE:
 		PROBE(kinetis_probe);
-		if (t->part_id == 0x88cU) {
-			t->driver = "MIMXRT10xx(no flash)";
-			target_halt_resume(t, 0);
-		}
 		break;
 	case JEP106_MANUFACTURER_GIGADEVICE:
 		PROBE(gd32f1_probe);

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -76,7 +76,7 @@ uint32_t jtag_scan(const uint8_t *irlens)
 	 */
 	DEBUG_INFO("Resetting TAP\n");
 #if PC_HOSTED == 1
-	if (platform_jtagtap_init()) {
+	if (!platform_jtagtap_init()) {
 		DEBUG_WARN("JTAG not available\n");
 		return 0;
 	}

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -339,7 +339,7 @@ bool mm32l0xx_probe(target_s *t)
 	target_add_ram(t, 0x20000000U, ram_kbyte * 1024U);
 	stm32f1_add_flash(t, 0x08000000U, flash_kbyte * 1024U, block_size);
 	target_add_commands(t, stm32f1_cmd_list, name);
-	cortexm_ap(t)->dp->mem_write_sized = mm32l0_mem_write_sized;
+	cortexm_ap(t)->dp->mem_write = mm32l0_mem_write_sized;
 	return true;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR does a couple of things:

1. It de-duplicates code in the ADIv5 implementation, fixing UB issues in the target memory write code, and improves our nomenclature
2. It partially reverts a change made in PR #857 which wrongly removed the SWD interface header and structures, which had made the ADIv5 code a bit of an inconsistent soup, and also expanded per-DP memory consumption by 16 bytes (48 bytes extra consumed for a RP2040 for example)

The results are more consistency, leaner firmware, and better compiler optimisation.
The re-introduction of the SWD structure also allowed removal of some of the reaching in that BMDA was doing to the firmware, allowing us to start decoupling BMDA

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
