### PR TITLE
Feature: improved target power backfeed safety

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -1,10 +1,11 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Copyright (C) 2011 Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
- * Copyright (C) 2021 Uwe Bonnes
- *                            (bon@elektron.ikp.physik.tu-darmstadt.de)
+ * Copyright (C) 2021 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -293,7 +293,7 @@ static void adc_init(void)
 	adc_disable_external_trigger_regular(ADC1);
 	adc_set_right_aligned(ADC1);
 	adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_239DOT5CYC);
-
+	adc_enable_temperature_sensor();
 	adc_power_on(ADC1);
 
 	/* Wait for the ADC to finish starting up */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

During a conversation on Discord with @compuphase it came up that the native hardware with current firmware allows you to some quite nasty things with the target power pin once feeding power from BMP has been enabled.

Saying "don't backfeed tpwr" is fine and all, but given the STM32F103 and related devices have an internal 1.2V bandgap reference, we set about figuring out how hard it might be to use the systick timer to sample that bandgap every few miliseconds and if we detect too much of a voltage rise or fall, switch tpwr feeding off.

This PR is the culmination of that work and should provide robust handling of tpwr backfeeding causing VCC to be driven up above 3.6V or down below 3.0V.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
