### PR TITLE
Fix: ternary and misc formatting fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,7 @@ BraceWrapping:
   BeforeElse: false
   IndentBraces: false
 BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: false
 BasedOnStyle: LLVM
 BinPackArguments: true
 BinPackParameters: true

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -653,9 +653,9 @@ void libftdi_jtagtap_tdi_tdo_seq(uint8_t *data_out, const bool final_tms, const 
 		return;
 
 	DEBUG_WIRE("libftdi_jtagtap_tdi_tdo_seq %s ticks: %d\n",
-		data_in && data_out ? "read/write"
-			: data_in       ? "write"
-							: "read",
+		data_in && data_out ? "read/write" :
+			data_in         ? "write" :
+							  "read",
 		ticks);
 	if (final_tms)
 		--ticks;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -399,15 +399,15 @@ int target_breakwatch_set(target_s *t, target_breakwatch_e type, target_addr_t a
 int target_breakwatch_clear(target_s *t, target_breakwatch_e type, target_addr_t addr, size_t len)
 {
 	breakwatch_s *bwp = NULL, *bw;
-	int ret = 1;
 	for (bw = t->bw_list; bw; bwp = bw, bw = bw->next) {
-		if ((bw->type == type) && (bw->addr == addr) && (bw->size == len))
+		if (bw->type == type && bw->addr == addr && bw->size == len)
 			break;
 	}
 
 	if (bw == NULL)
 		return -1;
 
+	int ret = 1;
 	if (t->breakwatch_clear)
 		ret = t->breakwatch_clear(t, bw);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

While building the RISC-V support branch, we hit upon a miss-formatting of multi-line ternaries and fixed several clang-tidy lints in the STM32F1 code. This PR promotes those changes into v1.10 ahead of the RISC-V support.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
