### PR TITLE
exception.h: Added include guards for setjmp.h and setjmpex.h

### DIFF
--- a/src/include/exception.h
+++ b/src/include/exception.h
@@ -42,7 +42,11 @@
 #ifndef INCLUDE_EXCEPTION_H
 #define INCLUDE_EXCEPTION_H
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#include <setjmpex.h>
+#else
 #include <setjmp.h>
+#endif
 #include <stdint.h>
 
 #define EXCEPTION_ERROR   0x01U


### PR DESCRIPTION
## Detailed description

Add include guards to use the correct header under Windows

Note this also needs back-porting to v1.9.0

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do


