### PR TITLE
Fix: STM32F1 option bytes handling correctness

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -487,23 +487,24 @@ bool stm32f1_probe(target_s *target)
 	return true;
 }
 
-static bool stm32f1_flash_unlock(target_s *t, uint32_t bank_offset)
+static bool stm32f1_flash_unlock(target_s *target, uint32_t bank_offset)
 {
-	target_mem_write32(t, FLASH_KEYR + bank_offset, KEY1);
-	target_mem_write32(t, FLASH_KEYR + bank_offset, KEY2);
-	uint32_t cr = target_mem_read32(t, FLASH_CR);
-	if (cr & FLASH_CR_LOCK)
-		DEBUG_WARN("unlock failed, cr: 0x%08" PRIx32 "\n", cr);
-	return !(cr & FLASH_CR_LOCK);
+	target_mem_write32(target, FLASH_KEYR + bank_offset, KEY1);
+	target_mem_write32(target, FLASH_KEYR + bank_offset, KEY2);
+	uint32_t ctrl = target_mem_read32(target, FLASH_CR);
+	if (ctrl & FLASH_CR_LOCK)
+		DEBUG_WARN("unlock failed, cr: 0x%08" PRIx32 "\n", ctrl);
+	return !(ctrl & FLASH_CR_LOCK);
 }
 
-static inline void stm32f1_flash_clear_eop(target_s *const t, const uint32_t bank_offset)
+static inline void stm32f1_flash_clear_eop(target_s *const target, const uint32_t bank_offset)
 {
-	const uint32_t status = target_mem_read32(t, FLASH_SR + bank_offset);
-	target_mem_write32(t, FLASH_SR + bank_offset, status | SR_EOP); /* EOP is W1C */
+	const uint32_t status = target_mem_read32(target, FLASH_SR + bank_offset);
+	target_mem_write32(target, FLASH_SR + bank_offset, status | SR_EOP); /* EOP is W1C */
 }
 
