### PR TITLE
Fix: Cortex-M halt/resume correctness

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -487,7 +487,7 @@ static void adiv5_component_probe(
 	/* CIDR preamble sanity check */
 	if ((cidr & ~CID_CLASS_MASK) != CID_PREAMBLE) {
 		DEBUG_WARN("%s%" PRIu32 " 0x%08" PRIx32 ": 0x%08" PRIx32 " <- does not match preamble (0x%08" PRIx32 ")\n",
-			indent + 1, num_entry, addr, cidr, CID_PREAMBLE);
+			indent, num_entry, addr, cidr, CID_PREAMBLE);
 		return;
 	}
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -391,24 +391,22 @@ static uint32_t cortexm_initial_halt(adiv5_access_port_s *ap)
 	return 0U;
 }
 
-/* Prepare to read SYSROM and SYSROM PIDR
+/*
+ * Prepare the core to read the ROM tables, PIDR, etc
  *
- * Try hard to halt, if not connecting under reset
- * Request TRCENA and default vector catch
- * release from reset when connecting under reset.
+ * Because of various errata, failing to halt the core is considered
+ * a hard error. We also need to set the debug exception and monitor
+ * control register (DEMCR) up but save its value to restore later,
+ * and release the core from reset when connecting under reset.
  *
- * E.g. Stm32F7
+ * Example errata for STM32F7:
  * - fails reading romtable in WFI
  * - fails with some AP accesses when romtable is read under reset.
  * - fails reading some ROMTABLE entries w/o TRCENA
- * - fails reading outside SYSROM when halted from WFI and
- *   DBGMCU_CR not set.
+ * - fails reading outside SYSROM when halted from WFI and DBGMCU_CR not set.
  *
- * E.g. Stm32F0
+ * Example errata for STM32F0
  * - fails reading DBGMCU when under reset
- *
- * Keep a copy of DEMCR at startup to restore with exit, to
- * not interrupt tracing initiated by the CPU.
  */
 static bool cortexm_prepare(adiv5_access_port_s *ap)
 {
@@ -423,21 +421,27 @@ static bool cortexm_prepare(adiv5_access_port_s *ap)
 		return false;
 	}
 	DEBUG_INFO("Halt via DHCSR(%08" PRIx32 "): success after %" PRId32 "ms\n", dhcsr, platform_time_ms() - start_time);
+	/* Save the old value of DEMCR and enable the DWT, and both vector table debug bits */
 	ap->ap_cortexm_demcr = adiv5_mem_read32(ap, CORTEXM_DEMCR);
 	const uint32_t demcr = CORTEXM_DEMCR_TRCENA | CORTEXM_DEMCR_VC_HARDERR | CORTEXM_DEMCR_VC_CORERESET;
 	adiv5_mem_write(ap, CORTEXM_DEMCR, &demcr, sizeof(demcr));
+	/* Having setup DEMCR, try to observe the core being released from reset */
 	platform_timeout_s reset_timeout;
 	platform_timeout_set(&reset_timeout, cortexm_wait_timeout);
+	/* Deassert the physical reset line */
 	platform_nrst_set_val(false);
 	while (true) {
+		/* Read back DHCSR and check if the reset status bit is still set */
 		dhcsr = adiv5_mem_read32(ap, CORTEXM_DHCSR);
-		if (!(dhcsr & CORTEXM_DHCSR_S_RESET_ST))
+		if ((dhcsr & CORTEXM_DHCSR_S_RESET_ST) == 0)
 			break;
+		/* If it is and we timeout, turn that into an error */
 		if (platform_timeout_is_expired(&reset_timeout)) {
 			DEBUG_WARN("Error releasing from reset\n");
 			return false;
 		}
 	}
+	/* Core is now in a good state */
 	return true;
 }
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -469,7 +469,7 @@ static void adiv5_component_probe(
 
 	const volatile uint32_t cidr = adiv5_ap_read_id(ap, addr + CIDR0_OFFSET);
 	if (ap->dp->fault) {
-		DEBUG_WARN("CIDR read timeout on AP%d, aborting.\n", ap->apsel);
+		DEBUG_WARN("Error reading CIDR on AP%u: %u\n", ap->apsel, ap->dp->fault);
 		return;
 	}
 	if ((cidr & ~CID_CLASS_MASK) != CID_PREAMBLE)

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -898,18 +898,18 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 		efm32_aap_probe(ap);
 		lpc55_dmap_probe(ap);
 
-		/* Halt the device and release from reset if reset is active! */
-		if (!ap->apsel && (ap->idr & 0xfU) == ARM_AP_TYPE_AHB)
-			cortexm_prepare(ap);
-		/* Should probe further here to make sure it's a valid target.
-		 * AP should be unref'd if not valid.
-		 */
+		/* Try to prepare the AP if it seems to be a AHB (memory) AP */
+		if (!ap->apsel && (ap->idr & 0xfU) == ARM_AP_TYPE_AHB) {
+			if (!cortexm_prepare(ap))
+				DEBUG_WARN("adiv5: Failed to prepare AP, results may be unpredictable\n");
+		}
 
 		/* The rest should only be added after checking ROM table */
 		adiv5_component_probe(ap, ap->base, 0, 0);
 		adiv5_ap_unref(ap);
 	}
