### PR TITLE
Fix: RP2040 Flash reliability

### DIFF
--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -430,10 +430,8 @@ static bool rp_flash_prepare(target_s *target)
 	bool result = true; /* catch false returns with &= */
 	if (!ps->is_prepared) {
 		DEBUG_INFO("rp_flash_prepare\n");
-		/* connect*/
-		result &= rp_rom_call(target, ps->regs, ps->rom_connect_internal_flash, 100);
-		/* exit_xip */
-		result &= rp_rom_call(target, ps->regs, ps->rom_flash_exit_xip, 100);
+		rp_flash_connect_internal(target);
+		rp_flash_exit_xip(target);
 		ps->is_prepared = true;
 	}
 	return result;
@@ -445,10 +443,8 @@ static bool rp_flash_resume(target_s *target)
 	bool result = true; /* catch false returns with &= */
 	if (ps->is_prepared) {
 		DEBUG_INFO("rp_flash_resume\n");
-		/* flush */
-		result &= rp_rom_call(target, ps->regs, ps->rom_flash_flush_cache, 100);
-		/* enter_cmd_xip */
-		result &= rp_rom_call(target, ps->regs, ps->rom_flash_enter_xip, 100);
+		rp_flash_flush_cache(target);
+		rp_flash_enter_xip(target);
 		ps->is_prepared = false;
 	}
 	return result;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -458,14 +458,17 @@ static bool rp_mass_erase(target_s *const target)
 	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 500U);
 	DEBUG_TARGET("%s\n", __func__);
+	rp_flash_prepare(target);
 	rp_spi_run_command(target, SPI_FLASH_CMD_WRITE_ENABLE, 0U);
-	if (!(rp_spi_read_status(target) & SPI_FLASH_STATUS_WRITE_ENABLED))
+	if (!(rp_spi_read_status(target) & SPI_FLASH_STATUS_WRITE_ENABLED)) {
+		rp_flash_resume(target);
 		return false;
+	}
 
 	rp_spi_run_command(target, SPI_FLASH_CMD_CHIP_ERASE, 0U);
 	while (rp_spi_read_status(target) & SPI_FLASH_STATUS_BUSY)
 		target_print_progress(&timeout);
-	return true;
+	return rp_flash_resume(target);
 }
 
 static void rp_spi_chip_select(target_s *const target, const uint32_t state)

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -378,16 +378,16 @@ static bool rp_read_rom_func_table(target_s *const t)
  * timeout == 0: Do not wait for poll, use for rom_reset_usb_boot()
  * timeout > 500 (ms) : display spinner
  */