-static bool stm32f1_flash_busy_wait(target_s *const t, const uint32_t bank_offset, platform_timeout_s *const timeout)
+static bool stm32f1_flash_busy_wait(
+	target_s *const target, const uint32_t bank_offset, platform_timeout_s *const timeout)
 {
 	/* Read FLASH_SR to poll for BSY bit */
 	uint32_t status = FLASH_SR_BSY;
@@ -515,8 +516,8 @@ static bool stm32f1_flash_busy_wait(target_s *const t, const uint32_t bank_offse
 	 * https://www.st.com/resource/en/programming_manual/pm0075-stm32f10xxx-flash-memory-microcontrollers-stmicroelectronics.pdf
 	 */
 	while (!(status & SR_EOP) && (status & FLASH_SR_BSY)) {
-		status = target_mem_read32(t, FLASH_SR + bank_offset);
-		if (target_check_error(t)) {
+		status = target_mem_read32(target, FLASH_SR + bank_offset);
+		if (target_check_error(target)) {
 			DEBUG_WARN("Lost communications with target");
 			return false;
 		}

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -40,7 +40,7 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
-static bool stm32f1_cmd_option(target_s *t, int argc, const char **argv);
+static bool stm32f1_cmd_option(target_s *target, int argc, const char **argv);
 
 const command_s stm32f1_cmd_list[] = {
 	{"option", stm32f1_cmd_option, "Manipulate option bytes"},
@@ -639,39 +639,39 @@ static bool stm32f1_mass_erase(target_s *target)
 	return true;
 }
 
-static bool stm32f1_option_erase(target_s *t)
+static bool stm32f1_option_erase(target_s *target)
 {
-	stm32f1_flash_clear_eop(t, FLASH_BANK1_OFFSET);
+	stm32f1_flash_clear_eop(target, FLASH_BANK1_OFFSET);
 
 	/* Erase option bytes instruction */
-	target_mem_write32(t, FLASH_CR, FLASH_CR_OPTER | FLASH_CR_OPTWRE);
-	target_mem_write32(t, FLASH_CR, FLASH_CR_STRT | FLASH_CR_OPTER | FLASH_CR_OPTWRE);
+	target_mem_write32(target, FLASH_CR, FLASH_CR_OPTER | FLASH_CR_OPTWRE);
+	target_mem_write32(target, FLASH_CR, FLASH_CR_STRT | FLASH_CR_OPTER | FLASH_CR_OPTWRE);
 
 	/* Wait for completion or an error */
-	return stm32f1_flash_busy_wait(t, FLASH_BANK1_OFFSET, NULL);
+	return stm32f1_flash_busy_wait(target, FLASH_BANK1_OFFSET, NULL);
 }
 
 static bool stm32f1_option_write_erased(
-	target_s *const t, const uint32_t addr, const uint16_t value, const bool write16_broken)
+	target_s *const target, const uint32_t addr, const uint16_t value, const bool write16_broken)
 {
 	if (value == 0xffffU)
 		return true;
 
-	stm32f1_flash_clear_eop(t, FLASH_BANK1_OFFSET);
+	stm32f1_flash_clear_eop(target, FLASH_BANK1_OFFSET);
 
 	/* Erase option bytes instruction */
-	target_mem_write32(t, FLASH_CR, FLASH_CR_OPTPG | FLASH_CR_OPTWRE);
+	target_mem_write32(target, FLASH_CR, FLASH_CR_OPTPG | FLASH_CR_OPTWRE);
 
 	if (write16_broken)
-		target_mem_write32(t, addr, 0xffff0000U | value);
+		target_mem_write32(target, addr, 0xffff0000U | value);
 	else
-		target_mem_write16(t, addr, value);
+		target_mem_write16(target, addr, value);
 
 	/* Wait for completion or an error */
-	return stm32f1_flash_busy_wait(t, FLASH_BANK1_OFFSET, NULL);
+	return stm32f1_flash_busy_wait(target, FLASH_BANK1_OFFSET, NULL);
 }
 
-static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const uint16_t value)
+static bool stm32f1_option_write(target_s *const target, const uint32_t addr, const uint16_t value)
 {
 	uint32_t index = (addr - FLASH_OBP_RDP) / 2U;
 	/* If index would be negative, the high most bit is set, so we get a giant positive number. */
@@ -682,7 +682,7 @@ static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const u
 	/* Retrieve old values */
 	for (size_t i = 0U; i < 16U; i += 4U) {
 		const size_t offset = i >> 1U;
-		uint32_t val = target_mem_read32(t, FLASH_OBP_RDP + i);
+		uint32_t val = target_mem_read32(target, FLASH_OBP_RDP + i);
 		opt_val[offset] = val & 0xffffU;
 		opt_val[offset + 1U] = val >> 16U;
 	}
@@ -691,7 +691,7 @@ static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const u
 		return true;
 
 	/* Check for erased value */
-	if (opt_val[index] != 0xffffU && !stm32f1_option_erase(t))
+	if (opt_val[index] != 0xffffU && !stm32f1_option_erase(target))
 		return false;
 	opt_val[index] = value;
 
@@ -699,19 +699,19 @@ static bool stm32f1_option_write(target_s *const t, const uint32_t addr, const u
 	 * Write changed values, taking into account if we can use 32- or have to use 16-bit writes.
 	 * GD32E230 is a special case as target_mem_write16 does not work
 	 */
-	const bool write16_broken = t->part_id == 0x410U && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
+	const bool write16_broken = target->part_id == 0x410U && (target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
 	for (size_t i = 0U; i < 8U; ++i) {
-		if (!stm32f1_option_write_erased(t, FLASH_OBP_RDP + (i * 2U), opt_val[i], write16_broken) && i != 0)
+		if (!stm32f1_option_write_erased(target, FLASH_OBP_RDP + (i * 2U), opt_val[i], write16_broken) && i != 0)
 			return false;
 	}
 
 	return true;
 }
 
-static bool stm32f1_cmd_option(target_s *t, int argc, const char **argv)
+static bool stm32f1_cmd_option(target_s *target, int argc, const char **argv)
 {
 	uint32_t flash_obp_rdp_key = FLASH_OBP_RDP_KEY;
-	switch (t->part_id) {
+	switch (target->part_id) {
 	case 0x422U: /* STM32F30x */
 	case 0x432U: /* STM32F37x */
 	case 0x438U: /* STM32F303x6/8 and STM32F328 */
@@ -724,36 +724,36 @@ static bool stm32f1_cmd_option(target_s *t, int argc, const char **argv)
 		break;
 	}
 
-	const uint32_t rdprt = target_mem_read32(t, FLASH_OBR) & FLASH_OBR_RDPRT;
+	const uint32_t rdprt = target_mem_read32(target, FLASH_OBR) & FLASH_OBR_RDPRT;
 
-	if (!stm32f1_flash_unlock(t, FLASH_BANK1_OFFSET))
+	if (!stm32f1_flash_unlock(target, FLASH_BANK1_OFFSET))
 		return false;
-	target_mem_write32(t, FLASH_OPTKEYR, KEY1);
-	target_mem_write32(t, FLASH_OPTKEYR, KEY2);
+	target_mem_write32(target, FLASH_OPTKEYR, KEY1);
+	target_mem_write32(target, FLASH_OPTKEYR, KEY2);
 
 	if (argc == 2 && strcmp(argv[1], "erase") == 0) {
-		stm32f1_option_erase(t);
+		stm32f1_option_erase(target);
 		/*
 		 * Write OBD RDP key, taking into account if we can use 32- or have to use 16-bit writes.
 		 * GD32E230 is a special case as target_mem_write16 does not work
 		 */
-		const bool write16_broken = t->part_id == 0x410U && (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
-		stm32f1_option_write_erased(t, FLASH_OBP_RDP, flash_obp_rdp_key, write16_broken);
+		const bool write16_broken = target->part_id == 0x410U && (target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
+		stm32f1_option_write_erased(target, FLASH_OBP_RDP, flash_obp_rdp_key, write16_broken);
 	} else if (rdprt) {
-		tc_printf(t, "Device is Read Protected\nUse `monitor option erase` to unprotect and erase device\n");
+		tc_printf(target, "Device is Read Protected\nUse `monitor option erase` to unprotect and erase device\n");
 		return true;
 	} else if (argc == 3) {
 		const uint32_t addr = strtol(argv[1], NULL, 0);
 		const uint32_t val = strtol(argv[2], NULL, 0);
-		stm32f1_option_write(t, addr, val);
+		stm32f1_option_write(target, addr, val);
 	} else
-		tc_printf(t, "usage: monitor option erase\nusage: monitor option <addr> <value>\n");
+		tc_printf(target, "usage: monitor option erase\nusage: monitor option <addr> <value>\n");
 
 	for (size_t i = 0U; i < 16U; i += 4U) {
 		const uint32_t addr = FLASH_OBP_RDP + i;
-		const uint32_t val = target_mem_read32(t, addr);
-		tc_printf(t, "0x%08X: 0x%04X\n", addr, val & 0xffffU);
-		tc_printf(t, "0x%08X: 0x%04X\n", addr + 2U, val >> 16U);
+		const uint32_t val = target_mem_read32(target, addr);
+		tc_printf(target, "0x%08X: 0x%04X\n", addr, val & 0xffffU);
+		tc_printf(target, "0x%08X: 0x%04X\n", addr + 2U, val >> 16U);
 	}
 
 	return true;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -47,9 +47,9 @@ const command_s stm32f1_cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
-static bool stm32f1_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
-static bool stm32f1_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
-static bool stm32f1_mass_erase(target_s *t);
+static bool stm32f1_flash_erase(target_flash_s *flash, target_addr_t addr, size_t len);
+static bool stm32f1_flash_write(target_flash_s *flash, target_addr_t dest, const void *src, size_t len);
+static bool stm32f1_mass_erase(target_s *target);
 
 /* Flash Program ad Erase Controller Register Map */
 #define FPEC_BASE     0x40022000U
@@ -607,34 +607,35 @@ static bool stm32f1_flash_write(target_flash_s *flash, target_addr_t dest, const
 	return true;
 }
 
-static bool stm32f1_mass_erase_bank(target_s *const t, const uint32_t bank_offset, platform_timeout_s *const timeout)
+static bool stm32f1_mass_erase_bank(
+	target_s *const target, const uint32_t bank_offset, platform_timeout_s *const timeout)
 {
 	/* Unlock the bank */
-	if (!stm32f1_flash_unlock(t, bank_offset))
+	if (!stm32f1_flash_unlock(target, bank_offset))
 		return false;
-	stm32f1_flash_clear_eop(t, bank_offset);
+	stm32f1_flash_clear_eop(target, bank_offset);
 
 	/* Flash mass erase start instruction */
-	target_mem_write32(t, FLASH_CR + bank_offset, FLASH_CR_MER);
-	target_mem_write32(t, FLASH_CR + bank_offset, FLASH_CR_STRT | FLASH_CR_MER);
+	target_mem_write32(target, FLASH_CR + bank_offset, FLASH_CR_MER);
+	target_mem_write32(target, FLASH_CR + bank_offset, FLASH_CR_STRT | FLASH_CR_MER);
 
 	/* Wait for completion or an error */
-	return stm32f1_flash_busy_wait(t, bank_offset, timeout);
+	return stm32f1_flash_busy_wait(target, bank_offset, timeout);
 }
 
-static bool stm32f1_mass_erase(target_s *t)
+static bool stm32f1_mass_erase(target_s *target)
 {
-	if (!stm32f1_flash_unlock(t, 0))
+	if (!stm32f1_flash_unlock(target, 0))
 		return false;
 
 	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 500);
-	if (!stm32f1_mass_erase_bank(t, FLASH_BANK1_OFFSET, &timeout))
+	if (!stm32f1_mass_erase_bank(target, FLASH_BANK1_OFFSET, &timeout))
 		return false;
 
 	/* If we're on a part that has a second bank, mass erase that bank too */
-	if (t->part_id == 0x430U)
-		return stm32f1_mass_erase_bank(t, FLASH_BANK2_OFFSET, &timeout);
+	if (target->part_id == 0x430U)
+		return stm32f1_mass_erase_bank(target, FLASH_BANK2_OFFSET, &timeout);
 	return true;
 }
 

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -701,7 +701,7 @@ static bool stm32f1_option_write_erased(
 
 static bool stm32f1_option_write(target_s *const target, const uint32_t addr, const uint16_t value)
 {
-	uint32_t index = (addr - FLASH_OBP_RDP) / 2U;
+	const uint32_t index = (addr - FLASH_OBP_RDP) >> 1U;
 	/* If index would be negative, the high most bit is set, so we get a giant positive number. */
 	if (index > 7U)
 		return false;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -104,66 +104,66 @@ static bool stm32f1_mass_erase(target_s *target);
 #define DBGMCU_IDCODE_MM32L0 0x40013400U
 #define DBGMCU_IDCODE_MM32F3 0x40007080U
 
-static void stm32f1_add_flash(target_s *t, uint32_t addr, size_t length, size_t erasesize)
+static void stm32f1_add_flash(target_s *target, uint32_t addr, size_t length, size_t erasesize)
 {
-	target_flash_s *f = calloc(1, sizeof(*f));
-	if (!f) { /* calloc failed: heap exhaustion */
+	target_flash_s *flash = calloc(1, sizeof(*flash));
+	if (!flash) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return;
 	}
 
-	f->start = addr;
-	f->length = length;
-	f->blocksize = erasesize;
-	f->erase = stm32f1_flash_erase;
-	f->write = stm32f1_flash_write;
-	f->writesize = erasesize;
-	f->erased = 0xff;
-	target_add_flash(t, f);
+	flash->start = addr;
+	flash->length = length;
+	flash->blocksize = erasesize;
+	flash->erase = stm32f1_flash_erase;
+	flash->write = stm32f1_flash_write;
+	flash->writesize = erasesize;
+	flash->erased = 0xff;
+	target_add_flash(target, flash);
 }
 
-static uint16_t stm32f1_read_idcode(target_s *const t)
+static uint16_t stm32f1_read_idcode(target_s *const target)
 {
-	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M0 || (t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
-		return target_mem_read32(t, DBGMCU_IDCODE_F0) & 0xfffU;
-	return target_mem_read32(t, DBGMCU_IDCODE) & 0xfffU;
+	if ((target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M0 || (target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
+		return target_mem_read32(target, DBGMCU_IDCODE_F0) & 0xfffU;
+	return target_mem_read32(target, DBGMCU_IDCODE) & 0xfffU;
 }
 
 /* Identify GD32F1 and GD32F3 chips */
-bool gd32f1_probe(target_s *t)
+bool gd32f1_probe(target_s *target)
 {
-	const uint16_t device_id = stm32f1_read_idcode(t);
+	const uint16_t device_id = stm32f1_read_idcode(target);
 	switch (device_id) {
 	case 0x414U: /* Gigadevice gd32f303 */
 	case 0x430U:
-		t->driver = "GD32F3";
+		target->driver = "GD32F3";
 		break;
 	case 0x410U: /* Gigadevice gd32f103, gd32e230 */
-		if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
-			t->driver = "GD32E230";
-		else if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M4)
-			t->driver = "GD32F3";
+		if ((target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)
+			target->driver = "GD32E230";
+		else if ((target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M4)
+			target->driver = "GD32F3";
 		else
-			t->driver = "GD32F1";
+			target->driver = "GD32F1";
 		break;
 	default:
 		return false;
 	}
 
-	const uint32_t signature = target_mem_read32(t, GD32Fx_FLASHSIZE);
+	const uint32_t signature = target_mem_read32(target, GD32Fx_FLASHSIZE);
 	const uint16_t flash_size = signature & 0xffffU;
 	const uint16_t ram_size = signature >> 16U;
 
-	t->part_id = device_id;
-	t->mass_erase = stm32f1_mass_erase;
-	target_add_ram(t, 0x20000000, ram_size * 1024U);
-	stm32f1_add_flash(t, 0x8000000, flash_size * 1024U, 0x400);
-	target_add_commands(t, stm32f1_cmd_list, t->driver);
+	target->part_id = device_id;
+	target->mass_erase = stm32f1_mass_erase;
+	target_add_ram(target, 0x20000000, ram_size * 1024U);
+	stm32f1_add_flash(target, 0x8000000, (size_t)flash_size * 1024U, 0x400);
+	target_add_commands(target, stm32f1_cmd_list, target->driver);
 
 	return true;
 }
 
-static bool at32f40_detect(target_s *t, const uint16_t part_id)
+static bool at32f40_detect(target_s *target, const uint16_t part_id)
 {
 	// Current driver supports only *default* memory layout (256 KB Flash / 96 KB SRAM)
 	// XXX: Support for external Flash for 512KB and 1024KB parts requires specific flash code (not implemented)
@@ -189,20 +189,20 @@ static bool at32f40_detect(target_s *t, const uint16_t part_id)
 	case 0x034cU: // AT32F407VGT7 1024KB / LQFP64 (*)
 	case 0x0353U: // AT32F407AVGT7 1024KB / LQFP100 (*)
 		// Flash: 256 KB / 2KB per block
-		stm32f1_add_flash(t, 0x08000000, 256U * 1024U, 2U * 1024U);
+		stm32f1_add_flash(target, 0x08000000, 256U * 1024U, 2U * 1024U);
 		break;
 	// Unknown/undocumented
 	default:
 		return false;
 	}
 	// All parts have 96KB SRAM
-	target_add_ram(t, 0x20000000, 96U * 1024U);
-	t->driver = "AT32F403A/407";
-	t->mass_erase = stm32f1_mass_erase;
+	target_add_ram(target, 0x20000000, 96U * 1024U);
+	target->driver = "AT32F403A/407";
+	target->mass_erase = stm32f1_mass_erase;
 	return true;
 }
 
-static bool at32f41_detect(target_s *t, const uint16_t part_id)
+static bool at32f41_detect(target_s *target, const uint16_t part_id)
 {
 	switch (part_id) {
 	case 0x0240U: // LQFP64_10x10
@@ -211,7 +211,7 @@ static bool at32f41_detect(target_s *t, const uint16_t part_id)
 	case 0x0243U: // LQFP64_7x7
 	case 0x024cU: // QFN48_6x6
 		// Flash: 256 KB / 2KB per block
-		stm32f1_add_flash(t, 0x08000000, 256U * 1024U, 2U * 1024U);
+		stm32f1_add_flash(target, 0x08000000, 256U * 1024U, 2U * 1024U);
 		break;
 	case 0x01c4U: // LQFP64_10x10
 	case 0x01c5U: // LQFP48_7x7
@@ -219,41 +219,41 @@ static bool at32f41_detect(target_s *t, const uint16_t part_id)
 	case 0x01c7U: // LQFP64_7x7
 	case 0x01cdU: // QFN48_6x6
 		// Flash: 128 KB / 2KB per block
-		stm32f1_add_flash(t, 0x08000000, 128U * 1024U, 2U * 1024U);
+		stm32f1_add_flash(target, 0x08000000, 128U * 1024U, 2U * 1024U);
 		break;
 	case 0x0108U: // LQFP64_10x10
 	case 0x0109U: // LQFP48_7x7
 	case 0x010aU: // QFN32_4x4
 		// Flash: 64 KB / 2KB per block
-		stm32f1_add_flash(t, 0x08000000, 64U * 1024U, 2U * 1024U);
+		stm32f1_add_flash(target, 0x08000000, 64U * 1024U, 2U * 1024U);
 		break;
 	// Unknown/undocumented
 	default:
 		return false;
 	}
 	// All parts have 32KB SRAM
-	target_add_ram(t, 0x20000000, 32U * 1024U);
-	t->driver = "AT32F415";
-	t->mass_erase = stm32f1_mass_erase;
+	target_add_ram(target, 0x20000000, 32U * 1024U);
+	target->driver = "AT32F415";
+	target->mass_erase = stm32f1_mass_erase;
 	return true;
 }
 
 /* Identify AT32F4x devices (Cortex-M4) */
-bool at32fxx_probe(target_s *t)
+bool at32fxx_probe(target_s *target)
 {
 	// Artery clones use Cortex M4 cores
-	if ((t->cpuid & CPUID_PARTNO_MASK) != CORTEX_M4)
+	if ((target->cpuid & CPUID_PARTNO_MASK) != CORTEX_M4)
 		return false;
 
 	// Artery chips use the complete idcode word for identification
-	const uint32_t idcode = target_mem_read32(t, DBGMCU_IDCODE);
+	const uint32_t idcode = target_mem_read32(target, DBGMCU_IDCODE);
 	const uint32_t series = idcode & AT32F4x_IDCODE_SERIES_MASK;
 	const uint16_t part_id = idcode & AT32F4x_IDCODE_PART_MASK;
 
 	if (series == AT32F40_SERIES)
-		return at32f40_detect(t, part_id);
+		return at32f40_detect(target, part_id);
 	if (series == AT32F41_SERIES)
-		return at32f41_detect(t, part_id);
+		return at32f41_detect(target, part_id);
 	return false;
 }
 
@@ -302,16 +302,15 @@ void mm32l0_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *
 
 /* Identify MM32 devices (Cortex-M0) */
 
-bool mm32l0xx_probe(target_s *t)
+bool mm32l0xx_probe(target_s *target)
 {
-	uint32_t mm32_id;
-	const char *name = "?";
+	const char *name;
 	size_t flash_kbyte = 0;
 	size_t ram_kbyte = 0;
 	size_t block_size = 0x400U;
 
-	mm32_id = target_mem_read32(t, DBGMCU_IDCODE_MM32L0);
-	if (target_check_error(t)) {
+	const uint32_t mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32L0);
+	if (target_check_error(target)) {
 		DEBUG_WARN("mm32l0xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32L0);
 		return false;
 	}
@@ -333,18 +332,18 @@ bool mm32l0xx_probe(target_s *t)
 		DEBUG_WARN("mm32l0xx_probe: unknown mm32 dev_id 0x%" PRIx32 "\n", mm32_id);
 		return false;
 	}
-	t->part_id = mm32_id & 0xfffU;
-	t->driver = name;
-	t->mass_erase = stm32f1_mass_erase;
-	target_add_ram(t, 0x20000000U, ram_kbyte * 1024U);
-	stm32f1_add_flash(t, 0x08000000U, flash_kbyte * 1024U, block_size);
-	target_add_commands(t, stm32f1_cmd_list, name);
-	cortexm_ap(t)->dp->mem_write = mm32l0_mem_write_sized;
+	target->part_id = mm32_id & 0xfffU;
+	target->driver = name;
+	target->mass_erase = stm32f1_mass_erase;
+	target_add_ram(target, 0x20000000U, ram_kbyte * 1024U);
+	stm32f1_add_flash(target, 0x08000000U, flash_kbyte * 1024U, block_size);
+	target_add_commands(target, stm32f1_cmd_list, name);
+	cortexm_ap(target)->dp->mem_write = mm32l0_mem_write_sized;
 	return true;
 }
 
 /* Identify MM32 devices (Cortex-M3, Star-MC1) */
-bool mm32f3xx_probe(target_s *t)
+bool mm32f3xx_probe(target_s *target)
 {
 	uint32_t mm32_id;
 	const char *name = "?";
@@ -353,8 +352,8 @@ bool mm32f3xx_probe(target_s *t)
 	size_t ram2_kbyte = 0; /* ram at 0x30000000 */
 	size_t block_size = 0x400U;
 
-	mm32_id = target_mem_read32(t, DBGMCU_IDCODE_MM32F3);
-	if (target_check_error(t)) {
+	mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32F3);
+	if (target_check_error(target)) {
 		DEBUG_WARN("mm32f3xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32F3);
 		return false;
 	}
@@ -377,24 +376,24 @@ bool mm32f3xx_probe(target_s *t)
 		DEBUG_WARN("mm32f3xx_probe: unknown mm32 dev_id 0x%" PRIx32 "\n", mm32_id);
 		return false;
 	}
-	t->part_id = mm32_id & 0xfffU;
-	t->driver = name;
-	t->mass_erase = stm32f1_mass_erase;
+	target->part_id = mm32_id & 0xfffU;
+	target->driver = name;
+	target->mass_erase = stm32f1_mass_erase;
 	if (ram1_kbyte != 0)
-		target_add_ram(t, 0x20000000U, ram1_kbyte * 1024U);
+		target_add_ram(target, 0x20000000U, ram1_kbyte * 1024U);
 	if (ram2_kbyte != 0)
-		target_add_ram(t, 0x30000000U, ram2_kbyte * 1024U);
-	stm32f1_add_flash(t, 0x08000000U, flash_kbyte * 1024U, block_size);
-	target_add_commands(t, stm32f1_cmd_list, name);
+		target_add_ram(target, 0x30000000U, ram2_kbyte * 1024U);
+	stm32f1_add_flash(target, 0x08000000U, flash_kbyte * 1024U, block_size);
+	target_add_commands(target, stm32f1_cmd_list, name);
 	return true;
 }
 
 /* Identify real STM32F0/F1/F3 devices */
-bool stm32f1_probe(target_s *t)
+bool stm32f1_probe(target_s *target)
 {
-	const uint16_t device_id = stm32f1_read_idcode(t);
+	const uint16_t device_id = stm32f1_read_idcode(target);
 
-	t->mass_erase = stm32f1_mass_erase;
+	target->mass_erase = stm32f1_mass_erase;
 	size_t flash_size = 0;
 	size_t block_size = 0x400;
 
@@ -403,76 +402,76 @@ bool stm32f1_probe(target_s *t)
 	case 0x410U: /* Medium density */
 	case 0x412U: /* Low density */
 	case 0x420U: /* Value Line, Low-/Medium density */
-		target_add_ram(t, 0x20000000, 0x5000);
-		stm32f1_add_flash(t, 0x8000000, 0x20000, 0x400);
-		target_add_commands(t, stm32f1_cmd_list, "STM32 LD/MD/VL-LD/VL-MD");
+		target_add_ram(target, 0x20000000, 0x5000);
+		stm32f1_add_flash(target, 0x8000000, 0x20000, 0x400);
+		target_add_commands(target, stm32f1_cmd_list, "STM32 LD/MD/VL-LD/VL-MD");
 		/* Test for clone parts with Core rev 2*/
-		adiv5_access_port_s *ap = cortexm_ap(t);
+		adiv5_access_port_s *ap = cortexm_ap(target);
 		if ((ap->idr >> 28U) > 1U) {
-			t->driver = "STM32F1 (clone) medium density";
+			target->driver = "STM32F1 (clone) medium density";
 			DEBUG_WARN("Detected clone STM32F1\n");
 		} else
-			t->driver = "STM32F1 medium density";
-		t->part_id = device_id;
+			target->driver = "STM32F1 medium density";
+		target->part_id = device_id;
 		return true;
 
 	case 0x414U: /* High density */
 	case 0x418U: /* Connectivity Line */
 	case 0x428U: /* Value Line, High Density */
-		t->driver = "STM32F1  VL density";
-		t->part_id = device_id;
-		target_add_ram(t, 0x20000000, 0x10000);
-		stm32f1_add_flash(t, 0x8000000, 0x80000, 0x800);
-		target_add_commands(t, stm32f1_cmd_list, "STM32 HF/CL/VL-HD");
+		target->driver = "STM32F1  VL density";
+		target->part_id = device_id;
+		target_add_ram(target, 0x20000000, 0x10000);
+		stm32f1_add_flash(target, 0x8000000, 0x80000, 0x800);
+		target_add_commands(target, stm32f1_cmd_list, "STM32 HF/CL/VL-HD");
 		return true;
 
 	case 0x430U: /* XL-density */
-		t->driver = "STM32F1  XL density";
-		t->part_id = device_id;
-		target_add_ram(t, 0x20000000, 0x18000);
-		stm32f1_add_flash(t, 0x8000000, 0x80000, 0x800);
-		stm32f1_add_flash(t, 0x8080000, 0x80000, 0x800);
-		target_add_commands(t, stm32f1_cmd_list, "STM32 XL/VL-XL");
+		target->driver = "STM32F1  XL density";
+		target->part_id = device_id;
+		target_add_ram(target, 0x20000000, 0x18000);
+		stm32f1_add_flash(target, 0x8000000, 0x80000, 0x800);
+		stm32f1_add_flash(target, 0x8080000, 0x80000, 0x800);
+		target_add_commands(target, stm32f1_cmd_list, "STM32 XL/VL-XL");
 		return true;
 
 	case 0x438U: /* STM32F303x6/8 and STM32F328 */
 	case 0x422U: /* STM32F30x */
 	case 0x446U: /* STM32F303xD/E and STM32F398xE */
-		target_add_ram(t, 0x10000000, 0x4000);
+		target_add_ram(target, 0x10000000, 0x4000);
 		/* fall through */
 
 	case 0x432U: /* STM32F37x */
 	case 0x439U: /* STM32F302C8 */
-		t->driver = "STM32F3";
-		t->part_id = device_id;
-		target_add_ram(t, 0x20000000, 0x10000);
-		stm32f1_add_flash(t, 0x8000000, 0x80000, 0x800);
-		target_add_commands(t, stm32f1_cmd_list, "STM32F3");
+		target->driver = "STM32F3";
+		target->part_id = device_id;
+		target_add_ram(target, 0x20000000, 0x10000);
+		stm32f1_add_flash(target, 0x8000000, 0x80000, 0x800);
+		target_add_commands(target, stm32f1_cmd_list, "STM32F3");
 		return true;
 
 	case 0x444U: /* STM32F03 RM0091 Rev. 7, STM32F030x[4|6] RM0360 Rev. 4 */
-		t->driver = "STM32F03";
+		target->driver = "STM32F03";
 		flash_size = 0x8000;
 		break;
 
 	case 0x445U: /* STM32F04 RM0091 Rev. 7, STM32F070x6 RM0360 Rev. 4 */
-		t->driver = "STM32F04/F070x6";
+		target->driver = "STM32F04/F070x6";
 		flash_size = 0x8000;
 		break;
 
 	case 0x440U: /* STM32F05 RM0091 Rev. 7, STM32F030x8 RM0360 Rev. 4 */
-		t->driver = "STM32F05/F030x8";
+		target->driver = "STM32F05/F030x8";
 		flash_size = 0x10000;
 		break;
 
 	case 0x448U: /* STM32F07 RM0091 Rev. 7, STM32F070xb RM0360 Rev. 4 */
-		t->driver = "STM32F07";
+		target->driver = "STM32F07";
 		flash_size = 0x20000;
 		block_size = 0x800;
 		break;
 
 	case 0x442U: /* STM32F09 RM0091 Rev. 7, STM32F030xc RM0360 Rev. 4 */
-		t->driver = "STM32F09/F030xc";
+		target->driver = "STM32F09/F030xc";
 		flash_size = 0x40000;
 		block_size = 0x800;
 		break;
@@ -481,10 +480,10 @@ bool stm32f1_probe(target_s *t)
 		return false;
 	}
 
-	t->part_id = device_id;
-	target_add_ram(t, 0x20000000, 0x5000);
-	stm32f1_add_flash(t, 0x8000000, flash_size, block_size);
-	target_add_commands(t, stm32f1_cmd_list, "STM32F0");
+	target->part_id = device_id;
+	target_add_ram(target, 0x20000000, 0x5000);
+	stm32f1_add_flash(target, 0x8000000, flash_size, block_size);
+	target_add_commands(target, stm32f1_cmd_list, "STM32F0");
 	return true;
 }
 

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -639,6 +639,22 @@ static bool stm32f1_mass_erase(target_s *target)
 	return true;
 }
 
+static uint16_t stm32f1_flash_readable_key(const target_s *const target)
+{
+	switch (target->part_id) {
+	case 0x422U: /* STM32F30x */
+	case 0x432U: /* STM32F37x */
+	case 0x438U: /* STM32F303x6/8 and STM32F328 */
+	case 0x440U: /* STM32F0 */
+	case 0x446U: /* STM32F303xD/E and STM32F398xE */
+	case 0x445U: /* STM32F04 RM0091 Rev.7, STM32F070x6 RM0360 Rev. 4*/
+	case 0x448U: /* STM32F07 RM0091 Rev.7, STM32F070xb RM0360 Rev. 4*/
+	case 0x442U: /* STM32F09 RM0091 Rev.7, STM32F030xc RM0360 Rev. 4*/
+		return FLASH_OBP_RDP_KEY_F3;
+	}
+	return FLASH_OBP_RDP_KEY;
+}
+
 static bool stm32f1_option_erase(target_s *target)
 {
 	stm32f1_flash_clear_eop(target, FLASH_BANK1_OFFSET);
@@ -710,45 +726,43 @@ static bool stm32f1_option_write(target_s *const target, const uint32_t addr, co
 
 static bool stm32f1_cmd_option(target_s *target, int argc, const char **argv)
 {
-	uint32_t flash_obp_rdp_key = FLASH_OBP_RDP_KEY;
-	switch (target->part_id) {
-	case 0x422U: /* STM32F30x */
-	case 0x432U: /* STM32F37x */
-	case 0x438U: /* STM32F303x6/8 and STM32F328 */
-	case 0x440U: /* STM32F0 */
-	case 0x446U: /* STM32F303xD/E and STM32F398xE */
-	case 0x445U: /* STM32F04 RM0091 Rev.7, STM32F070x6 RM0360 Rev. 4*/
-	case 0x448U: /* STM32F07 RM0091 Rev.7, STM32F070xb RM0360 Rev. 4*/
-	case 0x442U: /* STM32F09 RM0091 Rev.7, STM32F030xc RM0360 Rev. 4*/
-		flash_obp_rdp_key = FLASH_OBP_RDP_KEY_F3;
-		break;
+	const uint32_t read_protected = target_mem_read32(target, FLASH_OBR) & FLASH_OBR_RDPRT;
+	const bool erase_requested = argc == 2 && strcmp(argv[1], "erase") == 0;
+	/* Fast-exit if the Flash is not readable and the user didn't ask us to erase the option bytes */
+	if (read_protected && !erase_requested) {
+		tc_printf(target, "Device is Read Protected\nUse `monitor option erase` to unprotect and erase device\n");
+		return true;
 	}
 
-	const uint32_t rdprt = target_mem_read32(target, FLASH_OBR) & FLASH_OBR_RDPRT;
-
+	/* Unprotect the option bytes so we can modify them */
 	if (!stm32f1_flash_unlock(target, FLASH_BANK1_OFFSET))
 		return false;
 	target_mem_write32(target, FLASH_OPTKEYR, KEY1);
 	target_mem_write32(target, FLASH_OPTKEYR, KEY2);
 
-	if (argc == 2 && strcmp(argv[1], "erase") == 0) {
-		stm32f1_option_erase(target);
+	if (erase_requested) {
+		/* When the user asks us to erase the option bytes, kick of an erase */
+		if (!stm32f1_option_erase(target))
+			return false;
 		/*
-		 * Write OBD RDP key, taking into account if we can use 32- or have to use 16-bit writes.
+		 * Write the option bytes Flash readable key, taking into account if we can
+		 * use 32- or have to use 16-bit writes.
 		 * GD32E230 is a special case as target_mem_write16 does not work
 		 */
 		const bool write16_broken = target->part_id == 0x410U && (target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23;
-		stm32f1_option_write_erased(target, FLASH_OBP_RDP, flash_obp_rdp_key, write16_broken);
-	} else if (rdprt) {
-		tc_printf(target, "Device is Read Protected\nUse `monitor option erase` to unprotect and erase device\n");
-		return true;
+		if (!stm32f1_option_write_erased(target, FLASH_OBP_RDP, stm32f1_flash_readable_key(target), write16_broken))
+			return false;
 	} else if (argc == 3) {
+		/* If 3 arguments are given, assume the second is an address, and the third a value */
 		const uint32_t addr = strtol(argv[1], NULL, 0);
 		const uint32_t val = strtol(argv[2], NULL, 0);
-		stm32f1_option_write(target, addr, val);
+		/* Try and program the new option value to the requested option byte */
+		if (!stm32f1_option_write(target, addr, val))
+			return false;
 	} else
 		tc_printf(target, "usage: monitor option erase\nusage: monitor option <addr> <value>\n");
 
+	/* When all gets said and done, display the current option bytes values */
 	for (size_t i = 0U; i < 16U; i += 4U) {
 		const uint32_t addr = FLASH_OBP_RDP + i;
 		const uint32_t val = target_mem_read32(target, addr);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR is a follow-up to https://github.com/blackmagic-debug/blackmagic/pull/1306 which sought to address an issue with how we handle STM32F{0,1,3} option bytes that turned up when `stm32f1_flash_busy_wait` was made to properly check the Flash controller status and report it, and we made the Flash and options bytes handling code use and act on that status return.

The gist of what was wrong is that on the GD32F103, the options byte erase never actually erases option byte slot 0 (read protect), a request to write the option bytes then tries to program that slot back to its original value and fails by triggering the controller to report a programming error due to the the slot not being erased (0xffff) in hardware. This translated into it failing the write and reporting an error.

The old PR patched this by only failing if programming reported an error and we weren't trying to program slot 0, which worked but is not really correct. This replacement patch moves the check into `stm32f1_option_write_erased`, and verifies that the status register specifically reads back a program failure when writing slot 0 (preserving failure handling of write protection errors) before turning that into a success return.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
