### PR TITLE
Fix: JTAG correctness

### DIFF
--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -48,10 +48,9 @@ void jtagtap_init(void)
 	jtag_proc.tap_idle_cycles = 1;
 
 	/* Ensure we're in JTAG mode */
-	for (size_t i = 0; i <= 50U; ++i)
+	for (size_t i = 0; i < 50U; ++i)
 		jtagtap_next(true, false); /* 50 idle cylces for SWD reset */
 	jtagtap_tms_seq(0xe73cU, 16U); /* SWD to JTAG sequence */
-	jtagtap_soft_reset();
 }
 
 static void jtagtap_reset(void)

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -230,6 +230,7 @@ static void jtagtap_tdi_seq_swd_delay(const uint8_t *const data_in, const bool f
 static void jtagtap_tdi_seq_no_delay(const uint8_t *const data_in, const bool final_tms, size_t clock_cycles)
 {
 	for (size_t cycle = 0; cycle < clock_cycles; ++cycle) {
+		gpio_clear(TCK_PORT, TCK_PIN);
 		const size_t bit = cycle & 7U;
 		const size_t byte = cycle >> 3U;
 		/* On the last tick, assert final_tms to TMS_PIN */
@@ -238,8 +239,10 @@ static void jtagtap_tdi_seq_no_delay(const uint8_t *const data_in, const bool fi
 		gpio_set_val(TDI_PORT, TDI_PIN, data_in[byte] & (1U << bit));
 		gpio_set(TCK_PORT, TCK_PIN);
 		/* Finish the clock cycle */
-		gpio_clear(TCK_PORT, TCK_PIN);
 	}
+	__asm__("nop");
+	__asm__("nop");
+	gpio_clear(TCK_PORT, TCK_PIN);
 }
 
 static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *const data_in, const size_t clock_cycles)

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -64,6 +64,7 @@ bool remote_jtagtap_init(void)
 	jtag_proc.jtagtap_tms_seq = jtagtap_tms_seq;
 	jtag_proc.jtagtap_tdi_tdo_seq = jtagtap_tdi_tdo_seq;
 	jtag_proc.jtagtap_tdi_seq = jtagtap_tdi_seq;
+	jtag_proc.tap_idle_cycles = 1;
 
 	platform_buffer_write((uint8_t *)REMOTE_HL_CHECK_STR, sizeof(REMOTE_HL_CHECK_STR));
 	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -194,7 +194,7 @@ uint32_t jtag_scan(const uint8_t *irlens)
 	}
 	DEBUG_INFO("Return to Run-Test/Idle\n");
 	jtag_proc.jtagtap_next(true, true);
-	jtagtap_return_idle(jtag_proc.tap_idle_cycles);
+	jtagtap_return_idle(1);
 
 #if PC_HOSTED == 1
 	/*Transfer needed device information to firmware jtag_devs */

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -35,7 +35,7 @@ jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1U];
 uint32_t jtag_dev_count = 0;
 
 /* bucket of ones for don't care TDI */
-static const uint8_t ones[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+const uint8_t ones[8] = {0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU};
 
 #if PC_HOSTED == 0
 void jtag_add_device(const uint32_t dev_index, const jtag_dev_s *jtag_dev)

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -151,7 +151,7 @@ uint32_t jtag_scan(const uint8_t *irlens)
 	}
 
 	DEBUG_INFO("Return to Run-Test/Idle\n");
-	jtag_proc.jtagtap_next(1, 1);
+	jtag_proc.jtagtap_next(true, true);
 	jtagtap_return_idle(1);
 
 	/* All devices should be in BYPASS now */

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -46,6 +46,7 @@ typedef struct jtag_dev {
 
 extern jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1U];
 extern uint32_t jtag_dev_count;
+extern const uint8_t ones[8];
 
 void jtag_dev_write_ir(uint8_t jd_index, uint32_t ir);
 void jtag_dev_shift_dr(uint8_t jd_index, uint8_t *dout, const uint8_t *din, size_t ticks);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address several JTAG bugs (including a regression from PR #1131) which were impacting the ability for the firmware to correctly talk to RISC-V targets, among others. There are still issues with the timings being very tight on many devices, but this does at least appear to be reliable and gives reasonable clocking waveforms too as shown in the capture below.

![image](https://user-images.githubusercontent.com/691140/218310242-b667ab63-dfdf-4ec1-872f-e9f23ac49b2c.png)

This blocks PR #1380 till merged and must be applied on top of that PR if wishing to test RISC-V with BMP or other BMD firmware platforms.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
