### PR TITLE
Fix: Attaching to nRF Control Access Port Targets

### DIFF
--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -431,7 +431,7 @@ bool nrf51_mdm_probe(adiv5_access_port_s *ap)
 		t->driver = "Nordic nRF52 Access Port";
 	else
 		t->driver = "Nordic nRF52 Access Port (protected)";
-	t->regs_size = 4;
+	t->regs_size = 0;
 
 	return true;
 }


### PR DESCRIPTION

## Detailed description

This is a fix for a problem, which occured when trying to connect to the Control Access Port Targets on NRF52 chips: After attaching, it ran into an endless loop, because the CAP is no real CPU core and therefore no CPU Register Read is implemented. The fix adds the case, when 0 registers are available and respons to GDB by sending an dummy register with the value 'XX', which indicates, that the register value hasn't been collected.
This check is implemented when handling the 'g' packet.

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

fixes [#1353](https://github.com/blackmagic-debug/blackmagic/issues/1353)
