### PR TITLE
Fix: LPC IAP correctness

### DIFF
--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -169,7 +169,9 @@ extern unsigned cortexm_wait_timeout;
 #define REG_SPECIAL 19U
 
 #define ARM_THUMB_BREAKPOINT 0xbe00U
-#define CORTEXM_XPSR_THUMB   (1U << 24U)
+
+#define CORTEXM_XPSR_THUMB          (1U << 24U)
+#define CORTEXM_XPSR_EXCEPTION_MASK 0x0000001fU
 
 #define CORTEXM_TOPT_INHIBIT_NRST (1U << 2U)
 

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -133,7 +133,6 @@ static bool lpc11xx_detect(target_s *const target)
 		target->driver = "LPC11xx";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 
 	case 0x0a24902bU:
@@ -162,7 +161,6 @@ static bool lpc11xx_detect(target_s *const target)
 		 * Do not touch them!
 		 */
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x7800, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	}
 
@@ -197,7 +195,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC802";
 		target_add_ram(target, LPC_RAM_BASE, 0x800);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_84x, 2);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008040U: /* LPC804M101JBD64 - 32K Flash 4K SRAM */
 	case 0x00008041U: /* LPC804M101JDH20 */
@@ -207,7 +204,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC804";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_84x, 2);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008100U: /* LPC810M021FN8 - 4K Flash 1K SRAM */
 	case 0x00008110U: /* LPC811M001JDH16 - 8K Flash 2K SRAM */
@@ -217,7 +213,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC81x";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008221U: /* LPC822M101JHI33 - 16K Flash 4K SRAM */
 	case 0x00008222U: /* LPC822M101JDH20 */
@@ -226,19 +221,16 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC82x";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008322U: /* LPC832M101FDH20 - 16K Flash 4K SRAM */
 		target->driver = "LPC832";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008341U: /* LPC834M101FHI33 - 32K Flash 4K SRAM */
 		target->driver = "LPC834";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008441U: /* LPC844M201JBD64 - 64K Flash 8K SRAM */
 	case 0x00008442U: /* LPC844M201JBD48 */
@@ -247,7 +239,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC844";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x10000, 0x400, IAP_ENTRY_84x, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008451U: /* LPC845M301JBD64 - 64K Flash 16K SRAM */
 	case 0x00008452U: /* LPC845M301JBD48 */
@@ -256,7 +247,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC845";
 		target_add_ram(target, LPC_RAM_BASE, 0x4000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x10000, 0x400, IAP_ENTRY_84x, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x0003d440U: /* LPC11U34/311 - 40K Flash 8K SRAM */
 	case 0x0001cc40U: /* LPC11U34/421 - 48K Flash 8K SRAM */
@@ -269,7 +259,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC11U3x";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00010013U: /* LPC1111/103 - 8K Flash 2K SRAM */
 	case 0x00010012U: /* LPC1111/203 - 8K Flash 4K SRAM */
@@ -285,7 +274,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC11xx-XL";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00140040U: /* LPC1124/303 - 32K Flash 8K SRAM */
 	case 0x00150080U: /* LPC1125/303 - 64K Flash 8K SRAM */
@@ -293,7 +281,6 @@ static bool lpc8xx_detect(target_s *const target)
 		target_add_ram(target, LPC_RAM_BASE, 0x2000U);
 		lpc11xx_add_flash(
 			target, LPC_FLASH_BASE, device_id == 0x00140040U ? 0x8000U : 0x10000U, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	}
 
@@ -304,7 +291,10 @@ static bool lpc8xx_detect(target_s *const target)
 
 bool lpc11xx_probe(target_s *const target)
 {
-	return lpc11xx_detect(target) || lpc8xx_detect(target);
+	const bool result = lpc11xx_detect(target) || lpc8xx_detect(target);
+	if (result)
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
+	return result;
 }
 
 static bool lpc8xx_flash_mode(target_s *const target)

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -53,6 +53,7 @@
  * LPC845  16k   64k   64   1024
  */
 
+static bool lpc8xx_flash_mode(target_s *target);
 static bool lpc11xx_read_uid(target_s *target, int argc, const char **argv);
 
 const command_s lpc11xx_cmd_list[] = {
@@ -182,6 +183,8 @@ static bool lpc8xx_detect(target_s *const t)
 	 * LPC11U3x variants.
 	 */
 	const uint32_t device_id = target_mem_read32(t, LPC8XX_DEVICE_ID);
+	t->enter_flash_mode = lpc8xx_flash_mode;
+	t->exit_flash_mode = lpc8xx_flash_mode;
 
 	switch (device_id) {
 	case 0x00008021U: /* LPC802M001JDH20 - 16K Flash 2K SRAM */
@@ -291,6 +294,12 @@ static bool lpc8xx_detect(target_s *const t)
 bool lpc11xx_probe(target_s *t)
 {
 	return lpc11xx_detect(t) || lpc8xx_detect(t);
+}
+
+static bool lpc8xx_flash_mode(target_s *const target)
+{
+	(void)target;
+	return true;
 }
 
 static bool lpc11xx_read_uid(target_s *target, int argc, const char **argv)

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -133,7 +133,7 @@ static bool lpc11xx_detect(target_s *const target)
 		target->driver = "LPC11xx";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 
 	case 0x0a24902bU:
@@ -162,7 +162,7 @@ static bool lpc11xx_detect(target_s *const target)
 		 * Do not touch them!
 		 */
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x7800, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC8N04");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	}
 
@@ -197,7 +197,7 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC802";
 		target_add_ram(target, LPC_RAM_BASE, 0x800);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_84x, 2);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC802");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008040U: /* LPC804M101JBD64 - 32K Flash 4K SRAM */
 	case 0x00008041U: /* LPC804M101JDH20 */
@@ -207,7 +207,7 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC804";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_84x, 2);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC804");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008100U: /* LPC810M021FN8 - 4K Flash 1K SRAM */
 	case 0x00008110U: /* LPC811M001JDH16 - 8K Flash 2K SRAM */
@@ -217,7 +217,7 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC81x";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC81x");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008221U: /* LPC822M101JHI33 - 16K Flash 4K SRAM */
 	case 0x00008222U: /* LPC822M101JDH20 */
