### PR TITLE
Fix: JTAG IR quirk handling

### DIFF
--- a/src/target/jep106.h
+++ b/src/target/jep106.h
@@ -66,6 +66,7 @@
 #define JEP106_MANUFACTURER_GIGADEVICE   0x751U /* GigaDevice */
 #define JEP106_MANUFACTURER_RASPBERRY    0x913U /* Raspberry Pi */
 #define JEP106_MANUFACTURER_RENESAS      0x423U /* Renesas */
+#define JEP106_MANUFACTURER_XILINX       0x309U /* Xilinx */
 
 /*
  * This code is not listed in the JEP106 standard, but is used by some stm32f1 clones

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -105,6 +105,11 @@ const jtag_dev_descr_s dev_descr[] = {
 		.idcode = 0x00000093U,
 		.idmask = 0x00000fffU,
 		.descr = "Xilinx.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
 	},
 	{
 		.idcode = 0x0000063dU,

--- a/src/target/jtag_devs.h
+++ b/src/target/jtag_devs.h
@@ -23,11 +23,17 @@
 
 #include <stdint.h>
 
+typedef struct jtag_ir_quirks {
+	uint16_t ir_value;
+	uint8_t ir_length;
+} jtag_ir_quirks_s;
+
 typedef struct jtag_dev_descr {
 	uint32_t idcode;
 	uint32_t idmask;
 	const char *descr;
 	void (*handler)(uint8_t jd_index);
+	jtag_ir_quirks_s ir_quirks;
 } jtag_dev_descr_s;
 
 extern const jtag_dev_descr_s dev_descr[];

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -130,8 +130,14 @@ uint32_t jtag_scan(const uint8_t *irlens)
 		return 0;
 
 	/* Fill in the ir_postscan fields */
-	for (size_t device = jtag_dev_count - 1U; device > 0; --device)
-		jtag_devs[device - 1U].ir_postscan = jtag_devs[device].ir_postscan + jtag_devs[device].ir_len;
+	uint8_t postscan = 0;
+	for (size_t device = 0; device < jtag_dev_count; ++device) {
+		/* Traverse the device list from the back */
+		const size_t idx = (jtag_dev_count - 1U) - device;
+		/* Copy the current postscan value in and add this device's IR to it for the next lowest in the list  */
+		jtag_devs[idx].ir_postscan = postscan;
+		postscan += jtag_devs[idx].ir_len;
+	}
 
 #if PC_HOSTED == 1
 	/*Transfer needed device information to firmware jtag_devs */

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -49,7 +49,8 @@ void jtag_add_device(const uint32_t dev_index, const jtag_dev_s *jtag_dev)
 }
 #endif
 
-/* Scan JTAG chain for devices, store IR length and IDCODE (if present).
+/*
+ * Scan JTAG chain for devices, store IR length and IDCODE (if present).
  * Reset TAP state machine.
  * Select Shift-IR state.
  * Each device is assumed to shift out IR at 0x01. (this may not always be true)
@@ -68,13 +69,15 @@ void jtag_add_device(const uint32_t dev_index, const jtag_dev_s *jtag_dev)
  */
 uint32_t jtag_scan(const uint8_t *irlens)
 {
+	/* Free the device list if any, and clean state ready */
 	target_list_free();
 
 	jtag_dev_count = 0;
 	memset(&jtag_devs, 0, sizeof(jtag_devs));
 
-	/* Run through the SWD to JTAG sequence for the case where an attached SWJ-DP is
-	 * in SW-DP mode.
+	/*
+	 * Initialise the JTAG backend if it's not already
+	 * This will automatically do the SWD-to-JTAG sequence just in case we've got any SWJ-DP's in chain
 	 */
 	DEBUG_INFO("Resetting TAP\n");
 #if PC_HOSTED == 1

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -148,6 +148,16 @@ uint32_t jtag_scan(const uint8_t *irlens)
 
 	jtag_display_idcodes();
 
+#if PC_HOSTED == 1
+	DEBUG_PROBE("Enumerated %" PRIu32 " devices\n", jtag_dev_count);
+	for (size_t device = 0; device < jtag_dev_count; ++device) {
+		const jtag_dev_s *dev = &jtag_devs[device];
+		DEBUG_PROBE("%" PRIu32 ": IR length = %u, ID %08" PRIx32 "\n", (uint32_t)device, dev->ir_len, dev->jd_idcode);
+		DEBUG_PROBE("-> IR prescan: %u, postscan: %u\n", dev->ir_prescan, dev->ir_postscan);
+		DEBUG_PROBE("-> DR prescan: %u, postscan: %u\n", dev->dr_prescan, dev->dr_postscan);
+	}
+#endif
+
 	/* Check for known devices and handle accordingly */
 	for (size_t device = 0; device < jtag_dev_count; device++) {
 		for (size_t descr = 0; dev_descr[descr].idcode; descr++) {

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -3,7 +3,8 @@
  *
  * Copyright (C) 2011  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
- * Copyright (C) 2022  1bitsquared - Rachel Mant <git@dragonmux.network>
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +32,7 @@
 #include "adiv5.h"
 #include "jtag_devs.h"
 
-jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1U];
+jtag_dev_s jtag_devs[JTAG_MAX_DEVS];
 uint32_t jtag_dev_count = 0;
 
 /* bucket of ones for don't care TDI */

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2011  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +43,7 @@ typedef struct jtag_dev {
 	uint8_t ir_postscan;
 } jtag_dev_s;
 
-extern jtag_dev_s jtag_devs[JTAG_MAX_DEVS + 1U];
+extern jtag_dev_s jtag_devs[JTAG_MAX_DEVS];
 extern uint32_t jtag_dev_count;
 extern const uint8_t ones[8];
 

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -32,11 +32,8 @@ typedef struct jtag_dev {
 	uint32_t jd_idcode;
 	uint32_t current_ir;
 
-	union {
-		uint8_t jd_dev;
-		uint8_t dr_prescan;
-	};
-
+	/* The DR prescan doubles as the device index */
+	uint8_t dr_prescan;
 	uint8_t dr_postscan;
 
 	uint8_t ir_len;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As part of investigating further RISC-V support (ESP32-C3), and to address a long-standing issue with the handling of Xilinx parts, and other parts, this PR rewrites how we do JTAG scan so we first read out ID codes, then the IR chain w/ quirks to handle misbehaving parts, and finally the BYPASS DR chain to validate chain length.

We have tested this against all JTAG targets on our desk and have not seen any breakage, and it does fix the scan issues with the ESP32-C3 once a quirk is provided for that part.

This is suggested for v1.10 ahead of the RISC-V support so it gets time to be tested and stablised.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
