### PR TITLE
Fix: JTAG scan irlens handling

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -217,7 +217,7 @@ static bool cmd_jtag_scan(target_s *target, int argc, const char **argv)
 	volatile exception_s e;
 	TRY_CATCH (e, EXCEPTION_ALL) {
 #if PC_HOSTED == 1
-		devs = platform_jtag_scan(lengths_count ? ir_lengths : NULL, lengths_count);
+		devs = platform_jtag_scan(ir_lengths, lengths_count);
 #else
 		devs = jtag_scan(ir_lengths, lengths_count);
 #endif

--- a/src/command.c
+++ b/src/command.c
@@ -52,7 +52,7 @@
 static bool cmd_version(target_s *t, int argc, const char **argv);
 static bool cmd_help(target_s *t, int argc, const char **argv);
 
-static bool cmd_jtag_scan(target_s *t, int argc, const char **argv);
+static bool cmd_jtag_scan(target_s *target, int argc, const char **argv);
 static bool cmd_swdp_scan(target_s *t, int argc, const char **argv);
 static bool cmd_auto_scan(target_s *t, int argc, const char **argv);
 static bool cmd_frequency(target_s *t, int argc, const char **argv);
@@ -194,9 +194,9 @@ bool cmd_help(target_s *t, int argc, const char **argv)
 	return true;
 }
 
