### PR TITLE
gdb_main: don't reattach on connect

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -423,35 +423,34 @@ static void exec_q_supported(const char *packet, const size_t length)
 
 static void exec_q_memory_map(const char *packet, const size_t length)
 {
-	(void)packet;
 	(void)length;
+	target_s *target = cur_target;
+
 	/* Read target XML memory map */
-	if ((!cur_target) && last_target) {
-		/* Attach to last target if detached. */
-		cur_target = target_attach(last_target, &gdb_controller);
-	}
-	if (!cur_target) {
+	if (!target)
+		target = last_target;
+	if (!target) {
 		gdb_putpacketz("E01");
 		return;
 	}
 	char buf[1024];
-	target_mem_map(cur_target, buf, sizeof(buf)); /* Fixme: Check size!*/
+	target_mem_map(target, buf, sizeof(buf)); /* Fixme: Check size!*/
 	handle_q_string_reply(buf, packet);
 }
 
 static void exec_q_feature_read(const char *packet, const size_t length)
 {
 	(void)length;
-	/* Read target description */
-	if (!cur_target && last_target)
-		/* Attach to last target if detached. */
-		cur_target = target_attach(last_target, &gdb_controller);
+	target_s *target = cur_target;
 
-	if (!cur_target) {
+	/* Read target description */
+	if (!target)
+		target = last_target;
+	if (!target) {
 		gdb_putpacketz("E01");
 		return;
 	}
-	const char *const description = target_regs_description(cur_target);
+	const char *const description = target_regs_description(target);
 	handle_q_string_reply(description ? description : "", packet);
 	free((void *)description);
 }


### PR DESCRIPTION
Don't reattach the target when handling `qXfer:features` or `qXfer:memory-map`. GDB uses at least `qXfer:features` when connecting to the debug server, halting the target. Official documentation claims that connecting to the server won't attach the target.

## Detailed description

This change removes an unwanted behavior (see #1390) where reconnecting GDB to a BMP after detaching from a target will sometimes reattach the target. This is contrary to the official documentation. There is a workaround: scanning for targets before disconnecting from GDB in the first session, but that is non-intuitive and undocumented.

In case there is a benefit from retrieving the relevant information from `last_target`, it is still consulted, if available, for these `qXfer` requests, without reattaching the target.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

fixes #1390
