### PR TITLE
Fix: Semihosting

### DIFF
--- a/src/gdb_hostio.c
+++ b/src/gdb_hostio.c
@@ -24,8 +24,6 @@
 #include "gdb_hostio.h"
 #include "gdb_packet.h"
 
-int gdb_main_loop(target_controller_s *, bool in_syscall);
-
 int hostio_reply(target_controller_s *tc, char *pbuf, int len)
 {
 	(void)len;
@@ -46,75 +44,82 @@ int hostio_reply(target_controller_s *tc, char *pbuf, int len)
 	return retcode;
 }
 
+static int hostio_get_response(target_controller_s *const tc)
+{
+	char *const packet_buffer = gdb_packet_buffer();
+	const size_t size = gdb_getpacket(packet_buffer, GDB_PACKET_BUFFER_SIZE);
+	return gdb_main_loop(tc, packet_buffer, GDB_PACKET_BUFFER_SIZE, size, true);
+}
+
 /* Interface to host system calls */
 int hostio_open(target_controller_s *tc, target_addr_t path, size_t path_len, target_open_flags_e flags, mode_t mode)
 {
 	gdb_putpacket_f("Fopen,%08X/%X,%08X,%08X", path, path_len, flags, mode);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_close(target_controller_s *tc, int fd)
 {
 	gdb_putpacket_f("Fclose,%08X", fd);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_read(target_controller_s *tc, int fd, target_addr_t buf, unsigned int count)
 {
 	gdb_putpacket_f("Fread,%08X,%08X,%08X", fd, buf, count);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_write(target_controller_s *tc, int fd, target_addr_t buf, unsigned int count)
 {
 	gdb_putpacket_f("Fwrite,%08X,%08X,%08X", fd, buf, count);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 long hostio_lseek(target_controller_s *tc, int fd, long offset, target_seek_flag_e flag)
 {
 	gdb_putpacket_f("Flseek,%08X,%08X,%08X", fd, offset, flag);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_rename(target_controller_s *tc, target_addr_t oldpath, size_t old_len, target_addr_t newpath, size_t new_len)
 {
 	gdb_putpacket_f("Frename,%08X/%X,%08X/%X", oldpath, old_len, newpath, new_len);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_unlink(target_controller_s *tc, target_addr_t path, size_t path_len)
 {
 	gdb_putpacket_f("Funlink,%08X/%X", path, path_len);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_stat(target_controller_s *tc, target_addr_t path, size_t path_len, target_addr_t buf)
 {
 	gdb_putpacket_f("Fstat,%08X/%X,%08X", path, path_len, buf);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_fstat(target_controller_s *tc, int fd, target_addr_t buf)
 {
 	gdb_putpacket_f("Ffstat,%X,%08X", fd, buf);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_gettimeofday(target_controller_s *tc, target_addr_t tv, target_addr_t tz)
 {
 	gdb_putpacket_f("Fgettimeofday,%08X,%08X", tv, tz);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_isatty(target_controller_s *tc, int fd)
 {
 	gdb_putpacket_f("Fisatty,%08X", fd);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }
 
 int hostio_system(target_controller_s *tc, target_addr_t cmd, size_t cmd_len)
 {
 	gdb_putpacket_f("Fsystem,%08X/%X", cmd, cmd_len);
-	return gdb_main_loop(tc, true);
+	return hostio_get_response(tc);
 }

--- a/src/include/gdb_main.h
+++ b/src/include/gdb_main.h
@@ -23,11 +23,14 @@
 
 #include "target.h"
 
+#define GDB_PACKET_BUFFER_SIZE 1024U
+
 extern bool gdb_target_running;
 extern target_s *cur_target;
 
 void gdb_poll_target(void);
 void gdb_main(char *pbuf, size_t pbuf_size, size_t size);
+int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t size, bool in_syscall);
 char *gdb_packet_buffer();
 
 #endif /* INCLUDE_GDB_MAIN_H */

--- a/src/main.c
+++ b/src/main.c
@@ -32,9 +32,8 @@
 #include "rtt.h"
 #endif
 
-#define BUF_SIZE 1024U
 /* This has to be aligned so the remote protocol can re-use it without causing Problems */
-static char pbuf[BUF_SIZE + 1U] __attribute__((aligned(8)));
+static char pbuf[GDB_PACKET_BUFFER_SIZE + 1U] __attribute__((aligned(8)));
 
 char *gdb_packet_buffer()
 {
@@ -62,11 +61,11 @@ static void bmp_poll_loop(void)
 	}
 
 	SET_IDLE_STATE(true);
-	size_t size = gdb_getpacket(pbuf, BUF_SIZE);
+	size_t size = gdb_getpacket(pbuf, GDB_PACKET_BUFFER_SIZE);
 	// If port closed and target detached, stay idle
 	if (pbuf[0] != '\x04' || cur_target)
 		SET_IDLE_STATE(false);
-	gdb_main(pbuf, sizeof(pbuf), size);
+	gdb_main(pbuf, GDB_PACKET_BUFFER_SIZE, size);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In the wake of #1284, Koen correctly identified that a private (UB) declaration of gdb_main_loop() had the semihosting Host IO code broken with nobody having noticed. This PR addresses this by removing that declaration, putting one in the gdb_main.h header so mismatches with gdb_main.c result in compilation failure, and updating how the Host IO code calls the main loop.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1385
