### PR TITLE
Fix: ORBTrace version protection

### DIFF
--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -64,8 +64,11 @@ typedef enum dap_led_type {
 	DAP_LED_RUNNING = 1U,
 } dap_led_type_e;
 
+#define DAP_QUIRK_NO_JTAG_MUTLI_TAP (1U << 0U)
+
 extern uint8_t dap_caps;
 extern dap_cap_e dap_mode;
+extern uint8_t dap_quirks;
 extern bool dap_has_swd_sequence;
 
 bool dap_connect(void);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In the process of working on #1428 we encountered several bugs in the JTAG implementation of ORBTrace which renders older gateware unable to correctly handle a multi-TAP JTAG scanchain. This PR introduces an implementation quirks system and checks to guard against this and improve the experience of using adaptors that need updating or otherwise need workaround applied to work correctly.

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
