### PR TITLE
hosted/probe_info: don't use malloc.h

### DIFF
--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -31,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include "probe_info.h"
 #include "general.h"
 


### PR DESCRIPTION
Use stdlib.h instead of the non-standard malloc.h. Darwin doesn't have it.

## Detailed description

This fixes the build for `PROBE_HOST=hosted` on macOS (I have Ventura 13.2), which otherwise breaks due to a missing `malloc.h`. Previous OS versions or macOS SDKs might have had a compatibility `malloc.h` that is now removed; I'm not sure.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

N/A