### PR TITLE
crc32: Round up read length to a multiple of four

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -124,7 +124,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 			gdb_if_putchar(0, true);
 		}
 		const size_t read_len = MIN(sizeof(bytes), len);
-		if (target_mem_read(t, bytes, base, read_len)) {
+		if (target_mem_read(t, bytes, base, (read_len + 3U) & ~3U)) {
 			DEBUG_WARN("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
 			return false;
 		}


### PR DESCRIPTION
## Detailed description

Round up read length to a multiple of four so it'll be performed as 32b reads.

When I were working on a LPC4078-based project, `compare-sections` were failing on a section which length was not a multiple of four. Rounding up the read length fixed it.

I have not investigated why non multiple of four reads were not returning correct data; whether we've got a bug somewhere else, or whether this is a limitation of this specific MEM-AP implementation, but there's an argument to be made for performing the read as 32b reads in any case, also from a performance perspective.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
