### PR TITLE
Fix: SWD to JTAG sequence

### DIFF
--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -50,8 +50,8 @@ void jtagtap_init(void)
 	jtag_proc.tap_idle_cycles = 1;
 
 	/* Ensure we're in JTAG mode */
-	for (size_t i = 0; i < 50U; ++i)
-		jtagtap_next(true, false); /* 50 idle cylces for SWD reset */
+	for (size_t i = 0; i <= 50U; ++i)
+		jtagtap_next(true, false); /* 50 + 1 idle cycles for SWD reset */
 	jtagtap_tms_seq(0xe73cU, 16U); /* SWD to JTAG sequence */
 }
 

--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -102,8 +102,8 @@ bool ftdi_jtag_init(void)
 	ftdi_jtag_drain_potential_garbage();
 
 	/* Ensure we're in JTAG mode */
-	for (size_t i = 0; i < 50U; ++i)
-		ftdi_jtag_next(true, false); /* 50 idle cycles for SWD reset */
+	for (size_t i = 0; i <= 50U; ++i)
+		ftdi_jtag_next(true, false); /* 50 + 1 idle cycles for SWD reset */
 	ftdi_jtag_tms_seq(0xe73cU, 16U); /* SWD to JTAG sequence */
 	return true;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Due to an issue with marginal timings on some devices, SWD->JTAG sequence operations were not reliable after #1389 and #1430. This PR addresses this by adding the = back into the `<= 50` condition used to generate enough idle cycles before the sequence and documenting it as intended behaviour.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