-static bool cmd_jtag_scan(target_s *t, int argc, const char **argv)
+static bool cmd_jtag_scan(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	uint8_t irlens[argc];
 
 	if (platform_target_voltage())

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -36,10 +36,10 @@ typedef struct target_controller target_controller_s;
 
 #if PC_HOSTED == 1
 uint32_t platform_adiv5_swdp_scan(uint32_t targetid);
-uint32_t platform_jtag_scan(const uint8_t *lrlens);
+uint32_t platform_jtag_scan(const uint8_t *ir_lengths, size_t lengths_count);
 #endif
 uint32_t adiv5_swdp_scan(uint32_t targetid);
-uint32_t jtag_scan(const uint8_t *lrlens);
+uint32_t jtag_scan(const uint8_t *ir_lengths, size_t lengths_count);
 
 int target_foreach(void (*cb)(int i, target_s *t, void *context), void *context);
 void target_list_free(void);

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -550,16 +550,16 @@ found_targets:
 	else if (opt->opt_mode == BMP_MODE_FLASH_ERASE) {
 		DEBUG_INFO("Erase %zu bytes at 0x%08" PRIx32 "\n", opt->opt_flash_size, opt->opt_flash_start);
 		if (!target_flash_erase(t, opt->opt_flash_start, opt->opt_flash_size)) {
-			DEBUG_WARN("Erasure failed!\n");
+			DEBUG_WARN("Flash erase failed!\n");
 			res = -1;
 			goto free_map;
 		}
 		target_reset(t);
 	} else if (opt->opt_mode == BMP_MODE_FLASH_WRITE || opt->opt_mode == BMP_MODE_FLASH_WRITE_VERIFY) {
-		DEBUG_INFO("Erasing  %zu bytes at 0x%08" PRIx32 "\n", map.size, opt->opt_flash_start);
+		DEBUG_INFO("Erasing %zu bytes at 0x%08" PRIx32 "\n", map.size, opt->opt_flash_start);
 		const uint32_t start_time = platform_time_ms();
 		if (!target_flash_erase(t, opt->opt_flash_start, map.size)) {
-			DEBUG_WARN("Erasure failed!\n");
+			DEBUG_WARN("Flash erase failed!\n");
 			res = -1;
 			goto free_map;
 		}

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -422,11 +422,11 @@ int cl_execute(bmda_cli_options_s *opt)
 
 	int res = 0;
 	if (opt->opt_scanmode == BMP_SCAN_JTAG)
-		num_targets = platform_jtag_scan(NULL);
+		num_targets = platform_jtag_scan(NULL, 0);
 	else if (opt->opt_scanmode == BMP_SCAN_SWD)
 		num_targets = platform_adiv5_swdp_scan(opt->opt_targetid);
 	else {
-		num_targets = platform_jtag_scan(NULL);
+		num_targets = platform_jtag_scan(NULL, 0);
 		if (num_targets > 0)
 			goto found_targets;
 		DEBUG_INFO("JTAG scan found no devices, trying SWD.\n");

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -186,7 +186,7 @@ void platform_add_jtag_dev(uint32_t i, const jtag_dev_s *jtag_dev)
 		remote_add_jtag_dev(i, jtag_dev);
 }
 
-uint32_t platform_jtag_scan(const uint8_t *lrlens)
+uint32_t platform_jtag_scan(const uint8_t *lrlens, const size_t lengths_count)
 {
 	info.is_jtag = true;
 
@@ -197,7 +197,7 @@ uint32_t platform_jtag_scan(const uint8_t *lrlens)
 	case BMP_TYPE_LIBFTDI:
 	case BMP_TYPE_JLINK:
 	case BMP_TYPE_CMSIS_DAP:
-		return jtag_scan(lrlens);
+		return jtag_scan(lrlens, lengths_count);
 
 	case BMP_TYPE_STLINKV2:
 		return jtag_scan_stlinkv2(&info, lrlens);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -149,7 +149,7 @@ uint32_t platform_adiv5_swdp_scan(uint32_t targetid)
 		break;
 
 	case BMP_TYPE_STLINKV2:
-		return stlink_swdp_scan(&info);
+		return stlink_swdp_scan();
 
 	case BMP_TYPE_JLINK:
 		return jlink_swdp_scan(&info);
@@ -186,7 +186,7 @@ void platform_add_jtag_dev(uint32_t i, const jtag_dev_s *jtag_dev)
 		remote_add_jtag_dev(i, jtag_dev);
 }
 
-uint32_t platform_jtag_scan(const uint8_t *lrlens, const size_t lengths_count)
+uint32_t platform_jtag_scan(const uint8_t *ir_lengths, const size_t lengths_count)
 {
 	info.is_jtag = true;
 
@@ -197,10 +197,10 @@ uint32_t platform_jtag_scan(const uint8_t *lrlens, const size_t lengths_count)
 	case BMP_TYPE_LIBFTDI:
 	case BMP_TYPE_JLINK:
 	case BMP_TYPE_CMSIS_DAP:
-		return jtag_scan(lrlens, lengths_count);
+		return jtag_scan(ir_lengths, lengths_count);
 
 	case BMP_TYPE_STLINKV2:
-		return jtag_scan_stlinkv2(&info, lrlens);
+		return jtag_scan_stlinkv2(ir_lengths);
 
 	default:
 		return 0;

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -29,6 +29,7 @@
 #include "timing.h"
 #include "cli.h"
 #include "gdb_if.h"
+#include "gdb_packet.h"
 #include <signal.h>
 
 #ifdef ENABLE_RTT
@@ -200,7 +201,9 @@ uint32_t platform_jtag_scan(const uint8_t *ir_lengths, const size_t lengths_coun
 		return jtag_scan(ir_lengths, lengths_count);
 
 	case BMP_TYPE_STLINKV2:
-		return jtag_scan_stlinkv2(ir_lengths);
+		if (lengths_count)
+			gdb_outf("Manually specified IR lengths is not supported when using a ST-Link adaptor\n");
+		return jtag_scan_stlinkv2();
 
 	default:
 		return 0;

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -1023,10 +1023,9 @@ static uint32_t stlink_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 	return ret;
 }
 
-uint32_t jtag_scan_stlinkv2(const uint8_t *irlens)
+uint32_t jtag_scan_stlinkv2(void)
 {
 	uint32_t idcodes[JTAG_MAX_DEVS];
-	(void)irlens;
 	target_list_free();
 
 	jtag_dev_count = 0;

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -438,19 +438,19 @@ static void stlink_version(bmp_info_s *info)
 	DEBUG_INFO("\n");
 }
 
-static bool stlink_leave_state(bmp_info_s *info)
+static bool stlink_leave_state(void)
 {
 	uint8_t cmd[16];
 	uint8_t data[2];
 	memset(cmd, 0, sizeof(cmd));
 	cmd[0] = STLINK_GET_CURRENT_MODE;
-	send_recv(info->usb_link, cmd, 16, data, 2);
+	send_recv(info.usb_link, cmd, 16, data, 2);
 	if (data[0] == STLINK_DEV_DFU_MODE) {
 		DEBUG_INFO("Leaving DFU Mode\n");
 		memset(cmd, 0, sizeof(cmd));
 		cmd[0] = STLINK_DFU_COMMAND;
 		cmd[1] = STLINK_DFU_EXIT;
-		send_recv(info->usb_link, cmd, 16, NULL, 0);
+		send_recv(info.usb_link, cmd, 16, NULL, 0);
 		return true;
 	}
 	if (data[0] == STLINK_DEV_SWIM_MODE) {
@@ -458,13 +458,13 @@ static bool stlink_leave_state(bmp_info_s *info)
 		memset(cmd, 0, sizeof(cmd));
 		cmd[0] = STLINK_SWIM_COMMAND;
 		cmd[1] = STLINK_SWIM_EXIT;
-		send_recv(info->usb_link, cmd, 16, NULL, 0);
+		send_recv(info.usb_link, cmd, 16, NULL, 0);
 	} else if (data[0] == STLINK_DEV_DEBUG_MODE) {
 		DEBUG_INFO("Leaving DEBUG Mode\n");
 		memset(cmd, 0, sizeof(cmd));
 		cmd[0] = STLINK_DEBUG_COMMAND;
 		cmd[1] = STLINK_DEBUG_EXIT;
-		send_recv(info->usb_link, cmd, 16, NULL, 0);
+		send_recv(info.usb_link, cmd, 16, NULL, 0);
 	} else if (data[0] == STLINK_DEV_BOOTLOADER_MODE)
 		DEBUG_INFO("Leaving BOOTLOADER Mode\n");
 	else if (data[0] == STLINK_DEV_MASS_MODE)
@@ -623,7 +623,7 @@ int stlink_init(bmp_info_s *info)
 		DEBUG_WARN("Please update the firmware on your ST-Link\n");
 		return -1;
 	}
-	if (stlink_leave_state(info)) {
+	if (stlink_leave_state()) {
 		DEBUG_WARN("ST-Link board was in DFU mode. Restart\n");
 		return -1;
 	}
@@ -654,16 +654,16 @@ int stlink_hwversion(void)
 	return stlink.ver_stlink;
 }
 
-static int stlink_enter_debug_jtag(bmp_info_s *info)
+static int stlink_enter_debug_jtag(void)
 {
-	stlink_leave_state(info);
+	stlink_leave_state();
 	uint8_t cmd[16];
 	uint8_t data[2];
 	memset(cmd, 0, sizeof(cmd));
 	cmd[0] = STLINK_DEBUG_COMMAND;
 	cmd[1] = STLINK_DEBUG_APIV2_ENTER;
 	cmd[2] = STLINK_DEBUG_ENTER_JTAG_NO_RESET;
-	send_recv(info->usb_link, cmd, 16, data, 2);
+	send_recv(info.usb_link, cmd, 16, data, 2);
 	return stlink_usb_error_check(data, true);
 }
 
@@ -677,14 +677,14 @@ static int stlink_enter_debug_jtag(bmp_info_s *info)
 // 	return id;
 // }
 
-static size_t stlink_read_idcodes(bmp_info_s *info, uint32_t *idcodes)
+static size_t stlink_read_idcodes(uint32_t *idcodes)
 {
 	uint8_t cmd[16];
 	uint8_t data[12];
 	memset(cmd, 0, sizeof(cmd));
 	cmd[0] = STLINK_DEBUG_COMMAND;
 	cmd[1] = STLINK_DEBUG_APIV2_READ_IDCODES;
-	send_recv(info->usb_link, cmd, 16, data, 12);
+	send_recv(info.usb_link, cmd, 16, data, 12);
 	if (stlink_usb_error_check(data, true))
 		return 0;
 	idcodes[0] = data[4] | (data[5] << 8U) | (data[6] << 16U) | (data[7] << 24U);
@@ -1023,20 +1023,21 @@ static uint32_t stlink_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 	return ret;
 }
 
-uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens)
+uint32_t jtag_scan_stlinkv2(const uint8_t *irlens)
 {
-	uint32_t idcodes[JTAG_MAX_DEVS + 1U];
-	(void)*irlens;
+	uint32_t idcodes[JTAG_MAX_DEVS];
+	(void)irlens;
 	target_list_free();
 
 	jtag_dev_count = 0;
 	memset(jtag_devs, 0, sizeof(jtag_devs));
-	if (stlink_enter_debug_jtag(info))
+	if (stlink_enter_debug_jtag())
 		return 0;
-	jtag_dev_count = stlink_read_idcodes(info, idcodes);
+	jtag_dev_count = stlink_read_idcodes(idcodes);
 	/* Check for known devices and handle accordingly */
 	for (uint32_t i = 0; i < jtag_dev_count; ++i)
 		jtag_devs[i].jd_idcode = idcodes[i];
+
 	for (uint32_t i = 0; i < jtag_dev_count; ++i) {
 		for (size_t j = 0; dev_descr[j].idcode; ++j) {
 			if ((jtag_devs[i].jd_idcode & dev_descr[j].idmask) == dev_descr[j].idcode) {
@@ -1046,7 +1047,6 @@ uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens)
 			}
 		}
 	}
-
 	return jtag_dev_count;
 }
 
@@ -1070,11 +1070,11 @@ void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->mem_write = stlink_mem_write;
 }
 