-static bool rp_rom_call(target_s *t, uint32_t *regs, uint32_t cmd, uint32_t timeout)
+static bool rp_rom_call(target_s *t, uint32_t cmd, uint32_t timeout)
 {
 	rp_priv_s *ps = (rp_priv_s *)t->target_storage;
-	regs[7] = cmd;
-	regs[REG_LR] = ps->rom_debug_trampoline_end;
-	regs[REG_PC] = ps->rom_debug_trampoline_begin;
-	regs[REG_MSP] = 0x20042000;
-	regs[REG_XPSR] = CORTEXM_XPSR_THUMB;
+	ps->regs[7] = cmd;
+	ps->regs[REG_LR] = ps->rom_debug_trampoline_end;
+	ps->regs[REG_PC] = ps->rom_debug_trampoline_begin;
+	ps->regs[REG_MSP] = 0x20042000;
+	ps->regs[REG_XPSR] = CORTEXM_XPSR_THUMB;
 	uint32_t dbg_regs[t->regs_size / sizeof(uint32_t)];
-	target_regs_write(t, regs);
+	target_regs_write(t, ps->regs);
 	/* start the target and wait for it to halt again */
 	target_halt_resume(t, false);
 	if (!timeout)
@@ -876,7 +876,7 @@ static bool rp_cmd_reset_usb_boot(target_s *t, int argc, const char **argv)
 		ps->regs[0] = strtoul(argv[1], NULL, 0);
 	if (argc > 2)
 		ps->regs[1] = strtoul(argv[2], NULL, 0);
-	rp_rom_call(t, ps->regs, ps->rom_reset_usb_boot, 0);
+	rp_rom_call(t, ps->rom_reset_usb_boot, 0);
 	return true;
 }
 

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -219,8 +219,8 @@ static bool rp_flash_write(target_flash_s *f, target_addr_t dest, const void *sr
 
 static bool rp_read_rom_func_table(target_s *t);
 static bool rp_attach(target_s *t);
-static bool rp_flash_prepare(target_s *t);
-static bool rp_flash_resume(target_s *t);
+static bool rp_flash_prepare(target_s *target);
+static bool rp_flash_resume(target_s *target);
 static void rp_spi_read(target_s *target, uint16_t command, target_addr_t address, void *buffer, size_t length);
 static uint32_t rp_get_flash_length(target_s *t);
 static bool rp_mass_erase(target_s *t);
@@ -424,31 +424,31 @@ static bool rp_rom_call(target_s *t, uint32_t *regs, uint32_t cmd, uint32_t time
 	return result;
 }
 
-static bool rp_flash_prepare(target_s *t)
+static bool rp_flash_prepare(target_s *target)
 {
-	rp_priv_s *ps = (rp_priv_s *)t->target_storage;
+	rp_priv_s *ps = (rp_priv_s *)target->target_storage;
 	bool result = true; /* catch false returns with &= */
 	if (!ps->is_prepared) {
 		DEBUG_INFO("rp_flash_prepare\n");
 		/* connect*/
-		result &= rp_rom_call(t, ps->regs, ps->rom_connect_internal_flash, 100);
+		result &= rp_rom_call(target, ps->regs, ps->rom_connect_internal_flash, 100);
 		/* exit_xip */
-		result &= rp_rom_call(t, ps->regs, ps->rom_flash_exit_xip, 100);
+		result &= rp_rom_call(target, ps->regs, ps->rom_flash_exit_xip, 100);
 		ps->is_prepared = true;
 	}
 	return result;
 }
 
-static bool rp_flash_resume(target_s *t)
+static bool rp_flash_resume(target_s *target)
 {
-	rp_priv_s *ps = (rp_priv_s *)t->target_storage;
+	rp_priv_s *ps = (rp_priv_s *)target->target_storage;
 	bool result = true; /* catch false returns with &= */
 	if (ps->is_prepared) {
 		DEBUG_INFO("rp_flash_resume\n");
 		/* flush */
-		result &= rp_rom_call(t, ps->regs, ps->rom_flash_flush_cache, 100);
+		result &= rp_rom_call(target, ps->regs, ps->rom_flash_flush_cache, 100);
 		/* enter_cmd_xip */
-		result &= rp_rom_call(t, ps->regs, ps->rom_flash_enter_xip, 100);
+		result &= rp_rom_call(target, ps->regs, ps->rom_flash_enter_xip, 100);
 		ps->is_prepared = false;
 	}
 	return result;

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -49,7 +49,6 @@
 #include "cortexm.h"
 #include "sfdp.h"
 
-#define RP_ID                 "Raspberry RP2040"
 #define RP_MAX_TABLE_SIZE     0x80U
 #define BOOTROM_MAGIC_ADDR    0x00000010U
 #define BOOTROM_MAGIC         ((uint32_t)'M' | ((uint32_t)'u' << 8U) | (1U << 16U))
@@ -308,12 +307,12 @@ bool rp_probe(target_s *target)
 	target->target_storage = (void *)priv_storage;
 
 	target->mass_erase = rp_mass_erase;
-	target->driver = RP_ID;
+	target->driver = "Raspberry RP2040";
 	target->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 	target->attach = rp_attach;
 	target->enter_flash_mode = rp_flash_prepare;
 	target->exit_flash_mode = rp_flash_resume;
-	target_add_commands(target, rp_cmd_list, RP_ID);
+	target_add_commands(target, rp_cmd_list, target->driver);
 	return true;
 }
 

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -187,12 +187,8 @@
 typedef struct rp_priv {
 	uint16_t rom_debug_trampoline_begin;
 	uint16_t rom_debug_trampoline_end;
-	uint16_t rom_connect_internal_flash;
-	uint16_t rom_flash_enter_xip;
-	uint16_t rom_flash_exit_xip;
 	uint16_t rom_flash_range_erase;
 	uint16_t rom_flash_range_program;
-	uint16_t rom_flash_flush_cache;
 	uint16_t rom_reset_usb_boot;
 	bool is_prepared;
 	bool is_monitor;
@@ -352,23 +348,11 @@ static bool rp_read_rom_func_table(target_s *const t)
 		case BOOTROM_FUNC_TABLE_TAG('D', 'E'):
 			priv->rom_debug_trampoline_end = addr;
 			break;
-		case BOOTROM_FUNC_TABLE_TAG('I', 'F'):
-			priv->rom_connect_internal_flash = addr;
-			break;
-		case BOOTROM_FUNC_TABLE_TAG('C', 'X'):
-			priv->rom_flash_enter_xip = addr;
-			break;
-		case BOOTROM_FUNC_TABLE_TAG('E', 'X'):
-			priv->rom_flash_exit_xip = addr;
-			break;
 		case BOOTROM_FUNC_TABLE_TAG('R', 'E'):
 			priv->rom_flash_range_erase = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('R', 'P'):
 			priv->rom_flash_range_program = addr;
-			break;
-		case BOOTROM_FUNC_TABLE_TAG('F', 'C'):
-			priv->rom_flash_flush_cache = addr;
 			break;
 		case BOOTROM_FUNC_TABLE_TAG('U', 'B'):
 			priv->rom_reset_usb_boot = addr;
@@ -378,8 +362,8 @@ static bool rp_read_rom_func_table(target_s *const t)
 		}
 		++check;
 	}
