### PR TITLE
Fix: GDB register API nomenclature and organisation

### DIFF
--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -260,10 +260,8 @@ static size_t create_tdesc_cortex_a(char *buffer, size_t max_len)
 	// Start with the "preamble", which is generic across ARM targets,
 	// ...save for one word, so we'll have to do the preamble in halves, and then we'll
 	// follow it with the GDB ARM Core feature tag.
-	total += snprintf(buffer, printsz,
-		"%s feature %s "
-		"<feature name=\"org.gnu.gdb.arm.core\">",
-		gdb_arm_preamble_first, gdb_arm_preamble_second);
+	total += snprintf(buffer, printsz, "%s feature %sarm%s <feature name=\"org.gnu.gdb.arm.core\">",
+		gdb_xml_preamble_first, gdb_xml_preamble_second, gdb_xml_preamble_third);
 
 	// Then the general purpose registers, which have names of r0 to r12.
 	for (uint8_t i = 0; i <= 12; ++i) {

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -287,8 +287,8 @@ static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
 
 	// Start with the "preamble", which is generic across ARM targets,
 	// ...save for one word, so we'll have to do the preamble in halves.
-	total += snprintf(buffer, printsz, "%s target %s <feature name=\"org.gnu.gdb.arm.m-profile\">",
-		gdb_arm_preamble_first, gdb_arm_preamble_second);
+	total += snprintf(buffer, printsz, "%s target %sarm%s <feature name=\"org.gnu.gdb.arm.m-profile\">",
+		gdb_xml_preamble_first, gdb_xml_preamble_second, gdb_xml_preamble_third);
 
 	// Then the general purpose registers, which have names of r0 to r12,
 	// and all the same bitsize.

--- a/src/target/gdb_reg.c
+++ b/src/target/gdb_reg.c
@@ -1,8 +1,9 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2022  1bitsquared - Mikaela Szekely <mikaela.szekely@qyriad.me>
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
  * Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+ * With contributions from Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,13 +21,13 @@
 
 #include "gdb_reg.h"
 
-const char *gdb_arm_preamble_first = "<?xml version=\"1.0\"?>"
+const char *gdb_xml_preamble_first = "<?xml version=\"1.0\"?>"
 									 "<!DOCTYPE";
 
-const char *gdb_arm_preamble_second = "SYSTEM "
-									  "\"gdb-target.dtd\">"
+const char *gdb_xml_preamble_second = "SYSTEM \"gdb-target.dtd\">"
 									  "<target>"
-									  "  <architecture>arm</architecture>";
+									  "  <architecture>";
+const char *gdb_xml_preamble_third = "</architecture>";
 
 const char *gdb_reg_type_strings[] = {
 	"",                   // GDB_TYPE_UNSPECIFIED.

--- a/src/target/gdb_reg.h
+++ b/src/target/gdb_reg.h
@@ -1,8 +1,9 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2022  1bitsquared - Mikaela Szekely <mikaela.szekely@qyriad.me>
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
  * Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+ * With contributions from Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,17 +22,23 @@
 #ifndef TARGET_GDB_REG_H
 #define TARGET_GDB_REG_H
 
-// The beginning XML for GDB target descriptions that are common to ARM targets,
+// The beginning XML for GDB target descriptions that are common to all targets,
 // save for one word: the word after DOCTYPE, which is "target" for Cortex-M, and "feature"
-// for Cortex-A. The "preamble" is thus split into two halves, with this single word missing
+// for Cortex-A. The "preamble" is thus split into three parts, with this single word missing
 // and as the split point.
-extern const char *gdb_arm_preamble_first;
+extern const char *gdb_xml_preamble_first;
 
-// The beginning XML for GDB target descriptions that are common to ARM targets,
+// The beginning XML for GDB target descriptions that are common to all targets,
 // save for one word: the word after DOCTYPE, which is "target" for Cortex-M, and "feature"
-// for Cortex-A. The "preamble" is thus split into two halves, with this single word missing
+// for Cortex-A. The "preamble" is thus split into three parts, with this single word missing
 // and as the split point.
-extern const char *gdb_arm_preamble_second;
+extern const char *gdb_xml_preamble_second;
+
+// The beginning XML for GDB target descriptions that are common to all targets,
+// save for one word: the word after <architecture>, which is "arm" for Cortex-*, and "avr"
+// for AVR. The "preamble" is thus split into three parts, with this single word missing
+// and as the split point.
+extern const char *gdb_xml_preamble_third;
 
 // The "type" field of a register tag.
 typedef enum gdb_reg_type {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR does two things in preparation for both RISC-V and AVR support - it splits up the XML description preamble into 3 parts, and then adjusts the nomenclature to make the API non-specific to ARM as this improves the degree of reuse we get from Qyriad's excellent work

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
