### PR TITLE
Fix lack of target power control in BMDA

### DIFF
--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -35,7 +35,7 @@
 
 #include "adiv5.h"
 
-int remote_init(void)
+int remote_init(const bool power_up)
 {
 	char construct[REMOTE_MAX_MSG_SIZE];
 	int c = snprintf(construct, REMOTE_MAX_MSG_SIZE, "%s", REMOTE_START_STR);
@@ -46,6 +46,7 @@ int remote_init(void)
 		return -1;
 	}
 	DEBUG_PROBE("Remote is %s\n", construct + 1);
+	remote_target_set_power(power_up) ;
 	return 0;
 }
 

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -46,7 +46,7 @@ int remote_init(const bool power_up)
 		return -1;
 	}
 	DEBUG_PROBE("Remote is %s\n", construct + 1);
-	remote_target_set_power(power_up) ;
+	remote_target_set_power(power_up);
 	return 0;
 }
 

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -30,7 +30,7 @@
 int platform_buffer_write(const uint8_t *data, int size);
 int platform_buffer_read(uint8_t *data, int size);
 
-int remote_init(void);
+int remote_init(const bool power_up);
 bool remote_swdptap_init(void);
 bool remote_jtagtap_init(void);
 bool remote_target_get_power(void);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -98,7 +98,7 @@ void platform_init(int argc, char **argv)
 	case BMP_TYPE_BMP:
 		if (serial_open(&cl_opts, info.serial))
 			exit(-1);
-		remote_init();
+		remote_init(cl_opts.opt_tpwr);
 		break;
 
 	case BMP_TYPE_STLINKV2:


### PR DESCRIPTION
BMDA was not controlling the target power when the "--power" option was used.


* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
