### PR TITLE
Fix: Native platform pinout mistakes

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -267,7 +267,7 @@ static void adc_init(void)
 {
 	rcc_periph_clock_enable(RCC_ADC1);
 
-	gpio_set_mode(GPIOB, GPIO_MODE_INPUT, GPIO_CNF_INPUT_ANALOG, GPIO0);
+	gpio_set_mode(TPWR_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_ANALOG, TPWR_PIN);
 
 	adc_power_off(ADC1);
 	adc_disable_scan_mode(ADC1);

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -139,6 +139,8 @@ extern bool debug_bmp;
  */
 #define PWR_BR_PORT GPIOB
 #define PWR_BR_PIN  GPIO1
+#define TPWR_PORT   GPIOB
+#define TPWR_PIN    GPIO0
 
 #define USB_PU_PORT GPIOA
 #define USB_PU_PIN  GPIO8

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -55,7 +55,7 @@ extern bool debug_bmp;
  * nTRST    = PB1  (output) [blackmagic]
  * PWR_BR   = PB1  (output) [blackmagic_mini] -- supply power to the target, active low
  * TMS_DIR  = PA1  (output) [blackmagic_mini v2.1] -- choose direction of the TCK pin, input low, output high
- * nRST_OUT = PA2  (output) -- Hardware 5 and older
+ * nRST     = PA2  (output) -- Hardware 5 and older
  *          = PA9  (output) -- Hardware 6 and newer
  * TDI      = PA3  (output) -- Hardware 5 and older
  *          = PA7  (output) -- Hardware 6 and newer
@@ -67,7 +67,7 @@ extern bool debug_bmp;
  *                             Hardware 4 has a normally open jumper between TDO and TRACESWO
  *                             Hardware 5 has hardwired connection between TDO and TRACESWO
  *          = PA10 (input)  -- Hardware 6 and newer
- * nRST     = PA7  (input)  -- Hardware 5 and older
+ * nRST_SNS = PA7  (input)  -- Hardware 5 and older
  *          = PC13 (input)  -- Hardware 6 and newer
  *
  * USB_PU   = PA8  (output)
@@ -100,6 +100,8 @@ extern bool debug_bmp;
  * BTN1       = PB12 (input)  -- Shared with the DFU bootloader button
  * BTN2       = PB9  (input)
  * VBAT       = PA0  (input)  -- Battery voltage sense ADC2, CH0
+ *
+ * nRST_SNS is the nRST sense line
  */
 
 /* Hardware definitions... */
@@ -130,7 +132,7 @@ extern bool debug_bmp;
 #define PWR_BR_PIN      GPIO1
 #define NRST_PORT       GPIOA
 #define NRST_PIN        HW_SWITCH(6, GPIO2, GPIO9)
-#define NRST_SENSE_PORT GPIOA
+#define NRST_SENSE_PORT HW_SWITCH(6, GPIOA, GPIOC)
 #define NRST_SENSE_PIN  HW_SWITCH(6, GPIO7, GPIO13)
 
 #define USB_PU_PORT GPIOA

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -175,7 +175,6 @@ extern bool debug_bmp;
 #define AUX_DDC_PORT  AUX_PORT
 #define AUX_BTN1_PORT AUX_PORT
 #define AUX_BTN2_PORT AUX_PORT
-#define AUX_VBAT_PORT GPIOA
 #define AUX_SCLK      GPIO13
 #define AUX_COPI      GPIO15
 #define AUX_CIPO      GPIO14
@@ -186,6 +185,8 @@ extern bool debug_bmp;
 #define AUX_DDC       GPIO8
 #define AUX_BTN1      GPIO12
 #define AUX_BTN2      GPIO9
+/* Note that VBat is on PA0, not PB. */
+#define AUX_VBAT_PORT GPIOA
 #define AUX_VBAT      GPIO0
 
 #define SWD_CR       GPIO_CRL(SWDIO_PORT)

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -128,12 +128,17 @@ extern bool debug_bmp;
 
 #define TRST_PORT       GPIOB
 #define TRST_PIN        GPIO1
-#define PWR_BR_PORT     GPIOB
-#define PWR_BR_PIN      GPIO1
 #define NRST_PORT       GPIOA
 #define NRST_PIN        HW_SWITCH(6, GPIO2, GPIO9)
 #define NRST_SENSE_PORT HW_SWITCH(6, GPIOA, GPIOC)
 #define NRST_SENSE_PIN  HW_SWITCH(6, GPIO7, GPIO13)
+
+/*
+ * These are the control output pin definitions for TPWR.
+ * TPWR is sensed via PB0 by sampling ADC1's channel 8.
+ */
+#define PWR_BR_PORT GPIOB
+#define PWR_BR_PIN  GPIO1
 
 #define USB_PU_PORT GPIOA
 #define USB_PU_PIN  GPIO8


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

There were a couple of pinout mistakes in the native platform and a lack of clarity about how certain pins related to their respective functions. This PR seeks to clarify these relationships and fixes the issues in the pinout.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes: #1427 