-uint32_t stlink_swdp_scan(bmp_info_s *info)
+uint32_t stlink_swdp_scan(void)
 {
 	target_list_free();
 
-	stlink_leave_state(info);
+	stlink_leave_state();
 
 	uint8_t cmd[16];
 	uint8_t data[2];

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -56,7 +56,7 @@ bool stlink_nrst_get_val(void)
 	return true;
 }
 
-uint32_t stlink_swdp_scan(bmp_info_s *info)
+uint32_t stlink_swdp_scan(void)
 {
 	return 0;
 }
@@ -70,7 +70,7 @@ void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
 	(void)dp;
 }
 
-uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens)
+uint32_t jtag_scan_stlinkv2(const uint8_t *irlens)
 {
 	return 0;
 }
@@ -95,10 +95,10 @@ int stlink_hwversion(void);
 const char *stlink_target_voltage(bmp_info_s *info);
 void stlink_nrst_set_val(bmp_info_s *info, bool assert);
 bool stlink_nrst_get_val(void);
-uint32_t stlink_swdp_scan(bmp_info_s *info);
+uint32_t stlink_swdp_scan(void);
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp);
 void stlink_jtag_dp_init(adiv5_debug_port_s *dp);
-uint32_t jtag_scan_stlinkv2(bmp_info_s *info, const uint8_t *irlens);
+uint32_t jtag_scan_stlinkv2(const uint8_t *irlens);
 void stlink_exit_function(bmp_info_s *info);
 void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq);
 uint32_t stlink_max_frequency_get(bmp_info_s *info);

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -70,7 +70,7 @@ void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
 	(void)dp;
 }
 