@@ -226,19 +226,19 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC82x";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC82x");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008322U: /* LPC832M101FDH20 - 16K Flash 4K SRAM */
 		target->driver = "LPC832";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC832");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008341U: /* LPC834M101FHI33 - 32K Flash 4K SRAM */
 		target->driver = "LPC834";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC834");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008441U: /* LPC844M201JBD64 - 64K Flash 8K SRAM */
 	case 0x00008442U: /* LPC844M201JBD48 */
@@ -247,7 +247,7 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC844";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x10000, 0x400, IAP_ENTRY_84x, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC844");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00008451U: /* LPC845M301JBD64 - 64K Flash 16K SRAM */
 	case 0x00008452U: /* LPC845M301JBD48 */
@@ -256,7 +256,7 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC845";
 		target_add_ram(target, LPC_RAM_BASE, 0x4000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x10000, 0x400, IAP_ENTRY_84x, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC845");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x0003d440U: /* LPC11U34/311 - 40K Flash 8K SRAM */
 	case 0x0001cc40U: /* LPC11U34/421 - 48K Flash 8K SRAM */
@@ -269,7 +269,7 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC11U3x";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC11U3x");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	case 0x00010013U: /* LPC1111/103 - 8K Flash 2K SRAM */
 	case 0x00010012U: /* LPC1111/203 - 8K Flash 4K SRAM */
@@ -285,7 +285,7 @@ static bool lpc8xx_detect(target_s *const target)
 		target->driver = "LPC11xx-XL";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx-XL");
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
 	}
 

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -37,7 +37,8 @@
 #define LPC11XX_DEVICE_ID 0x400483f4U
 #define LPC8XX_DEVICE_ID  0x400483f8U
 
-#define LPC_RAM_BASE 0x10000000U
+#define LPC_RAM_BASE   0x10000000U
+#define LPC_FLASH_BASE 0x00000000U
 
 /*
  * CHIP    Ram Flash page sector   Rsvd pages  EEPROM
@@ -131,7 +132,7 @@ static bool lpc11xx_detect(target_s *const target)
 	case 0x2980002bU: /* LPC11u24x/401 - 32K Flash 8K SRAM */
 		target->driver = "LPC11xx";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
-		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx");
 		return true;
 
@@ -139,18 +140,18 @@ static bool lpc11xx_detect(target_s *const target)
 	case 0x1a24902bU:
 		target->driver = "LPC1112";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
-		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x1000, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x10000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x1000002bU: /* FX LPC11U6 32 kB SRAM/256 kB flash (max) */
 		target->driver = "LPC11U6";
 		target_add_ram(target, LPC_RAM_BASE, 0x8000);
-		lpc11xx_add_flash(target, 0x00000000, 0x40000, 0x1000, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x40000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x3000002bU:
 	case 0x3d00002bU:
 		target->driver = "LPC1343";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
-		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x1000, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x00008a04U: /* LPC8N04 (see UM11074 Rev.1.3 §4.5.19) */
 		target->driver = "LPC8N04";
@@ -160,7 +161,7 @@ static bool lpc11xx_detect(target_s *const target)
 		 * contain the initialization code and IAP firmware.
 		 * Do not touch them!
 		 */
-		lpc11xx_add_flash(target, 0x00000000, 0x7800, 0x400, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x7800, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC8N04");
 		return true;
 	}
@@ -195,7 +196,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008024U: /* LPC802M001JHI33 */
 		target->driver = "LPC802";
 		target_add_ram(target, LPC_RAM_BASE, 0x800);
-		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_84x, 2);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_84x, 2);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC802");
 		return true;
 	case 0x00008040U: /* LPC804M101JBD64 - 32K Flash 4K SRAM */
@@ -205,7 +206,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008044U: /* LPC804M101JHI33 */
 		target->driver = "LPC804";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
-		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_84x, 2);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_84x, 2);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC804");
 		return true;
 	case 0x00008100U: /* LPC810M021FN8 - 4K Flash 1K SRAM */
@@ -215,7 +216,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008122U: /* LPC812M101JDH20 / LPC812M101JTB16 - 16K Flash 4K SRAM */
 		target->driver = "LPC81x";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
-		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC81x");
 		return true;
 	case 0x00008221U: /* LPC822M101JHI33 - 16K Flash 4K SRAM */
@@ -224,19 +225,19 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008242U: /* LPC824M201JDH20 */
 		target->driver = "LPC82x";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
-		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC82x");
 		return true;
 	case 0x00008322U: /* LPC832M101FDH20 - 16K Flash 4K SRAM */
 		target->driver = "LPC832";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
-		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC832");
 		return true;
 	case 0x00008341U: /* LPC834M101FHI33 - 32K Flash 4K SRAM */
 		target->driver = "LPC834";
 		target_add_ram(target, LPC_RAM_BASE, 0x1000);
-		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC834");
 		return true;
 	case 0x00008441U: /* LPC844M201JBD64 - 64K Flash 8K SRAM */
@@ -245,7 +246,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008444U: /* LPC844M201JHI33 */
 		target->driver = "LPC844";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
-		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x10000, 0x400, IAP_ENTRY_84x, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC844");
 		return true;
 	case 0x00008451U: /* LPC845M301JBD64 - 64K Flash 16K SRAM */
@@ -254,7 +255,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008454U: /* LPC845M301JHI33 */
 		target->driver = "LPC845";
 		target_add_ram(target, LPC_RAM_BASE, 0x4000);
-		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x10000, 0x400, IAP_ENTRY_84x, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC845");
 		return true;
 	case 0x0003d440U: /* LPC11U34/311 - 40K Flash 8K SRAM */
@@ -267,7 +268,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00007c40U: /* LPC11U37FBD64/501 */
 		target->driver = "LPC11U3x";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
-		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC11U3x");
 		return true;
 	case 0x00010013U: /* LPC1111/103 - 8K Flash 2K SRAM */
