### PR TITLE
target/lpc55xx: Fix memory leak in lpc55xx_add_flash

### DIFF
--- a/src/target/lpc55xx.c
+++ b/src/target/lpc55xx.c
@@ -487,8 +487,10 @@ static target_flash_s *lpc55xx_add_flash(target_s *target)
 
 	lpc55xx_flash_config_s config;
 
-	if (!lpc55xx_flash_init(target, &config))
+	if (!lpc55xx_flash_init(target, &config)) {
+		free(flash);
 		return NULL;
+	}
 
 	DEBUG_INFO("LPC55xx: Detected flash with %" PRIu32 " bytes, %" PRIu32 "-byte pages\n", config.flash_total_size,
 		config.flash_page_size);


### PR DESCRIPTION
## Detailed description

This pull request fixes a memory leak of `flash` variable in function `lpc55xx_add_flash` if `lpc55xx_flash_init` fails.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

No issues fixed.