-uint32_t jtag_scan_stlinkv2(const uint8_t *irlens)
+uint32_t jtag_scan_stlinkv2(void)
 {
 	return 0;
 }
@@ -98,7 +98,7 @@ bool stlink_nrst_get_val(void);
 uint32_t stlink_swdp_scan(void);
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp);
 void stlink_jtag_dp_init(adiv5_debug_port_s *dp);
-uint32_t jtag_scan_stlinkv2(const uint8_t *irlens);
+uint32_t jtag_scan_stlinkv2(void);
 void stlink_exit_function(bmp_info_s *info);
 void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq);
 uint32_t stlink_max_frequency_get(bmp_info_s *info);

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -72,7 +72,7 @@ void jtag_add_device(const uint32_t dev_index, const jtag_dev_s *jtag_dev)
  * and inspection. Finally, we loop through seeing if we understand any of the
  * ID codes seen and dispatching to suitable handlers if we do.
  */
-uint32_t jtag_scan(const uint8_t *irlens)
+uint32_t jtag_scan(const uint8_t *irlens, const size_t lengths_count)
 {
 	/* Free the device list if any, and clean state ready */
 	target_list_free();
@@ -99,7 +99,7 @@ uint32_t jtag_scan(const uint8_t *irlens)
 		return 0;
 
 	/* If we've been given a set of IR lengths, use those to verify the chain length and set things up */
-	if (irlens) {
+	if (lengths_count) {
 		DEBUG_WARN("Given list of IR lengths, skipping probe\n");
 		DEBUG_INFO("Change state to Shift-IR\n");
 		jtagtap_shift_ir();

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -324,7 +324,7 @@ static bool jtag_validate_irs(const uint8_t *const ir_lengths, const size_t leng
 
 		/* IEEE 1149.1 requires the first bit to be a 1, but not all devices conform (see #1130 on GH) */
 		if (!(irout & 1U))
-			DEBUG_WARN("check failed: IR[0] != 1\n");
+			DEBUG_WARN("jtag_scan: Sanity check failed: IR[0] shifted out as 0\n");
 
 		jtag_devs[device].ir_len = ir_lengths[device];
 		jtag_devs[device].ir_prescan = prescan;

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -308,6 +308,7 @@ static bool jtag_validate_irs(const uint8_t *const ir_lengths, const size_t leng
 	/* Start with no prescan and the first device */
 	size_t prescan = 0;
 	for (size_t device = 0; device < lengths_count; ++device) {
+		/* Validate the next ir_lengths value */
 		if (ir_lengths[device] > JTAG_MAX_IR_LEN) {
 			DEBUG_WARN("jtag_scan: Maximum IR length exceeded\n");
 			jtag_dev_count = 0U;
@@ -319,6 +320,7 @@ static bool jtag_validate_irs(const uint8_t *const ir_lengths, const size_t leng
 			return false;
 		}
 
+		/* Read out the IR to validate it */
 		uint32_t irout = 0;
 		jtag_proc.jtagtap_tdi_tdo_seq((uint8_t *)&irout, 0, ones, ir_lengths[device]);
 
@@ -326,6 +328,7 @@ static bool jtag_validate_irs(const uint8_t *const ir_lengths, const size_t leng
 		if (!(irout & 1U))
 			DEBUG_WARN("jtag_scan: Sanity check failed: IR[0] shifted out as 0\n");
 
+		/* Set up the IR fileds for the device */
 		jtag_devs[device].ir_len = ir_lengths[device];
 		jtag_devs[device].ir_prescan = prescan;
 		jtag_devs[device].current_ir = UINT32_MAX;

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -109,6 +109,11 @@ uint32_t jtag_scan(const uint8_t *const ir_lengths, const size_t lengths_count)
 	else if (!jtag_read_irs())
 		return 0;
 
+	/* IRs are all succesfully accounted for, so clean up and do housekeeping */
+	DEBUG_INFO("Return to Run-Test/Idle\n");
+	jtag_proc.jtagtap_next(true, true);
+	jtagtap_return_idle(1);
+
 	/* All devices should be in BYPASS now so do the sanity check */
 	if (!jtag_sanity_check())
 		return 0;
@@ -284,11 +289,6 @@ static bool jtag_read_irs()
 		jtag_dev_count = 0;
 		return 0;
 	}
-
-	/* IRs are all succesfully accounted for, so clean up and do housekeeping */
-	DEBUG_INFO("Return to Run-Test/Idle\n");
-	jtag_proc.jtagtap_next(true, true);
-	jtagtap_return_idle(1);
 	return true;
 }
 

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -39,11 +39,11 @@ uint32_t jtag_dev_count = 0;
 /* bucket of ones for don't care TDI */
 const uint8_t ones[8] = {0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU};
 
-static bool jtag_read_idcodes();
-static void jtag_display_idcodes();
-static bool jtag_read_irs();
+static bool jtag_read_idcodes(void);
+static void jtag_display_idcodes(void);
+static bool jtag_read_irs(void);
 static bool jtag_validate_irs(const uint8_t *ir_lengths, size_t lengths_count);
-static bool jtag_sanity_check();
+static bool jtag_sanity_check(void);
 
 #if PC_HOSTED == 0
 void jtag_add_device(const uint32_t dev_index, const jtag_dev_s *jtag_dev)
@@ -163,7 +163,7 @@ uint32_t jtag_scan(const uint8_t *const ir_lengths, const size_t lengths_count)
 	return jtag_dev_count;
 }
 
-static bool jtag_read_idcodes()
+static bool jtag_read_idcodes(void)
 {
 	/* Reset the chain ready and transition to Shift-DR */
 	jtag_proc.jtagtap_reset();
@@ -198,7 +198,7 @@ static bool jtag_read_idcodes()
 	return true;
 }
 
-static void jtag_display_idcodes()
+static void jtag_display_idcodes(void)
 {
 #if ENABLE_DEBUG
 	for (size_t device = 0; device < jtag_dev_count; ++device) {
@@ -224,7 +224,7 @@ static jtag_ir_quirks_s jtag_device_get_quirks(const uint32_t idcode)
 	return (jtag_ir_quirks_s){};
 }
 
-static bool jtag_read_irs()
+static bool jtag_read_irs(void)
 {
 	/* Transition to Shift-IR */
 	DEBUG_INFO("Change state to Shift-IR\n");
@@ -324,7 +324,7 @@ static bool jtag_validate_irs(const uint8_t *const ir_lengths, const size_t leng
 	return true;
 }
 
-static bool jtag_sanity_check()
+static bool jtag_sanity_check(void)
 {
 	/* Transition to Shift-DR */
 	DEBUG_INFO("Change state to Shift-DR\n");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Thanks to #1446 spurring us on, we have now addressed the way the manually specified IR lengths logic is handled as between the VLA usage, lack of length checking and other handling issues, the soundness of the IR lengths code was questionable.

This PR addresses this with a partial rewrite and finishes the refactoring work began in #1389 in jtag_scan() + cleans up the ST-Link v2 specific version of this routine. The result should be more consistent and robust with better user feedback.

This PR does slightly alter how the IR lengths are specified - dropping the need for a trailing 0 in the array, and making any 0's specified on the command line errors - but as this fixes a bug in how they could be specified and the user was not visibly aware of this behaviour/need, we think it's a safe change (changing only implementation details),

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
