### PR TITLE
Fix: SAM3Xxx Flash programming

### DIFF
--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -27,6 +27,7 @@
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
+#include "cortexm.h"
 
 static bool sam_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
 static bool sam3_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
@@ -423,6 +424,7 @@ bool sam3x_probe(target_s *t)
 	case CHIPID_CIDR_ARCH_SAM3XxE | CHIPID_CIDR_EPROC_CM3:
 	case CHIPID_CIDR_ARCH_SAM3XxG | CHIPID_CIDR_EPROC_CM3:
 		t->driver = "Atmel SAM3X";
+		t->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 		target_add_ram(t, 0x20000000, 0x200000);
 		/* 2 Flash memories back-to-back starting at 0x80000 */
 		sam3_add_flash(t, SAM3X_EEFC_BASE(0), 0x80000, size / 2U);
@@ -481,7 +483,7 @@ bool sam3x_probe(target_s *t)
 
 static bool sam_flash_cmd(target_s *t, uint32_t base, uint8_t cmd, uint16_t arg)
 {
-	DEBUG_INFO("%s: base = 0x%08" PRIx32 " cmd = 0x%02X, arg = 0x%06X\n", __func__, base, cmd, arg);
+	DEBUG_INFO("%s: base = 0x%08" PRIx32 " cmd = 0x%02X, arg = 0x%04X\n", __func__, base, cmd, arg);
 
 	if (base == 0)
 		return false;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Many thanks to the Discord user "Colonel Panic" for reporting this issue. On ATSAM3Xxx parts, toggling the nRST line during setup to enter/exit Flash mode causes a complete reset of the device (including the debug components). This disconnects us from the target and trashes the ability to read or write debug registers.

This PR solves this by using `CORTEXM_TOPT_INHIBIT_NRST` to inhibit this physical reset, which allows Flash programming to proceed normally.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