@@ -283,7 +284,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00050080U: /* LPC1115/303 - 64K Flash 8K SRAM */
 		target->driver = "LPC11xx-XL";
 		target_add_ram(target, LPC_RAM_BASE, 0x2000);
-		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
+		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx-XL");
 		return true;
 	}

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -287,6 +287,14 @@ static bool lpc8xx_detect(target_s *const target)
 		lpc11xx_add_flash(target, LPC_FLASH_BASE, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, target->driver);
 		return true;
+	case 0x00140040U: /* LPC1124/303 - 32K Flash 8K SRAM */
+	case 0x00150080U: /* LPC1125/303 - 64K Flash 8K SRAM */
+		target->driver = "LPC112x";
+		target_add_ram(target, LPC_RAM_BASE, 0x2000U);
+		lpc11xx_add_flash(
+			target, LPC_FLASH_BASE, device_id == 0x00140040U ? 0x8000U : 0x10000U, 0x1000, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, target->driver);
+		return true;
 	}
 
 	if (device_id)

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -73,7 +73,7 @@ static void lpc11xx_add_flash(target_s *target, const uint32_t addr, const size_
 	flash->reserved_pages = reserved_pages;
 }
 
-static bool lpc11xx_detect(target_s *const t)
+static bool lpc11xx_detect(target_s *const target)
 {
 	/*
 	 * Read the device ID register
@@ -85,7 +85,7 @@ static bool lpc11xx_detect(target_s *const t)
 	 *   2) the LPC11U3x series, see UM10462 Rev.5.5 §3.1
 	 * But see the comment for the LPC8xx series below.
 	 */
-	const uint32_t device_id = target_mem_read32(t, LPC11XX_DEVICE_ID);
+	const uint32_t device_id = target_mem_read32(target, LPC11XX_DEVICE_ID);
 
 	switch (device_id) {
 	case 0x0a07102bU: /* LPC1110 - 4K Flash 1K SRAM */
@@ -127,48 +127,48 @@ static bool lpc11xx_detect(target_s *const t)
 	case 0x2972402bU: /* LPC11u23/301 - 24K Flash 6K SRAM */
 	case 0x2988402bU: /* LPC11u24x/301 - 32K Flash 6K SRAM */
 	case 0x2980002bU: /* LPC11u24x/401 - 32K Flash 8K SRAM */
-		t->driver = "LPC11xx";
-		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC11xx");
+		target->driver = "LPC11xx";
+		target_add_ram(target, 0x10000000, 0x2000);
+		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx");
 		return true;
 
 	case 0x0a24902bU:
 	case 0x1a24902bU:
-		t->driver = "LPC1112";
-		target_add_ram(t, 0x10000000, 0x1000);
-		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x1000, IAP_ENTRY_MOST, 0);
+		target->driver = "LPC1112";
+		target_add_ram(target, 0x10000000, 0x1000);
+		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x1000002bU: /* FX LPC11U6 32 kB SRAM/256 kB flash (max) */
-		t->driver = "LPC11U6";
-		target_add_ram(t, 0x10000000, 0x8000);
-		lpc11xx_add_flash(t, 0x00000000, 0x40000, 0x1000, IAP_ENTRY_MOST, 0);
+		target->driver = "LPC11U6";
+		target_add_ram(target, 0x10000000, 0x8000);
+		lpc11xx_add_flash(target, 0x00000000, 0x40000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x3000002bU:
 	case 0x3d00002bU:
-		t->driver = "LPC1343";
-		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x1000, IAP_ENTRY_MOST, 0);
+		target->driver = "LPC1343";
+		target_add_ram(target, 0x10000000, 0x2000);
+		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x00008a04U: /* LPC8N04 (see UM11074 Rev.1.3 §4.5.19) */
-		t->driver = "LPC8N04";
-		target_add_ram(t, 0x10000000, 0x2000);
+		target->driver = "LPC8N04";
+		target_add_ram(target, 0x10000000, 0x2000);
 		/*
 		 * UM11074/ Flash controller/15.2: The two topmost sectors
 		 * contain the initialization code and IAP firmware.
 		 * Do not touch them!
 		 */
-		lpc11xx_add_flash(t, 0x00000000, 0x7800, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC8N04");
+		lpc11xx_add_flash(target, 0x00000000, 0x7800, 0x400, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC8N04");
 		return true;
 	}
 
-	if (device_id && t->designer_code != JEP106_MANUFACTURER_SPECULAR)
+	if (device_id && target->designer_code != JEP106_MANUFACTURER_SPECULAR)
 		DEBUG_INFO("LPC11xx: Unknown Device ID 0x%08" PRIx32 "\n", device_id);
 	return false;
 }
 
-static bool lpc8xx_detect(target_s *const t)
+static bool lpc8xx_detect(target_s *const target)
 {
 	/*
 	 * For LPC802, see UM11045 Rev. 1.4 §6.6.29 Table 84
@@ -182,78 +182,78 @@ static bool lpc8xx_detect(target_s *const t)
 	 * for the LPC8xx series is also valid for the LPC11xx "XL" and the
 	 * LPC11U3x variants.
 	 */
-	const uint32_t device_id = target_mem_read32(t, LPC8XX_DEVICE_ID);
-	t->enter_flash_mode = lpc8xx_flash_mode;
-	t->exit_flash_mode = lpc8xx_flash_mode;
+	const uint32_t device_id = target_mem_read32(target, LPC8XX_DEVICE_ID);
+	target->enter_flash_mode = lpc8xx_flash_mode;
+	target->exit_flash_mode = lpc8xx_flash_mode;
 
 	switch (device_id) {
 	case 0x00008021U: /* LPC802M001JDH20 - 16K Flash 2K SRAM */
 	case 0x00008022U: /* LPC802M011JDH20 */
 	case 0x00008023U: /* LPC802M001JDH16 */
 	case 0x00008024U: /* LPC802M001JHI33 */
-		t->driver = "LPC802";
-		target_add_ram(t, 0x10000000, 0x800);
-		lpc11xx_add_flash(t, 0x00000000, 0x4000, 0x400, IAP_ENTRY_84x, 2);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC802");
+		target->driver = "LPC802";
+		target_add_ram(target, 0x10000000, 0x800);
+		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_84x, 2);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC802");
 		return true;
 	case 0x00008040U: /* LPC804M101JBD64 - 32K Flash 4K SRAM */
 	case 0x00008041U: /* LPC804M101JDH20 */
 	case 0x00008042U: /* LPC804M101JDH24 */
 	case 0x00008043U: /* LPC804M111JDH24 */
 	case 0x00008044U: /* LPC804M101JHI33 */
-		t->driver = "LPC804";
-		target_add_ram(t, 0x10000000, 0x1000);
-		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400, IAP_ENTRY_84x, 2);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC804");
+		target->driver = "LPC804";
+		target_add_ram(target, 0x10000000, 0x1000);
+		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_84x, 2);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC804");
 		return true;
 	case 0x00008100U: /* LPC810M021FN8 - 4K Flash 1K SRAM */
 	case 0x00008110U: /* LPC811M001JDH16 - 8K Flash 2K SRAM */
 	case 0x00008120U: /* LPC812M101JDH16 - 16K Flash 4K SRAM */
 	case 0x00008121U: /* LPC812M101JD20 - 16K Flash 4K SRAM */
 	case 0x00008122U: /* LPC812M101JDH20 / LPC812M101JTB16 - 16K Flash 4K SRAM */
