### PR TITLE
Two fixes related to CH32F103C8T6 MCU found on some Blue Pill boards

### DIFF
--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -266,7 +266,7 @@ static bool ch32f1_wait_flash_ready(target_s *t, uint32_t addr)
 {
 	uint32_t flash_val = 0;
 	/* Certain ch32f103c8t6 MCU's found on Blue Pill boards need some uninterrupted time (no SWD link activity) */
-	platform_delay(1);
+	platform_delay(2);
 	for (size_t cnt = 0; cnt < 32U && flash_val != 0xffffffffU; ++cnt)
 		flash_val = target_mem_read32(t, addr);
 	if (flash_val != 0xffffffffU) {

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -147,9 +147,12 @@ static bool ch32f1_flash_unlock(target_s *t)
 static bool ch32f1_flash_lock(target_s *t)
 {
 	DEBUG_INFO("CH32: flash lock \n");
-	SET_CR(FLASH_CR_LOCK);
+	/*
+	 * The LOCK (bit 7) and FLOCK (bit 15) must be set (1) in the same write
+	 * operation, if not FLOCK will be read back as unset (0).
+	 */
+	SET_CR(FLASH_CR_LOCK | FLASH_CR_FLOCK_CH32);
 	const uint32_t cr = target_mem_read32(t, FLASH_CR);
-	// FLASH_CR_FLOCK_CH32 bit does not exists on *regular* clones and defaults to '0' (see PM0075 for STM32F1xx)
 	if (!(cr & FLASH_CR_FLOCK_CH32)) {
 		DEBUG_WARN("Fast lock failed, cr: 0x%08" PRIx32 "\n", cr);
 	}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
Fix no. 1
It is not possible to run blackmagic (PROBE_HOST=hosted) without flag -H, --high-level when writing to CH32F103C8T6 MCU’s flash memory.

Fixed by increasing the delay (that does not interrupt the MCU) in function ch32f1_wait_flash_ready().

Note! This problem does not show when using arm-none-eabi-gdb load.

Fix no. 2
Using blackmagic (PROBE_HOST=hosted) for writing to CH32F103C8T6 MCU’s flash memory  prints a lot of DEBUG_WARN messages to the console.

The condition tested for, FLOCK bit set in the FLASH_CTLR register, is never be met. Fixed by setting the FLOCK bit in the FLASH_CTLR register in function ch32f1_flash_lock().

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
