### PR TITLE
Fix: ARM JTAG regressions

### DIFF
--- a/src/hex_utils.c
+++ b/src/hex_utils.c
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2011  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,7 +25,14 @@
 #include "general.h"
 #include "hex_utils.h"
 
-static const char hexdigits[] = "0123456789abcdef";
+static char hex_digit(const uint8_t value)
+{
+	char digit = (char)value;
+	if (value > 9U)
+		digit += 'A' - '0' - 10U;
+	digit += '0';
+	return digit;
+}
 
 char *hexify(char *const hex, const void *const buf, const size_t size)
 {
@@ -31,8 +40,8 @@ char *hexify(char *const hex, const void *const buf, const size_t size)
 	const uint8_t *const src = buf;
 
 	for (size_t idx = 0; idx < size; ++idx) {
-		*dst++ = hexdigits[src[idx] >> 4U];
-		*dst++ = hexdigits[src[idx] & 0xfU];
+		*dst++ = hex_digit(src[idx] >> 4U);
+		*dst++ = hex_digit(src[idx] & 0xfU);
 	}
 	*dst = 0;
 

--- a/src/hex_utils.c
+++ b/src/hex_utils.c
@@ -25,7 +25,7 @@
 #include "general.h"
 #include "hex_utils.h"
 
-static char hex_digit(const uint8_t value)
+char hex_digit(const uint8_t value)
 {
 	char digit = (char)value;
 	if (value > 9U)
@@ -48,7 +48,7 @@ char *hexify(char *const hex, const void *const buf, const size_t size)
 	return hex;
 }
 
-static uint8_t unhex_digit(const char hex)
+uint8_t unhex_digit(const char hex)
 {
 	uint8_t tmp = hex - '0';
 	if (tmp > 9U)

--- a/src/include/gdb_main.h
+++ b/src/include/gdb_main.h
@@ -22,9 +22,12 @@
 #define INCLUDE_GDB_MAIN_H
 
 #include "target.h"
+
 extern bool gdb_target_running;
 extern target_s *cur_target;
+
 void gdb_poll_target(void);
 void gdb_main(char *pbuf, size_t pbuf_size, size_t size);
+char *gdb_packet_buffer();
 
 #endif /* INCLUDE_GDB_MAIN_H */

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -103,80 +103,73 @@ extern int cl_debuglevel;
 
 static inline void DEBUG_WARN(const char *format, ...)
 {
-	va_list ap;
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	return;
+	va_list args;
+	va_start(args, format);
+	vfprintf(stderr, format, args);
+	va_end(args);
 }
 
 static inline void DEBUG_INFO(const char *format, ...)
 {
 	if (~cl_debuglevel & BMP_DEBUG_INFO)
 		return;
-	va_list ap;
-	va_start(ap, format);
+	va_list args;
+	va_start(args, format);
 	if (cl_debuglevel & BMP_DEBUG_STDOUT)
-		vfprintf(stdout, format, ap);
+		vfprintf(stdout, format, args);
 	else
-		vfprintf(stderr, format, ap);
-	va_end(ap);
-	return;
+		vfprintf(stderr, format, args);
+	va_end(args);
 }
 
 static inline void DEBUG_GDB(const char *format, ...)
 {
 	if (~cl_debuglevel & BMP_DEBUG_GDB)
 		return;
-	va_list ap;
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	return;
+	va_list args;
+	va_start(args, format);
+	vfprintf(stderr, format, args);
+	va_end(args);
 }
 
 static inline void DEBUG_GDB_WIRE(const char *format, ...)
 {
 	if ((cl_debuglevel & (BMP_DEBUG_GDB | BMP_DEBUG_WIRE)) != (BMP_DEBUG_GDB | BMP_DEBUG_WIRE))
 		return;
-	va_list ap;
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	return;
+	va_list args;
+	va_start(args, format);
+	vfprintf(stderr, format, args);
+	va_end(args);
 }
 
 static inline void DEBUG_TARGET(const char *format, ...)
 {
 	if (~cl_debuglevel & BMP_DEBUG_TARGET)
 		return;
-	va_list ap;
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	return;
+	va_list args;
+	va_start(args, format);
+	vfprintf(stderr, format, args);
+	va_end(args);
 }
 
 static inline void DEBUG_PROBE(const char *format, ...)
 {
 	if (~cl_debuglevel & BMP_DEBUG_PROBE)
 		return;
-	va_list ap;
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	return;
+	va_list args;
+	va_start(args, format);
+	vfprintf(stderr, format, args);
+	va_end(args);
 }
 
 static inline void DEBUG_WIRE(const char *format, ...)
 {
 	if (~cl_debuglevel & BMP_DEBUG_WIRE)
 		return;
-	va_list ap;
-	va_start(ap, format);
-	vfprintf(stderr, format, ap);
-	va_end(ap);
-	return;
+	va_list args;
+	va_start(args, format);
+	vfprintf(stderr, format, args);
+	va_end(args);
 }
 #endif
 

--- a/src/include/hex_utils.h
+++ b/src/include/hex_utils.h
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2011  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,9 +23,13 @@
 #ifndef INCLUDE_HEX_UTILS_H
 #define INCLUDE_HEX_UTILS_H
 
+#include <stdint.h>
 #include <stddef.h>
 
 char *hexify(char *hex, const void *buf, size_t size);
 char *unhexify(void *buf, const char *hex, size_t size);
+
+char hex_digit(uint8_t value);
+uint8_t unhex_digit(char hex);
 
 #endif /* INCLUDE_HEX_UTILS_H */

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,13 @@
 #endif
 
 #define BUF_SIZE 1024U
-static char pbuf[BUF_SIZE + 1U];
+/* This has to be aligned so the remote protocol can re-use it without causing Problems */
+static char pbuf[BUF_SIZE + 1U] __attribute__((aligned(8)));
+
+char *gdb_packet_buffer()
+{
+	return pbuf;
+}
 
 static void bmp_poll_loop(void)
 {

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -173,21 +173,31 @@ static void jtagtap_tdi_tdo_seq_no_delay(
 {
 	uint8_t value = 0;
 	for (size_t cycle = 0; cycle < clock_cycles;) {
-		gpio_clear(TCK_PORT, TCK_PIN);
 		/* Calculate the next bit and byte to consume data from */
 		const uint8_t bit = cycle & 7U;
 		const size_t byte = cycle >> 3U;
+		const bool tms = cycle + 1U >= clock_cycles && final_tms;
+		const bool tdi = (data_in[byte] >> bit) & 1U;
+		/* Block the compiler from re-ordering the calculations to preserve timings */
+		__asm__ volatile("" ::: "memory");
+		gpio_clear(TCK_PORT, TCK_PIN);
+		/* Block the compiler from re-ordering the calculations to preserve timings */
+		__asm__ volatile("" ::: "memory");
 		/* Configure the bus for the next cycle */
-		gpio_set_val(TMS_PORT, TMS_PIN, cycle + 1U >= clock_cycles && final_tms);
-		gpio_set_val(TDI_PORT, TDI_PIN, data_in[byte] & (1U << bit));
+		gpio_set_val(TDI_PORT, TDI_PIN, tdi);
+		gpio_set_val(TMS_PORT, TMS_PIN, tms);
+		/* Block the compiler from re-ordering the calculations to preserve timings */
+		__asm__ volatile("" ::: "memory");
 		/* Increment the cycle counter */
 		++cycle;
+		__asm__("nop");
+		__asm__("nop");
 		/* Block the compiler from re-ordering the calculations to preserve timings */
 		__asm__ volatile("nop" ::: "memory");
 		/* Start the clock cycle */
 		gpio_set(TCK_PORT, TCK_PIN);
 		/* If TDO is high, store a 1 in the appropriate position in the value being accumulated */
-		if (gpio_get(TDO_PORT, TDO_PIN))
+		if (gpio_get(TDO_PORT, TDO_PIN)) /* XXX: Try to remove the need for the if here */
 			value |= 1U << bit;
 		/* If we've got the next whole byte, store the accumulated value and reset state */
 		if (bit == 7U) {

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -27,6 +27,7 @@
 #include "bmp_remote.h"
 #include "cli.h"
 #include "hex_utils.h"
+#include "exception.h"
 
 #include <assert.h>
 #include <sys/time.h>
@@ -169,6 +170,9 @@ static bool remote_adiv5_check_error(
 		/* If the error part of the response code indicates a fault, store the fault value */
 		if (error == REMOTE_ERROR_FAULT)
 			target_dp->fault = response_code >> 8U;
+		/* If the error part indicates an exception had occured, make that happen here too */
+		else if (error == REMOTE_ERROR_EXCEPTION)
+			raise_exception(response_code >> 8U, "Remote protocol exception");
 		/* Otherwise it's an unexpected error */
 		else
 			DEBUG_WARN("%s: Unexpected error %u\n", func, error);

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -164,7 +164,7 @@ static uint32_t remote_adiv5_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uin
 {
 	(void)dp;
 	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_LOW_ACCESS_STR, dp->dp_jd_index, RnW, addr, value);
+	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_RAW_ACCESS_STR, dp->dp_jd_index, RnW, addr, value);
 	platform_buffer_write((uint8_t *)construct, s);
 	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
 	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
@@ -206,7 +206,7 @@ static void remote_ap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src
 	size_t batchsize = (REMOTE_MAX_MSG_SIZE - 0x20U) / 2U;
 	for (size_t offset = 0; offset < len; offset += batchsize) {
 		const size_t count = MIN(len - offset, batchsize);
-		int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_AP_MEM_READ_STR, ap->dp->dp_jd_index, ap->apsel,
+		int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_READ_STR, ap->dp->dp_jd_index, ap->apsel,
 			ap->csw, src + offset, count);
 		platform_buffer_write((uint8_t *)construct, s);
 		s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
@@ -237,7 +237,7 @@ static void remote_ap_mem_write_sized(
 	const char *data = (const char *)src;
 	for (size_t offset = 0; offset < len; offset += batchsize) {
 		const size_t count = MIN(len - offset, batchsize);
-		int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_AP_MEM_WRITE_SIZED_STR, ap->dp->dp_jd_index, ap->apsel,
+		int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_WRITE_STR, ap->dp->dp_jd_index, ap->apsel,
 			ap->csw, align, dest + offset, count);
 		assert(s > 0);
 		hexify(construct + s, data + offset, count);

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -147,7 +147,7 @@ void remote_target_clk_output_enable(const bool enable)
 static uint32_t remote_adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
-	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_DP_READ_STR, dp->dp_jd_index, addr);
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_DP_READ_STR, dp->dev_index, addr);
 	platform_buffer_write(buffer, length);
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
@@ -161,7 +161,7 @@ static uint32_t remote_adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 static uint32_t remote_adiv5_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
-	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_RAW_ACCESS_STR, dp->dp_jd_index, RnW, addr, value);
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_RAW_ACCESS_STR, dp->dev_index, RnW, addr, value);
 	platform_buffer_write(buffer, length);
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
@@ -174,7 +174,7 @@ static uint32_t remote_adiv5_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uin
 static uint32_t remote_adiv5_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
-	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_AP_READ_STR, ap->dp->dp_jd_index, ap->apsel, addr);
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_AP_READ_STR, ap->dp->dev_index, ap->apsel, addr);
 	platform_buffer_write(buffer, length);
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
@@ -187,8 +187,7 @@ static uint32_t remote_adiv5_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 static void remote_adiv5_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
-	int length =
-		snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_AP_WRITE_STR, ap->dp->dp_jd_index, ap->apsel, addr, value);
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_AP_WRITE_STR, ap->dp->dev_index, ap->apsel, addr, value);
 	platform_buffer_write(buffer, length);
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
@@ -204,8 +203,8 @@ static void remote_ap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src
 	size_t batchsize = (REMOTE_MAX_MSG_SIZE - 0x20U) / 2U;
 	for (size_t offset = 0; offset < len; offset += batchsize) {
 		const size_t count = MIN(len - offset, batchsize);
-		int s = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_READ_STR, ap->dp->dp_jd_index, ap->apsel,
-			ap->csw, src + offset, count);
+		int s = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_READ_STR, ap->dp->dev_index, ap->apsel, ap->csw,
+			src + offset, count);
 		platform_buffer_write(buffer, s);
 		s = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 		if (s > 0 && buffer[0] == REMOTE_RESP_OK) {
@@ -234,8 +233,8 @@ static void remote_ap_mem_write_sized(
 	const char *data = (const char *)src;
 	for (size_t offset = 0; offset < len; offset += batchsize) {
 		const size_t count = MIN(len - offset, batchsize);
-		int s = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_WRITE_STR, ap->dp->dp_jd_index, ap->apsel,
-			ap->csw, align, dest + offset, count);
+		int s = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_WRITE_STR, ap->dp->dev_index, ap->apsel, ap->csw,
+			align, dest + offset, count);
 		assert(s > 0);
 		hexify(buffer + s, data + offset, count);
 		const size_t hex_length = s + (count * 2U);

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -30,17 +30,16 @@
 
 #include <assert.h>
 #include <sys/time.h>
-#include <sys/time.h>
 #include <errno.h>
 
 #include "adiv5.h"
 
 int remote_init(const bool power_up)
 {
+	platform_buffer_write(REMOTE_START_STR, sizeof(REMOTE_START_STR));
+
 	char buffer[REMOTE_MAX_MSG_SIZE];
-	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_START_STR);
-	platform_buffer_write(buffer, length);
-	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	const int length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("Remote Start failed, error %s\n", length ? buffer + 1 : "unknown");
 		return -1;

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -277,12 +277,12 @@ void remote_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->mem_write = remote_ap_mem_write_sized;
 }
 
