### PR TITLE
Fix: BMDA's BMP remote protocol SWD cleanup

### DIFF
--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -32,7 +32,7 @@
 #include "bmp_remote.h"
 
 static bool remote_swd_seq_in_parity(uint32_t *res, size_t clock_cycles);
-static uint32_t swdptap_seq_in(size_t clock_cycles);
+static uint32_t remote_swd_seq_in(size_t clock_cycles);
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
@@ -48,7 +48,7 @@ bool remote_swdptap_init(void)
 		exit(-1);
 	}
 
-	swd_proc.seq_in = swdptap_seq_in;
+	swd_proc.seq_in = remote_swd_seq_in;
 	swd_proc.seq_in_parity = remote_swd_seq_in_parity;
 	swd_proc.seq_out = swdptap_seq_out;
 	swd_proc.seq_out_parity = swdptap_seq_out_parity;
@@ -74,7 +74,7 @@ static bool remote_swd_seq_in_parity(uint32_t *res, size_t clock_cycles)
 	return buffer[0] != REMOTE_RESP_OK;
 }
 
-static uint32_t swdptap_seq_in(size_t clock_cycles)
+static uint32_t remote_swd_seq_in(size_t clock_cycles)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 
@@ -83,11 +83,11 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 2 || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_in failed, error %s\n", length ? buffer + 1 : "short response");
+		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 	uint32_t res = remote_hex_string_to_num(-1, buffer + 1);
-	DEBUG_PROBE("swdptap_seq_in %zu clock_cycles: %08" PRIx32 "\n", clock_cycles, res);
+	DEBUG_PROBE("%s %zu clock_cycles: %08" PRIx32 "\n", __func__, clock_cycles, res);
 	return res;
 }
 

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -33,7 +33,7 @@
 
 static bool remote_swd_seq_in_parity(uint32_t *res, size_t clock_cycles);
 static uint32_t remote_swd_seq_in(size_t clock_cycles);
-static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
+static void remote_swd_seq_out(uint32_t tms_states, size_t clock_cycles);
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
 bool remote_swdptap_init(void)
@@ -50,7 +50,7 @@ bool remote_swdptap_init(void)
 
 	swd_proc.seq_in = remote_swd_seq_in;
 	swd_proc.seq_in_parity = remote_swd_seq_in_parity;
-	swd_proc.seq_out = swdptap_seq_out;
+	swd_proc.seq_out = remote_swd_seq_out;
 	swd_proc.seq_out_parity = swdptap_seq_out_parity;
 	return true;
 }
@@ -91,17 +91,17 @@ static uint32_t remote_swd_seq_in(size_t clock_cycles)
 	return res;
 }
 
-static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
+static void remote_swd_seq_out(uint32_t tms_states, size_t clock_cycles)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 
-	DEBUG_PROBE("swdptap_seq_out %zu clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
+	DEBUG_PROBE("%s %zu clock_cycles: %08" PRIx32 "\n", __func__, clock_cycles, tms_states);
 	int length = sprintf(buffer, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
 	platform_buffer_write(buffer, length);
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_out failed, error %s\n", length ? buffer + 1 : "short response");
+		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -34,7 +34,7 @@
 static bool remote_swd_seq_in_parity(uint32_t *res, size_t clock_cycles);
 static uint32_t remote_swd_seq_in(size_t clock_cycles);
 static void remote_swd_seq_out(uint32_t tms_states, size_t clock_cycles);
-static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
+static void remote_swd_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
 bool remote_swdptap_init(void)
 {
@@ -51,7 +51,7 @@ bool remote_swdptap_init(void)
 	swd_proc.seq_in = remote_swd_seq_in;
 	swd_proc.seq_in_parity = remote_swd_seq_in_parity;
 	swd_proc.seq_out = remote_swd_seq_out;
-	swd_proc.seq_out_parity = swdptap_seq_out_parity;
+	swd_proc.seq_out_parity = remote_swd_seq_out_parity;
 	return true;
 }
 
@@ -106,17 +106,17 @@ static void remote_swd_seq_out(uint32_t tms_states, size_t clock_cycles)
 	}
 }
 
