### PR TITLE
Feature: NTB component entry

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -278,6 +278,7 @@ static const struct {
 	{0x132, 0x00, 0x2a04, aa_cortexm, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 SCS", "(System Control Space)")},
 	{0x132, 0x13, 0x4a13, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 ETM", "(Embedded Trace)")},
 	{0x132, 0x11, 0, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("STAR-MC1 TPIU", "(Trace Port Interface Unit)")},
+	{0x9a3, 0x13, 0, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("nRF NTB", "(Nordic Trace Buffer)")},
 	{0xfff, 0x00, 0, aa_end, cidc_unknown, ARM_COMPONENT_STR("end", "end")},
 };
 
@@ -596,9 +597,8 @@ static void adiv5_component_probe(
 
 			uint32_t devarch = adiv5_mem_read32(ap, addr + DEVARCH_OFFSET);
 
-			if (devarch & DEVARCH_PRESENT) {
+			if (devarch & DEVARCH_PRESENT)
 				arch_id = devarch & DEVARCH_ARCHID_MASK;
-			}
 		}
 
 		/* Find the part number in our part list and run the appropriate probe routine if applicable. */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR adds an ADIv5 component entry to the arm_component_lut for Nordic Semi's nRF series Nordic Trace Buffer (NTB)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes https://github.com/blackmagic-debug/blackmagic/issues/1394