### PR TITLE
gdb_main: Handle continue with signal command

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -196,6 +196,7 @@ int gdb_main_loop(target_controller_s *tc, bool in_syscall)
 			single_step = true;
 			/* fall through */
 		case 'c': /* 'c [addr]': Continue [at addr] */
+		case 'C': /* 'C sig[;addr]': Continue with signal [at addr] */
 			if (!cur_target) {
 				gdb_putpacketz("X1D");
 				break;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

After catching a fault, some versions of gdb (haven't mapped out exactly which, but behavior is observed with gdb-multiarch 10.1.90.20210103-git as shipped with Debian stable) sends a continue with signal command (`C`) rather than a regular continue (`c`), and when this goes unhandled, gdb gets confused and thinks the target is running, causing the symptoms seen in #1090.

Since the command arguments are ignored in any case, simply making `C` an alias of `c` solves the problem.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1090