-static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
+static void remote_swd_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 
-	DEBUG_PROBE("swdptap_seq_out_parity %zu clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
+	DEBUG_PROBE("%s %zu clock_cycles: %08" PRIx32 "\n", __func__, clock_cycles, tms_states);
 	int length = sprintf(buffer, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
 	platform_buffer_write(buffer, length);
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[1] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", length ? buffer + 2 : "short response");
+		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 2 : "short response");
 		exit(-1);
 	}
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -41,10 +41,10 @@ bool remote_swdptap_init(void)
 	DEBUG_WIRE("remote_swdptap_init\n");
 	platform_buffer_write(REMOTE_SWDP_INIT_STR, sizeof(REMOTE_SWDP_INIT_STR));
 
-	char construct[REMOTE_MAX_MSG_SIZE];
-	int length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if (!length || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_init failed, error %s\n", length ? construct + 1 : "unknown");
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	int length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (!length || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_init failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -31,7 +31,7 @@
 #include "jtagtap.h"
 #include "bmp_remote.h"
 
-static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles);
+static bool remote_swd_seq_in_parity(uint32_t *res, size_t clock_cycles);
 static uint32_t swdptap_seq_in(size_t clock_cycles);
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles);
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
@@ -49,13 +49,13 @@ bool remote_swdptap_init(void)
 	}
 
 	swd_proc.seq_in = swdptap_seq_in;
-	swd_proc.seq_in_parity = swdptap_seq_in_parity;
+	swd_proc.seq_in_parity = remote_swd_seq_in_parity;
 	swd_proc.seq_out = swdptap_seq_out;
 	swd_proc.seq_out_parity = swdptap_seq_out_parity;
 	return true;
 }
 
-static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
+static bool remote_swd_seq_in_parity(uint32_t *res, size_t clock_cycles)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 
@@ -64,12 +64,12 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 2 || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", length ? buffer + 1 : "short response");
+		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 
 	*res = remote_hex_string_to_num(-1, buffer + 1);