-		t->driver = "LPC81x";
-		target_add_ram(t, 0x10000000, 0x1000);
-		lpc11xx_add_flash(t, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC81x");
+		target->driver = "LPC81x";
+		target_add_ram(target, 0x10000000, 0x1000);
+		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC81x");
 		return true;
 	case 0x00008221U: /* LPC822M101JHI33 - 16K Flash 4K SRAM */
 	case 0x00008222U: /* LPC822M101JDH20 */
 	case 0x00008241U: /* LPC824M201JHI33 - 32K Flash 8K SRAM */
 	case 0x00008242U: /* LPC824M201JDH20 */
-		t->driver = "LPC82x";
-		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC82x");
+		target->driver = "LPC82x";
+		target_add_ram(target, 0x10000000, 0x2000);
+		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC82x");
 		return true;
 	case 0x00008322U: /* LPC832M101FDH20 - 16K Flash 4K SRAM */
-		t->driver = "LPC832";
-		target_add_ram(t, 0x10000000, 0x1000);
-		lpc11xx_add_flash(t, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC832");
+		target->driver = "LPC832";
+		target_add_ram(target, 0x10000000, 0x1000);
+		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC832");
 		return true;
 	case 0x00008341U: /* LPC834M101FHI33 - 32K Flash 4K SRAM */
-		t->driver = "LPC834";
-		target_add_ram(t, 0x10000000, 0x1000);
-		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC834");
+		target->driver = "LPC834";
+		target_add_ram(target, 0x10000000, 0x1000);
+		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC834");
 		return true;
 	case 0x00008441U: /* LPC844M201JBD64 - 64K Flash 8K SRAM */
 	case 0x00008442U: /* LPC844M201JBD48 */
 	case 0x00008443U: /* LPC844M201JHI48, note UM11029 Rev.1.4 table 29 is wrong, see table 174 (in same manual) */
 	case 0x00008444U: /* LPC844M201JHI33 */
-		t->driver = "LPC844";
-		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC844");
+		target->driver = "LPC844";
+		target_add_ram(target, 0x10000000, 0x2000);
+		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC844");
 		return true;
 	case 0x00008451U: /* LPC845M301JBD64 - 64K Flash 16K SRAM */
 	case 0x00008452U: /* LPC845M301JBD48 */
 	case 0x00008453U: /* LPC845M301JHI48 */
 	case 0x00008454U: /* LPC845M301JHI33 */
-		t->driver = "LPC845";
-		target_add_ram(t, 0x10000000, 0x4000);
-		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC845");
+		target->driver = "LPC845";
+		target_add_ram(target, 0x10000000, 0x4000);
+		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC845");
 		return true;
 	case 0x0003d440U: /* LPC11U34/311 - 40K Flash 8K SRAM */
 	case 0x0001cc40U: /* LPC11U34/421 - 48K Flash 8K SRAM */
@@ -263,10 +263,10 @@ static bool lpc8xx_detect(target_s *const t)
 	case 0x00017c40U: /* LPC11U37FBD48/401 - 128K Flash 8K SRAM */
 	case 0x00007c44U: /* LPC11U37HFBD64/401 */
 	case 0x00007c40U: /* LPC11U37FBD64/501 */
-		t->driver = "LPC11U3x";
-		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC11U3x");
+		target->driver = "LPC11U3x";
+		target_add_ram(target, 0x10000000, 0x2000);
+		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC11U3x");
 		return true;
 	case 0x00010013U: /* LPC1111/103 - 8K Flash 2K SRAM */
 	case 0x00010012U: /* LPC1111/203 - 8K Flash 4K SRAM */
@@ -279,10 +279,10 @@ static bool lpc8xx_detect(target_s *const t)
 	case 0x00040060U: /* LPC1114/323 - 48K Flash 8K SRAM */
 	case 0x00040070U: /* LPC1114/333 - 56K Flash 8K SRAM */
 	case 0x00050080U: /* LPC1115/303 - 64K Flash 8K SRAM */
-		t->driver = "LPC11xx-XL";
-		target_add_ram(t, 0x10000000, 0x2000);
-		lpc11xx_add_flash(t, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
-		target_add_commands(t, lpc11xx_cmd_list, "LPC11xx-XL");
+		target->driver = "LPC11xx-XL";
+		target_add_ram(target, 0x10000000, 0x2000);
+		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
+		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx-XL");
 		return true;
 	}
 
@@ -291,9 +291,9 @@ static bool lpc8xx_detect(target_s *const t)
 	return false;
 }
 
-bool lpc11xx_probe(target_s *t)
+bool lpc11xx_probe(target_s *const target)
 {
-	return lpc11xx_detect(t) || lpc8xx_detect(t);
+	return lpc11xx_detect(target) || lpc8xx_detect(target);
 }
 
 static bool lpc8xx_flash_mode(target_s *const target)

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -37,6 +37,8 @@
 #define LPC11XX_DEVICE_ID 0x400483f4U
 #define LPC8XX_DEVICE_ID  0x400483f8U
 
+#define LPC_RAM_BASE 0x10000000U
+
 /*
  * CHIP    Ram Flash page sector   Rsvd pages  EEPROM
  * LPX80x   2k   16k   64   1024            2
@@ -128,7 +130,7 @@ static bool lpc11xx_detect(target_s *const target)
 	case 0x2988402bU: /* LPC11u24x/301 - 32K Flash 6K SRAM */
 	case 0x2980002bU: /* LPC11u24x/401 - 32K Flash 8K SRAM */
 		target->driver = "LPC11xx";
-		target_add_ram(target, 0x10000000, 0x2000);
+		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx");
 		return true;
@@ -136,23 +138,23 @@ static bool lpc11xx_detect(target_s *const target)
 	case 0x0a24902bU:
 	case 0x1a24902bU:
 		target->driver = "LPC1112";
-		target_add_ram(target, 0x10000000, 0x1000);
+		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x1000002bU: /* FX LPC11U6 32 kB SRAM/256 kB flash (max) */
 		target->driver = "LPC11U6";
-		target_add_ram(target, 0x10000000, 0x8000);
+		target_add_ram(target, LPC_RAM_BASE, 0x8000);
 		lpc11xx_add_flash(target, 0x00000000, 0x40000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x3000002bU:
 	case 0x3d00002bU:
 		target->driver = "LPC1343";
-		target_add_ram(target, 0x10000000, 0x2000);
+		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x1000, IAP_ENTRY_MOST, 0);
 		return true;
 	case 0x00008a04U: /* LPC8N04 (see UM11074 Rev.1.3 §4.5.19) */
 		target->driver = "LPC8N04";
-		target_add_ram(target, 0x10000000, 0x2000);
+		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		/*
 		 * UM11074/ Flash controller/15.2: The two topmost sectors
 		 * contain the initialization code and IAP firmware.
@@ -192,7 +194,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008023U: /* LPC802M001JDH16 */
 	case 0x00008024U: /* LPC802M001JHI33 */
 		target->driver = "LPC802";
-		target_add_ram(target, 0x10000000, 0x800);
+		target_add_ram(target, LPC_RAM_BASE, 0x800);
 		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_84x, 2);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC802");
 		return true;