-	/* We halted at least CortexM for Romtable scan.
+	/*
+	 * We halted at least Cortex-M for Romtable scan.
 	 * With connect under reset, keep the devices halted.
 	 * Otherwise, release the devices now.
 	 * Attach() will halt them again.

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -33,6 +33,9 @@
 #include "adiv5.h"
 #include "cortexm.h"
 #include "exception.h"
+#if PC_HOSTED == 1
+#include "bmp_hosted.h"
+#endif
 
 /* All this should probably be defined in a dedicated ADIV5 header, so that they
  * are consistently named and accessible when needed in the codebase.
@@ -374,7 +377,11 @@ static uint32_t cortexm_initial_halt(adiv5_access_port_s *ap)
 		 * data we want to read will be returned in the first raw access, and on others the read
 		 * will do nothing (return 0) and instead need RDBUFF read to get the data.
 		 */
-		if (ap->dp->mindp)
+		if (ap->dp->mindp
+#if PC_HOSTED == 1
+			&& info.bmp_type != BMP_TYPE_CMSIS_DAP
+#endif
+		)
 			dhcsr = adiv5_dp_low_access(ap->dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
 
 		/*

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -906,18 +906,18 @@ void adiv5_dp_init(adiv5_debug_port_s *dp, const uint32_t idcode)
 
 		/* The rest should only be added after checking ROM table */
 		adiv5_component_probe(ap, ap->base, 0, 0);
-		adiv5_ap_unref(ap);
-	}
-	/*
-	 * We halted at least Cortex-M for Romtable scan.
-	 * With connect under reset, keep the devices halted.
-	 * Otherwise, release the devices now.
-	 * Attach() will halt them again.
-	 */
-	for (target_s *t = target_list; t; t = t->next) {
-		if (!connect_assert_nrst) {
-			target_halt_resume(t, false);
+		/*
+		 * Having completed discovery on this AP, if we're not in connect-under-reset mode,
+		 * and now that we're done with this AP's ROM tables, look for the target and resume the core.
+		 */
+		for (target_s *target = target_list; target; target = target->next) {
+			if (!connect_assert_nrst && target->priv_free == cortexm_priv_free) {
+				adiv5_access_port_s *target_ap = cortexm_ap(target);
+				if (target_ap == ap)
+					target_halt_resume(target, false);
+			}
 		}
+		adiv5_ap_unref(ap);
 	}
 	adiv5_dp_unref(dp);
 }

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -105,7 +105,7 @@
 #define ADIV5_DP_CTRLSTAT_CDBGRSTREQ   (1U << 26U)
 /* Bits 25:24 - Reserved */
 /* Bits 23:12 - TRNCNT */
-#define ADIV5_DP_CTRLSTAT_TRNCNT (1U << 12U)
+#define ADIV5_DP_CTRLSTAT_TRNCNT(x) ((x & 0xfffU) << 12U)
 /* Bits 11:8 - MASKLANE */
 #define ADIV5_DP_CTRLSTAT_MASKLANE
 /* Bits 7:6 - Reserved in JTAG-DP */

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -489,7 +489,7 @@ static bool cortexm_check_error(target_s *t)
 	return adiv5_dp_error(ap->dp) != 0;
 }
 
