### PR TITLE
Remove dead code from cl_execute

### DIFF
--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -406,10 +406,6 @@ static void display_target(int i, target_s *t, void *context)
 int cl_execute(bmda_cli_options_s *opt)
 {
 	int num_targets;
-	if (opt->opt_tpwr) {
-		platform_target_set_power(true);
-		platform_delay(500);
-	}
 	if (opt->opt_mode == BMP_MODE_RESET_HW) {
 		platform_nrst_set_val(true);
 		platform_delay(1);


### PR DESCRIPTION
The function cl_execute is not called in BMDA when a BMP is attached. The code removed was an attempt to control the target power and was never called.

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
