### PR TITLE
mm32: support for mm32f5277

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -270,6 +270,14 @@ static const struct {
 	{0xd21, 0x14, 0x1a14, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-M33", "(Cross Trigger)")},
 	{0xd21, 0x13, 0x4a13, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-M33", "(Embedded Trace)")},
 	{0xd21, 0x11, 0, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-M33", "(Trace Port Interface Unit)")},
+	{0x132, 0x31, 0x0a31, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 MTB", "(Execution Trace)")},
+	{0x132, 0x43, 0x1a01, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 ITM", "(Instrumentation Trace Module)")},
+	{0x132, 0x00, 0x1a02, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 DWT", "(Data Watchpoint and Trace)")},
+	{0x132, 0x00, 0x1a03, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 BPU", "(Breakpoint Unit)")},
+	{0x132, 0x14, 0x1a14, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 CTI", "(Cross Trigger)")},
+	{0x132, 0x00, 0x2a04, aa_cortexm, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 SCS", "(System Control Space)")},
+	{0x132, 0x13, 0x4a13, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 ETM", "(Embedded Trace)")},
+	{0x132, 0x11, 0, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 TPIU", "(Trace Port Interface Unit)")},
 	{0xfff, 0x00, 0, aa_end, cidc_unknown, ARM_COMPONENT_STR("end", "end")},
 };
 
@@ -573,7 +581,7 @@ static void adiv5_component_probe(
 		DEBUG_INFO("%sROM: Table END\n", indent);
 
 	} else {
-		if (designer_code != JEP106_MANUFACTURER_ARM) {
+		if (designer_code != JEP106_MANUFACTURER_ARM && designer_code != JEP106_MANUFACTURER_ARM_CHINA) {
 			/* non arm components not supported currently */
 			DEBUG_WARN("%s0x%" PRIx32 ": 0x%08" PRIx32 "%08" PRIx32 " Non ARM component ignored\n", indent, addr,
 				(uint32_t)(pidr >> 32U), (uint32_t)pidr);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -572,6 +572,11 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 		t->part_id = ap->partno;
 	}
 
+	/* MM32F5xxx: part designer code is Arm China, target designer code uses forbidden continuation code */
+	if (t->designer_code == JEP106_MANUFACTURER_ERRATA_ARM_CHINA &&
+		ap->dp->designer_code == JEP106_MANUFACTURER_ARM_CHINA)
+		t->designer_code = JEP106_MANUFACTURER_ARM_CHINA;
+
 	cortexm_priv_s *priv = calloc(1, sizeof(*priv));
 	if (!priv) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);

--- a/src/target/jep106.h
+++ b/src/target/jep106.h
@@ -90,4 +90,7 @@
  */
 #define JEP106_MANUFACTURER_ERRATA_STM32WX 0x420U
 
+/* MindMotion MM32F5 uses the forbidden continuation code */
+#define JEP106_MANUFACTURER_ERRATA_ARM_CHINA 0xc7fU
+
 #endif /*TARGET_JEP106_H*/


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
Adds support for MindMotion MM32F5277, Arm China STAR-MC1 architecture.
Cleanup and document MM32 Cortex-M0 flashing code.
Tested flashing the following:
- MM32SPIN27 M0
- MM32L073 M0
- MM32F3273 M3
- MM32F5277 STAR-MC1

bmda session log attached: [f5277.txt](https://github.com/blackmagic-debug/blackmagic/files/10817039/f5277.txt)
Additional MM32 processors can be added as described in #1362.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