-	DEBUG_TARGET("RP ROM routines connect %04x debug_trampoline %04x end %04x\n", priv->rom_connect_internal_flash,
-		priv->rom_debug_trampoline_begin, priv->rom_debug_trampoline_end);
+	DEBUG_TARGET("RP ROM routines debug_trampoline %04x end %04x\n", priv->rom_debug_trampoline_begin,
+		priv->rom_debug_trampoline_end);
 	return check == 9;
 }
 

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -362,7 +362,7 @@ static bool rp_flash_prepare(target_s *target)
 	rp_priv_s *ps = (rp_priv_s *)target->target_storage;
 	bool result = true; /* catch false returns with &= */
 	if (!ps->is_prepared) {
-		DEBUG_INFO("rp_flash_prepare\n");
+		DEBUG_TARGET("%s\n", __func__);
 		rp_flash_connect_internal(target);
 		rp_flash_exit_xip(target);
 		ps->is_prepared = true;
@@ -375,7 +375,7 @@ static bool rp_flash_resume(target_s *target)
 	rp_priv_s *ps = (rp_priv_s *)target->target_storage;
 	bool result = true; /* catch false returns with &= */
 	if (ps->is_prepared) {
-		DEBUG_INFO("rp_flash_resume\n");
+		DEBUG_TARGET("%s\n", __func__);
 		rp_flash_flush_cache(target);
 		rp_flash_enter_xip(target);
 		ps->is_prepared = false;
@@ -395,6 +395,7 @@ static bool rp_flash_erase(target_flash_s *const flash, const target_addr_t addr
 	target_s *const target = flash->t;
 	const rp_flash_s *const spi_flash = (rp_flash_s *)flash;
 	const target_addr_t begin = addr - flash->start;
+	DEBUG_TARGET("%s: %zu bytes starting at %08" PRIx32 " (%08" PRIx32 ")\n", __func__, length, addr, begin);
 	for (size_t offset = 0; offset < length; offset += flash->blocksize) {
 		rp_spi_run_command(target, SPI_FLASH_CMD_WRITE_ENABLE, 0U);
 		if (!(rp_spi_read_status(target) & SPI_FLASH_STATUS_WRITE_ENABLED))
@@ -414,6 +415,7 @@ static bool rp_flash_write(target_flash_s *const flash, target_addr_t dest, cons
 	const rp_flash_s *const spi_flash = (rp_flash_s *)flash;
 	const target_addr_t begin = dest - flash->start;
 	const char *const buffer = (const char *)src;
+	DEBUG_TARGET("%s: %zu bytes starting at %08" PRIx32 " (%08" PRIx32 ")\n", __func__, length, dest, begin);
 	for (size_t offset = 0; offset < length; offset += spi_flash->page_size) {
 		rp_spi_run_command(target, SPI_FLASH_CMD_WRITE_ENABLE, 0U);
 		if (!(rp_spi_read_status(target) & SPI_FLASH_STATUS_WRITE_ENABLED))
@@ -431,6 +433,7 @@ static bool rp_mass_erase(target_s *target)
 {
 	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 500U);
+	DEBUG_TARGET("%s\n", __func__);
 	rp_spi_run_command(target, SPI_FLASH_CMD_WRITE_ENABLE, 0U);
 	if (!(rp_spi_read_status(target) & SPI_FLASH_STATUS_WRITE_ENABLED))
 		return false;
@@ -438,7 +441,6 @@ static bool rp_mass_erase(target_s *target)
 	rp_spi_run_command(target, SPI_FLASH_CMD_CHIP_ERASE, 0U);
 	while (rp_spi_read_status(target) & SPI_FLASH_STATUS_BUSY)
 		target_print_progress(&timeout);
-
 	return true;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Performing ROM calls on the RP2040 is not completely reliable as if the device starts off in a bad state, the calls will simply fail with no real recourse. Instead of trying to hit our head on that, and noting that the ROM call code was consuming a fair whack of Flash on BMP, we've opted to rewrite the SPI Flash erase and programming routines using the same mechanism we're using to directly talk with the SPI controller as used for SFDP readout.

This PR is the culmination of that work. Tested working on both a ROM v0 and ROM v2 RP2040.

This PR does not address the secondary bug of `kill` in GDB after `load` on the RP2040 causing the target to spin off to 0xfffffffe and trap rather than execute the newly loaded program. We will address that in a follow-up PR

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1364
