### PR TITLE
target/cortexm.c: Added missing probe call to sam3x_probe

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -726,6 +726,7 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 			PROBE(lpc43xx_probe);
 			PROBE(mm32l0xx_probe);         /* MindMotion MM32 */
 		} else if (t->part_id == 0x4c4U) { /* Cortex-M4 ROM */
+			PROBE(sam3x_probe);
 			PROBE(lmi_probe);
 			/* The LPC546xx and LPC43xx parts present with the same AP ROM Part
 			Number, so we need to probe both. Unfortunately, when probing for


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Added a missing probe call to sam3x_probe, which re-enables support to SAM* devices.

Without this the target MCUs are shown as unknown devices, and flashing routines fail on them.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