@@ -202,7 +204,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008043U: /* LPC804M111JDH24 */
 	case 0x00008044U: /* LPC804M101JHI33 */
 		target->driver = "LPC804";
-		target_add_ram(target, 0x10000000, 0x1000);
+		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_84x, 2);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC804");
 		return true;
@@ -212,7 +214,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008121U: /* LPC812M101JD20 - 16K Flash 4K SRAM */
 	case 0x00008122U: /* LPC812M101JDH20 / LPC812M101JTB16 - 16K Flash 4K SRAM */
 		target->driver = "LPC81x";
-		target_add_ram(target, 0x10000000, 0x1000);
+		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC81x");
 		return true;
@@ -221,19 +223,19 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008241U: /* LPC824M201JHI33 - 32K Flash 8K SRAM */
 	case 0x00008242U: /* LPC824M201JDH20 */
 		target->driver = "LPC82x";
-		target_add_ram(target, 0x10000000, 0x2000);
+		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC82x");
 		return true;
 	case 0x00008322U: /* LPC832M101FDH20 - 16K Flash 4K SRAM */
 		target->driver = "LPC832";
-		target_add_ram(target, 0x10000000, 0x1000);
+		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, 0x00000000, 0x4000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC832");
 		return true;
 	case 0x00008341U: /* LPC834M101FHI33 - 32K Flash 4K SRAM */
 		target->driver = "LPC834";