-static void cortexm_priv_free(void *priv)
+void cortexm_priv_free(void *priv)
 {
 	adiv5_ap_unref(((cortexm_priv_s *)priv)->ap);
 	free(priv);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -146,7 +146,7 @@ static const uint32_t regnum_cortex_mf[] = {
 	0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, /* s24-s31 */
 };
 
-/**
+/*
  * Fields for Cortex-M special purpose registers, used in the generation of GDB's target description XML.
  * The general purpose registers r0-r12 and the vector floating point registers d0-d15 all follow a very
  * regular format, so we only need to store fields for the special purpose registers.
@@ -497,7 +497,8 @@ static void cortexm_priv_free(void *priv)
 
 static void cortexm_read_cpuid(target_s *const t, const adiv5_access_port_s *const ap)
 {
-	/* The CPUID register is defined in the ARMv7-M and ARMv8-M
+	/*
+	 * The CPUID register is defined in the ARMv6-M, ARMv7-M and ARMv8-M
 	 * architecture manuals. The PARTNO field is implementation defined,
 	 * that is, the actual values are found in the Technical Reference Manual
 	 * for each Cortex-M core.
@@ -533,7 +534,7 @@ static void cortexm_read_cpuid(target_s *const t, const adiv5_access_port_s *con
 		t->core = "M0";
 		break;
 	default:
-		if (ap->designer_code != JEP106_MANUFACTURER_ATMEL) /* Protected Atmel device?*/
+		if (ap->designer_code != JEP106_MANUFACTURER_ATMEL) /* Protected Atmel device? */
 			DEBUG_WARN("Unexpected Cortex-M CPU partno %04x\n", cpuid_partno);
 	}
 	DEBUG_INFO("CPUID 0x%08" PRIx32 " (%s var %" PRIx32 " rev %" PRIx32 ")\n", t->cpuid, t->core,

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -3,6 +3,8 @@
  *
  * Copyright (C) 2012-2020  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>,
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  * Koen De Vleeschauwer and Uwe Bonnes
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,12 +21,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* This file implements debugging functionality specific to ARM
- * the Cortex-M3 core.  This should be generic to ARMv7-M as it is
- * implemented according to the "ARMv7-M Architectue Reference Manual",
- * ARM doc DDI0403C.
- *
- * Also supports Cortex-M0 / ARMv6-M
+/*
+ * This file implements debugging functionality specific ARM Cortex-M cores.
+ * This is be generic to both the ARMv6-M and ARMv7-M profiles as defined in
+ * the architecture TRMs with ARM document IDs DDI0419E and DDI0403C.
  */
 
 #include "general.h"

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -844,10 +844,11 @@ void cortexm_detach(target_s *t)
 	for (size_t i = 0; i < priv->hw_watchpoint_max; i++)
 		target_mem_write32(t, CORTEXM_DWT_FUNC(i), 0);
 
-	/* Restort DEMCR */
+	/* Restore DEMCR */
 	adiv5_access_port_s *ap = cortexm_ap(t);
 	target_mem_write32(t, CORTEXM_DEMCR, ap->ap_cortexm_demcr);
-	/* Resume target and disable debug */
+	/* Resume target and disable debug, re-enabling interrupts in the process */
+	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY | CORTEXM_DHCSR_C_DEBUGEN | CORTEXM_DHCSR_C_HALT);
 	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY | CORTEXM_DHCSR_C_DEBUGEN);
 	target_mem_write32(t, CORTEXM_DHCSR, CORTEXM_DHCSR_DBGKEY);
 }

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -194,4 +194,7 @@ void cortexm_halt_resume(target_s *t, bool step);
 bool cortexm_run_stub(target_s *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3);
 int cortexm_mem_write_sized(target_s *t, target_addr_t dest, const void *src, size_t len, align_e align);
 
+/* This is only for the ADIv5 implementation's use, do not call. */
+void cortexm_priv_free(void *priv);
+
 #endif /* TARGET_CORTEXM_H */

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -959,7 +959,7 @@ bool efm32_aap_probe(adiv5_access_port_s *ap)
 	efm32_aap_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
 	sprintf(priv_storage->aap_driver_string, "EFM32 Authentication Access Port rev.%hu", aap_revision);
 	t->driver = priv_storage->aap_driver_string;
-	t->regs_size = 4;
+	t->regs_size = 0;
 
 	return true;
 }

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -552,7 +552,7 @@ bool kinetis_mdm_probe(adiv5_access_port_s *ap)
 	t->priv_free = (void *)adiv5_ap_unref;
 
 	t->driver = "Kinetis Recovery (MDM-AP)";
-	t->regs_size = 4;
+	t->regs_size = 0;
 	target_add_commands(t, kinetis_mdm_cmd_list, t->driver);
 
 	return true;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As prompted by #968, we took a dive into the halt/resume code which was subtly broken in a couple of ways. This PR addresses these issues and documents how this tricky part of the Cortex-M support works better.

The exact issues addressed are:

* Recovery APs wrongly specified non-0 register size information which leads to a crash on main
* Our handling of the C_HALT and C_DEBUGEN bits was dubious at best
* C_MASKINTS (interrupt masking) was being mishandled during detach
* Post-DP-scan resumption was doing bad things to targets not found in the current adiv5_dp_init() call
* DHCSR halt was being done wrongly for minimal DP targets
* State was spilling from DHCSR halt into CIDR readout, making that fail under some circumstances when it shouldn't
* Error messages around CIDR readout failing and DHCSR halt failing were misleading/inaccurate

This has been thoroughly tested on: RP2040, Tiva-C, LPC4370, LPC4332, LPC4350, STM32F411. Testing was conducted via BMP, ORBTrace, and Tigard. With this patch, LPC43xx scan in particular progresses correctly when enumerating the Cortex-M0+ cores where previously DHCSR halt would fail and the cores would not be discovered correctly.

This should eliminate the Cortex-M halt/resume issues

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #968 
