### PR TITLE
Fix: Tiva-C TM4C129 identification

### DIFF
--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -42,7 +42,8 @@
 #define DID0_CLASS_MASK           0x00ff0000U
 #define DID0_CLASS_STELLARIS_FURY 0x00010000U
 #define DID0_CLASS_STELLARIS_DUST 0x00030000U
-#define DID0_CLASS_TIVA           0x00050000U
+#define DID0_CLASS_TIVA_C123      0x00050000U
+#define DID0_CLASS_TIVA_C129      0x000a0000U
 
 #define DID1_LM3S3748      0x1049U
 #define DID1_LM3S5732      0x1096U
@@ -150,7 +151,8 @@ bool lmi_probe(target_s *const t)
 	case DID0_CLASS_STELLARIS_FURY:
 	case DID0_CLASS_STELLARIS_DUST:
 		return lm3s_probe(t, did1);
-	case DID0_CLASS_TIVA:
+	case DID0_CLASS_TIVA_C123:
+	case DID0_CLASS_TIVA_C129:
 		return tm4c_probe(t, did1);
 	default:
 		return false;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As identified in https://github.com/blackmagic-debug/blackmagic/issues/1412 , we were missing the DID0 value for Tiva-C TM4C129 parts. This PR fixes this so we can properly detect those pparts again.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Partially fixes #1412
