### PR TITLE
target: Fix out of bound array access in jtag_scan

### DIFF
--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -105,7 +105,7 @@ uint32_t jtag_scan(const uint8_t *irlens)
 		jtagtap_shift_ir();
 
 		size_t device = 0;
-		for (size_t prescan = 0; device <= JTAG_MAX_DEVS && jtag_devs[device].ir_len <= JTAG_MAX_IR_LEN; ++device) {
+		for (size_t prescan = 0; device < JTAG_MAX_DEVS && jtag_devs[device].ir_len <= JTAG_MAX_IR_LEN; ++device) {
 			if (irlens[device] == 0)
 				break;
 


### PR DESCRIPTION
## Detailed description

This pull request fixes an out of bound array access in `jtag_scan` function if `device` variable reaches 32.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

This PR does not fix any existing issues.