-void remote_add_jtag_dev(uint32_t i, const jtag_dev_s *jtag_dev)
+void remote_add_jtag_dev(uint32_t dev_indx, const jtag_dev_s *jtag_dev)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
-	const int s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_ADD_DEV_STR, i, jtag_dev->dr_prescan,
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	const int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_ADD_DEV_STR, dev_indx, jtag_dev->dr_prescan,
 		jtag_dev->dr_postscan, jtag_dev->ir_len, jtag_dev->ir_prescan, jtag_dev->ir_postscan, jtag_dev->current_ir);
-	platform_buffer_write(construct, s);
-	(void)platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
+	platform_buffer_write(buffer, length);
+	(void)platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	/* Don't need to check for error here - it's already done in remote_adiv5_dp_defaults */
 }

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -37,164 +37,163 @@
 
 int remote_init(const bool power_up)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int c = snprintf(construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_START_STR);
-	platform_buffer_write((uint8_t *)construct, c);
-	c = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (c < 1 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("Remote Start failed, error %s\n", c ? construct + 1 : "unknown");
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_START_STR);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("Remote Start failed, error %s\n", length ? buffer + 1 : "unknown");
 		return -1;
 	}
-	DEBUG_PROBE("Remote is %s\n", construct + 1);
+	DEBUG_PROBE("Remote is %s\n", buffer + 1);
 	remote_target_set_power(power_up);
 	return 0;
 }
 
 bool remote_target_get_power(void)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_PWR_GET_STR);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("platform_target_get_power failed, error %s\n", s ? construct + 1 : "unknown");
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_PWR_GET_STR);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("platform_target_get_power failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
-	return construct[1] == '1';
+	return buffer[1] == '1';
 }
 
 bool remote_target_set_power(const bool power)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_PWR_SET_STR, power ? '1' : '0');
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
-		DEBUG_WARN("platform_target_set_power failed, error %s\n", s ? construct + 1 : "unknown");
-	return s > 0 && construct[0] == REMOTE_RESP_OK;
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_PWR_SET_STR, power ? '1' : '0');
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
+		DEBUG_WARN("platform_target_set_power failed, error %s\n", length ? buffer + 1 : "unknown");
+	return length > 0 && buffer[0] == REMOTE_RESP_OK;
 }
 
 void remote_nrst_set_val(bool assert)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_NRST_SET_STR, assert ? '1' : '0');
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("platform_nrst_set_val failed, error %s\n", s ? construct + 1 : "unknown");
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_NRST_SET_STR, assert ? '1' : '0');
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("platform_nrst_set_val failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 }
 
 bool remote_nrst_get_val(void)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_NRST_GET_STR);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("platform_nrst_set_val failed, error %s\n", s ? construct + 1 : "unknown");
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_NRST_GET_STR);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("platform_nrst_set_val failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
-	return construct[1] == '1';
+	return buffer[1] == '1';
 }
 
 void remote_max_frequency_set(uint32_t freq)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_FREQ_SET_STR, freq);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_FREQ_SET_STR, freq);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
 		DEBUG_WARN("Update Firmware to allow to set max SWJ frequency\n");
 }
 
 uint32_t remote_max_frequency_get(void)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_FREQ_GET_STR);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_FREQ_GET_STR);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
 		return FREQ_FIXED;
 	uint32_t freq;
-	unhexify(&freq, construct + 1, 4);
+	unhexify(&freq, buffer + 1, 4);
 	return freq;
 }
 
 const char *remote_target_voltage(void)
 {
-	static char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, " %s", REMOTE_VOLTAGE_STR);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("platform_target_voltage failed, error %s\n", s ? construct + 1 : "unknown");
+	static char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, " %s", REMOTE_VOLTAGE_STR);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("platform_target_voltage failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
-	return construct + 1;
+	return buffer + 1;
 }
 
 void remote_target_clk_output_enable(const bool enable)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_TARGET_CLK_OE_STR, enable ? '1' : '0');
-	platform_buffer_write((uint8_t *)buffer, length);
-	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
 		DEBUG_WARN("remote_target_clk_output_enable failed, error %s\n", length ? buffer + 1 : "unknown");
 }
 
 static uint32_t remote_adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 {
-	(void)dp;
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_DP_READ_STR, dp->dp_jd_index, addr);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
-		DEBUG_WARN("%s error %d\n", __func__, s);
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_DP_READ_STR, dp->dp_jd_index, addr);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
+		DEBUG_WARN("%s error %d\n", __func__, length);
 	uint32_t dest;
-	unhexify(&dest, construct + 1, 4);
+	unhexify(&dest, buffer + 1, 4);
 	DEBUG_PROBE("dp_read addr %04x: %08" PRIx32 "\n", dest);
 	return dest;
 }
 
 static uint32_t remote_adiv5_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
 {
-	(void)dp;
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_RAW_ACCESS_STR, dp->dp_jd_index, RnW, addr, value);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
-		DEBUG_WARN("%s error %d\n", __func__, s);
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_RAW_ACCESS_STR, dp->dp_jd_index, RnW, addr, value);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
+		DEBUG_WARN("%s error %d\n", __func__, length);
 	uint32_t dest;
-	unhexify(&dest, construct + 1, 4);
+	unhexify(&dest, buffer + 1, 4);
 	return dest;
 }
 
 static uint32_t remote_adiv5_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_AP_READ_STR, ap->dp->dp_jd_index, ap->apsel, addr);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
-		DEBUG_WARN("%s error %d\n", __func__, s);
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_AP_READ_STR, ap->dp->dp_jd_index, ap->apsel, addr);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
+		DEBUG_WARN("%s error %d\n", __func__, length);
 	uint32_t dest;
-	unhexify(&dest, construct + 1, 4);
+	unhexify(&dest, buffer + 1, 4);
 	return dest;
 }
 
 static void remote_adiv5_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_AP_WRITE_STR, ap->dp->dp_jd_index, ap->apsel, addr, value);
-	platform_buffer_write((uint8_t *)construct, s);
-	s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR)
-		DEBUG_WARN("%s error %d\n", __func__, s);
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length =
+		snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_AP_WRITE_STR, ap->dp->dp_jd_index, ap->apsel, addr, value);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR)
+		DEBUG_WARN("%s error %d\n", __func__, length);
 }
 
 static void remote_ap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
@@ -202,19 +201,19 @@ static void remote_ap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src
 	(void)ap;
 	if (len == 0)
 		return;
-	char construct[REMOTE_MAX_MSG_SIZE];
+	char buffer[REMOTE_MAX_MSG_SIZE];
 	size_t batchsize = (REMOTE_MAX_MSG_SIZE - 0x20U) / 2U;
 	for (size_t offset = 0; offset < len; offset += batchsize) {
 		const size_t count = MIN(len - offset, batchsize);
-		int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_READ_STR, ap->dp->dp_jd_index, ap->apsel,
+		int s = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_READ_STR, ap->dp->dp_jd_index, ap->apsel,
 			ap->csw, src + offset, count);
