### PR TITLE
Fix: LPC Flash registration

### DIFF
--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -62,9 +62,8 @@ const command_s lpc11xx_cmd_list[] = {
 static void lpc11xx_add_flash(target_s *target, const uint32_t addr, const size_t len, const size_t erase_block_len,
 	const uint32_t iap_entry, const size_t reserved_pages)
 {
-	lpc_flash_s *const flash = lpc_add_flash(target, addr, len);
+	lpc_flash_s *const flash = lpc_add_flash(target, addr, len, IAP_PGM_CHUNKSIZE);
 	flash->f.blocksize = erase_block_len;
-	flash->f.writesize = IAP_PGM_CHUNKSIZE;
 	flash->f.write = lpc_flash_write_magic_vect;
 	flash->iap_entry = iap_entry;
 	flash->iap_ram = IAP_RAM_BASE;

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -59,17 +59,17 @@ const command_s lpc11xx_cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
-static void lpc11xx_add_flash(target_s *t, const uint32_t addr, const size_t len, const size_t erase_block_len,
+static void lpc11xx_add_flash(target_s *target, const uint32_t addr, const size_t len, const size_t erase_block_len,
 	const uint32_t iap_entry, const size_t reserved_pages)
 {
-	lpc_flash_s *lf = lpc_add_flash(t, addr, len);
-	lf->f.blocksize = erase_block_len;
-	lf->f.writesize = IAP_PGM_CHUNKSIZE;
-	lf->f.write = lpc_flash_write_magic_vect;
-	lf->iap_entry = iap_entry;
-	lf->iap_ram = IAP_RAM_BASE;
-	lf->iap_msp = IAP_RAM_BASE + MIN_RAM_SIZE - RAM_USAGE_FOR_IAP_ROUTINES;
-	lf->reserved_pages = reserved_pages;
+	lpc_flash_s *const flash = lpc_add_flash(target, addr, len);
+	flash->f.blocksize = erase_block_len;
+	flash->f.writesize = IAP_PGM_CHUNKSIZE;
+	flash->f.write = lpc_flash_write_magic_vect;
+	flash->iap_entry = iap_entry;
+	flash->iap_ram = IAP_RAM_BASE;
+	flash->iap_msp = IAP_RAM_BASE + MIN_RAM_SIZE - RAM_USAGE_FOR_IAP_ROUTINES;
+	flash->reserved_pages = reserved_pages;
 }
 
 static bool lpc11xx_detect(target_s *const t)

--- a/src/target/lpc15xx.c
+++ b/src/target/lpc15xx.c
@@ -57,9 +57,8 @@ const command_s lpc15xx_cmd_list[] = {
 
 static void lpc15xx_add_flash(target_s *target, uint32_t addr, size_t len, size_t erasesize)
 {
-	struct lpc_flash *flash = lpc_add_flash(target, addr, len);
+	struct lpc_flash *flash = lpc_add_flash(target, addr, len, IAP_PGM_CHUNKSIZE);
 	flash->f.blocksize = erasesize;
-	flash->f.writesize = IAP_PGM_CHUNKSIZE;
 	flash->f.write = lpc_flash_write_magic_vect;
 	flash->iap_entry = IAP_ENTRYPOINT;
 	flash->iap_ram = IAP_RAM_BASE;

--- a/src/target/lpc15xx.c
+++ b/src/target/lpc15xx.c
@@ -55,15 +55,15 @@ const command_s lpc15xx_cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
-static void lpc15xx_add_flash(target_s *t, uint32_t addr, size_t len, size_t erasesize)
+static void lpc15xx_add_flash(target_s *target, uint32_t addr, size_t len, size_t erasesize)
 {
-	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
-	lf->f.blocksize = erasesize;
-	lf->f.writesize = IAP_PGM_CHUNKSIZE;
-	lf->f.write = lpc_flash_write_magic_vect;
-	lf->iap_entry = IAP_ENTRYPOINT;
-	lf->iap_ram = IAP_RAM_BASE;
-	lf->iap_msp = IAP_RAM_BASE + MIN_RAM_SIZE - RAM_USAGE_FOR_IAP_ROUTINES;
+	struct lpc_flash *flash = lpc_add_flash(target, addr, len);
+	flash->f.blocksize = erasesize;
+	flash->f.writesize = IAP_PGM_CHUNKSIZE;
+	flash->f.write = lpc_flash_write_magic_vect;
+	flash->iap_entry = IAP_ENTRYPOINT;
+	flash->iap_ram = IAP_RAM_BASE;
+	flash->iap_msp = IAP_RAM_BASE + MIN_RAM_SIZE - RAM_USAGE_FOR_IAP_ROUTINES;
 }
 
 bool lpc15xx_probe(target_s *t)

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -75,10 +75,9 @@ iap_status_e lpc17xx_iap_call(target_s *target, iap_result_s *result, iap_cmd_e 
 
 static void lpc17xx_add_flash(target_s *target, uint32_t addr, size_t len, size_t erasesize, uint8_t base_sector)
 {
-	lpc_flash_s *flash = lpc_add_flash(target, addr, len);
+	lpc_flash_s *flash = lpc_add_flash(target, addr, len, IAP_PGM_CHUNKSIZE);
 	flash->f.blocksize = erasesize;
 	flash->base_sector = base_sector;
-	flash->f.writesize = IAP_PGM_CHUNKSIZE;
 	flash->f.write = lpc_flash_write_magic_vect;
 	flash->iap_entry = IAP_ENTRYPOINT;
 	flash->iap_ram = IAP_RAM_BASE;

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -309,19 +309,19 @@ const command_s lpc43xx_cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
-static void lpc43xx_add_iap_flash(
-	target_s *t, uint32_t iap_entry, uint8_t bank, uint8_t base_sector, uint32_t addr, size_t len, size_t erasesize)
+static void lpc43xx_add_iap_flash(target_s *target, uint32_t iap_entry, uint8_t bank, uint8_t base_sector,
+	uint32_t addr, size_t len, size_t erasesize)
 {
-	lpc_flash_s *lf = lpc_add_flash(t, addr, len);
-	lf->f.erase = lpc43xx_iap_flash_erase;
-	lf->f.blocksize = erasesize;
-	lf->f.writesize = IAP_PGM_CHUNKSIZE;
-	lf->bank = bank;
-	lf->base_sector = base_sector;
-	lf->iap_entry = iap_entry;
-	lf->iap_ram = IAP_RAM_BASE;
-	lf->iap_msp = IAP_RAM_BASE + IAP_RAM_SIZE;
-	lf->wdt_kick = lpc43xx_wdt_kick;
+	lpc_flash_s *flash = lpc_add_flash(target, addr, len);
+	flash->f.blocksize = erasesize;
+	flash->f.writesize = IAP_PGM_CHUNKSIZE;
+	flash->f.erase = lpc43xx_iap_flash_erase;
+	flash->bank = bank;
+	flash->base_sector = base_sector;
+	flash->iap_entry = iap_entry;
+	flash->iap_ram = IAP_RAM_BASE;
+	flash->iap_msp = IAP_RAM_BASE + IAP_RAM_SIZE;
+	flash->wdt_kick = lpc43xx_wdt_kick;
 }
 
 static void lpc43xx_detect(target_s *const t, const lpc43xx_partid_s part_id)

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -312,9 +312,8 @@ const command_s lpc43xx_cmd_list[] = {
 static void lpc43xx_add_iap_flash(target_s *target, uint32_t iap_entry, uint8_t bank, uint8_t base_sector,
 	uint32_t addr, size_t len, size_t erasesize)
 {
-	lpc_flash_s *flash = lpc_add_flash(target, addr, len);
+	lpc_flash_s *flash = lpc_add_flash(target, addr, len, IAP_PGM_CHUNKSIZE);
 	flash->f.blocksize = erasesize;
-	flash->f.writesize = IAP_PGM_CHUNKSIZE;
 	flash->f.erase = lpc43xx_iap_flash_erase;
 	flash->bank = bank;
 	flash->base_sector = base_sector;

--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -78,22 +78,20 @@ const command_s lpc546xx_cmd_list[] = {
 };
 
 static void lpc546xx_add_flash(
-	target_s *t, uint32_t iap_entry, uint8_t base_sector, uint32_t addr, size_t len, size_t erasesize)
+	target_s *target, uint32_t iap_entry, uint8_t base_sector, uint32_t addr, size_t len, size_t erasesize)
 {
-	struct lpc_flash *lf = lpc_add_flash(t, addr, len);
-	lf->f.erase = lpc546xx_flash_erase;
-
+	lpc_flash_s *flash = lpc_add_flash(target, addr, len);
+	flash->f.blocksize = erasesize;
+	flash->f.writesize = IAP_PGM_CHUNKSIZE;
+	flash->f.erase = lpc546xx_flash_erase;
 	/* LPC546xx devices require the checksum value written into the vector table in sector 0 */
-	lf->f.write = lpc_flash_write_magic_vect;
-
-	lf->f.blocksize = erasesize;
-	lf->f.writesize = IAP_PGM_CHUNKSIZE;
-	lf->bank = 0;
-	lf->base_sector = base_sector;
-	lf->iap_entry = iap_entry;
-	lf->iap_ram = IAP_RAM_BASE;
-	lf->iap_msp = IAP_RAM_BASE + IAP_RAM_SIZE;
-	lf->wdt_kick = lpc546xx_wdt_kick;
+	flash->f.write = lpc_flash_write_magic_vect;
+	flash->bank = 0;
+	flash->base_sector = base_sector;
+	flash->iap_entry = iap_entry;
+	flash->iap_ram = IAP_RAM_BASE;
+	flash->iap_msp = IAP_RAM_BASE + IAP_RAM_SIZE;
+	flash->wdt_kick = lpc546xx_wdt_kick;
 }
 
 bool lpc546xx_probe(target_s *t)

--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -80,9 +80,8 @@ const command_s lpc546xx_cmd_list[] = {
 static void lpc546xx_add_flash(
 	target_s *target, uint32_t iap_entry, uint8_t base_sector, uint32_t addr, size_t len, size_t erasesize)
 {
-	lpc_flash_s *flash = lpc_add_flash(target, addr, len);
+	lpc_flash_s *flash = lpc_add_flash(target, addr, len, IAP_PGM_CHUNKSIZE);
 	flash->f.blocksize = erasesize;
-	flash->f.writesize = IAP_PGM_CHUNKSIZE;
 	flash->f.erase = lpc546xx_flash_erase;
 	/* LPC546xx devices require the checksum value written into the vector table in sector 0 */
 	flash->f.write = lpc_flash_write_magic_vect;

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -75,22 +75,22 @@ static const char *const iap_error[] = {
 
 static bool lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *src, size_t len);
 
-lpc_flash_s *lpc_add_flash(target_s *t, target_addr_t addr, size_t length)
+lpc_flash_s *lpc_add_flash(target_s *const target, const target_addr_t addr, const size_t length)
 {
-	lpc_flash_s *lf = calloc(1, sizeof(*lf));
-	if (!lf) { /* calloc failed: heap exhaustion */
+	lpc_flash_s *const lpc_flash = calloc(1, sizeof(*lpc_flash));
+	if (!lpc_flash) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return NULL;
 	}
 
-	target_flash_s *f = &lf->f;
-	f->start = addr;
-	f->length = length;
-	f->erase = lpc_flash_erase;
-	f->write = lpc_flash_write;
-	f->erased = 0xff;
-	target_add_flash(t, f);
-	return lf;
+	target_flash_s *const flash = &lpc_flash->f;
+	flash->start = addr;
+	flash->length = length;
+	flash->erase = lpc_flash_erase;
+	flash->write = lpc_flash_write;
+	flash->erased = 0xff;
+	target_add_flash(target, flash);
+	return lpc_flash;
 }
 
 static uint8_t lpc_sector_for_addr(lpc_flash_s *f, uint32_t addr)

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -78,14 +78,12 @@ static bool lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *
 lpc_flash_s *lpc_add_flash(target_s *t, target_addr_t addr, size_t length)
 {
 	lpc_flash_s *lf = calloc(1, sizeof(*lf));
-	target_flash_s *f;
-
 	if (!lf) { /* calloc failed: heap exhaustion */
 		DEBUG_WARN("calloc: failed in %s\n", __func__);
 		return NULL;
 	}
 
-	f = &lf->f;
+	target_flash_s *f = &lf->f;
 	f->start = addr;
 	f->length = length;
 	f->erase = lpc_flash_erase;

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -75,7 +75,8 @@ static const char *const iap_error[] = {
 
 static bool lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *src, size_t len);
 
-lpc_flash_s *lpc_add_flash(target_s *const target, const target_addr_t addr, const size_t length)
+lpc_flash_s *lpc_add_flash(
+	target_s *const target, const target_addr_t addr, const size_t length, const size_t write_size)
 {
 	lpc_flash_s *const lpc_flash = calloc(1, sizeof(*lpc_flash));
 	if (!lpc_flash) { /* calloc failed: heap exhaustion */
@@ -89,6 +90,7 @@ lpc_flash_s *lpc_add_flash(target_s *const target, const target_addr_t addr, con
 	flash->erase = lpc_flash_erase;
 	flash->write = lpc_flash_write;
 	flash->erased = 0xff;
+	flash->writesize = write_size;
 	target_add_flash(target, flash);
 	return lpc_flash;
 }

--- a/src/target/lpc_common.h
+++ b/src/target/lpc_common.h
@@ -83,7 +83,7 @@ typedef struct lpc_flash {
 	uint32_t iap_msp;
 } lpc_flash_s;
 
-lpc_flash_s *lpc_add_flash(target_s *t, target_addr_t addr, size_t length);
+lpc_flash_s *lpc_add_flash(target_s *target, target_addr_t addr, size_t length, size_t write_size);
 iap_status_e lpc_iap_call(struct lpc_flash *f, void *result, iap_cmd_e cmd, ...);
 bool lpc_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
 bool lpc_flash_write_magic_vect(target_flash_s *f, target_addr_t dest, const void *src, size_t len);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

After the changes in #1323 which makes the Flash structure member `writebufsize` a computed value, it was found that on supported LPC targets BMD would attempt to divide by 0.

This PR addresses that by lifting the code that initalises the writesize member into lpc_add_flash() so initialisation occurs in the proper order and we avoid dividing by 0.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
