### PR TITLE
Fix CMSIS-DAP access to RP2040

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -87,6 +87,8 @@ typedef enum cmsis_type {
 typedef struct hid_device_info hid_device_info_s;
 #endif
 
+static bool dap_dp_low_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t data);
+
 /*- Variables ---------------------------------------------------------------*/
 static cmsis_type_e type;
 static libusb_device_handle *usb_handle = NULL;
@@ -292,7 +294,7 @@ static uint32_t dap_swd_dp_error(adiv5_debug_port_s *dp, const bool protocol_rec
 		 */
 		dap_line_reset();
 		if (dp->version >= 2)
-			dap_write_reg_no_check(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+			dap_dp_low_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
 		dap_read_reg(dp, ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */
 	}

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -370,7 +370,7 @@ void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
 
 bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align)
 {
-	const size_t blocks = len >> MAX(align, 2U);
+	const size_t blocks = len >> MIN(align, 2U);
 	uint32_t data[256];
 	if (!perform_dap_transfer_block_read(ap->dp, SWD_AP_DRW, blocks, data)) {
 		DEBUG_WARN("dap_read_block failed\n");

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -368,24 +368,6 @@ void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
 	}
 }
 
-bool dap_write_reg_no_check(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
-{
-	DEBUG_PROBE("\tdap_write_reg %02x %08x\n", reg, data);
-
-	uint8_t buf[8] = {
-		ID_DAP_TRANSFER,
-		dp->dp_jd_index,
-		0x01, // Request size
-		reg & ~DAP_TRANSFER_RnW,
-		data & 0xffU,
-		(data >> 8U) & 0xffU,
-		(data >> 16U) & 0xffU,
-		(data >> 24U) & 0xffU,
-	};
-	dbg_dap_cmd(buf, sizeof(buf), 8);
-	return buf[1] != DAP_TRANSFER_OK;
-}
-
 bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align)
 {
 	const size_t blocks = len >> MAX(align, 2U);

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -72,7 +72,6 @@ void dap_reset_pin(int state);
 void dap_line_reset(void);
 uint32_t dap_read_reg(adiv5_debug_port_s *dp, uint8_t reg);
 void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data);
-bool dap_write_reg_no_check(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data);
 void dap_reset_link(bool jtag);
 uint32_t dap_read_idcode(adiv5_debug_port_s *dp);
 bool dap_read_block(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len, align_e align);


### PR DESCRIPTION
## Detailed description

This fixes #1370:

- Fixes attaching to multi-drop targets by using correct write sequence.
- Fixes memory reading, allowing to correctly decode ROM tables.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

fixes #1370 
