### PR TITLE
STM32L4, STM32WB: Clear OPTVERR before checking FLASH_SR_ERROR_MASK

### DIFF
--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -693,13 +693,14 @@ static bool stm32l4_flash_erase(target_flash_s *const f, const target_addr_t add
 {
 	target_s *t = f->t;
 	const stm32l4_flash_s *const sf = (stm32l4_flash_s *)f;
+
+	/* STM32WBXX ERRATA ES0394 2.2.9: OPTVERR flag is always set after system reset */
+	stm32l4_flash_write32(t, FLASH_SR, stm32l4_flash_read32(t, FLASH_SR));
+
 	/* Unlock the Flash and wait for the operation to complete, reporting any errors */
 	stm32l4_flash_unlock(t);
 	if (!stm32l4_flash_busy_wait(t, NULL))
 		return false;
-
-	/* Fixme: OPTVER always set after reset! Wrong option defaults? */
-	stm32l4_flash_write32(t, FLASH_SR, stm32l4_flash_read32(t, FLASH_SR));
 
 	/* Erase the requested chunk of flash, one page at a time. */
 	for (size_t offset = 0; offset < len; offset += f->blocksize) {


### PR DESCRIPTION
## Detailed description

Right now stm32wb55 cannot be flashed, with the "Error erasing flash with vFlashErase packet".

This is because stm32l4_flash_busy_wait checks FLASH_SR_ERROR_MASK before resetting FLASH_SR and FLASH_SR_OPTVERR is already set when stm32wbXX is started, as written in ERRATA ES0394 2.2.9.

That PR fixes that.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