-	DEBUG_PROBE("swdptap_seq_in_parity %zu clock_cycles: %08" PRIx32 " %s\n", clock_cycles, *res,
+	DEBUG_PROBE("%s %zu clock_cycles: %08" PRIx32 " %s\n", __func__, clock_cycles, *res,
 		buffer[0] != REMOTE_RESP_OK ? "ERR" : "OK");
 	return buffer[0] != REMOTE_RESP_OK;
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -76,17 +76,17 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 
 static uint32_t swdptap_seq_in(size_t clock_cycles)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
+	char buffer[REMOTE_MAX_MSG_SIZE];
 
-	int length = sprintf(construct, REMOTE_SWDP_IN_STR, clock_cycles);
-	platform_buffer_write(construct, length);
+	int length = sprintf(buffer, REMOTE_SWDP_IN_STR, clock_cycles);
+	platform_buffer_write(buffer, length);
 
-	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if (length < 2 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_in failed, error %s\n", length ? construct + 1 : "short response");
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 2 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_in failed, error %s\n", length ? buffer + 1 : "short response");
 		exit(-1);
 	}
-	uint32_t res = remote_hex_string_to_num(-1, &construct[1]);
+	uint32_t res = remote_hex_string_to_num(-1, buffer + 1);
 	DEBUG_PROBE("swdptap_seq_in         %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, res);
 	return res;
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -108,15 +108,15 @@ static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
 
 static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
+	char buffer[REMOTE_MAX_MSG_SIZE];
 
 	DEBUG_PROBE("swdptap_seq_out_parity %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
-	int length = sprintf(construct, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
-	platform_buffer_write(construct, length);
+	int length = sprintf(buffer, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
+	platform_buffer_write(buffer, length);
 
-	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if (length < 1 || construct[1] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", length ? construct + 2 : "short response");
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[1] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_out_parity failed, error %s\n", length ? buffer + 2 : "short response");
 		exit(-1);
 	}
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -57,21 +57,21 @@ bool remote_swdptap_init(void)
 
 static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
+	char buffer[REMOTE_MAX_MSG_SIZE];
 
-	int length = sprintf(construct, REMOTE_SWDP_IN_PAR_STR, clock_cycles);
-	platform_buffer_write(construct, length);
+	int length = sprintf(buffer, REMOTE_SWDP_IN_PAR_STR, clock_cycles);
+	platform_buffer_write(buffer, length);
 
-	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if (length < 2 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", length ? &(construct[1]) : "short response");
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 2 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_in_parity failed, error %s\n", length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 
-	*res = remote_hex_string_to_num(-1, &construct[1]);
+	*res = remote_hex_string_to_num(-1, buffer + 1);
 	DEBUG_PROBE("swdptap_seq_in_parity  %2d clock_cycles: %08" PRIx32 " %s\n", clock_cycles, *res,
-		construct[0] != REMOTE_RESP_OK ? "ERR" : "OK");
-	return construct[0] != REMOTE_RESP_OK;
+		buffer[0] != REMOTE_RESP_OK ? "ERR" : "OK");
+	return buffer[0] != REMOTE_RESP_OK;
 }
 
 static uint32_t swdptap_seq_in(size_t clock_cycles)

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -38,7 +38,7 @@ static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles);
 
 bool remote_swdptap_init(void)
 {
-	DEBUG_WIRE("remote_swdptap_init\n");
+	DEBUG_PROBE("remote_swdptap_init\n");
 	platform_buffer_write(REMOTE_SWDP_INIT_STR, sizeof(REMOTE_SWDP_INIT_STR));
 
 	char buffer[REMOTE_MAX_MSG_SIZE];
@@ -69,7 +69,7 @@ static bool swdptap_seq_in_parity(uint32_t *res, size_t clock_cycles)
 	}
 
 	*res = remote_hex_string_to_num(-1, buffer + 1);
-	DEBUG_PROBE("swdptap_seq_in_parity  %2d clock_cycles: %08" PRIx32 " %s\n", clock_cycles, *res,
+	DEBUG_PROBE("swdptap_seq_in_parity %zu clock_cycles: %08" PRIx32 " %s\n", clock_cycles, *res,
 		buffer[0] != REMOTE_RESP_OK ? "ERR" : "OK");
 	return buffer[0] != REMOTE_RESP_OK;
 }
@@ -87,7 +87,7 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 		exit(-1);
 	}
 	uint32_t res = remote_hex_string_to_num(-1, buffer + 1);
-	DEBUG_PROBE("swdptap_seq_in         %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, res);
+	DEBUG_PROBE("swdptap_seq_in %zu clock_cycles: %08" PRIx32 "\n", clock_cycles, res);
 	return res;
 }
 
@@ -95,7 +95,7 @@ static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 
-	DEBUG_PROBE("swdptap_seq_out        %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
+	DEBUG_PROBE("swdptap_seq_out %zu clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
 	int length = sprintf(buffer, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
 	platform_buffer_write(buffer, length);
 
@@ -110,7 +110,7 @@ static void swdptap_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 {
 	char buffer[REMOTE_MAX_MSG_SIZE];
 
-	DEBUG_PROBE("swdptap_seq_out_parity %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
+	DEBUG_PROBE("swdptap_seq_out_parity %zu clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
 	int length = sprintf(buffer, REMOTE_SWDP_OUT_PAR_STR, clock_cycles, tms_states);
 	platform_buffer_write(buffer, length);
 

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -93,15 +93,15 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 
 static void swdptap_seq_out(uint32_t tms_states, size_t clock_cycles)
 {
-	char construct[REMOTE_MAX_MSG_SIZE];
+	char buffer[REMOTE_MAX_MSG_SIZE];
 
 	DEBUG_PROBE("swdptap_seq_out        %2d clock_cycles: %08" PRIx32 "\n", clock_cycles, tms_states);
-	int length = sprintf(construct, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
-	platform_buffer_write(construct, length);
+	int length = sprintf(buffer, REMOTE_SWDP_OUT_STR, clock_cycles, tms_states);
+	platform_buffer_write(buffer, length);
 
-	length = platform_buffer_read(construct, REMOTE_MAX_MSG_SIZE);
-	if (length < 1 || construct[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_seq_out failed, error %s\n", length ? construct + 1 : "short response");
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
+		DEBUG_WARN("swdptap_seq_out failed, error %s\n", length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR acts as a follow-up to #1389 which saw the remote protocol implementation largely rewritten. That PR focused on JTAG but there were some outstanding consistency issues with the SWD implementation. This PR addresses those.

The result should be a consistent naming scheme for the BMDA remote protocol functions - both SWD and JTAG - and consistent variable naming within those functions + consistent use of logging levels.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