-		target_add_ram(target, 0x10000000, 0x1000);
+		target_add_ram(target, LPC_RAM_BASE, 0x1000);
 		lpc11xx_add_flash(target, 0x00000000, 0x8000, 0x400, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC834");
 		return true;
@@ -242,7 +244,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008443U: /* LPC844M201JHI48, note UM11029 Rev.1.4 table 29 is wrong, see table 174 (in same manual) */
 	case 0x00008444U: /* LPC844M201JHI33 */
 		target->driver = "LPC844";
-		target_add_ram(target, 0x10000000, 0x2000);
+		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC844");
 		return true;
@@ -251,7 +253,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00008453U: /* LPC845M301JHI48 */
 	case 0x00008454U: /* LPC845M301JHI33 */
 		target->driver = "LPC845";
-		target_add_ram(target, 0x10000000, 0x4000);
+		target_add_ram(target, LPC_RAM_BASE, 0x4000);
 		lpc11xx_add_flash(target, 0x00000000, 0x10000, 0x400, IAP_ENTRY_84x, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC845");
 		return true;
@@ -264,7 +266,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00007c44U: /* LPC11U37HFBD64/401 */
 	case 0x00007c40U: /* LPC11U37FBD64/501 */
 		target->driver = "LPC11U3x";
-		target_add_ram(target, 0x10000000, 0x2000);
+		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC11U3x");
 		return true;
@@ -280,7 +282,7 @@ static bool lpc8xx_detect(target_s *const target)
 	case 0x00040070U: /* LPC1114/333 - 56K Flash 8K SRAM */
 	case 0x00050080U: /* LPC1115/303 - 64K Flash 8K SRAM */
 		target->driver = "LPC11xx-XL";
-		target_add_ram(target, 0x10000000, 0x2000);
+		target_add_ram(target, LPC_RAM_BASE, 0x2000);
 		lpc11xx_add_flash(target, 0x00000000, 0x20000, 0x1000, IAP_ENTRY_MOST, 0);
 		target_add_commands(target, lpc11xx_cmd_list, "LPC11xx-XL");
 		return true;

--- a/src/target/lpc15xx.c
+++ b/src/target/lpc15xx.c
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <string.h>
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
@@ -35,18 +36,20 @@
 
 #define LPC15XX_DEVICE_ID 0x400743f8U
 
-static bool lpc15xx_read_uid(target_s *t, int argc, const char *argv[])
+static bool lpc15xx_read_uid(target_s *target, int argc, const char *argv[])
 {
 	(void)argc;
 	(void)argv;
-	struct lpc_flash *f = (struct lpc_flash *)t->flash;
-	uint8_t uid[16];
-	if (lpc_iap_call(f, uid, IAP_CMD_READUID))
+	struct lpc_flash *flash = (struct lpc_flash *)target->flash;
+	iap_result_s result = {};
+	if (lpc_iap_call(flash, &result, IAP_CMD_READUID))
 		return false;
-	tc_printf(t, "UID: 0x");
+	uint8_t uid[16] = {};
+	memcpy(&uid, result.values, sizeof(uid));
+	tc_printf(target, "UID: 0x");
 	for (uint32_t i = 0; i < sizeof(uid); ++i)
-		tc_printf(t, "%02x", uid[i]);
-	tc_printf(t, "\n");
+		tc_printf(target, "%02x", uid[i]);
+	tc_printf(target, "\n");
 	return true;
 }
 

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -57,11 +57,6 @@ typedef struct __attribute__((aligned(4))) iap_frame {
 	iap_config_s config;
 } iap_frame_s;
 
-typedef struct iap_result {
-	uint32_t return_code;
-	uint32_t values[4];
-} iap_result_s;
-
 typedef struct lpc17xx_priv {
 	uint32_t mpu_ctrl_state;
 	uint32_t memmap_state;

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -233,7 +233,7 @@ iap_status_e lpc17xx_iap_call(target_s *target, iap_result_s *result, iap_cmd_e 
 	/* Set up our IAP frame with the break opcode and command to run */
 	iap_frame_s frame = {
 		.opcode = ARM_THUMB_BREAKPOINT,
-		{.command = cmd},
+		.config = {.command = cmd},
 	};
 
 	/* Fill out the remainder of the parameters */
@@ -260,7 +260,7 @@ iap_status_e lpc17xx_iap_call(target_s *target, iap_result_s *result, iap_cmd_e 
 	/* Set the top of stack to the top of the RAM block we're using */
 	regs[REG_MSP] = IAP_RAM_BASE + MIN_RAM_SIZE;
 	/* Point the return address to our breakpoint opcode (thumb mode) */
-	regs[REG_LR] = IAP_RAM_BASE | 1;
+	regs[REG_LR] = IAP_RAM_BASE | 1U;
 	/* And set the program counter to the IAP ROM entrypoint */
 	regs[REG_PC] = IAP_ENTRYPOINT;
 	target_regs_write(target, regs);

--- a/src/target/lpc40xx.c
+++ b/src/target/lpc40xx.c
@@ -58,11 +58,6 @@ typedef struct __attribute__((aligned(4))) iap_frame {
 	iap_config_s config;
 } iap_frame_s;
 
-typedef struct iap_result {
-	uint32_t return_code;
-	uint32_t values[4];
-} iap_result_s;
-
 typedef struct lpc40xx_priv {
 	uint32_t mpu_ctrl_state;
 	uint32_t memmap_state;

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -1038,8 +1038,13 @@ static bool lpc43xx_iap_init(target_flash_s *const target_flash)
 	/* Force internal clock */
 	target_mem_write32(target, LPC43xx_CGU_CPU_CLK, LPC43xx_CGU_BASE_CLK_AUTOBLOCK | LPC43xx_CGU_BASE_CLK_SEL_IRC);
 
-	/* Initialize flash IAP */
-	return lpc_iap_call(flash, NULL, IAP_CMD_INIT) == IAP_STATUS_CMD_SUCCESS;
+	/*
+	 * Initialize flash IAP
+	 * errata: should return IAP_STATUS_SUCCESS, may just not alter the result code resulting in
+	 * returning IAP_CMD_INIT. Test instead that it didn't fail by testing for the internally
+	 * generated IAP_STATUS_INVALID_COMMAND used by lpc_iap_call()'s failure paths.
+	 */
+	return lpc_iap_call(flash, NULL, IAP_CMD_INIT) != IAP_STATUS_INVALID_COMMAND;
 }
 
 /*

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -137,6 +137,10 @@
 #define LPC43xx_EMC_DYN_CONFIG_MAPPING_8    0x00000000U
 #define LPC43xx_EMC_DYN_CONFIG_MAPPING_16   0x00001000U
 
+#define LPC43xx_RGU_BASE  0x40053000U
+#define LPC43xx_RGU_CTRL0 (LPC43xx_RGU_BASE + 0x100U)
+#define LPC43xx_RGU_CTRL1 (LPC43xx_RGU_BASE + 0x104U)
+
 /* Cortex-M4 Application Interrupt and Reset Control Register */
 #define LPC43xx_AIRCR 0xe000ed0cU
 /* Magic value reset key */
@@ -501,6 +505,12 @@ bool lpc43xx_probe(target_s *const t)
 
 	const uint32_t chip_code = (chipid & LPC43xx_CHIPID_CHIP_MASK) >> LPC43xx_CHIPID_CHIP_SHIFT;
 	t->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
+
+	/* If we're on the M4 core, poke the M0APP and M0SUB core resets to make them available */
+	if ((t->cpuid & CPUID_PARTNO_MASK) == CORTEX_M4) {
+		target_mem_write32(t, LPC43xx_RGU_CTRL0, 0);
+		target_mem_write32(t, LPC43xx_RGU_CTRL1, 0);
+	}
 
 	/* 4 is for rev '-' parts with on-chip Flash, 7 is for rev 'A' parts with on-chip Flash */
 	if (chip_code == 4U || chip_code == 7U) {

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -1001,18 +1001,18 @@ static bool lpc43x0_spi_flash_write(target_flash_s *f, target_addr_t dest, const
 
 /* LPC43xx IAP On-board Flash part routines */
 
-static bool lpc43xx_iap_init(target_flash_s *const flash)
+static bool lpc43xx_iap_init(target_flash_s *const target_flash)
 {
-	target_s *const t = flash->t;
-	lpc_flash_s *const f = (lpc_flash_s *)flash;
+	target_s *const target = target_flash->t;
+	lpc_flash_s *const flash = (lpc_flash_s *)target_flash;
 	/* Deal with WDT */
-	lpc43xx_wdt_set_period(t);
+	lpc43xx_wdt_set_period(target);
 
 	/* Force internal clock */
-	target_mem_write32(t, LPC43xx_CGU_CPU_CLK, LPC43xx_CGU_BASE_CLK_AUTOBLOCK | LPC43xx_CGU_BASE_CLK_SEL_IRC);
+	target_mem_write32(target, LPC43xx_CGU_CPU_CLK, LPC43xx_CGU_BASE_CLK_AUTOBLOCK | LPC43xx_CGU_BASE_CLK_SEL_IRC);
 
 	/* Initialize flash IAP */
-	return lpc_iap_call(f, NULL, IAP_CMD_INIT) == IAP_STATUS_CMD_SUCCESS;
+	return lpc_iap_call(flash, NULL, IAP_CMD_INIT) == IAP_STATUS_CMD_SUCCESS;
 }
 
 /*

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -1024,17 +1024,14 @@ static lpc43xx_partid_s lpc43xx_iap_read_partid(target_s *const t)
 	result.part = LPC43xx_PARTID_INVALID;
 	result.flash_config = LPC43xx_PARTID_FLASH_CONFIG_NONE;
 
-	/* Read back the part ID
-	 * XXX: We only use the first 2 values but because of limitations in lpc_iap_call,
-	 * we have to declare an array of 4
-	 */
-	uint32_t part_id[4];
-	if (!lpc43xx_iap_init(&flash.f) || lpc_iap_call(&flash, part_id, IAP_CMD_PARTID) != IAP_STATUS_CMD_SUCCESS)
+	/* Read back the part ID */
+	iap_result_s iap_result;
+	if (!lpc43xx_iap_init(&flash.f) || lpc_iap_call(&flash, &iap_result, IAP_CMD_PARTID) != IAP_STATUS_CMD_SUCCESS)
 		return result;
 
 	/* Prepare the result and return it */
-	result.part = part_id[0];
-	result.flash_config = part_id[1] & LPC43xx_PARTID_FLASH_CONFIG_MASK;
+	result.part = iap_result.values[0];
+	result.flash_config = iap_result.values[1] & LPC43xx_PARTID_FLASH_CONFIG_MASK;
 	return result;
 }
 

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -514,17 +514,20 @@ bool lpc43xx_probe(target_s *const t)
 
 	/* 4 is for rev '-' parts with on-chip Flash, 7 is for rev 'A' parts with on-chip Flash */
 	if (chip_code == 4U || chip_code == 7U) {
-		const lpc43xx_partid_s part_id = lpc43xx_iap_read_partid(t);
-		DEBUG_WARN("LPC43xx part ID: 0x%08" PRIx32 ":%02x\n", part_id.part, part_id.flash_config);
-		if (part_id.part == LPC43xx_PARTID_INVALID)
-			return false;
-
 		lpc43xx_priv_s *priv = calloc(1, sizeof(lpc43xx_priv_s));
 		if (!priv) { /* calloc failed: heap exhaustion */
 			DEBUG_ERROR("calloc: failed in %s\n", __func__);
 			return false;
 		}
 		t->target_storage = priv;
+
+		const lpc43xx_partid_s part_id = lpc43xx_iap_read_partid(t);
+		DEBUG_WARN("LPC43xx part ID: 0x%08" PRIx32 ":%02x\n", part_id.part, part_id.flash_config);
+		if (part_id.part == LPC43xx_PARTID_INVALID) {
+			free(priv);
+			t->target_storage = NULL;
+			return false;
+		}
 
 		t->mass_erase = lpc43xx_iap_mass_erase;
 		t->enter_flash_mode = lpc43xx_enter_flash_mode;

--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <string.h>
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
@@ -192,30 +193,32 @@ static bool lpc546xx_cmd_erase_sector(target_s *t, int argc, const char **argv)
 	return true;
 }
 
-static bool lpc546xx_cmd_read_partid(target_s *t, int argc, const char **argv)
+static bool lpc546xx_cmd_read_partid(target_s *target, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
-	struct lpc_flash *f = (struct lpc_flash *)t->flash;
-	uint32_t partid[4];
-	if (lpc_iap_call(f, partid, IAP_CMD_PARTID))
+	lpc_flash_s *flash = (lpc_flash_s *)target->flash;
+	iap_result_s result;
+	if (lpc_iap_call(flash, &result, IAP_CMD_PARTID))
 		return false;
-	tc_printf(t, "PART ID: 0x%08x\n", partid[0]);
+	tc_printf(target, "PART ID: 0x%08x\n", result.values[0]);
 	return true;
 }
 
-static bool lpc546xx_cmd_read_uid(target_s *t, int argc, const char **argv)
+static bool lpc546xx_cmd_read_uid(target_s *target, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
-	struct lpc_flash *f = (struct lpc_flash *)t->flash;
-	uint8_t uid[16];
-	if (lpc_iap_call(f, uid, IAP_CMD_READUID))
+	lpc_flash_s *flash = (lpc_flash_s *)target->flash;
+	iap_result_s result = {};
+	if (lpc_iap_call(flash, &result, IAP_CMD_READUID))
 		return false;
-	tc_printf(t, "UID: 0x");
+	uint8_t uid[16] = {};
+	memcpy(&uid, result.values, sizeof(uid));
+	tc_printf(target, "UID: 0x");
 	for (uint32_t i = 0; i < sizeof(uid); ++i)
-		tc_printf(t, "%02x", uid[i]);
-	tc_printf(t, "\n");
+		tc_printf(target, "%02x", uid[i]);
+	tc_printf(target, "\n");
 	return true;
 }
 

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -171,6 +171,9 @@ iap_status_e lpc_iap_call(lpc_flash_s *const flash, iap_result_s *const result, 
 	for (size_t i = params_count; i < 4; ++i)
 		frame.config.params[i] = 0U;
 
+	DEBUG_INFO("%s: cmd %d (%x), params: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n", __func__, cmd, cmd,
+		frame.config.params[0], frame.config.params[1], frame.config.params[2], frame.config.params[3]);
+
 	/* Copy the structure to RAM */
 	target_mem_write(target, flash->iap_ram, &frame, sizeof(iap_frame_s));
 	const uint32_t iap_params_addr = flash->iap_ram + offsetof(iap_frame_s, config);
@@ -221,16 +224,16 @@ iap_status_e lpc_iap_call(lpc_flash_s *const flash, iap_result_s *const result, 
 	if (result != NULL)
 		*result = results;
 
+/* This guard block deals with the fact iap_error is only defined when ENABLE_DEBUG is */
 #if defined(ENABLE_DEBUG)
-	if (results.return_code != IAP_STATUS_CMD_SUCCESS) {
-		if (results.return_code > ARRAY_LENGTH(iap_error))
-			DEBUG_WARN("IAP cmd %d: %" PRIu32 "\n", cmd, results.return_code);
-		else
-			DEBUG_WARN("IAP cmd %d: %s\n", cmd, iap_error[results.return_code]);
-		DEBUG_WARN("return parameters: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n", results.values[0],
-			results.values[1], results.values[2], results.values[3]);
-	}
+	if (results.return_code < ARRAY_LENGTH(iap_error))
+		DEBUG_INFO("%s: result %s, ", __func__, iap_error[results.return_code]);
+	else
+		DEBUG_INFO("%s: result %" PRIu32 ", ", __func__, results.return_code);
 #endif
+	DEBUG_INFO("return values: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n", results.values[0],
+		results.values[1], results.values[2], results.values[3]);
+
 	return results.return_code;
 }
 

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -37,11 +37,6 @@ typedef struct __attribute__((aligned(4))) iap_frame {
 	iap_config_s config;
 } iap_frame_s;
 
-typedef struct iap_result {
-	uint32_t return_code;
-	uint32_t values[4];
-} iap_result_s;
-
 #if defined(ENABLE_DEBUG)
 static const char *const iap_error[] = {
 	"CMD_SUCCESS",
@@ -130,7 +125,7 @@ void lpc_restore_state(
 	target_regs_write(target, regs);
 }
 
-iap_status_e lpc_iap_call(lpc_flash_s *const flash, void *result, iap_cmd_e cmd, ...)
+iap_status_e lpc_iap_call(lpc_flash_s *const flash, iap_result_s *const result, iap_cmd_e cmd, ...)
 {
 	target_s *const target = flash->f.t;
 
@@ -204,7 +199,7 @@ iap_status_e lpc_iap_call(lpc_flash_s *const flash, void *result, iap_cmd_e cmd,
 
 	/* If the user expected a result, set the result (16 bytes). */
 	if (result != NULL)
-		memcpy(result, results.values, sizeof(results.values));
+		*result = results;
 
 #if defined(ENABLE_DEBUG)
 	if (results.return_code != IAP_STATUS_CMD_SUCCESS) {

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -234,10 +234,13 @@ iap_status_e lpc_iap_call(lpc_flash_s *const flash, iap_result_s *const result, 
 		if (status & CORTEXM_XPSR_THUMB)
 			fault_address |= 1U;
 
-		DEBUG_WARN("%s: Failure due to fault (%" PRIu32 ")\n", __func__, status & CORTEXM_XPSR_EXCEPTION_MASK);
-		DEBUG_WARN("\t-> Fault at %08" PRIx32 "\n", fault_address);
-		lpc_restore_state(target, flash->iap_ram, &saved_frame, saved_regs);
-		return IAP_STATUS_INVALID_COMMAND;
+		/* If the fault is not because of our break instruction at the end of the IAP sequence */
+		if (fault_address != (flash->iap_ram | 1U)) {
+			DEBUG_WARN("%s: Failure due to fault (%" PRIu32 ")\n", __func__, status & CORTEXM_XPSR_EXCEPTION_MASK);
+			DEBUG_WARN("\t-> Fault at %08" PRIx32 "\n", fault_address);
+			lpc_restore_state(target, flash->iap_ram, &saved_frame, saved_regs);
+			return IAP_STATUS_INVALID_COMMAND;
+		}
 	}
 
 	/* Copy back just the results */

--- a/src/target/lpc_common.h
+++ b/src/target/lpc_common.h
@@ -68,6 +68,11 @@ typedef enum iap_status {
 	IAP_STATUS_INVALID_PAGE = 33,
 } iap_status_e;
 
+typedef struct iap_result {
+	uint32_t return_code;
+	uint32_t values[4];
+} iap_result_s;
+
 /* CPU Frequency */
 #define CPU_CLK_KHZ 12000U
 
@@ -84,7 +89,7 @@ typedef struct lpc_flash {
 } lpc_flash_s;
 
 lpc_flash_s *lpc_add_flash(target_s *target, target_addr_t addr, size_t length, size_t write_size);
-iap_status_e lpc_iap_call(struct lpc_flash *f, void *result, iap_cmd_e cmd, ...);
+iap_status_e lpc_iap_call(lpc_flash_s *flash, iap_result_s *result, iap_cmd_e cmd, ...);
 bool lpc_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
 bool lpc_flash_write_magic_vect(target_flash_s *f, target_addr_t dest, const void *src, size_t len);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses the breakage that occurred between v1.8.2 and v1.9 in the IAP routines used by the LPC8xx parts, among others. While investigating this it turned out that the `lpc_iap_call` was invoking undefined behaviour and was quite poorly documented.

We've addressed this with a near complete rewrite of the routines affected and adding handling for the LPC8xx parts support to handle their needs around `target_reset()` and entering/exiting Flash mode

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1230 