-		platform_buffer_write((uint8_t *)construct, s);
-		s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-		if (s > 0 && construct[0] == REMOTE_RESP_OK) {
-			unhexify(dest + offset, (const char *)&construct[1], count);
+		platform_buffer_write(buffer, s);
+		s = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+		if (s > 0 && buffer[0] == REMOTE_RESP_OK) {
+			unhexify(dest + offset, (const char *)&buffer[1], count);
 			continue;
 		}
-		if (construct[0] == REMOTE_RESP_ERR) {
+		if (buffer[0] == REMOTE_RESP_ERR) {
 			ap->dp->fault = 1;
 			DEBUG_WARN(
 				"%s returned REMOTE_RESP_ERR at apsel %u, addr: 0x%08zx\n", __func__, ap->apsel, (size_t)src + offset);
@@ -228,28 +227,27 @@ static void remote_ap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src
 static void remote_ap_mem_write_sized(
 	adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
-	(void)ap;
 	if (len == 0)
 		return;
-	char construct[REMOTE_MAX_MSG_SIZE];
+	char buffer[REMOTE_MAX_MSG_SIZE];
 	/* (5 * 1 (char)) + (2 * 2 (bytes)) + (3 * 8 (words)) */
 	size_t batchsize = (REMOTE_MAX_MSG_SIZE - 0x30U) / 2U;
 	const char *data = (const char *)src;
 	for (size_t offset = 0; offset < len; offset += batchsize) {
 		const size_t count = MIN(len - offset, batchsize);
-		int s = snprintf(construct, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_WRITE_STR, ap->dp->dp_jd_index, ap->apsel,
+		int s = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_ADIv5_MEM_WRITE_STR, ap->dp->dp_jd_index, ap->apsel,
 			ap->csw, align, dest + offset, count);
 		assert(s > 0);
-		hexify(construct + s, data + offset, count);
+		hexify(buffer + s, data + offset, count);
 		const size_t hex_length = s + (count * 2U);
-		construct[hex_length] = REMOTE_EOM;
-		construct[hex_length + 1U] = '\0';
-		platform_buffer_write((uint8_t *)construct, hex_length + 2U);
+		buffer[hex_length] = REMOTE_EOM;
+		buffer[hex_length + 1U] = '\0';
+		platform_buffer_write(buffer, hex_length + 2U);
 
-		s = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
-		if (s > 0 && construct[0] == REMOTE_RESP_OK)
+		s = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+		if (s > 0 && buffer[0] == REMOTE_RESP_OK)
 			continue;
-		if (s > 0 && construct[0] == REMOTE_RESP_ERR) {
+		if (s > 0 && buffer[0] == REMOTE_RESP_ERR) {
 			ap->dp->fault = 1;
 			DEBUG_WARN(
 				"%s returned REMOTE_RESP_ERR at apsel %u, addr: 0x%08zx\n", __func__, ap->apsel, (size_t)dest + offset);
@@ -261,11 +259,11 @@ static void remote_ap_mem_write_sized(
 
 void remote_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
-	uint8_t construct[REMOTE_MAX_MSG_SIZE];
-	int s = snprintf((char *)construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_HL_CHECK_STR);
-	platform_buffer_write(construct, s);
-	s = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if (s < 1 || construct[0] == REMOTE_RESP_ERR || construct[1] - '0' < REMOTE_HL_VERSION) {
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_HL_CHECK_STR);
+	platform_buffer_write(buffer, length);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR || buffer[1] - '0' < REMOTE_HL_VERSION) {
 		DEBUG_WARN("Please update BMP firmware for substantial speed increase!\n");
 		return;
 	}

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -27,8 +27,8 @@
 
 #define REMOTE_MAX_MSG_SIZE 1024U
 
-int platform_buffer_write(const uint8_t *data, int size);
-int platform_buffer_read(uint8_t *data, int size);
+bool platform_buffer_write(const void *data, size_t size);
+int platform_buffer_read(void *data, size_t size);
 
 int remote_init(const bool power_up);
 bool remote_swdptap_init(void);

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -529,8 +529,11 @@ static void dap_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *sr
 
 void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
-	if (mode == DAP_CAP_JTAG && dap_jtag_configure())
+	/* Try to configure the JTAG engine on the adaptor if we're in JTAG mode */
+	/* XXX: If this fails we don't currently tell the invoking code which will make things go v. wrong */
+	if (mode == DAP_CAP_JTAG && !dap_jtag_configure())
 		return;
+	/* Setup the access functions for this adaptor */
 	dp->ap_read = dap_ap_read;
 	dp->ap_write = dap_ap_write;
 	dp->mem_read = dap_mem_read;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -263,11 +263,11 @@ static uint32_t dap_jtag_dp_error(adiv5_debug_port_s *dp, const bool protocol_re
 {
 	(void)protocol_recovery;
 	/* XXX: This seems entirely wrong considering adiv5_jtagdp.c adiv5_jtagdp_error */
-	uint32_t ctrlstat = dap_read_reg(dp, ADIV5_DP_CTRLSTAT);
-	uint32_t err = ctrlstat &
+	const uint32_t err = dap_read_reg(dp, ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 			ADIV5_DP_CTRLSTAT_WDATAERR);
 	uint32_t clr = 0;
+
 	if (err & ADIV5_DP_CTRLSTAT_STICKYORUN)
 		clr |= ADIV5_DP_ABORT_ORUNERRCLR;
 	if (err & ADIV5_DP_CTRLSTAT_STICKYCMP)
@@ -276,7 +276,9 @@ static uint32_t dap_jtag_dp_error(adiv5_debug_port_s *dp, const bool protocol_re
 		clr |= ADIV5_DP_ABORT_STKERRCLR;
 	if (err & ADIV5_DP_CTRLSTAT_WDATAERR)
 		clr |= ADIV5_DP_ABORT_WDERRCLR;
-	dap_write_reg(dp, ADIV5_DP_ABORT, clr);
+
+	if (clr)
+		dap_write_reg(dp, ADIV5_DP_ABORT, clr);
 	dp->fault = 0;
 	return err;
 }

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -506,10 +506,6 @@ static void dap_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *sr
 
 void dap_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
-	/* Try to configure the JTAG engine on the adaptor if we're in JTAG mode */
-	/* XXX: If this fails we don't currently tell the invoking code which will make things go v. wrong */
-	if (mode == DAP_CAP_JTAG && !dap_jtag_configure())
-		return;
 	/* Setup the access functions for this adaptor */
 	dp->ap_read = dap_ap_read;
 	dp->ap_write = dap_ap_write;
@@ -573,6 +569,9 @@ bool dap_jtagtap_init(void)
 
 void dap_jtag_dp_init(adiv5_debug_port_s *dp)
 {
+	/* Try to configure the JTAG engine on the adaptor */
+	if (!dap_jtag_configure())
+		return;
 	dp->dp_read = dap_dp_read_reg;
 	dp->low_access = dap_dp_low_access;
 	dp->abort = dap_dp_abort;

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -690,7 +690,7 @@ int dap_jtag_configure(void)
 		*p++ = jtag_dev->ir_len;
 		DEBUG_PROBE("irlen %d\n", jtag_dev->ir_len);
 	}
-	if ((!i || i >= JTAG_MAX_DEVS))
+	if (!i || i >= JTAG_MAX_DEVS)
 		return -1;
 	buf[0] = 0x15;
 	buf[1] = i;

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -325,7 +325,7 @@ uint32_t dap_read_reg(adiv5_debug_port_s *dp, uint8_t reg)
 {
 	uint8_t buf[8];
 	uint8_t dap_index = 0;
-	dap_index = dp->dp_jd_index;
+	dap_index = dp->dev_index;
 	buf[0] = ID_DAP_TRANSFER;
 	buf[1] = dap_index;
 	buf[2] = 0x01; // Request size
@@ -342,7 +342,7 @@ void dap_write_reg(adiv5_debug_port_s *dp, uint8_t reg, uint32_t data)
 
 	uint8_t buf[8] = {
 		ID_DAP_TRANSFER,
-		dp->dp_jd_index,
+		dp->dev_index,
 		0x01, // Request size
 		reg & ~DAP_TRANSFER_RnW,
 		data & 0xffU,
@@ -508,7 +508,7 @@ uint32_t dap_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 	uint8_t buf[63], *p = buf;
 	buf[0] = ID_DAP_TRANSFER;
 	uint8_t dap_index = 0;
-	dap_index = ap->dp->dp_jd_index;
+	dap_index = ap->dp->dev_index;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 2; /* Nr transfers */
@@ -529,7 +529,7 @@ void dap_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 	DEBUG_PROBE("dap_ap_write addr %04x value %08x\n", addr, value);
 	uint8_t buf[63], *p = buf;
 	uint8_t dap_index = 0;
-	dap_index = ap->dp->dp_jd_index;
+	dap_index = ap->dp->dev_index;
 	*p++ = ID_DAP_TRANSFER;
 	*p++ = dap_index;
 	*p++ = 2; /* Nr transfers */

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -85,7 +85,7 @@ ssize_t dbg_dap_cmd(uint8_t *data, size_t response_length, size_t request_length
 bool dap_run_cmd(const void *request_data, size_t request_length, void *response_data, size_t response_length);
 void dap_jtagtap_tdi_tdo_seq(
 	uint8_t *data_out, bool final_tms, const uint8_t *tms, const uint8_t *data_in, size_t clock_cycles);
-int dap_jtag_configure(void);
+bool dap_jtag_configure(void);
 
 uint32_t dap_swdptap_seq_in(size_t clock_cycles);
 bool dap_swdptap_seq_in_parity(uint32_t *result, size_t clock_cycles);

--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -117,7 +117,7 @@ bool perform_dap_transfer(adiv5_debug_port_s *const dp, const dap_transfer_reque
 	/* 63 is 3 + (12 * 5) where 5 is the max length of each transfer request */
 	uint8_t request[63] = {
 		DAP_TRANSFER,
-		dp->dp_jd_index,
+		dp->dev_index,
 		requests,
 	};
 	/* Encode the transfers into the buffer and detect if we're doing any reads */
@@ -164,7 +164,7 @@ bool perform_dap_transfer_block_read(
 	DEBUG_PROBE("-> dap_transfer_block (%u transfer blocks)\n", block_count);
 	dap_transfer_block_request_read_s request = {
 		DAP_TRANSFER_BLOCK,
-		dp->dp_jd_index,
+		dp->dev_index,
 		{},
 		reg | DAP_TRANSFER_RnW,
 	};
@@ -197,7 +197,7 @@ bool perform_dap_transfer_block_write(
 	DEBUG_PROBE("-> dap_transfer_block (%u transfer blocks)\n", block_count);
 	dap_transfer_block_request_write_s request = {
 		DAP_TRANSFER_BLOCK,
-		dp->dp_jd_index,
+		dp->dev_index,
 		{},
 		reg & ~DAP_TRANSFER_RnW,
 	};

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -95,12 +95,13 @@ typedef struct dap_transfer_block_response_write {
 } dap_transfer_block_response_write_s;
 
 bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data);
-bool perform_dap_transfer(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests, size_t requests,
-	uint32_t *response_data, size_t responses);
-bool perform_dap_transfer_recoverable(adiv5_debug_port_s *dp, const dap_transfer_request_s *transfer_requests,
+bool perform_dap_transfer(adiv5_debug_port_s *target_dp, const dap_transfer_request_s *transfer_requests,
 	size_t requests, uint32_t *response_data, size_t responses);
-bool perform_dap_transfer_block_read(adiv5_debug_port_s *dp, uint8_t reg, uint16_t block_count, uint32_t *blocks);
+bool perform_dap_transfer_recoverable(adiv5_debug_port_s *target_dp, const dap_transfer_request_s *transfer_requests,
+	size_t requests, uint32_t *response_data, size_t responses);
+bool perform_dap_transfer_block_read(
+	adiv5_debug_port_s *target_dp, uint8_t reg, uint16_t block_count, uint32_t *blocks);
 bool perform_dap_transfer_block_write(
-	adiv5_debug_port_s *dp, uint8_t reg, uint16_t block_count, const uint32_t *blocks);
+	adiv5_debug_port_s *target_dp, uint8_t reg, uint16_t block_count, const uint32_t *blocks);
 
 #endif /*PLATFORMS_HOSTED_DAP_COMMAND_H*/

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -50,10 +50,10 @@ static inline unsigned int bool_to_int(const bool value)
 
 bool remote_jtagtap_init(void)
 {
-	platform_buffer_write((uint8_t *)REMOTE_JTAG_INIT_STR, sizeof(REMOTE_JTAG_INIT_STR));
+	platform_buffer_write(REMOTE_JTAG_INIT_STR, sizeof(REMOTE_JTAG_INIT_STR));
 
 	char buffer[REMOTE_MAX_MSG_SIZE];
-	int length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	int length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("jtagtap_init failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
@@ -66,8 +66,8 @@ bool remote_jtagtap_init(void)
 	jtag_proc.jtagtap_tdi_seq = jtagtap_tdi_seq;
 	jtag_proc.tap_idle_cycles = 1;
 
-	platform_buffer_write((uint8_t *)REMOTE_HL_CHECK_STR, sizeof(REMOTE_HL_CHECK_STR));
-	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	platform_buffer_write(REMOTE_HL_CHECK_STR, sizeof(REMOTE_HL_CHECK_STR));
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR || buffer[0] == 1)
 		PRINT_INFO("Firmware does not support newer JTAG commands, please update it.");
 	else
@@ -80,9 +80,9 @@ bool remote_jtagtap_init(void)
 
 static void jtagtap_reset(void)
 {
-	platform_buffer_write((uint8_t *)REMOTE_JTAG_RESET_STR, sizeof(REMOTE_JTAG_RESET_STR));
+	platform_buffer_write(REMOTE_JTAG_RESET_STR, sizeof(REMOTE_JTAG_RESET_STR));
 	char buffer[REMOTE_MAX_MSG_SIZE];
-	const int length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	const int length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("jtagtap_reset failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
@@ -93,9 +93,9 @@ static void jtagtap_tms_seq(uint32_t tms_states, size_t clock_cycles)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_TMS_STR, clock_cycles, tms_states);
-	platform_buffer_write((uint8_t *)buffer, length);
+	platform_buffer_write(buffer, length);
 
-	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("jtagtap_tms_seq failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
@@ -144,10 +144,10 @@ static void jtagtap_tdi_tdo_seq(
 		 */
 		int length =
 			snprintf(buffer, REMOTE_MAX_MSG_SIZE, "!J%c%02zx%" PRIx64 "%c", tms_state, chunk, data, REMOTE_EOM);
-		platform_buffer_write((uint8_t *)buffer, length);
+		platform_buffer_write(buffer, length);
 
 		/* Receive the response and check if it's an error response */
-		length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+		length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 		if (!length || buffer[0] == REMOTE_RESP_ERR) {
 			DEBUG_WARN("jtagtap_tdi_tdo_seq failed, error %s\n", length ? buffer + 1 : "unknown");
 			exit(-1);
@@ -169,9 +169,9 @@ static bool jtagtap_next(const bool tms, const bool tdi)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	int length = snprintf((char *)buffer, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_NEXT, bool_to_int(tms), bool_to_int(tdi));
-	platform_buffer_write((uint8_t *)buffer, length);
+	platform_buffer_write(buffer, length);
 
-	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("jtagtap_next failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
@@ -185,9 +185,9 @@ static void jtagtap_cycle(const bool tms, const bool tdi, const size_t clock_cyc
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	int length =
 		snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_JTAG_CYCLE_STR, bool_to_int(tms), bool_to_int(tdi), clock_cycles);
-	platform_buffer_write((uint8_t *)buffer, length);
+	platform_buffer_write(buffer, length);
 
-	length = platform_buffer_read((uint8_t *)buffer, REMOTE_MAX_MSG_SIZE);
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("jtagtap_cycle failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -153,7 +153,7 @@ static void jtagtap_tdi_tdo_seq(
 			exit(-1);
 		}
 		if (data_out) {
-			const uint64_t data = remotehston(-1, buffer + 1);
+			const uint64_t data = remote_hex_string_to_num(-1, buffer + 1);
 			for (size_t i = 0; i < bytes; ++i)
 				data_out[out_offset++] = (uint8_t)(data >> (i * 8U));
 		}
@@ -177,7 +177,7 @@ static bool jtagtap_next(const bool tms, const bool tdi)
 		exit(-1);
 	}
 
-	return remotehston(-1, buffer + 1);
+	return remote_hex_string_to_num(-1, buffer + 1);
 }
 
 static void jtagtap_cycle(const bool tms, const bool tdi, const size_t clock_cycles)

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -39,10 +39,10 @@ static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 bool remote_swdptap_init(void)
 {
 	DEBUG_WIRE("remote_swdptap_init\n");
-	platform_buffer_write((uint8_t *)REMOTE_SWDP_INIT_STR, sizeof(REMOTE_SWDP_INIT_STR));
+	platform_buffer_write(REMOTE_SWDP_INIT_STR, sizeof(REMOTE_SWDP_INIT_STR));
 
 	char construct[REMOTE_MAX_MSG_SIZE];
-	int length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	int length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if (!length || construct[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("swdptap_init failed, error %s\n", length ? construct + 1 : "unknown");
 		exit(-1);
@@ -60,9 +60,9 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 	char construct[REMOTE_MAX_MSG_SIZE];
 
 	int length = sprintf(construct, REMOTE_SWDP_IN_PAR_STR, clock_cycles);
-	platform_buffer_write((uint8_t *)construct, length);
+	platform_buffer_write(construct, length);
 
-	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if (length < 2 || construct[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", length ? &(construct[1]) : "short response");
 		exit(-1);
@@ -79,9 +79,9 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 	char construct[REMOTE_MAX_MSG_SIZE];
 
 	int length = sprintf(construct, REMOTE_SWDP_IN_STR, clock_cycles);
-	platform_buffer_write((uint8_t *)construct, length);
+	platform_buffer_write(construct, length);
 
-	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if (length < 2 || construct[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("swdptap_seq_in failed, error %s\n", length ? construct + 1 : "short response");
 		exit(-1);
@@ -97,9 +97,9 @@ static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
 
 	DEBUG_PROBE("swdptap_seq_out        %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
 	int length = sprintf(construct, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
-	platform_buffer_write((uint8_t *)construct, length);
+	platform_buffer_write(construct, length);
 
-	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || construct[0] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("swdptap_seq_out failed, error %s\n", length ? construct + 1 : "short response");
 		exit(-1);
@@ -112,9 +112,9 @@ static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 
 	DEBUG_PROBE("swdptap_seq_out_parity %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
 	int length = sprintf(construct, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
-	platform_buffer_write((uint8_t *)construct, length);
+	platform_buffer_write(construct, length);
 
-	length = platform_buffer_read((uint8_t *)construct, REMOTE_MAX_MSG_SIZE);
+	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || construct[1] == REMOTE_RESP_ERR) {
 		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", length ? construct + 2 : "short response");
 		exit(-1);

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -68,7 +68,7 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 		exit(-1);
 	}
 
-	*res = remotehston(-1, &construct[1]);
+	*res = remote_hex_string_to_num(-1, &construct[1]);
 	DEBUG_PROBE("swdptap_seq_in_parity  %2d clock_cycles: %08" PRIx32 " %s\n", clock_cycles, *res,
 		construct[0] != REMOTE_RESP_OK ? "ERR" : "OK");
 	return construct[0] != REMOTE_RESP_OK;
@@ -86,7 +86,7 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 		DEBUG_WARN("swdptap_seq_in failed, error %s\n", length ? construct + 1 : "short response");
 		exit(-1);
 	}
-	uint32_t res = remotehston(-1, &construct[1]);
+	uint32_t res = remote_hex_string_to_num(-1, &construct[1]);
 	DEBUG_PROBE("swdptap_seq_in         %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, res);
 	return res;
 }

--- a/src/remote.c
+++ b/src/remote.c
@@ -4,6 +4,8 @@
  * Copyright (C) 2019  Black Sphere Technologies Ltd.
  * Written by Dave Marples <dave@marples.net>
  * Modified 2020 - 2021 by Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/remote.c
+++ b/src/remote.c
@@ -63,10 +63,11 @@ static void remote_send_buf(const void *const buffer, const size_t len)
 	}
 }
 
-static void remote_respond_buf(char respCode, uint8_t *buffer, size_t len)
+/* Send a response with some data following */
+static void remote_respond_buf(const char response_code, const void *const buffer, const size_t len)
 {
 	gdb_if_putchar(REMOTE_RESP, 0);
-	gdb_if_putchar(respCode, 0);
+	gdb_if_putchar(response_code, 0);
 
 	remote_send_buf(buffer, len);
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -102,18 +102,19 @@ static void remote_respond(const char response_code, uint64_t param)
 	gdb_if_putchar(REMOTE_EOM, true);
 }
 
-static void remote_respond_string(char response_code, const char *s)
-/* Send response to far end */
+/* Send a response with a string following */
+static void remote_respond_string(const char response_code, const char *const str)
 {
 	gdb_if_putchar(REMOTE_RESP, 0);
 	gdb_if_putchar(response_code, 0);
-	while (*s) {
-		/* Just clobber illegal characters so they don't disturb the protocol */
-		if ((*s == '$') || (*s == REMOTE_SOM) || (*s == REMOTE_EOM))
+	const size_t str_length = strlen(str);
+	for (size_t idx = 0; idx < str_length; ++idx) {
+		const char chr = str[idx];
+		/* Replace problematic/illegal characters with a space to not disturb the protocol */
+		if (chr == '$' || chr == REMOTE_SOM || chr == REMOTE_EOM)
 			gdb_if_putchar(' ', 0);
 		else
-			gdb_if_putchar(*s, 0);
-		s++;
+			gdb_if_putchar(chr, 0);
 	}
 	gdb_if_putchar(REMOTE_EOM, 1);
 }

--- a/src/remote.c
+++ b/src/remote.c
@@ -359,7 +359,7 @@ static void remote_packet_process_high_level(unsigned i, char *packet)
 	remote_ap.dp = &remote_dp;
 	packet += 2;
 	switch (index) {
-	case REMOTE_AP_MEM_READ: /* HM = Read from Mem and set csw */
+	case REMOTE_MEM_READ_CSW: /* HM = Read from Mem and set csw */
 		remote_ap.csw = remote_hex_string_to_num(8, packet);
 		packet += 6;
 		/*fall through*/
@@ -376,11 +376,11 @@ static void remote_packet_process_high_level(unsigned i, char *packet)
 		remote_ap.dp->fault = 0;
 		break;
 	}
-	case REMOTE_AP_MEM_WRITE_SIZED: /* Hm = Write to memory and set csw */
+	case REMOTE_MEM_WRITE_CSW: /* Hm = Write to memory and set csw */
 		remote_ap.csw = remote_hex_string_to_num(8, packet);
 		packet += 6;
 		/* fall through */
-	case REMOTE_MEM_WRITE_SIZED: { /* HH = Write to memory */
+	case REMOTE_MEM_WRITE: { /* HH = Write to memory */
 		const align_e align = remote_hex_string_to_num(2, packet);
 		packet += 2;
 		const uint32_t dest = remote_hex_string_to_num(8, packet);

--- a/src/remote.c
+++ b/src/remote.c
@@ -51,17 +51,16 @@ uint64_t remotehston(const uint32_t max, const char *const str)
 }
 
 #if PC_HOSTED == 0
-static void remote_send_buf(uint8_t *buffer, size_t len)
+/* hex-ify and send a buffer of data */
+static void remote_send_buf(const void *const buffer, const size_t len)
 {
-	uint8_t *p = buffer;
-	char hex[2];
-	do {
-		hexify(hex, (const void *)p++, 1);
-
+	char hex[2] = {};
+	const uint8_t *const data = (const uint8_t *)buffer;
+	for (size_t offset = 0; offset < len; ++offset) {
+		hexify(hex, data + offset, 1U);
 		gdb_if_putchar(hex[0], 0);
 		gdb_if_putchar(hex[1], 0);
-
-	} while (p < (buffer + len));
+	}
 }
 
 static void remote_respond_buf(char respCode, uint8_t *buffer, size_t len)

--- a/src/remote.c
+++ b/src/remote.c
@@ -380,7 +380,7 @@ static void remote_packet_process_adiv5(const char *const packet, const size_t p
 	}
 
 	/* Set up the DP and a fake AP structure to perform the access with */
-	remote_dp.dp_jd_index = remote_hex_string_to_num(2, packet + 2);
+	remote_dp.dev_index = remote_hex_string_to_num(2, packet + 2);
 	adiv5_access_port_s remote_ap;
 	remote_ap.apsel = remote_hex_string_to_num(2, packet + 4);
 	remote_ap.dp = &remote_dp;

--- a/src/remote.c
+++ b/src/remote.c
@@ -325,12 +325,11 @@ static void remote_packet_process_general(unsigned i, char *packet)
 static void remote_packet_process_high_level(const char *packet, const size_t packet_len)
 {
 	SET_IDLE_STATE(0);
-	char index = packet[1];
-	if (index == REMOTE_HL_CHECK) {
+	switch (packet[1]) {
+	case REMOTE_HL_CHECK: /* HC = check the version of the protocol */
 		remote_respond(REMOTE_RESP_OK, REMOTE_HL_VERSION);
-		return;
-	}
-	switch (index) {
+		break;
+
 	case REMOTE_ADD_JTAG_DEV: /* HJ = fill firmware jtag_devs */
 		if (packet_len < 22U) {
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);

--- a/src/remote.c
+++ b/src/remote.c
@@ -330,22 +330,25 @@ static void remote_packet_process_high_level(const char *packet, const size_t pa
 		remote_respond(REMOTE_RESP_OK, REMOTE_HL_VERSION);
 		break;
 
-	case REMOTE_ADD_JTAG_DEV: /* HJ = fill firmware jtag_devs */
+	case REMOTE_ADD_JTAG_DEV: { /* HJ = fill firmware jtag_devs */
+		/* Check the packet is an appropriate length */
 		if (packet_len < 22U) {
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
-		} else {
-			jtag_dev_s jtag_dev = {};
-			const uint32_t index = remote_hex_string_to_num(2, &packet[2]);
-			jtag_dev.dr_prescan = remote_hex_string_to_num(2, &packet[4]);
-			jtag_dev.dr_postscan = remote_hex_string_to_num(2, &packet[6]);
-			jtag_dev.ir_len = remote_hex_string_to_num(2, &packet[8]);
-			jtag_dev.ir_prescan = remote_hex_string_to_num(2, &packet[10]);
-			jtag_dev.ir_postscan = remote_hex_string_to_num(2, &packet[12]);
-			jtag_dev.current_ir = remote_hex_string_to_num(8, &packet[14]);
-			jtag_add_device(index, &jtag_dev);
-			remote_respond(REMOTE_RESP_OK, 0);
+			break;
 		}
+
+		jtag_dev_s jtag_dev = {};
+		const uint8_t index = remote_hex_string_to_num(2, packet + 2);
+		jtag_dev.dr_prescan = remote_hex_string_to_num(2, packet + 4);
+		jtag_dev.dr_postscan = remote_hex_string_to_num(2, packet + 6);
+		jtag_dev.ir_len = remote_hex_string_to_num(2, packet + 8);
+		jtag_dev.ir_prescan = remote_hex_string_to_num(2, packet + 10);
+		jtag_dev.ir_postscan = remote_hex_string_to_num(2, packet + 12);
+		jtag_dev.current_ir = remote_hex_string_to_num(8, packet + 14);
+		jtag_add_device(index, &jtag_dev);
+		remote_respond(REMOTE_RESP_OK, 0);
 		break;
+	}
 
 	default:
 		remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_UNRECOGNISED);

--- a/src/remote.c
+++ b/src/remote.c
@@ -371,8 +371,14 @@ static void remote_adiv5_respond(const void *const data, const size_t length)
 	}
 }
 
-static void remote_packet_process_adiv5(const char *const packet)
+static void remote_packet_process_adiv5(const char *const packet, const size_t packet_len)
 {
+	/* Our shortest ADIv5 packet is 8 bytes long, check that we have at least that */
+	if (packet_len < 8U) {
+		remote_respond(REMOTE_RESP_PARERR, 0);
+		return;
+	}
+
 	/* Set up the DP and a fake AP structure to perform the access with */
 	remote_dp.dp_jd_index = remote_hex_string_to_num(2, packet + 2);
 	adiv5_access_port_s remote_ap;
@@ -489,7 +495,7 @@ void remote_packet_process(unsigned i, char *packet)
 		break;
 
 	case REMOTE_ADIv5_PACKET:
-		remote_packet_process_adiv5(packet);
+		remote_packet_process_adiv5(packet, i);
 		break;
 
 	default: /* Oh dear, unrecognised, return an error */

--- a/src/remote.c
+++ b/src/remote.c
@@ -419,6 +419,7 @@ static void remote_packet_process_adiv5(const char *const packet)
 
 	SET_IDLE_STATE(0);
 	switch (packet[1]) {
+	/* DP access commands */
 	case REMOTE_DP_READ: { /* Ad = Read from DP register */
 		/* Grab the address to read from and try to perform the access */
 		const uint16_t addr = remote_hex_string_to_num(4, packet + 6);
@@ -426,20 +427,26 @@ static void remote_packet_process_adiv5(const char *const packet)
 		remote_adiv5_respond(&data, 4U);
 		break;
 	}
+	/* Raw access comands */
 	case REMOTE_ADIv5_RAW_ACCESS: { /* AR = Perform a raw ADIv5 access */
+		/* Grab the address to perform an access against and the value to work with */
 		const uint16_t addr = remote_hex_string_to_num(4, packet + 6);
 		const uint32_t value = remote_hex_string_to_num(8, packet + 10);
+		/* Try to perform the access using the AP selection value as R/!W */
 		const uint32_t data = adiv5_dp_low_access(&remote_dp, remote_ap.apsel, addr, value);
 		remote_adiv5_respond(&data, 4U);
 		break;
 	}
+	/* AP access commands */
 	case REMOTE_AP_READ: { /* Aa = Read from AP register */
+		/* Grab the AP address to read from and try to perform the access */
 		const uint16_t addr = remote_hex_string_to_num(4, packet + 6);
 		const uint32_t data = adiv5_ap_read(&remote_ap, addr);
 		remote_adiv5_respond(&data, 4U);
 		break;
 	}
 	case REMOTE_AP_WRITE: { /* AA = Write to AP register */
+		/* Grab the AP address to write to and the data to write then try to perform the access */
 		const uint16_t addr = remote_hex_string_to_num(4, packet + 6);
 		const uint32_t value = remote_hex_string_to_num(8, packet + 10);
 		adiv5_ap_write(&remote_ap, addr, value);

--- a/src/remote.c
+++ b/src/remote.c
@@ -322,7 +322,7 @@ static void remote_packet_process_general(unsigned i, char *packet)
 	}
 }
 
-static void remote_packet_process_high_level(unsigned i, char *packet)
+static void remote_packet_process_high_level(const char *packet, const size_t packet_len)
 {
 	SET_IDLE_STATE(0);
 	char index = packet[1];
@@ -332,7 +332,7 @@ static void remote_packet_process_high_level(unsigned i, char *packet)
 	}
 	switch (index) {
 	case REMOTE_ADD_JTAG_DEV: /* HJ = fill firmware jtag_devs */
-		if (i < 22U) {
+		if (packet_len < 22U) {
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		} else {
 			jtag_dev_s jtag_dev = {};
@@ -489,7 +489,7 @@ void remote_packet_process(unsigned i, char *packet)
 		break;
 
 	case REMOTE_HL_PACKET:
-		remote_packet_process_high_level(i, packet);
+		remote_packet_process_high_level(packet, i);
 		break;
 
 	case REMOTE_ADIv5_PACKET:

--- a/src/remote.h
+++ b/src/remote.h
@@ -57,6 +57,7 @@
 /* Protocol error messages */
 #define REMOTE_ERROR_UNRECOGNISED 1
 #define REMOTE_ERROR_WRONGLEN     2
+#define REMOTE_ERROR_FAULT        3
 
 /* Start and end of message identifiers */
 #define REMOTE_SOM  '!'
@@ -211,16 +212,8 @@
 	}
 
 /* High-level protocol elements */
-#define REMOTE_HL_PACKET          'H'
-#define REMOTE_HL_CHECK           'C'
-#define REMOTE_DP_READ            'd'
-#define REMOTE_LOW_ACCESS         'L'
-#define REMOTE_AP_READ            'a'
-#define REMOTE_AP_WRITE           'A'
-#define REMOTE_AP_MEM_READ        'M'
-#define REMOTE_MEM_READ           'h'
-#define REMOTE_MEM_WRITE_SIZED    'H'
-#define REMOTE_AP_MEM_WRITE_SIZED 'm'
+#define REMOTE_HL_PACKET 'H'
+#define REMOTE_HL_CHECK  'C'
 
 #define HEX        '%', '0', '2', 'x'
 #define HEX_U32(x) '%', '0', '8', 'x'
@@ -244,11 +237,29 @@
 	{                                                                \
 		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_HL_CHECK, REMOTE_EOM, 0 \
 	}
-#define REMOTE_DP_READ_STR                                                                                            \
-	(char[])                                                                                                          \
-	{                                                                                                                 \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_DP_READ, '%', '0', '2', 'x', 'f', 'f', '%', '0', '4', 'x', REMOTE_EOM, 0 \
+
+/* ADIv5 protocol elements */
+#define REMOTE_ADIv5_PACKET       'A'
+#define REMOTE_DP_READ            'd'
+#define REMOTE_LOW_ACCESS         'L'
+#define REMOTE_AP_READ            'a'
+#define REMOTE_AP_WRITE           'A'
+#define REMOTE_AP_MEM_READ        'M'
+#define REMOTE_MEM_READ           'm'
+#define REMOTE_MEM_WRITE_SIZED    'H'
+#define REMOTE_AP_MEM_WRITE_SIZED 'S'
+
+#define REMOTE_ADIv5_DEV_INDEX '%', '0', '2', 'x'
+#define REMOTE_ADIv5_AP_SEL    '%', '0', '2', 'x'
+#define REMOTE_ADIv5_ADDR      '%', '0', '4', 'x'
+
+#define REMOTE_DP_READ_STR                                                                                    \
+	(char[])                                                                                                  \
+	{                                                                                                         \
+		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_DP_READ, REMOTE_ADIv5_DEV_INDEX, 'f', 'f', REMOTE_ADIv5_ADDR, \
+			REMOTE_EOM, 0                                                                                     \
 	}
+
 #define REMOTE_LOW_ACCESS_STR                                                                                        \
 	(char[])                                                                                                         \
 	{                                                                                                                \

--- a/src/remote.h
+++ b/src/remote.h
@@ -297,6 +297,11 @@
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_MEM_WRITE, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
 			REMOTE_ADIv5_CSW, REMOTE_ADIv5_ALIGNMENT, REMOTE_ADIv5_ADDR32, REMOTE_ADIv5_COUNT, 0        \
 	}
+/*
+ * 3 leader bytes + 2 bytes for dev index + 2 bytes for AP select + 8 for CSW + 2 for the alignment +
+ * 8 for the address and 8 for the count and one trailer gives 34U
+ */
+#define REMOTE_ADIv5_MEM_WRITE_LENGTH 34U
 
 uint64_t remote_hex_string_to_num(uint32_t limit, const char *str);
 void remote_packet_process(unsigned int i, char *packet);

--- a/src/remote.h
+++ b/src/remote.h
@@ -297,7 +297,7 @@
 			HEX_U32(address), HEX_U32(count), 0                                                          \
 	}
 
-uint64_t remotehston(uint32_t limit, const char *s);
+uint64_t remote_hex_string_to_num(uint32_t limit, const char *str);
 void remote_packet_process(unsigned int i, char *packet);
 
 #endif /* REMOTE_H */

--- a/src/remote.h
+++ b/src/remote.h
@@ -245,8 +245,6 @@
 #define REMOTE_ADIv5_RAW_ACCESS 'R'
 #define REMOTE_MEM_READ         'm'
 #define REMOTE_MEM_WRITE        'M'
-#define REMOTE_MEM_READ_CSW     'c'
-#define REMOTE_MEM_WRITE_CSW    'C'
 
 #define REMOTE_ADIv5_DEV_INDEX '%', '0', '2', 'x'
 #define REMOTE_ADIv5_AP_SEL    '%', '0', '2', 'x'
@@ -254,6 +252,7 @@
 #define REMOTE_ADIv5_ADDR32    '%', '0', '8', 'x'
 #define REMOTE_ADIv5_DATA      '%', '0', '8', 'x'
 #define REMOTE_ADIv5_CSW       '%', '0', '8', 'x'
+#define REMOTE_ADIv5_ALIGNMENT '%', '0', '2', 'x'
 #define REMOTE_ADIv5_COUNT     '%', '0', '8', 'x'
 
 #define REMOTE_DP_READ_STR                                                                                      \
@@ -286,18 +285,11 @@
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_MEM_READ, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
 			REMOTE_ADIv5_CSW, REMOTE_ADIv5_ADDR32, REMOTE_ADIv5_COUNT, REMOTE_EOM, 0                   \
 	}
-
-#define REMOTE_AP_MEM_WRITE_SIZED_STR                                                                                  \
-	(char[])                                                                                                           \
-	{                                                                                                                  \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_WRITE_CSW, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), '%', \
-			'0', '2', 'x', HEX_U32(address), HEX_U32(count), 0                                                         \
-	}
-#define REMOTE_MEM_WRITE_SIZED_STR                                                                                    \
-	(char[])                                                                                                          \
-	{                                                                                                                 \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_WRITE_CSW, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(address), \
-			HEX_U32(count), 0                                                                                         \
+#define REMOTE_ADIv5_MEM_WRITE_STR                                                                      \
+	(char[])                                                                                            \
+	{                                                                                                   \
+		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_MEM_WRITE, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
+			REMOTE_ADIv5_CSW, REMOTE_ADIv5_ALIGNMENT, REMOTE_ADIv5_ADDR32, REMOTE_ADIv5_COUNT, 0        \
 	}
 
 uint64_t remote_hex_string_to_num(uint32_t limit, const char *str);

--- a/src/remote.h
+++ b/src/remote.h
@@ -260,6 +260,18 @@
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_DP_READ, REMOTE_ADIv5_DEV_INDEX, 'f', 'f', REMOTE_ADIv5_ADDR, \
 			REMOTE_EOM, 0                                                                                     \
 	}
+#define REMOTE_AP_READ_STR                                                                            \
+	(char[])                                                                                          \
+	{                                                                                                 \
+		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_AP_READ, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
+			REMOTE_ADIv5_ADDR, REMOTE_EOM, 0                                                          \
+	}
+#define REMOTE_AP_WRITE_STR                                                                            \
+	(char[])                                                                                           \
+	{                                                                                                  \
+		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_AP_WRITE, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
+			REMOTE_ADIv5_ADDR, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                        \
+	}
 #define REMOTE_ADIv5_RAW_ACCESS_STR                                                                            \
 	(char[])                                                                                                   \
 	{                                                                                                          \
@@ -267,18 +279,6 @@
 			REMOTE_ADIv5_ADDR, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                                \
 	}
 
-#define REMOTE_AP_READ_STR                                                                                        \
-	(char[])                                                                                                      \
-	{                                                                                                             \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_READ, '%', '0', '2', 'x', '%', '0', '2', 'x', '%', '0', '4', 'x', \
-			REMOTE_EOM, 0                                                                                         \
-	}
-#define REMOTE_AP_WRITE_STR                                                                                        \
-	(char[])                                                                                                       \
-	{                                                                                                              \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_WRITE, '%', '0', '2', 'x', '%', '0', '2', 'x', '%', '0', '4', 'x', \
-			HEX_U32(csw), REMOTE_EOM, 0                                                                            \
-	}
 #define REMOTE_AP_MEM_READ_STR                                                                                  \
 	(char[])                                                                                                    \
 	{                                                                                                           \

--- a/src/remote.h
+++ b/src/remote.h
@@ -70,6 +70,11 @@
 #define REMOTE_RESP_ERR    'E'
 #define REMOTE_RESP_NOTSUP 'N'
 
+/* Protocol data elements */
+#define REMOTE_UINT8  '%', '0', '2', 'x'
+#define REMOTE_UINT16 '%', '0', '4', 'x'
+#define REMOTE_UINT32 '%', '0', '8', 'x'
+
 /* Generic protocol elements */
 #define REMOTE_GEN_PACKET 'G'
 
@@ -215,23 +220,22 @@
 #define REMOTE_HL_PACKET 'H'
 #define REMOTE_HL_CHECK  'C'
 
-#define REMOTE_JTAG_ADD_DEV_STR                                                                  \
-	(char[])                                                                                     \
-	{                                                                                            \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_ADD_JTAG_DEV, '%', '0', '2', 'x', /* index */       \
-			'%', '0', '2', 'x',                                                /* dr_prescan */  \
-			'%', '0', '2', 'x',                                                /* dr_postscan */ \
-			'%', '0', '2', 'x',                                                /* ir_len */      \
-			'%', '0', '2', 'x',                                                /* ir_prescan */  \
-			'%', '0', '2', 'x',                                                /* ir_postscan */ \
-			'%', '0', '8', 'x',                                                /* current_ir */  \
-			REMOTE_EOM, 0                                                                        \
-	}
-
 #define REMOTE_HL_CHECK_STR                                          \
 	(char[])                                                         \
 	{                                                                \
 		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_HL_CHECK, REMOTE_EOM, 0 \
+	}
+#define REMOTE_JTAG_ADD_DEV_STR                                                            \
+	(char[])                                                                               \
+	{                                                                                      \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_ADD_JTAG_DEV, REMOTE_UINT8, /* index */       \
+			REMOTE_UINT8,                                                /* dr_prescan */  \
+			REMOTE_UINT8,                                                /* dr_postscan */ \
+			REMOTE_UINT8,                                                /* ir_len */      \
+			REMOTE_UINT8,                                                /* ir_prescan */  \
+			REMOTE_UINT8,                                                /* ir_postscan */ \
+			REMOTE_UINT32,                                               /* current_ir */  \
+			REMOTE_EOM, 0                                                                  \
 	}
 
 /* ADIv5 protocol elements */
@@ -243,14 +247,14 @@
 #define REMOTE_MEM_READ         'm'
 #define REMOTE_MEM_WRITE        'M'
 
-#define REMOTE_ADIv5_DEV_INDEX '%', '0', '2', 'x'
-#define REMOTE_ADIv5_AP_SEL    '%', '0', '2', 'x'
-#define REMOTE_ADIv5_ADDR16    '%', '0', '4', 'x'
-#define REMOTE_ADIv5_ADDR32    '%', '0', '8', 'x'
-#define REMOTE_ADIv5_DATA      '%', '0', '8', 'x'
-#define REMOTE_ADIv5_CSW       '%', '0', '8', 'x'
-#define REMOTE_ADIv5_ALIGNMENT '%', '0', '2', 'x'
-#define REMOTE_ADIv5_COUNT     '%', '0', '8', 'x'
+#define REMOTE_ADIv5_DEV_INDEX REMOTE_UINT8
+#define REMOTE_ADIv5_AP_SEL    REMOTE_UINT8
+#define REMOTE_ADIv5_ADDR16    REMOTE_UINT16
+#define REMOTE_ADIv5_ADDR32    REMOTE_UINT32
+#define REMOTE_ADIv5_DATA      REMOTE_UINT32
+#define REMOTE_ADIv5_CSW       REMOTE_UINT32
+#define REMOTE_ADIv5_ALIGNMENT REMOTE_UINT8
+#define REMOTE_ADIv5_COUNT     REMOTE_UINT32
 
 #define REMOTE_DP_READ_STR                                                                                      \
 	(char[])                                                                                                    \

--- a/src/remote.h
+++ b/src/remote.h
@@ -286,6 +286,11 @@
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_MEM_READ, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
 			REMOTE_ADIv5_CSW, REMOTE_ADIv5_ADDR32, REMOTE_ADIv5_COUNT, REMOTE_EOM, 0                   \
 	}
+/*
+ * 3 leader bytes + 2 bytes for dev index + 2 bytes for AP select + 8 for CSW + 8 for the address
+ * and 8 for the count and one trailer gives 32U
+ */
+#define REMOTE_ADIv5_MEM_READ_LENGTH 32U
 #define REMOTE_ADIv5_MEM_WRITE_STR                                                                      \
 	(char[])                                                                                            \
 	{                                                                                                   \

--- a/src/remote.h
+++ b/src/remote.h
@@ -215,20 +215,17 @@
 #define REMOTE_HL_PACKET 'H'
 #define REMOTE_HL_CHECK  'C'
 
-#define HEX_U32(x) '%', '0', '8', 'x'
-#define CHR(x)     '%', 'c'
-
-#define REMOTE_JTAG_ADD_DEV_STR                                                                    \
-	(char[])                                                                                       \
-	{                                                                                              \
-		REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_ADD_JTAG_DEV, '%', '0', '2', 'x', /* index */       \
-			'%', '0', '2', 'x',                                                  /* dr_prescan */  \
-			'%', '0', '2', 'x',                                                  /*	dr_postscan	*/ \
-			'%', '0', '2', 'x',                                                  /* ir_len */      \
-			'%', '0', '2', 'x',                                                  /* ir_prescan */  \
-			'%', '0', '2', 'x',                                                  /* ir_postscan */ \
-			HEX_U32(current_ir),                                                 /* current_ir */  \
-			REMOTE_EOM, 0                                                                          \
+#define REMOTE_JTAG_ADD_DEV_STR                                                                  \
+	(char[])                                                                                     \
+	{                                                                                            \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_ADD_JTAG_DEV, '%', '0', '2', 'x', /* index */       \
+			'%', '0', '2', 'x',                                                /* dr_prescan */  \
+			'%', '0', '2', 'x',                                                /* dr_postscan */ \
+			'%', '0', '2', 'x',                                                /* ir_len */      \
+			'%', '0', '2', 'x',                                                /* ir_prescan */  \
+			'%', '0', '2', 'x',                                                /* ir_postscan */ \
+			'%', '0', '8', 'x',                                                /* current_ir */  \
+			REMOTE_EOM, 0                                                                        \
 	}
 
 #define REMOTE_HL_CHECK_STR                                          \

--- a/src/remote.h
+++ b/src/remote.h
@@ -63,7 +63,15 @@
 #define REMOTE_EOM  '#'
 #define REMOTE_RESP '&'
 
+/* Protocol response options */
+#define REMOTE_RESP_OK     'K'
+#define REMOTE_RESP_PARERR 'P'
+#define REMOTE_RESP_ERR    'E'
+#define REMOTE_RESP_NOTSUP 'N'
+
 /* Generic protocol elements */
+#define REMOTE_GEN_PACKET 'G'
+
 #define REMOTE_START         'A'
 #define REMOTE_TDITDO_TMS    'D'
 #define REMOTE_TDITDO_NOTMS  'd'
@@ -86,26 +94,6 @@
 #define REMOTE_NRST_GET      'z'
 #define REMOTE_ADD_JTAG_DEV  'J'
 
-/* Protocol response options */
-#define REMOTE_RESP_OK     'K'
-#define REMOTE_RESP_PARERR 'P'
-#define REMOTE_RESP_ERR    'E'
-#define REMOTE_RESP_NOTSUP 'N'
-
-/* High level protocol elements */
-#define REMOTE_HL_CHECK           'C'
-#define REMOTE_HL_PACKET          'H'
-#define REMOTE_DP_READ            'd'
-#define REMOTE_LOW_ACCESS         'L'
-#define REMOTE_AP_READ            'a'
-#define REMOTE_AP_WRITE           'A'
-#define REMOTE_AP_MEM_READ        'M'
-#define REMOTE_MEM_READ           'h'
-#define REMOTE_MEM_WRITE_SIZED    'H'
-#define REMOTE_AP_MEM_WRITE_SIZED 'm'
-
-/* Generic protocol elements */
-#define REMOTE_GEN_PACKET 'G'
 #define REMOTE_START_STR                                                            \
 	(char[])                                                                        \
 	{                                                                               \
@@ -222,7 +210,18 @@
 		REMOTE_SOM, REMOTE_JTAG_PACKET, REMOTE_NEXT, '%', 'u', '%', 'u', REMOTE_EOM, 0 \
 	}
 
-/* HL protocol elements */
+/* High-level protocol elements */
+#define REMOTE_HL_PACKET          'H'
+#define REMOTE_HL_CHECK           'C'
+#define REMOTE_DP_READ            'd'
+#define REMOTE_LOW_ACCESS         'L'
+#define REMOTE_AP_READ            'a'
+#define REMOTE_AP_WRITE           'A'
+#define REMOTE_AP_MEM_READ        'M'
+#define REMOTE_MEM_READ           'h'
+#define REMOTE_MEM_WRITE_SIZED    'H'
+#define REMOTE_AP_MEM_WRITE_SIZED 'm'
+
 #define HEX        '%', '0', '2', 'x'
 #define HEX_U32(x) '%', '0', '8', 'x'
 #define CHR(x)     '%', 'c'

--- a/src/remote.h
+++ b/src/remote.h
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2019  Black Sphere Technologies Ltd.
  * Written by Dave Marples <dave@marples.net>
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,7 +26,7 @@
 #include <inttypes.h>
 #include "general.h"
 
-#define REMOTE_HL_VERSION 2
+#define REMOTE_HL_VERSION 3
 
 /*
  * Commands to remote end, and responses

--- a/src/remote.h
+++ b/src/remote.h
@@ -215,7 +215,6 @@
 #define REMOTE_HL_PACKET 'H'
 #define REMOTE_HL_CHECK  'C'
 
-#define HEX        '%', '0', '2', 'x'
 #define HEX_U32(x) '%', '0', '8', 'x'
 #define CHR(x)     '%', 'c'
 
@@ -251,40 +250,43 @@
 
 #define REMOTE_ADIv5_DEV_INDEX '%', '0', '2', 'x'
 #define REMOTE_ADIv5_AP_SEL    '%', '0', '2', 'x'
-#define REMOTE_ADIv5_ADDR      '%', '0', '4', 'x'
+#define REMOTE_ADIv5_ADDR16    '%', '0', '4', 'x'
+#define REMOTE_ADIv5_ADDR32    '%', '0', '8', 'x'
 #define REMOTE_ADIv5_DATA      '%', '0', '8', 'x'
+#define REMOTE_ADIv5_CSW       '%', '0', '8', 'x'
+#define REMOTE_ADIv5_COUNT     '%', '0', '8', 'x'
 
-#define REMOTE_DP_READ_STR                                                                                    \
-	(char[])                                                                                                  \
-	{                                                                                                         \
-		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_DP_READ, REMOTE_ADIv5_DEV_INDEX, 'f', 'f', REMOTE_ADIv5_ADDR, \
-			REMOTE_EOM, 0                                                                                     \
+#define REMOTE_DP_READ_STR                                                                                      \
+	(char[])                                                                                                    \
+	{                                                                                                           \
+		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_DP_READ, REMOTE_ADIv5_DEV_INDEX, 'f', 'f', REMOTE_ADIv5_ADDR16, \
+			REMOTE_EOM, 0                                                                                       \
 	}
 #define REMOTE_AP_READ_STR                                                                            \
 	(char[])                                                                                          \
 	{                                                                                                 \
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_AP_READ, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
-			REMOTE_ADIv5_ADDR, REMOTE_EOM, 0                                                          \
+			REMOTE_ADIv5_ADDR16, REMOTE_EOM, 0                                                        \
 	}
 #define REMOTE_AP_WRITE_STR                                                                            \
 	(char[])                                                                                           \
 	{                                                                                                  \
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_AP_WRITE, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
-			REMOTE_ADIv5_ADDR, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                        \
+			REMOTE_ADIv5_ADDR16, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                      \
 	}
 #define REMOTE_ADIv5_RAW_ACCESS_STR                                                                            \
 	(char[])                                                                                                   \
 	{                                                                                                          \
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_ADIv5_RAW_ACCESS, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
-			REMOTE_ADIv5_ADDR, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                                \
+			REMOTE_ADIv5_ADDR16, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                              \
+	}
+#define REMOTE_ADIv5_MEM_READ_STR                                                                      \
+	(char[])                                                                                           \
+	{                                                                                                  \
+		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_MEM_READ, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
+			REMOTE_ADIv5_CSW, REMOTE_ADIv5_ADDR32, REMOTE_ADIv5_COUNT, REMOTE_EOM, 0                   \
 	}
 
-#define REMOTE_AP_MEM_READ_STR                                                                                   \
-	(char[])                                                                                                     \
-	{                                                                                                            \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_READ_CSW, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), \
-			HEX_U32(address), HEX_U32(count), REMOTE_EOM, 0                                                      \
-	}
 #define REMOTE_AP_MEM_WRITE_SIZED_STR                                                                                  \
 	(char[])                                                                                                           \
 	{                                                                                                                  \

--- a/src/remote.h
+++ b/src/remote.h
@@ -239,15 +239,15 @@
 	}
 
 /* ADIv5 protocol elements */
-#define REMOTE_ADIv5_PACKET       'A'
-#define REMOTE_DP_READ            'd'
-#define REMOTE_AP_READ            'a'
-#define REMOTE_AP_WRITE           'A'
-#define REMOTE_ADIv5_RAW_ACCESS   'R'
-#define REMOTE_AP_MEM_READ        'M'
-#define REMOTE_MEM_READ           'm'
-#define REMOTE_MEM_WRITE_SIZED    'H'
-#define REMOTE_AP_MEM_WRITE_SIZED 'S'
+#define REMOTE_ADIv5_PACKET     'A'
+#define REMOTE_DP_READ          'd'
+#define REMOTE_AP_READ          'a'
+#define REMOTE_AP_WRITE         'A'
+#define REMOTE_ADIv5_RAW_ACCESS 'R'
+#define REMOTE_MEM_READ         'm'
+#define REMOTE_MEM_WRITE        'M'
+#define REMOTE_MEM_READ_CSW     'c'
+#define REMOTE_MEM_WRITE_CSW    'C'
 
 #define REMOTE_ADIv5_DEV_INDEX '%', '0', '2', 'x'
 #define REMOTE_ADIv5_AP_SEL    '%', '0', '2', 'x'
@@ -279,23 +279,23 @@
 			REMOTE_ADIv5_ADDR, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                                \
 	}
 
-#define REMOTE_AP_MEM_READ_STR                                                                                  \
-	(char[])                                                                                                    \
-	{                                                                                                           \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_READ, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), \
-			HEX_U32(address), HEX_U32(count), REMOTE_EOM, 0                                                     \
+#define REMOTE_AP_MEM_READ_STR                                                                                   \
+	(char[])                                                                                                     \
+	{                                                                                                            \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_READ_CSW, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), \
+			HEX_U32(address), HEX_U32(count), REMOTE_EOM, 0                                                      \
 	}
 #define REMOTE_AP_MEM_WRITE_SIZED_STR                                                                                  \
 	(char[])                                                                                                           \
 	{                                                                                                                  \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_WRITE_SIZED, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), \
-			'%', '0', '2', 'x', HEX_U32(address), HEX_U32(count), 0                                                    \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_WRITE_CSW, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(csw), '%', \
+			'0', '2', 'x', HEX_U32(address), HEX_U32(count), 0                                                         \
 	}
-#define REMOTE_MEM_WRITE_SIZED_STR                                                                       \
-	(char[])                                                                                             \
-	{                                                                                                    \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_AP_MEM_WRITE_SIZED, '%', '0', '2', 'x', '%', '0', '2', 'x', \
-			HEX_U32(address), HEX_U32(count), 0                                                          \
+#define REMOTE_MEM_WRITE_SIZED_STR                                                                                    \
+	(char[])                                                                                                          \
+	{                                                                                                                 \
+		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_MEM_WRITE_CSW, '%', '0', '2', 'x', '%', '0', '2', 'x', HEX_U32(address), \
+			HEX_U32(count), 0                                                                                         \
 	}
 
 uint64_t remote_hex_string_to_num(uint32_t limit, const char *str);

--- a/src/remote.h
+++ b/src/remote.h
@@ -241,9 +241,9 @@
 /* ADIv5 protocol elements */
 #define REMOTE_ADIv5_PACKET       'A'
 #define REMOTE_DP_READ            'd'
-#define REMOTE_LOW_ACCESS         'L'
 #define REMOTE_AP_READ            'a'
 #define REMOTE_AP_WRITE           'A'
+#define REMOTE_ADIv5_RAW_ACCESS   'R'
 #define REMOTE_AP_MEM_READ        'M'
 #define REMOTE_MEM_READ           'm'
 #define REMOTE_MEM_WRITE_SIZED    'H'
@@ -252,6 +252,7 @@
 #define REMOTE_ADIv5_DEV_INDEX '%', '0', '2', 'x'
 #define REMOTE_ADIv5_AP_SEL    '%', '0', '2', 'x'
 #define REMOTE_ADIv5_ADDR      '%', '0', '4', 'x'
+#define REMOTE_ADIv5_DATA      '%', '0', '8', 'x'
 
 #define REMOTE_DP_READ_STR                                                                                    \
 	(char[])                                                                                                  \
@@ -259,13 +260,13 @@
 		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_DP_READ, REMOTE_ADIv5_DEV_INDEX, 'f', 'f', REMOTE_ADIv5_ADDR, \
 			REMOTE_EOM, 0                                                                                     \
 	}
-
-#define REMOTE_LOW_ACCESS_STR                                                                                        \
-	(char[])                                                                                                         \
-	{                                                                                                                \
-		REMOTE_SOM, REMOTE_HL_PACKET, REMOTE_LOW_ACCESS, '%', '0', '2', 'x', '%', '0', '2', 'x', '%', '0', '4', 'x', \
-			HEX_U32(csw), REMOTE_EOM, 0                                                                              \
+#define REMOTE_ADIv5_RAW_ACCESS_STR                                                                            \
+	(char[])                                                                                                   \
+	{                                                                                                          \
+		REMOTE_SOM, REMOTE_ADIv5_PACKET, REMOTE_ADIv5_RAW_ACCESS, REMOTE_ADIv5_DEV_INDEX, REMOTE_ADIv5_AP_SEL, \
+			REMOTE_ADIv5_ADDR, REMOTE_ADIv5_DATA, REMOTE_EOM, 0                                                \
 	}
+
 #define REMOTE_AP_READ_STR                                                                                        \
 	(char[])                                                                                                      \
 	{                                                                                                             \

--- a/src/remote.h
+++ b/src/remote.h
@@ -58,6 +58,7 @@
 #define REMOTE_ERROR_UNRECOGNISED 1
 #define REMOTE_ERROR_WRONGLEN     2
 #define REMOTE_ERROR_FAULT        3
+#define REMOTE_ERROR_EXCEPTION    4
 
 /* Start and end of message identifiers */
 #define REMOTE_SOM  '!'

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -589,7 +589,7 @@ static void adiv5_component_probe(
 			return;
 		}
 
-		/* ADIv6: For CoreSight components, read DEVTYPE and ARCHID */
+		/* ADIv5: For CoreSight components, read DEVTYPE and ARCHID */
 		uint16_t arch_id = 0;
 		uint8_t dev_type = 0;
 		if (cid_class == cidc_dc) {
@@ -824,7 +824,7 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 		ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
 	}
 	if (e.type) {
-		DEBUG_WARN("DP not responding!  Trying abort sequence...\n");
+		DEBUG_WARN("DP not responding! Trying abort sequence...\n");
 		adiv5_dp_abort(dp, ADIV5_DP_ABORT_DAPABORT);
 		ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
 	}
@@ -836,8 +836,9 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 	/* Wait for acknowledge */
 	while (true) {
 		ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
-		uint32_t check = ctrlstat & (ADIV5_DP_CTRLSTAT_CSYSPWRUPACK | ADIV5_DP_CTRLSTAT_CDBGPWRUPACK);
-		if (check == (ADIV5_DP_CTRLSTAT_CSYSPWRUPACK | ADIV5_DP_CTRLSTAT_CDBGPWRUPACK))
+		const uint32_t status = ctrlstat & (ADIV5_DP_CTRLSTAT_CSYSPWRUPACK | ADIV5_DP_CTRLSTAT_CDBGPWRUPACK);
+		//DEBUG_INFO("status %08" PRIx32 " (%08" PRIx32 ")\n", ctrlstat, status);
+		if (status == (ADIV5_DP_CTRLSTAT_CSYSPWRUPACK | ADIV5_DP_CTRLSTAT_CDBGPWRUPACK))
 			break;
 		if (platform_timeout_is_expired(&timeout)) {
 			DEBUG_INFO("DEBUG Power-Up failed\n");

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -214,7 +214,7 @@ struct adiv5_debug_port {
 
 	void (*mem_read)(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len);
 	void (*mem_write)(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align);
-	uint8_t dp_jd_index;
+	uint8_t dev_index;
 	uint8_t fault;
 
 	/* targetsel DPv2 */

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -57,6 +57,10 @@ void adiv5_jtag_dp_handler(uint8_t jd_index)
 	platform_jtag_dp_init(dp);
 #endif
 
+	if (jtag_devs[jd_index].jd_idcode == JTAG_IDCODE_ARM_DPv0)
+		adiv5_dp_error(dp);
+	else
+		adiv5_dp_abort(dp, ADIV5_DP_ABORT_STKERRCLR);
 	adiv5_dp_init(dp, jtag_devs[jd_index].jd_idcode);
 }
 

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -73,9 +73,9 @@ uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
 	(void)protocol_recovery;
-	const uint32_t status = fw_adiv5_jtagdp_read(dp, ADIV5_DP_CTRLSTAT) & ADIV5_DP_CTRLSTAT_ERRMASK;
+	const uint32_t status = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT) & ADIV5_DP_CTRLSTAT_ERRMASK;
 	dp->fault = 0;
-	return fw_adiv5_jtagdp_low_access(dp, ADIV5_LOW_WRITE, ADIV5_DP_CTRLSTAT, status) & 0x32U;
+	return adiv5_dp_low_access(dp, ADIV5_LOW_WRITE, ADIV5_DP_CTRLSTAT, status) & 0x32U;
 }
 
 uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -47,7 +47,7 @@ void adiv5_jtag_dp_handler(uint8_t jd_index)
 		return;
 	}
 
-	dp->dp_jd_index = jd_index;
+	dp->dev_index = jd_index;
 
 	dp->dp_read = fw_adiv5_jtagdp_read;
 	dp->error = adiv5_jtagdp_error;
@@ -88,13 +88,13 @@ uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_
 	uint32_t result;
 	uint8_t ack;
 
-	jtag_dev_write_ir(dp->dp_jd_index, APnDP ? IR_APACC : IR_DPACC);
+	jtag_dev_write_ir(dp->dev_index, APnDP ? IR_APACC : IR_DPACC);
 
 	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 250);
 	do {
 		uint64_t response;
-		jtag_dev_shift_dr(dp->dp_jd_index, (uint8_t *)&response, (uint8_t *)&request, 35);
+		jtag_dev_shift_dr(dp->dev_index, (uint8_t *)&response, (uint8_t *)&request, 35);
 		result = response >> 3U;
 		ack = response & 0x07U;
 	} while (!platform_timeout_is_expired(&timeout) && ack == JTAGDP_ACK_WAIT);
@@ -117,6 +117,6 @@ uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_
 void adiv5_jtagdp_abort(adiv5_debug_port_s *dp, uint32_t abort)
 {
 	uint64_t request = (uint64_t)abort << 3U;
-	jtag_dev_write_ir(dp->dp_jd_index, IR_ABORT);
-	jtag_dev_shift_dr(dp->dp_jd_index, NULL, (const uint8_t *)&request, 35);
+	jtag_dev_write_ir(dp->dev_index, IR_ABORT);
+	jtag_dev_shift_dr(dp->dev_index, NULL, (const uint8_t *)&request, 35);
 }

--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -201,6 +201,7 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 		memcpy(dp, initial_dp, sizeof(adiv5_debug_port_s));
 		dp->instance = i;
 
+		adiv5_dp_abort(dp, ADIV5_DP_ABORT_STKERRCLR);
 		adiv5_dp_init(dp, 0);
 	}
 	return target_list ? 1U : 0U;

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -843,10 +843,11 @@ void cortexm_detach(target_s *t)
 	for (size_t i = 0; i < priv->hw_watchpoint_max; i++)
 		target_mem_write32(t, CORTEXM_DWT_FUNC(i), 0);
 
-	/* Restort DEMCR*/
+	/* Restort DEMCR */
 	adiv5_access_port_s *ap = cortexm_ap(t);
 	target_mem_write32(t, CORTEXM_DEMCR, ap->ap_cortexm_demcr);
-	/* Disable debug */
+	/* Resume target and disable debug */
+	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY | CORTEXM_DHCSR_C_DEBUGEN);
 	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY);
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses several regressions in ARM JTAG handling detailed below and necessarily rewrites the ADIv5 high level remote protocol.

The regressions fixed are as follows:

* Fixed a regression introduced with 6dcc5d41 which broke non-multiple-of-8 TDI-TDO sequences
* Fixed an issue whereby CMSIS-DAP adaptors such as ORBTrace should never have worked with JTAG ADIv5 devices due to initialising the IR length information too late
* Fixed a timing issue in the TDI sequence function much like the TDI-TDO sequence one
* Fixed the remote protocol going "everything's ok" even when dp->fault is set non-zero and everything is not ok
* Fixed the remote protocol pretending exceptions don't exist and the ADIv5 JTAG and SWD layers can't throw them (they can) resulting in permanent comms loss when one occurs
* Fixed the BMDA side of the remote protocol never doing protocol recovery and driving the remote into a state due to not handling any errors at all

As part of the remote protocol rewrite we have pre-emptively split the high-level component of the protocol into generic high-level commands and ADIv5-specific ones to make organisational space for the RISC-V specific ones when v2.0 happens. This happens to also make reading BMDA probe logs easier.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #858