### PR TITLE
Feature: Improved debug logging

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -125,7 +125,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 		}
 		const size_t read_len = MIN(sizeof(bytes), len);
 		if (target_mem_read(t, bytes, base, (read_len + 3U) & ~3U)) {
-			DEBUG_WARN("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
+			DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
 			return false;
 		}
 
@@ -157,7 +157,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 		}
 		const size_t read_len = MIN(sizeof(bytes), len) & ~3U;
 		if (target_mem_read(t, bytes, base, read_len)) {
-			DEBUG_WARN("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
+			DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
 			return false;
 		}
 
@@ -171,7 +171,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 	uint32_t crc = CRC_DR;
 
 	if (target_mem_read(t, bytes, base, len)) {
-		DEBUG_WARN("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
+		DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
 		return false;
 	}
 	uint8_t *data = bytes;

--- a/src/exception.c
+++ b/src/exception.c
@@ -33,6 +33,6 @@ void raise_exception(const uint32_t type, const char *const msg)
 			longjmp(exception->jmpbuf, type);
 		}
 	}
-	DEBUG_WARN("Unhandled exception: %s\n", msg);
+	DEBUG_ERROR("Unhandled exception: %s\n", msg);
 	abort();
 }

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -89,42 +89,13 @@ extern uint32_t delay_cnt;
 void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #else
 #include "debug.h"
-#include <stdarg.h>
 
-#define DEBUG_ERROR(...) debug_error(__VA_ARGS__)
-#define DEBUG_WARN(...)  debug_warning(__VA_ARGS__)
-#define DEBUG_INFO(...)  debug_info(__VA_ARGS__)
-#define DEBUG_GDB(...)   debug_gdb(__VA_ARGS__)
-
-static inline void DEBUG_TARGET(const char *format, ...)
-{
-	if (~bmda_debug_flags & BMD_DEBUG_TARGET)
-		return;
-	va_list args;
-	va_start(args, format);
-	vfprintf(stderr, format, args);
-	va_end(args);
-}
-
-static inline void DEBUG_PROBE(const char *format, ...)
-{
-	if (~bmda_debug_flags & BMD_DEBUG_PROBE)
-		return;
-	va_list args;
-	va_start(args, format);
-	vfprintf(stderr, format, args);
-	va_end(args);
-}
-
-static inline void DEBUG_WIRE(const char *format, ...)
-{
-	if (~bmda_debug_flags & BMD_DEBUG_WIRE)
-		return;
-	va_list args;
-	va_start(args, format);
-	vfprintf(stderr, format, args);
-	va_end(args);
-}
+#define DEBUG_WARN(...)   debug_warning(__VA_ARGS__)
+#define DEBUG_INFO(...)   debug_info(__VA_ARGS__)
+#define DEBUG_GDB(...)    debug_gdb(__VA_ARGS__)
+#define DEBUG_TARGET(...) debug_target(__VA_ARGS__)
+#define DEBUG_PROBE(...)  debug_probe(__VA_ARGS__)
+#define DEBUG_WIRE(...)   debug_wire(__VA_ARGS__)
 #endif
 
 #define ALIGN(x, n) (((x) + (n)-1) & ~((n)-1))

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -92,26 +92,9 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #include "debug.h"
 #include <stdarg.h>
 
-static inline void DEBUG_WARN(const char *format, ...)
-{
-	va_list args;
-	va_start(args, format);
-	vfprintf(stderr, format, args);
-	va_end(args);
-}
-
-static inline void DEBUG_INFO(const char *format, ...)
-{
-	if (~bmda_debug_flags & BMD_DEBUG_INFO)
-		return;
-	va_list args;
-	va_start(args, format);
-	if (bmda_debug_flags & BMD_DEBUG_USE_STDERR)
-		vfprintf(stderr, format, args);
-	else
-		vfprintf(stdout, format, args);
-	va_end(args);
-}
+#define DEBUG_ERROR(...) debug_error(__VA_ARGS__)
+#define DEBUG_WARN(...)  debug_warning(__VA_ARGS__)
+#define DEBUG_INFO(...)  debug_info(__VA_ARGS__)
 
 static inline void DEBUG_GDB(const char *format, ...)
 {

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -84,6 +84,7 @@ extern uint32_t delay_cnt;
 #endif
 #define DEBUG_GDB(...)    PRINT_NOOP(__VA_ARGS__)
 #define DEBUG_TARGET(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_PROTO(...)  PRINT_NOOP(__VA_ARGS__)
 #define DEBUG_PROBE(...)  PRINT_NOOP(__VA_ARGS__)
 #define DEBUG_WIRE(...)   PRINT_NOOP(__VA_ARGS__)
 
@@ -96,6 +97,7 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #define DEBUG_INFO(...)   debug_info(__VA_ARGS__)
 #define DEBUG_GDB(...)    debug_gdb(__VA_ARGS__)
 #define DEBUG_TARGET(...) debug_target(__VA_ARGS__)
+#define DEBUG_PROTO(...)  debug_protocol(__VA_ARGS__)
 #define DEBUG_PROBE(...)  debug_probe(__VA_ARGS__)
 #define DEBUG_WIRE(...)   debug_wire(__VA_ARGS__)
 #endif

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -92,6 +92,17 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #else
 #include "debug.h"
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define DEBUG_WIDEN(fmt)       L##fmt
+#define DEBUG_ERROR(fmt, ...)  debug_error(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#define DEBUG_WARN(fmt, ...)   debug_warning(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#define DEBUG_INFO(fmt, ...)   debug_info(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#define DEBUG_GDB(fmt, ...)    debug_gdb(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#define DEBUG_TARGET(fmt, ...) debug_target(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#define DEBUG_PROTO(fmt, ...)  debug_protocol(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#define DEBUG_PROBE(fmt, ...)  debug_probe(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#define DEBUG_WIRE(fmt, ...)   debug_wire(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
+#else
 #define DEBUG_ERROR(...)  debug_error(__VA_ARGS__)
 #define DEBUG_WARN(...)   debug_warning(__VA_ARGS__)
 #define DEBUG_INFO(...)   debug_info(__VA_ARGS__)
@@ -100,6 +111,7 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #define DEBUG_PROTO(...)  debug_protocol(__VA_ARGS__)
 #define DEBUG_PROBE(...)  debug_probe(__VA_ARGS__)
 #define DEBUG_WIRE(...)   debug_wire(__VA_ARGS__)
+#endif
 #endif
 
 #define ALIGN(x, n) (((x) + (n)-1) & ~((n)-1))

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -81,11 +81,10 @@ extern uint32_t delay_cnt;
 #define DEBUG_WARN(...) PRINT_NOOP(__VA_ARGS__)
 #define DEBUG_INFO(...) PRINT_NOOP(__VA_ARGS__)
 #endif
-#define DEBUG_GDB(...)      PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_TARGET(...)   PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_PROBE(...)    PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_WIRE(...)     PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_GDB_WIRE(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_GDB(...)    PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_TARGET(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_PROBE(...)  PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_WIRE(...)   PRINT_NOOP(__VA_ARGS__)
 
 void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #else
@@ -95,26 +94,7 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #define DEBUG_ERROR(...) debug_error(__VA_ARGS__)
 #define DEBUG_WARN(...)  debug_warning(__VA_ARGS__)
 #define DEBUG_INFO(...)  debug_info(__VA_ARGS__)
-
-static inline void DEBUG_GDB(const char *format, ...)
-{
-	if (~bmda_debug_flags & BMD_DEBUG_GDB)
-		return;
-	va_list args;
-	va_start(args, format);
-	vfprintf(stderr, format, args);
-	va_end(args);
-}
-
-static inline void DEBUG_GDB_WIRE(const char *format, ...)
-{
-	if ((bmda_debug_flags & (BMD_DEBUG_GDB | BMD_DEBUG_WIRE)) != (BMD_DEBUG_GDB | BMD_DEBUG_WIRE))
-		return;
-	va_list args;
-	va_start(args, format);
-	vfprintf(stderr, format, args);
-	va_end(args);
-}
+#define DEBUG_GDB(...)   debug_gdb(__VA_ARGS__)
 
 static inline void DEBUG_TARGET(const char *format, ...)
 {

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -53,11 +53,10 @@ extern uint32_t delay_cnt;
 #if PC_HOSTED == 0
 /*
  * XXX: This entire system needs replacing with something better thought out
- * XXX: This has no error diagnostic level.
  *
- * When built as firmware, if the target supports debugging, DEBUG_WARN and DEBUG_INFO
- * get defined to a macro that turns them into printf() calls. The rest of the levels
- * turn into no-ops.
+ * When built as firmware, if the target supports debugging, DEBUG_ERROR, DEBUG_WARN and
+ * DEBUG_INFO get defined to a macro that turns them into printf() calls. The rest of the
+ * levels turn into no-ops.
  *
  * When built as BMDA, the debug macros all turn into various kinds of console-printing
  * function, w/ gating for diagnostics other than warnings and info.
@@ -75,11 +74,13 @@ extern uint32_t delay_cnt;
 	do {                \
 	} while (false)
 #if defined(ENABLE_DEBUG)
-#define DEBUG_WARN(...) PLATFORM_PRINTF(__VA_ARGS__)
-#define DEBUG_INFO(...) PLATFORM_PRINTF(__VA_ARGS__)
+#define DEBUG_ERROR(...) PLATFORM_PRINTF(__VA_ARGS__)
+#define DEBUG_WARN(...)  PLATFORM_PRINTF(__VA_ARGS__)
+#define DEBUG_INFO(...)  PLATFORM_PRINTF(__VA_ARGS__)
 #else
-#define DEBUG_WARN(...) PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_INFO(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_ERROR(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_WARN(...)  PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_INFO(...)  PRINT_NOOP(__VA_ARGS__)
 #endif
 #define DEBUG_GDB(...)    PRINT_NOOP(__VA_ARGS__)
 #define DEBUG_TARGET(...) PRINT_NOOP(__VA_ARGS__)
@@ -90,6 +91,7 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #else
 #include "debug.h"
 
+#define DEBUG_ERROR(...)  debug_error(__VA_ARGS__)
 #define DEBUG_WARN(...)   debug_warning(__VA_ARGS__)
 #define DEBUG_INFO(...)   debug_info(__VA_ARGS__)
 #define DEBUG_GDB(...)    debug_gdb(__VA_ARGS__)

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -43,19 +43,10 @@
 #include "platform_support.h"
 
 #ifndef ARRAY_LENGTH
-#define ARRAY_LENGTH(arr) (sizeof(arr) / sizeof(arr[0]))
+#define ARRAY_LENGTH(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
 extern uint32_t delay_cnt;
-
-#define BMP_DEBUG_NONE   0U
-#define BMP_DEBUG_INFO   (1U << 0U)
-#define BMP_DEBUG_GDB    (1U << 1U)
-#define BMP_DEBUG_TARGET (1U << 2U)
-#define BMP_DEBUG_PROBE  (1U << 3U)
-#define BMP_DEBUG_WIRE   (1U << 4U)
-#define BMP_DEBUG_MAX    (1U << 5U)
-#define BMP_DEBUG_STDOUT (1U << 15U)
 
 #define FREQ_FIXED 0xffffffffU
 
@@ -98,8 +89,8 @@ extern uint32_t delay_cnt;
 
 void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #else
+#include "debug.h"
 #include <stdarg.h>
-extern int cl_debuglevel;
 
 static inline void DEBUG_WARN(const char *format, ...)
 {
@@ -111,20 +102,20 @@ static inline void DEBUG_WARN(const char *format, ...)
 
 static inline void DEBUG_INFO(const char *format, ...)
 {
-	if (~cl_debuglevel & BMP_DEBUG_INFO)
+	if (~bmda_debug_flags & BMD_DEBUG_INFO)
 		return;
 	va_list args;
 	va_start(args, format);
-	if (cl_debuglevel & BMP_DEBUG_STDOUT)
-		vfprintf(stdout, format, args);
-	else
+	if (bmda_debug_flags & BMD_DEBUG_USE_STDERR)
 		vfprintf(stderr, format, args);
+	else
+		vfprintf(stdout, format, args);
 	va_end(args);
 }
 
 static inline void DEBUG_GDB(const char *format, ...)
 {
-	if (~cl_debuglevel & BMP_DEBUG_GDB)
+	if (~bmda_debug_flags & BMD_DEBUG_GDB)
 		return;
 	va_list args;
 	va_start(args, format);
@@ -134,7 +125,7 @@ static inline void DEBUG_GDB(const char *format, ...)
 
 static inline void DEBUG_GDB_WIRE(const char *format, ...)
 {
-	if ((cl_debuglevel & (BMP_DEBUG_GDB | BMP_DEBUG_WIRE)) != (BMP_DEBUG_GDB | BMP_DEBUG_WIRE))
+	if ((bmda_debug_flags & (BMD_DEBUG_GDB | BMD_DEBUG_WIRE)) != (BMD_DEBUG_GDB | BMD_DEBUG_WIRE))
 		return;
 	va_list args;
 	va_start(args, format);
@@ -144,7 +135,7 @@ static inline void DEBUG_GDB_WIRE(const char *format, ...)
 
 static inline void DEBUG_TARGET(const char *format, ...)
 {
-	if (~cl_debuglevel & BMP_DEBUG_TARGET)
+	if (~bmda_debug_flags & BMD_DEBUG_TARGET)
 		return;
 	va_list args;
 	va_start(args, format);
@@ -154,7 +145,7 @@ static inline void DEBUG_TARGET(const char *format, ...)
 
 static inline void DEBUG_PROBE(const char *format, ...)
 {
-	if (~cl_debuglevel & BMP_DEBUG_PROBE)
+	if (~bmda_debug_flags & BMD_DEBUG_PROBE)
 		return;
 	va_list args;
 	va_start(args, format);
@@ -164,7 +155,7 @@ static inline void DEBUG_PROBE(const char *format, ...)
 
 static inline void DEBUG_WIRE(const char *format, ...)
 {
-	if (~cl_debuglevel & BMP_DEBUG_WIRE)
+	if (~bmda_debug_flags & BMD_DEBUG_WIRE)
 		return;
 	va_list args;
 	va_start(args, format);

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -91,7 +91,7 @@ ifneq ($(HOSTED_BMP_ONLY), 1)
     LDFLAGS += $(shell pkg-config --libs $(HIDAPILIB))
 endif
 
-SRC += timing.c cli.c utils.c probe_info.c
+SRC += timing.c cli.c utils.c probe_info.c debug.c
 SRC += bmp_remote.c remote_swdptap.c remote_jtagtap.c
 ifneq ($(HOSTED_BMP_ONLY), 1)
     SRC += bmp_libusb.c stlinkv2.c

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -103,12 +103,4 @@ bool device_is_bmp_gdb_port(const char *device);
 int send_recv(usb_link_s *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
 #endif
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <wchar.h>
-#define PRINT_INFO(fmt, ...) wprintf(L##fmt, ##__VA_ARGS__)
-#else
-#include <stdio.h>
-#define PRINT_INFO(fmt, ...) printf((fmt), ##__VA_ARGS__)
-#endif
-
 #endif /* PLATFORMS_HOSTED_BMP_HOSTED_H */

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -28,8 +28,8 @@
 
 void bmp_ident(bmp_info_s *info)
 {
-	PRINT_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP,"
-			   " JLink and libftdi/MPSSE\n",
+	PRINT_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP, "
+			   "JLink and libftdi/MPSSE\n",
 		FIRMWARE_VERSION);
 	if (info && info->vid && info->pid) {
 		PRINT_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -28,11 +28,11 @@
 
 void bmp_ident(bmp_info_s *info)
 {
-	PRINT_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP, "
+	DEBUG_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP, "
 			   "JLink and libftdi/MPSSE\n",
 		FIRMWARE_VERSION);
 	if (info && info->vid && info->pid) {
-		PRINT_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,
+		DEBUG_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,
 			(info->serial[0]) ? info->serial : NO_SERIAL_NUMBER, info->manufacturer, info->product);
 	}
 }

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -50,7 +50,7 @@ void libusb_exit_function(bmp_info_s *info)
 #ifdef __APPLE__
 int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 {
-	DEBUG_WARN("Please implement find_debuggers for MACOS!\n");
+	DEBUG_ERROR("Please implement find_debuggers for MACOS!\n");
 	(void)cl_opts;
 	(void)info;
 	return -1;
@@ -145,7 +145,7 @@ print_probes_info:
 		 * in the detection loop, so use this probe. */
 		return 0;
 	if (probes_found < 1U) {
-		DEBUG_WARN("No BMP probe found\n");
+		DEBUG_ERROR("No BMP probe found\n");
 		return -1;
 	}
 	/* Otherwise, if this line is reached, then more than one probe has been found,
@@ -217,7 +217,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 	while (name[prefix_length] == '_' && prefix_length < name_len)
 		++prefix_length;
 	if (prefix_length == name_len) {
-		DEBUG_WARN("Unexpected end\n");
+		DEBUG_ERROR("Unexpected end\n");
 		return probe_list;
 	}
 
@@ -283,7 +283,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 	}
 
 	if (!version || !type) {
-		DEBUG_WARN("Failed to construct version of type string");
+		DEBUG_ERROR("Failed to construct version of type string");
 		free(serial);
 		free(version);
 		free(type);
@@ -314,7 +314,7 @@ static const probe_info_s *scan_for_devices(void)
 			}
 			/* If the operation returned the probe_list unchanged, it failed to parse the node */
 			if (probe_info == probe_list)
-				DEBUG_WARN("Error parsing device name \"%s\"\n", entry->d_name);
+				DEBUG_ERROR("Error parsing device name \"%s\"\n", entry->d_name);
 			probe_list = probe_info;
 		}
 	}
@@ -329,7 +329,7 @@ int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 	/* Scan for all possible probes on the system */
 	const probe_info_s *const probe_list = scan_for_devices();
 	if (!probe_list) {
-		DEBUG_WARN("No BMP probe found\n");
+		DEBUG_ERROR("No BMP probe found\n");
 		return -1;
 	}
 	/* Count up how many were found and filter the list for a match to the program options request */

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -36,10 +36,10 @@
 
 void bmp_ident(bmp_info_s *info)
 {
-	PRINT_INFO("Black Magic Debug App (for BMP only) %s\n", FIRMWARE_VERSION);
+	DEBUG_INFO("Black Magic Debug App (for BMP only) %s\n", FIRMWARE_VERSION);
 	if (!info)
 		return;
-	PRINT_INFO("Using:\n %s %s %s\n", info->manufacturer, info->version, info->serial);
+	DEBUG_INFO("Using:\n %s %s %s\n", info->manufacturer, info->version, info->serial);
 }
 
 void libusb_exit_function(bmp_info_s *info)

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -255,7 +255,13 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 			break;
 		case 'v':
 			if (optarg) {
-				const uint16_t level = (strtoul(optarg, NULL, 10) << BMD_DEBUG_LEVEL_SHIFT) & BMD_DEBUG_LEVEL_MASK;
+				const char *end = optarg + strlen(optarg);
+				char *valid = NULL;
+				const uint16_t level = (strtoul(optarg, &valid, 10) << BMD_DEBUG_LEVEL_SHIFT) & BMD_DEBUG_LEVEL_MASK;
+				if (valid != end) {
+					DEBUG_ERROR("Value after verbosity flag was not a valid positive integer, got '%s'\n", optarg);
+					exit(1);
+				}
 				bmda_debug_flags |= level;
 			}
 			break;

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -128,7 +128,7 @@ static void bmp_munmap(mmap_data_s *map)
 static void cl_help(char **argv)
 {
 	bmp_ident(NULL);
-	PRINT_INFO("\n"
+	DEBUG_INFO("\n"
 			   "Usage: %s [-h | -l | [-v BITMASK] [-O] [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]\n"
 			   "\t[-n NUMBER] [-j | -A] [-C] [-t | -T] [-e] [-p] [-R[h]] [-H] [-M STRING ...]\n"
 			   "\t[-f | -m] [-E | -w | -V | -r] [-a ADDR] [-S number] [file]]\n"

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -414,9 +414,25 @@ static void display_target(int i, target_s *t, void *context)
 			"*** %2d %c %s %s\n", i, target_attached(t) ? '*' : ' ', target_driver_name(t), core_name ? core_name : "");
 }
 
+uint32_t scan_for_targets(const bmda_cli_options_s *const opt)
+{
+	if (opt->opt_scanmode == BMP_SCAN_JTAG)
+		return platform_jtag_scan(NULL, 0);
+	if (opt->opt_scanmode == BMP_SCAN_SWD)
+		return platform_adiv5_swdp_scan(opt->opt_targetid);
+	uint32_t num_targets = platform_jtag_scan(NULL, 0);
+	if (num_targets)
+		return num_targets;
+	DEBUG_WARN("JTAG scan found no devices, trying SWD.\n");
+	num_targets = platform_adiv5_swdp_scan(opt->opt_targetid);
+	if (num_targets)
+		return num_targets;
+	DEBUG_ERROR("SW-DP scan failed!\n");
+	return 0U;
+}
+
 int cl_execute(bmda_cli_options_s *opt)
 {
-	int num_targets;
 	if (opt->opt_mode == BMP_MODE_RESET_HW) {
 		platform_nrst_set_val(true);
 		platform_delay(1);
@@ -432,22 +448,8 @@ int cl_execute(bmda_cli_options_s *opt)
 	DEBUG_INFO("Target voltage: %s Volt\n", platform_target_voltage());
 
 	int res = 0;
-	if (opt->opt_scanmode == BMP_SCAN_JTAG)
-		num_targets = platform_jtag_scan(NULL, 0);
-	else if (opt->opt_scanmode == BMP_SCAN_SWD)
-		num_targets = platform_adiv5_swdp_scan(opt->opt_targetid);
-	else {
-		num_targets = platform_jtag_scan(NULL, 0);
-		if (num_targets > 0)
-			goto found_targets;
-		DEBUG_INFO("JTAG scan found no devices, trying SWD.\n");
-		num_targets = platform_adiv5_swdp_scan(opt->opt_targetid);
-		if (num_targets > 0)
-			goto found_targets;
-		DEBUG_INFO("SW-DP scan failed!\n");
-	}
+	uint32_t num_targets = scan_for_targets(opt);
 
-found_targets:
 	if (!num_targets) {
 		DEBUG_WARN("No target found\n");
 		return -1;
@@ -455,7 +457,8 @@ found_targets:
 	num_targets = target_foreach(display_target, &num_targets);
 
 	if (opt->opt_target_dev > num_targets) {
-		DEBUG_WARN("Given target number %d not available max %d\n", opt->opt_target_dev, num_targets);
+		DEBUG_ERROR(
+			"Given target number %" PRIu32 " not available max %" PRIu32 "\n", opt->opt_target_dev, num_targets);
 		return -1;
 	}
 	target_s *t = target_attach_n(opt->opt_target_dev, &cl_controller);

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -129,16 +129,18 @@ static void cl_help(char **argv)
 {
 	bmp_ident(NULL);
 	PRINT_INFO("\n"
-			   "Usage: %s [-h | -l | [-vBITMASK] [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]\n"
+			   "Usage: %s [-h | -l | [-v BITMASK] [-O] [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]\n"
 			   "\t[-n NUMBER] [-j | -A] [-C] [-t | -T] [-e] [-p] [-R[h]] [-H] [-M STRING ...]\n"
 			   "\t[-f | -m] [-E | -w | -V | -r] [-a ADDR] [-S number] [file]]\n"
 			   "\n"
 			   "The default is to start a debug server at localhost:2000\n\n"
-			   "Single-shot and verbosity options [-h | -l | -vBITMASK]:\n"
+			   "Single-shot and verbosity options [-h | -l | -v BITMASK]:\n"
 			   "\t-h, --help       Show the version and this help, then exit\n"
 			   "\t-l, --list       List available supported probes\n"
 			   "\t-v, --verbose    Set the output verbosity level based on some combination of:\n"
 			   "\t                   1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROTO, 16 = PROBE, 32 = WIRE\n"
+			   "\t-O, --no-stdout  Don't use stdout for debugging output, making it available\n"
+			   "\t                   for use by RTT, Semihosting, or other target output\n"
 			   "\n"
 			   "Probe selection arguments [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]:\n"
 			   "\t-d, --device     Use a serial device at the given path\n"
@@ -198,6 +200,7 @@ static const getopt_option_s long_options[] = {
 	{"help", no_argument, NULL, 'h'},
 	{"list", no_argument, NULL, 'l'},
 	{"verbose", required_argument, NULL, 'v'},
+	{"no-stdout", no_argument, NULL, 'O'},
 	{"device", required_argument, NULL, 'd'},
 	{"probe", required_argument, NULL, 'P'},
 	{"serial", required_argument, NULL, 's'},
@@ -233,9 +236,8 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 	opt->opt_max_swj_frequency = 4000000;
 	opt->opt_scanmode = BMP_SCAN_SWD;
 	opt->opt_mode = BMP_MODE_DEBUG;
-	bmda_debug_flags |= BMD_DEBUG_USE_STDERR;
 	while (true) {
-		const int option = getopt_long(argc, argv, "eEFhHv:d:f:s:I:c:Cln:m:M:wVtTa:S:jApP:rR::", long_options, NULL);
+		const int option = getopt_long(argc, argv, "eEFhHv:Od:f:s:I:c:Cln:m:M:wVtTa:S:jApP:rR::", long_options, NULL);
 		if (option == -1)
 			break;
 
@@ -257,6 +259,9 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 				bmda_debug_flags |= level;
 			}
 			break;
+		case 'O':
+			bmda_debug_flags |= BMD_DEBUG_USE_STDERR;
+			break;
 		case 'j':
 			opt->opt_scanmode = BMP_SCAN_JTAG;
 			break;
@@ -265,7 +270,6 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 			break;
 		case 'l':
 			opt->opt_list_only = true;
-			bmda_debug_flags &= ~BMD_DEBUG_USE_STDERR;
 			break;
 		case 'C':
 			opt->opt_connect_under_reset = true;
@@ -309,7 +313,6 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 		case 't':
 			opt->opt_mode = BMP_MODE_TEST;
 			bmda_debug_flags |= BMD_DEBUG_INFO;
-			bmda_debug_flags &= ~BMD_DEBUG_USE_STDERR;
 			break;
 		case 'T':
 			opt->opt_mode = BMP_MODE_SWJ_TEST;

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -138,7 +138,7 @@ static void cl_help(char **argv)
 			   "\t-h, --help       Show the version and this help, then exit\n"
 			   "\t-l, --list       List available supported probes\n"
 			   "\t-v, --verbose    Set the output verbosity level based on some combination of:\n"
-			   "\t                   1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROBE, 16 = WIRE\n"
+			   "\t                   1 = INFO, 2 = GDB, 4 = TARGET, 8 = PROTO, 16 = PROBE, 32 = WIRE\n"
 			   "\n"
 			   "Probe selection arguments [-d PATH | -P NUMBER | -s SERIAL | -c TYPE]:\n"
 			   "\t-d, --device     Use a serial device at the given path\n"

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -76,7 +76,7 @@ static bool bmp_mmap(char *file, mmap_data_s *map)
 #if defined(_WIN32) || defined(__CYGWIN__)
 	map->hFile = CreateFile(file, GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_ALWAYS, 0, NULL);
 	if (map->hFile == INVALID_HANDLE_VALUE) {
-		DEBUG_WARN("Open file %s failed: %s\n", file, strerror(errno));
+		DEBUG_ERROR("Open file %s failed: %s\n", file, strerror(errno));
 		return false;
 	}
 	map->size = GetFileSize(map->hFile, NULL);
@@ -87,20 +87,20 @@ static bool bmp_mmap(char *file, mmap_data_s *map)
 		NULL);                                          /* name of mapping object */
 
 	if (map->hMapFile == NULL || map->hMapFile == INVALID_HANDLE_VALUE) {
-		DEBUG_WARN("Map file %s failed: %s\n", file, strerror(errno));
+		DEBUG_ERROR("Map file %s failed: %s\n", file, strerror(errno));
 		CloseHandle(map->hFile);
 		return false;
 	}
 	map->data = MapViewOfFile(map->hMapFile, FILE_MAP_READ, 0, 0, 0);
 	if (!map->data) {
-		DEBUG_WARN("Could not create file mapping object (%s).\n", strerror(errno));
+		DEBUG_ERROR("Could not create file mapping object (%s).\n", strerror(errno));
 		CloseHandle(map->hMapFile);
 		return false;
 	}
 #else
 	map->fd = open(file, O_RDONLY | O_BINARY);
 	if (map->fd < 0) {
-		DEBUG_WARN("Open file %s failed: %s\n", file, strerror(errno));
+		DEBUG_ERROR("Open file %s failed: %s\n", file, strerror(errno));
 		return false;
 	}
 	struct stat stat = {};
@@ -529,7 +529,7 @@ int cl_execute(bmda_cli_options_s *opt)
 				platform_delay(1); /* To allow trigger */
 			}
 		} else
-			DEBUG_WARN("No test for this core type yet\n");
+			DEBUG_ERROR("No test for this core type yet\n");
 	}
 	if (opt->opt_mode == BMP_MODE_TEST || opt->opt_mode == BMP_MODE_SWJ_TEST)
 		goto target_detach;

--- a/src/platforms/hosted/cli.h
+++ b/src/platforms/hosted/cli.h
@@ -63,8 +63,7 @@ typedef struct bmda_cli_options {
 	size_t opt_position;
 	char *opt_cable;
 	char *opt_monitor;
-	int opt_debuglevel;
-	int opt_target_dev;
+	uint32_t opt_target_dev;
 	uint32_t opt_flash_start;
 	uint32_t opt_max_swj_frequency;
 	size_t opt_flash_size;

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -38,7 +38,7 @@ void dap_nrst_set_val(bool assert);
 bool dap_init(bmp_info_s *info)
 {
 	(void)info;
-	DEBUG_WARN("FATAL: Missing hidapi-libusb\n");
+	DEBUG_ERROR("Missing hidapi-libusb\n");
 	return false;
 }
 

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -266,7 +266,7 @@ bool dap_read_block(
 	const size_t blocks = len >> MIN(align, 2U);
 	uint32_t data[256];
 	if (!perform_dap_transfer_block_read(target_ap->dp, SWD_AP_DRW, blocks, data)) {
-		DEBUG_WARN("dap_read_block failed\n");
+		DEBUG_ERROR("dap_read_block failed\n");
 		return false;
 	}
 
@@ -298,7 +298,7 @@ bool dap_write_block(
 
 	const bool result = perform_dap_transfer_block_write(target_ap->dp, SWD_AP_DRW, blocks, data);
 	if (!result)
-		DEBUG_WARN("dap_write_block failed\n");
+		DEBUG_ERROR("dap_write_block failed\n");
 	return result;
 }
 
@@ -368,9 +368,9 @@ void dap_ap_mem_access_setup(adiv5_access_port_s *const target_ap, const uint32_
 	/* If it didn't go well, say something and abort */
 	if (!result) {
 		if (target_dp->fault != DAP_TRANSFER_NO_RESPONSE)
-			DEBUG_WARN("Transport error (%u), aborting\n", target_dp->fault);
+			DEBUG_ERROR("Transport error (%u), aborting\n", target_dp->fault);
 		else
-			DEBUG_WARN("Transaction unrecoverably failed\n");
+			DEBUG_ERROR("Transaction unrecoverably failed\n");
 		exit(-1);
 	}
 }
@@ -387,7 +387,7 @@ uint32_t dap_ap_read(adiv5_access_port_s *const target_ap, const uint16_t addr)
 	uint32_t result = 0;
 	adiv5_debug_port_s *const target_dp = target_ap->dp;
 	if (!perform_dap_transfer(target_dp, requests, 2U, &result, 1U)) {
-		DEBUG_WARN("dap_ap_read failed (fault = %u)\n", target_dp->fault);
+		DEBUG_ERROR("dap_ap_read failed (fault = %u)\n", target_dp->fault);
 		return 0U;
 	}
 	return result;
@@ -405,7 +405,7 @@ void dap_ap_write(adiv5_access_port_s *const target_ap, const uint16_t addr, con
 	requests[1].data = value;
 	adiv5_debug_port_s *const target_dp = target_ap->dp;
 	if (!perform_dap_transfer(target_dp, requests, 2U, NULL, 0U))
-		DEBUG_WARN("dap_ap_write failed (fault = %u)\n", target_dp->fault);
+		DEBUG_ERROR("dap_ap_write failed (fault = %u)\n", target_dp->fault);
 }
 
 void dap_read_single(adiv5_access_port_s *const target_ap, void *const dest, const uint32_t src, const align_e align)
@@ -416,7 +416,7 @@ void dap_read_single(adiv5_access_port_s *const target_ap, void *const dest, con
 	uint32_t result;
 	adiv5_debug_port_s *target_dp = target_ap->dp;
 	if (!perform_dap_transfer_recoverable(target_dp, requests, 4U, &result, 1U)) {
-		DEBUG_WARN("dap_read_single failed (fault = %u)\n", target_dp->fault);
+		DEBUG_ERROR("dap_read_single failed (fault = %u)\n", target_dp->fault);
 		memset(dest, 0, 1U << align);
 		return;
 	}
@@ -434,5 +434,5 @@ void dap_write_single(
 	adiv5_pack_data(dest, src, &requests[3].data, align);
 	adiv5_debug_port_s *target_dp = target_ap->dp;
 	if (!perform_dap_transfer_recoverable(target_dp, requests, 4U, NULL, 0U))
-		DEBUG_WARN("dap_write_single failed (fault = %u)\n", target_dp->fault);
+		DEBUG_ERROR("dap_write_single failed (fault = %u)\n", target_dp->fault);
 }

--- a/src/platforms/hosted/dap_jtag.c
+++ b/src/platforms/hosted/dap_jtag.c
@@ -128,6 +128,6 @@ bool dap_jtag_configure(void)
 	uint8_t response = DAP_RESPONSE_OK;
 	/* Send the configuration and ensure it succeeded */
 	if (!dap_run_cmd(request, 2U + jtag_dev_count, &response, 1U) || response != DAP_RESPONSE_OK)
-		DEBUG_WARN("dap_jtag_configure failed with %02x\n", response);
+		DEBUG_ERROR("dap_jtag_configure failed with %02x\n", response);
 	return response == DAP_RESPONSE_OK;
 }

--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -116,7 +116,7 @@ static void dap_swd_seq_out(const uint32_t tms_states, const size_t clock_cycles
 	write_le4(sequence.data, 0, tms_states);
 	/* And perform it */
 	if (!perform_dap_swd_sequences(&sequence, 1U))
-		DEBUG_WARN("dap_swd_seq_out failed\n");
+		DEBUG_ERROR("dap_swd_seq_out failed\n");
 }
 
 static void dap_swd_seq_out_parity(const uint32_t tms_states, const size_t clock_cycles)
@@ -130,7 +130,7 @@ static void dap_swd_seq_out_parity(const uint32_t tms_states, const size_t clock
 	sequence.data[4] = __builtin_parity(tms_states);
 	/* And perform it */
 	if (!perform_dap_swd_sequences(&sequence, 1U))
-		DEBUG_WARN("dap_swd_seq_out_parity failed\n");
+		DEBUG_ERROR("dap_swd_seq_out_parity failed\n");
 }
 
 static uint32_t dap_swd_seq_in(const size_t clock_cycles)
@@ -142,7 +142,7 @@ static uint32_t dap_swd_seq_in(const size_t clock_cycles)
 	};
 	/* And perform it */
 	if (!perform_dap_swd_sequences(&sequence, 1U)) {
-		DEBUG_WARN("dap_swd_seq_in failed\n");
+		DEBUG_ERROR("dap_swd_seq_in failed\n");
 		return 0U;
 	}
 
@@ -161,7 +161,7 @@ static bool dap_swd_seq_in_parity(uint32_t *const result, const size_t clock_cyc
 	};
 	/* And perform it */
 	if (!perform_dap_swd_sequences(&sequence, 1U)) {
-		DEBUG_WARN("dap_swd_seq_in_parity failed\n");
+		DEBUG_ERROR("dap_swd_seq_in_parity failed\n");
 		return false;
 	}
 
@@ -187,7 +187,7 @@ static void dap_line_reset(void)
 		0x0fU,
 	};
 	if (!perform_dap_swj_sequence(64, data))
-		DEBUG_WARN("line reset failed\n");
+		DEBUG_ERROR("line reset failed\n");
 }
 
 static bool dap_write_reg_no_check(uint16_t addr, const uint32_t data)
@@ -216,7 +216,7 @@ static bool dap_write_reg_no_check(uint16_t addr, const uint32_t data)
 	write_le4(sequences[3].data, 0, data);
 	/* Now perform the sequences */
 	if (!perform_dap_swd_sequences(sequences, 4U)) {
-		DEBUG_WARN("dap_write_reg_no_check failed\n");
+		DEBUG_ERROR("dap_write_reg_no_check failed\n");
 		return false;
 	}
 	/* Check the ack state */

--- a/src/platforms/hosted/debug.c
+++ b/src/platforms/hosted/debug.c
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include "general.h"
+#include "debug.h"
+
+uint16_t bmda_debug_flags = BMD_DEBUG_ERROR | BMD_DEBUG_WARNING;
+
+static void debug_print(const uint16_t level, const char *const format, va_list args)
+{
+	/* Check if the required level is enabled */
+	if (!(bmda_debug_flags & level))
+		return;
+	/* Check to see which of stderr and stdout the message should go to */
+	FILE *const where = bmda_debug_flags & BMD_DEBUG_USE_STDERR ? stderr : stdout;
+	/* And shoot the message to the correct place */
+	(void)vfprintf(where, format, args);
+	/* Note: we have no useful way to use the output of the above call, so we ignore it. */
+}
+
+#define DEBUG_PRINT(level)              \
+	va_list args;                       \
+	va_start(args, format);             \
+	debug_print((level), format, args); \
+	va_end(args)
+
+void debug_error(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_ERROR);
+}
+
+void debug_warning(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_WARNING);
+}
+
+void debug_info(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_INFO);
+}
+
+void debug_gdb(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_GDB);
+}
+
+void debug_target(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_TARGET);
+}
+
+void debug_protocol(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_PROTO);
+}
+
+void debug_probe(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_PROBE);
+}
+
+void debug_wire(const char *const format, ...)
+{
+	DEBUG_PRINT(BMD_DEBUG_WIRE);
+}

--- a/src/platforms/hosted/debug.c
+++ b/src/platforms/hosted/debug.c
@@ -31,14 +31,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <wchar.h>
+#define PRINT_FN vfwprintf
+#else
 #include <stdio.h>
+#define PRINT_FN vfprintf
+#endif
 #include <stdarg.h>
 #include "general.h"
 #include "debug.h"
 
 uint16_t bmda_debug_flags = BMD_DEBUG_ERROR | BMD_DEBUG_WARNING;
 
-static void debug_print(const uint16_t level, const char *const format, va_list args)
+static void debug_print(const uint16_t level, const debug_str_t format, va_list args)
 {
 	/* Check if the required level is enabled */
 	if (!(bmda_debug_flags & level))
@@ -46,7 +52,7 @@ static void debug_print(const uint16_t level, const char *const format, va_list 
 	/* Check to see which of stderr and stdout the message should go to */
 	FILE *const where = bmda_debug_flags & BMD_DEBUG_USE_STDERR ? stderr : stdout;
 	/* And shoot the message to the correct place */
-	(void)vfprintf(where, format, args);
+	(void)PRINT_FN(where, format, args);
 	/* Note: we have no useful way to use the output of the above call, so we ignore it. */
 }
 
@@ -56,42 +62,42 @@ static void debug_print(const uint16_t level, const char *const format, va_list 
 	debug_print((level), format, args); \
 	va_end(args)
 
-void debug_error(const char *const format, ...)
+void debug_error(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_ERROR);
 }
 
-void debug_warning(const char *const format, ...)
+void debug_warning(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_WARNING);
 }
 
-void debug_info(const char *const format, ...)
+void debug_info(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_INFO);
 }
 
-void debug_gdb(const char *const format, ...)
+void debug_gdb(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_GDB);
 }
 
-void debug_target(const char *const format, ...)
+void debug_target(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_TARGET);
 }
 
-void debug_protocol(const char *const format, ...)
+void debug_protocol(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_PROTO);
 }
 
-void debug_probe(const char *const format, ...)
+void debug_probe(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_PROBE);
 }
 
-void debug_wire(const char *const format, ...)
+void debug_wire(const debug_str_t format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_WIRE);
 }

--- a/src/platforms/hosted/debug.h
+++ b/src/platforms/hosted/debug.h
@@ -46,6 +46,10 @@
 #define BMD_DEBUG_WIRE       (1U << 7U)
 #define BMD_DEBUG_USE_STDERR (1U << 15U)
 
+/* These two macros control which of the above levels are accessible from the verbosity CLI argument */
+#define BMD_DEBUG_LEVEL_MASK  0x00fcU
+#define BMD_DEBUG_LEVEL_SHIFT 2U
+
 extern uint16_t bmda_debug_flags;
 
 void debug_error(const char *format, ...) __attribute__((format(printf, 1, 2)));

--- a/src/platforms/hosted/debug.h
+++ b/src/platforms/hosted/debug.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORMS_HOSTED_DEBUG_H
+#define PLATFORMS_HOSTED_DEBUG_H
+
+#include <stdint.h>
+
+#define BMD_DEBUG_ERROR      (1U << 0U)
+#define BMD_DEBUG_WARNING    (1U << 1U)
+#define BMD_DEBUG_INFO       (1U << 2U)
+#define BMD_DEBUG_GDB        (1U << 3U)
+#define BMD_DEBUG_TARGET     (1U << 4U)
+#define BMD_DEBUG_PROTO      (1U << 5U)
+#define BMD_DEBUG_PROBE      (1U << 6U)
+#define BMD_DEBUG_WIRE       (1U << 7U)
+#define BMD_DEBUG_USE_STDERR (1U << 15U)
+
+extern uint16_t bmda_debug_flags;
+
+void debug_error(const char *format, ...);
+void debug_warning(const char *format, ...);
+void debug_info(const char *format, ...);
+void debug_gdb(const char *format, ...);
+void debug_target(const char *format, ...);
+void debug_protocol(const char *format, ...);
+void debug_probe(const char *format, ...);
+void debug_wire(const char *format, ...);
+
+#endif /*PLATFORMS_HOSTED_DEBUG_H*/

--- a/src/platforms/hosted/debug.h
+++ b/src/platforms/hosted/debug.h
@@ -35,6 +35,13 @@
 #define PLATFORMS_HOSTED_DEBUG_H
 
 #include <stdint.h>
+#if defined(_WIN32) || defined(__CYGWIN__)
+typedef const wchar_t *debug_str_t;
+#define DEBUG_FORMAT_ATTR /*__attribute__((format(__wprintf__, 1, 2)))*/
+#else
+typedef const char *debug_str_t;
+#define DEBUG_FORMAT_ATTR __attribute__((format(printf, 1, 2)))
+#endif
 
 #define BMD_DEBUG_ERROR      (1U << 0U)
 #define BMD_DEBUG_WARNING    (1U << 1U)
@@ -52,13 +59,13 @@
 
 extern uint16_t bmda_debug_flags;
 
-void debug_error(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void debug_warning(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void debug_info(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void debug_gdb(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void debug_target(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void debug_protocol(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void debug_probe(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void debug_wire(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_error(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_warning(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_info(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_gdb(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_target(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_protocol(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_probe(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_wire(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
 
 #endif /*PLATFORMS_HOSTED_DEBUG_H*/

--- a/src/platforms/hosted/debug.h
+++ b/src/platforms/hosted/debug.h
@@ -48,13 +48,13 @@
 
 extern uint16_t bmda_debug_flags;
 
-void debug_error(const char *format, ...);
-void debug_warning(const char *format, ...);
-void debug_info(const char *format, ...);
-void debug_gdb(const char *format, ...);
-void debug_target(const char *format, ...);
-void debug_protocol(const char *format, ...);
-void debug_probe(const char *format, ...);
-void debug_wire(const char *format, ...);
+void debug_error(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_warning(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_info(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_gdb(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_target(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_protocol(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_probe(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void debug_wire(const char *format, ...) __attribute__((format(printf, 1, 2)));
 
 #endif /*PLATFORMS_HOSTED_DEBUG_H*/

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -389,7 +389,7 @@ bool ftdi_bmp_init(bmda_cli_options_s *const cl_opts)
 	}
 
 	if (!cable->name) {
-		DEBUG_WARN("No adaptor matching found for %s\n", cl_opts->opt_cable);
+		DEBUG_ERROR("No adaptor matching found for %s\n", cl_opts->opt_cable);
 		return false;
 	}
 
@@ -418,33 +418,33 @@ bool ftdi_bmp_init(bmda_cli_options_s *const cl_opts)
 
 	ftdi_context_s *ctx = ftdi_new();
 	if (ctx == NULL) {
-		DEBUG_WARN("ftdi_new: %s\n", ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_new: %s\n", ftdi_get_error_string(ctx));
 		abort();
 	}
 	err = ftdi_set_interface(ctx, active_cable.interface);
 	if (err != 0) {
-		DEBUG_WARN("ftdi_set_interface: %d: %s\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_set_interface: %d: %s\n", err, ftdi_get_error_string(ctx));
 		goto error_1;
 	}
 	err = ftdi_usb_open_desc(
 		ctx, active_cable.vendor, active_cable.product, active_cable.description, cl_opts->opt_serial);
 	if (err != 0) {
-		DEBUG_WARN("unable to open ftdi device: %d (%s)\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("unable to open ftdi device: %d (%s)\n", err, ftdi_get_error_string(ctx));
 		goto error_1;
 	}
 	err = ftdi_set_latency_timer(ctx, 1);
 	if (err != 0) {
-		DEBUG_WARN("ftdi_set_latency_timer: %d: %s\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_set_latency_timer: %d: %s\n", err, ftdi_get_error_string(ctx));
 		goto error_2;
 	}
 	err = ftdi_set_baudrate(ctx, 1000000);
 	if (err != 0) {
-		DEBUG_WARN("ftdi_set_baudrate: %d: %s\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_set_baudrate: %d: %s\n", err, ftdi_get_error_string(ctx));
 		goto error_2;
 	}
 	err = ftdi_write_data_set_chunksize(ctx, BUF_SIZE);
 	if (err != 0) {
-		DEBUG_WARN("ftdi_write_data_set_chunksize: %d: %s\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_write_data_set_chunksize: %d: %s\n", err, ftdi_get_error_string(ctx));
 		goto error_2;
 	}
 	assert(ctx != NULL);
@@ -454,19 +454,19 @@ bool ftdi_bmp_init(bmda_cli_options_s *const cl_opts)
 	err = ftdi_usb_purge_buffers(ctx);
 #endif
 	if (err != 0) {
-		DEBUG_WARN("ftdi_tcioflush(ftdi_usb_purge_buffer): %d: %s\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_tcioflush(ftdi_usb_purge_buffer): %d: %s\n", err, ftdi_get_error_string(ctx));
 		goto error_2;
 	}
 	/* Reset MPSSE controller. */
 	err = ftdi_set_bitmode(ctx, 0, BITMODE_RESET);
 	if (err != 0) {
-		DEBUG_WARN("ftdi_set_bitmode: %d: %s\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_set_bitmode: %d: %s\n", err, ftdi_get_error_string(ctx));
 		goto error_2;
 	}
 	/* Enable MPSSE controller. Pin directions are set later.*/
 	err = ftdi_set_bitmode(ctx, 0, BITMODE_MPSSE);
 	if (err != 0) {
-		DEBUG_WARN("ftdi_set_bitmode: %d: %s\n", err, ftdi_get_error_string(ctx));
+		DEBUG_ERROR("ftdi_set_bitmode: %d: %s\n", err, ftdi_get_error_string(ctx));
 		goto error_2;
 	}
 	uint8_t ftdi_init[16];
@@ -489,7 +489,7 @@ bool ftdi_bmp_init(bmda_cli_options_s *const cl_opts)
 	case TYPE_2232C:
 		break;
 	default:
-		DEBUG_WARN("FTDI Chip has no MPSSE\n");
+		DEBUG_ERROR("FTDI Chip has no MPSSE\n");
 		goto error_2;
 	}
 

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -170,7 +170,7 @@ static void display_socket_error(const int error, const socket_t socket, const c
 #else
 	const char *message = strerror(error);
 #endif
-	DEBUG_WARN("Error %s %d, got error %d: %s\n", operation, socket, error, message);
+	DEBUG_ERROR("Error %s %d, got error %d: %s\n", operation, socket, error, message);
 #if defined(_WIN32) || defined(__CYGWIN__)
 	LocalFree(message);
 #endif
@@ -207,7 +207,7 @@ static void socket_set_flags(const socket_t socket, const int flags)
 	ULONG option = (flags & O_NONBLOCK) ? 1U : 0U;
 	const int result = ioctlsocket(socket, FIONBIO, &option);
 	if (result != NO_ERROR)
-		DEBUG_WARN("ioctlsocket failed with error: %d\n", result);
+		DEBUG_ERROR("ioctlsocket failed with error: %d\n", result);
 #else
 	fcntl(socket, F_SETFL, flags);
 #endif
@@ -219,14 +219,14 @@ int gdb_if_init(void)
 	WSADATA wsa_data = {};
 	const int result = WSAStartup(MAKEWORD(2, 2), &wsa_data);
 	if (result != NO_ERROR) {
-		DEBUG_WARN("WSAStartup failed with error: %d\n", result);
+		DEBUG_ERROR("WSAStartup failed with error: %d\n", result);
 		return -1;
 	}
 #endif
 	for (uint16_t port = default_port; port < max_port; ++port) {
 		const sockaddr_storage_s addr = sockaddr_prepare(port);
 		if (addr.ss_family == AF_UNSPEC) {
-			DEBUG_WARN("Failed to get a suitable socket address\n");
+			DEBUG_ERROR("Failed to get a suitable socket address\n");
 			return -1;
 		}
 
@@ -254,7 +254,7 @@ int gdb_if_init(void)
 		return 0;
 	}
 
-	DEBUG_WARN("Failed to acquire a port to listen on\n");
+	DEBUG_ERROR("Failed to acquire a port to listen on\n");
 	return -1;
 }
 

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -125,7 +125,7 @@ static bool claim_jlink_interface(bmp_info_s *info, libusb_device *dev)
 	libusb_config_descriptor_s *config;
 	const int result = libusb_get_active_config_descriptor(dev, &config);
 	if (result != LIBUSB_SUCCESS) {
-		DEBUG_WARN("Failed to get configuration descriptor: %s\n", libusb_error_name(result));
+		DEBUG_ERROR("Failed to get configuration descriptor: %s\n", libusb_error_name(result));
 		return false;
 	}
 	const libusb_interface_descriptor_s *descriptor = NULL;
@@ -137,7 +137,7 @@ static bool claim_jlink_interface(bmp_info_s *info, libusb_device *dev)
 			interface_desc->bInterfaceSubClass == LIBUSB_CLASS_VENDOR_SPEC && interface_desc->bNumEndpoints > 1U) {
 			const int result = libusb_claim_interface(info->usb_link->ul_libusb_device_handle, i);
 			if (result) {
-				DEBUG_WARN("Can not claim handle: %s\n", libusb_error_name(result));
+				DEBUG_ERROR("Can not claim handle: %s\n", libusb_error_name(result));
 				break;
 			}
 			info->usb_link->interface = i;
@@ -145,7 +145,7 @@ static bool claim_jlink_interface(bmp_info_s *info, libusb_device *dev)
 		}
 	}
 	if (!descriptor) {
-		DEBUG_WARN("No suitable interface found\n");
+		DEBUG_ERROR("No suitable interface found\n");
 		libusb_free_config_descriptor(config);
 		return false;
 	}
@@ -174,7 +174,7 @@ bool jlink_init(bmp_info_s *const info)
 	libusb_device **device_list = NULL;
 	const ssize_t devices = libusb_get_device_list(info->libusb_ctx, &device_list);
 	if (devices < 0) {
-		DEBUG_WARN("libusb_get_device_list() failed");
+		DEBUG_ERROR("libusb_get_device_list() failed");
 		return false;
 	}
 	libusb_device *dev = NULL;
@@ -184,7 +184,7 @@ bool jlink_init(bmp_info_s *const info)
 		libusb_device *const device = device_list[index];
 		struct libusb_device_descriptor dev_desc;
 		if (libusb_get_device_descriptor(device, &dev_desc) < 0) {
-			DEBUG_WARN("libusb_get_device_descriptor() failed");
+			DEBUG_ERROR("libusb_get_device_descriptor() failed");
 			libusb_free_device_list(device_list, devices);
 			return false;
 		}
@@ -217,7 +217,7 @@ bool jlink_init(bmp_info_s *const info)
 	link->req_trans = libusb_alloc_transfer(0);
 	link->rep_trans = libusb_alloc_transfer(0);
 	if (!link->req_trans || !link->rep_trans || !link->ep_tx || !link->ep_rx) {
-		DEBUG_WARN("Device setup failed\n");
+		DEBUG_ERROR("Device setup failed\n");
 		libusb_release_interface(info->usb_link->ul_libusb_device_handle, info->usb_link->interface);
 		libusb_close(info->usb_link->ul_libusb_device_handle);
 		libusb_free_device_list(device_list, devices);

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -62,7 +62,7 @@ static bool line_reset(bmp_info_s *const info)
 	send_recv(info->usb_link, NULL, 0U, res, 1U);
 
 	if (res[0] != 0) {
-		DEBUG_WARN("Line reset failed\n");
+		DEBUG_ERROR("Line reset failed\n");
 		return false;
 	}
 	return true;
@@ -113,13 +113,13 @@ uint32_t jlink_swdp_scan(bmp_info_s *const info)
 	send_recv(info->usb_link, NULL, 0U, res, 1U);
 
 	if (res[0] != 0) {
-		DEBUG_WARN("Line reset failed\n");
+		DEBUG_ERROR("Line reset failed\n");
 		return 0;
 	}
 
 	adiv5_debug_port_s *dp = calloc(1, sizeof(*dp));
 	if (!dp) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return 0;
 	}
 
@@ -257,7 +257,7 @@ static uint32_t jlink_adiv5_swdp_low_read(adiv5_debug_port_s *const dp)
 	if (bit_count & 1U) /* Give up on parity error */
 	{
 		dp->fault = 1;
-		DEBUG_WARN("SWD access resulted in parity error\n");
+		DEBUG_ERROR("SWD access resulted in parity error\n");
 		raise_exception(EXCEPTION_ERROR, "SWD parity error");
 	}
 	return response;
@@ -314,19 +314,19 @@ static uint32_t jlink_adiv5_swdp_low_access(
 	}
 
 	if (ack == SWDP_ACK_FAULT) {
-		DEBUG_WARN("SWD access resulted in fault\n");
+		DEBUG_ERROR("SWD access resulted in fault\n");
 		dp->fault = ack;
 		return 0;
 	}
 
 	if (ack == SWDP_ACK_NO_RESPONSE) {
-		DEBUG_WARN("SWD access resulted in no response\n");
+		DEBUG_ERROR("SWD access resulted in no response\n");
 		dp->fault = ack;
 		return 0;
 	}
 
 	if (ack != SWDP_ACK_OK) {
-		DEBUG_WARN("SWD access has invalid ack %x\n", ack);
+		DEBUG_ERROR("SWD access has invalid ack %x\n", ack);
 		raise_exception(EXCEPTION_ERROR, "SWD invalid ACK");
 	}
 

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -137,7 +137,7 @@ static void jtagtap_tdi_tdo_seq(
 	if (!clock_cycles)
 		return;
 	const size_t total_chunks = (clock_cycles >> 3U) + ((clock_cycles & 7U) ? 1U : 0U);
-	DEBUG_PROBE("jtagtap_tdi_tdo final tms: %u, clock cycles: %u, data_in: ", final_tms ? 1 : 0, clock_cycles);
+	DEBUG_PROBE("jtagtap_tdi_tdo final tms: %u, clock cycles: %zu, data_in: ", final_tms ? 1 : 0, clock_cycles);
 	for (size_t i = 0; i < total_chunks; ++i)
 		DEBUG_PROBE("%02x", data_in[i]);
 	DEBUG_PROBE("\n");

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -137,12 +137,10 @@ static void jtagtap_tdi_tdo_seq(
 	if (!clock_cycles)
 		return;
 	const size_t total_chunks = (clock_cycles >> 3U) + ((clock_cycles & 7U) ? 1U : 0U);
-	if (cl_debuglevel & BMP_DEBUG_PROBE) {
-		DEBUG_PROBE("jtagtap_tdi_tdo final tms: %u, clock cycles: %u, data_in: ", final_tms ? 1 : 0, clock_cycles);
-		for (size_t i = 0; i < total_chunks; ++i)
-			DEBUG_PROBE("%02x", data_in[i]);
-		DEBUG_PROBE("\n");
-	}
+	DEBUG_PROBE("jtagtap_tdi_tdo final tms: %u, clock cycles: %u, data_in: ", final_tms ? 1 : 0, clock_cycles);
+	for (size_t i = 0; i < total_chunks; ++i)
+		DEBUG_PROBE("%02x", data_in[i]);
+	DEBUG_PROBE("\n");
 	const size_t cmd_len = 4 + (total_chunks * 2U);
 	uint8_t *cmd = calloc(1, cmd_len);
 	cmd[0] = CMD_HW_JTAG3;
@@ -168,18 +166,16 @@ static void jtagtap_tdi_tdo_seq(
 
 static void jtagtap_tdi_seq(const bool final_tms, const uint8_t *const data_in, const size_t clock_cycles)
 {
-	if (cl_debuglevel & BMP_DEBUG_PROBE) {
-		DEBUG_PROBE("jtagtap_tdi_seq final tms: %u, data_in: ", final_tms ? 1 : 0);
-		for (size_t cycle = 0; cycle < clock_cycles; cycle += 8U) {
-			const size_t chunk = cycle >> 3U;
-			if (chunk > 16U) {
-				DEBUG_PROBE(" ...");
-				break;
-			}
-			DEBUG_PROBE(" %02x", data_in[chunk]);
+	DEBUG_PROBE("jtagtap_tdi_seq final tms: %u, data_in: ", final_tms ? 1 : 0);
+	for (size_t cycle = 0; cycle < clock_cycles; cycle += 8U) {
+		const size_t chunk = cycle >> 3U;
+		if (chunk > 16U) {
+			DEBUG_PROBE(" ...");
+			break;
 		}
-		DEBUG_PROBE("\n");
+		DEBUG_PROBE(" %02x", data_in[chunk]);
 	}
+	DEBUG_PROBE("\n");
 	return jtagtap_tdi_tdo_seq(NULL, final_tms, data_in, clock_cycles);
 }
 

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -66,7 +66,7 @@ bool jlink_jtagtap_init(bmp_info_s *const info)
 	uint8_t res[4];
 	send_recv(info->usb_link, cmd_switch, 2, res, sizeof(res));
 	if (!(res[0] & JLINK_IF_JTAG)) {
-		DEBUG_WARN("JTAG not available\n");
+		DEBUG_ERROR("JTAG not available\n");
 		return false;
 	}
 	cmd_switch[1] = SELECT_IF_JTAG;
@@ -92,7 +92,7 @@ bool jlink_jtagtap_init(bmp_info_s *const info)
 	send_recv(info->usb_link, NULL, 0, res, 1);
 
 	if (res[0] != 0) {
-		DEBUG_WARN("Switch to JTAG failed\n");
+		DEBUG_ERROR("Switch to JTAG failed\n");
 		return false;
 	}
 	jtag_proc.jtagtap_reset = jtagtap_reset;

--- a/src/platforms/hosted/libftdi_jtagtap.c
+++ b/src/platforms/hosted/libftdi_jtagtap.c
@@ -68,7 +68,7 @@ void ftdi_jtag_drain_potential_garbage(void)
 bool ftdi_jtag_init(void)
 {
 	if (active_cable.mpsse_swd_read.set_data_low == MPSSE_DO && active_cable.mpsse_swd_write.set_data_low == MPSSE_DO) {
-		DEBUG_WARN("JTAG not possible with resistor SWD!\n");
+		DEBUG_ERROR("JTAG not possible with resistor SWD!\n");
 		return false;
 	}
 

--- a/src/platforms/hosted/libftdi_swdptap.c
+++ b/src/platforms/hosted/libftdi_swdptap.c
@@ -76,7 +76,7 @@ bool ftdi_swd_possible(void)
 bool ftdi_swd_init(void)
 {
 	if (!ftdi_swd_possible()) {
-		DEBUG_WARN("SWD not possible or missing item in adaptor description.\n");
+		DEBUG_ERROR("SWD not possible or missing item in adaptor description.\n");
 		return false;
 	}
 	DEBUG_PROBE("%s\n", __func__);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -584,7 +584,7 @@ static void ap_decode_access(uint16_t addr, uint8_t RnW)
 
 void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value)
 {
-	if (cl_debuglevel & BMP_DEBUG_TARGET) {
+	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
 		ap_decode_access(addr, ADIV5_LOW_WRITE);
 		fprintf(stderr, " 0x%08" PRIx32 "\n", value);
 	}
@@ -594,7 +594,7 @@ void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value)
 uint32_t adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 {
 	uint32_t ret = dp->dp_read(dp, addr);
-	if (cl_debuglevel & BMP_DEBUG_TARGET) {
+	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
 		ap_decode_access(addr, ADIV5_LOW_READ);
 		fprintf(stderr, " 0x%08" PRIx32 "\n", ret);
 	}
@@ -611,7 +611,7 @@ uint32_t adiv5_dp_error(adiv5_debug_port_s *dp)
 uint32_t adiv5_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
 {
 	uint32_t ret = dp->low_access(dp, RnW, addr, value);
-	if (cl_debuglevel & BMP_DEBUG_TARGET) {
+	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
 		ap_decode_access(addr, RnW);
 		fprintf(stderr, " 0x%08" PRIx32 "\n", RnW ? ret : value);
 	}
@@ -621,7 +621,7 @@ uint32_t adiv5_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr,
 uint32_t adiv5_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 {
 	uint32_t ret = ap->dp->ap_read(ap, addr);
-	if (cl_debuglevel & BMP_DEBUG_TARGET) {
+	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
 		ap_decode_access(addr, ADIV5_LOW_READ);
 		fprintf(stderr, " 0x%08" PRIx32 "\n", ret);
 	}
@@ -630,7 +630,7 @@ uint32_t adiv5_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 
 void adiv5_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 {
-	if (cl_debuglevel & BMP_DEBUG_TARGET) {
+	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
 		ap_decode_access(addr, ADIV5_LOW_WRITE);
 		fprintf(stderr, " 0x%08" PRIx32 "\n", value);
 	}
@@ -640,7 +640,7 @@ void adiv5_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 void adiv5_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
 {
 	ap->dp->mem_read(ap, dest, src, len);
-	if (cl_debuglevel & BMP_DEBUG_TARGET) {
+	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
 		fprintf(stderr, "ap_memread @ %" PRIx32 " len %zu:", src, len);
 		const uint8_t *const data = (const uint8_t *)dest;
 		for (size_t offset = 0; offset < len; ++offset) {
@@ -656,7 +656,7 @@ void adiv5_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t le
 
 void adiv5_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
-	if (cl_debuglevel & BMP_DEBUG_TARGET) {
+	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
 		fprintf(stderr, "ap_mem_write_sized @ %" PRIx32 " len %zu, align %d:", dest, len, 1 << align);
 		const uint8_t *const data = (const uint8_t *)src;
 		for (size_t offset = 0; offset < len; ++offset) {

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -427,7 +427,7 @@ void platform_target_set_power(const bool power)
 		if (remote_target_set_power(power))
 			DEBUG_INFO("Powering up device!\n");
 		else
-			DEBUG_WARN("Powering up device unimplemented or failed\n");
+			DEBUG_ERROR("Powering up device unimplemented or failed\n");
 		break;
 
 	default:

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -501,178 +501,164 @@ void platform_target_clk_output_enable(const bool enable)
 static void ap_decode_access(uint16_t addr, uint8_t RnW)
 {
 	if (RnW)
-		fprintf(stderr, "Read ");
+		DEBUG_PROTO("Read ");
 	else
-		fprintf(stderr, "Write ");
+		DEBUG_PROTO("Write ");
 
 	if (addr < 0x100U) {
 		switch (addr) {
 		case 0x00U:
 			if (RnW)
-				fprintf(stderr, "DP_DPIDR:");
+				DEBUG_PROTO("DP_DPIDR:");
 			else
-				fprintf(stderr, "DP_ABORT:");
+				DEBUG_PROTO("DP_ABORT:");
 			break;
 
 		case 0x04U:
-			fprintf(stderr, "CTRL/STAT:");
+			DEBUG_PROTO("CTRL/STAT:");
 			break;
 
 		case 0x08U:
 			if (RnW)
-				fprintf(stderr, "RESEND:");
+				DEBUG_PROTO("RESEND:");
 			else
-				fprintf(stderr, "DP_SELECT:");
+				DEBUG_PROTO("DP_SELECT:");
 			break;
 
 		case 0x0cU:
-			fprintf(stderr, "DP_RDBUFF:");
+			DEBUG_PROTO("DP_RDBUFF:");
 			break;
 
 		default:
-			fprintf(stderr, "Unknown register %02x:", addr);
+			DEBUG_PROTO("Unknown register %02x:", addr);
 		}
 	} else {
-		fprintf(stderr, "AP %u ", addr >> 8U);
+		DEBUG_PROTO("AP %u ", addr >> 8U);
 
 		switch (addr & 0xffU) {
 		case 0x00U:
-			fprintf(stderr, "CSW:");
+			DEBUG_PROTO("CSW:");
 			break;
 
 		case 0x04U:
-			fprintf(stderr, "TAR:");
+			DEBUG_PROTO("TAR:");
 			break;
 
 		case 0x0cU:
-			fprintf(stderr, "DRW:");
+			DEBUG_PROTO("DRW:");
 			break;
 
 		case 0x10U:
-			fprintf(stderr, "DB0:");
+			DEBUG_PROTO("DB0:");
 			break;
 
 		case 0x14U:
-			fprintf(stderr, "DB1:");
+			DEBUG_PROTO("DB1:");
 			break;
 
 		case 0x18U:
-			fprintf(stderr, "DB2:");
+			DEBUG_PROTO("DB2:");
 			break;
 
 		case 0x1cU:
-			fprintf(stderr, "DB3:");
+			DEBUG_PROTO("DB3:");
 			break;
 
 		case 0xf8U:
-			fprintf(stderr, "BASE:");
+			DEBUG_PROTO("BASE:");
 			break;
 
 		case 0xf4U:
-			fprintf(stderr, "CFG:");
+			DEBUG_PROTO("CFG:");
 			break;
 
 		case 0xfcU:
-			fprintf(stderr, "IDR:");
+			DEBUG_PROTO("IDR:");
 			break;
 
 		default:
-			fprintf(stderr, "RSVD%02x:", addr & 0xffU);
+			DEBUG_PROTO("RSVD%02x:", addr & 0xffU);
 		}
 	}
 }
 
 void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value)
 {
-	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
-		ap_decode_access(addr, ADIV5_LOW_WRITE);
-		fprintf(stderr, " 0x%08" PRIx32 "\n", value);
-	}
+	ap_decode_access(addr, ADIV5_LOW_WRITE);
+	DEBUG_PROTO(" 0x%08" PRIx32 "\n", value);
 	dp->low_access(dp, ADIV5_LOW_WRITE, addr, value);
 }
 
 uint32_t adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 {
 	uint32_t ret = dp->dp_read(dp, addr);
-	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
-		ap_decode_access(addr, ADIV5_LOW_READ);
-		fprintf(stderr, " 0x%08" PRIx32 "\n", ret);
-	}
+	ap_decode_access(addr, ADIV5_LOW_READ);
+	DEBUG_PROTO(" 0x%08" PRIx32 "\n", ret);
 	return ret;
 }
 
 uint32_t adiv5_dp_error(adiv5_debug_port_s *dp)
 {
 	uint32_t ret = dp->error(dp, false);
-	DEBUG_TARGET("DP Error 0x%08" PRIx32 "\n", ret);
+	DEBUG_PROTO("DP Error 0x%08" PRIx32 "\n", ret);
 	return ret;
 }
 
 uint32_t adiv5_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
 {
 	uint32_t ret = dp->low_access(dp, RnW, addr, value);
-	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
-		ap_decode_access(addr, RnW);
-		fprintf(stderr, " 0x%08" PRIx32 "\n", RnW ? ret : value);
-	}
+	ap_decode_access(addr, RnW);
+	DEBUG_PROTO(" 0x%08" PRIx32 "\n", RnW ? ret : value);
 	return ret;
 }
 
 uint32_t adiv5_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 {
 	uint32_t ret = ap->dp->ap_read(ap, addr);
-	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
-		ap_decode_access(addr, ADIV5_LOW_READ);
-		fprintf(stderr, " 0x%08" PRIx32 "\n", ret);
-	}
+	ap_decode_access(addr, ADIV5_LOW_READ);
+	DEBUG_PROTO(" 0x%08" PRIx32 "\n", ret);
 	return ret;
 }
 
 void adiv5_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 {
-	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
-		ap_decode_access(addr, ADIV5_LOW_WRITE);
-		fprintf(stderr, " 0x%08" PRIx32 "\n", value);
-	}
+	ap_decode_access(addr, ADIV5_LOW_WRITE);
+	DEBUG_PROTO(" 0x%08" PRIx32 "\n", value);
 	return ap->dp->ap_write(ap, addr, value);
 }
 
 void adiv5_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
 {
 	ap->dp->mem_read(ap, dest, src, len);
-	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
-		fprintf(stderr, "ap_memread @ %" PRIx32 " len %zu:", src, len);
-		const uint8_t *const data = (const uint8_t *)dest;
-		for (size_t offset = 0; offset < len; ++offset) {
-			if (offset == 16U)
-				break;
-			fprintf(stderr, " %02x", data[offset]);
-		}
-		if (len > 16U)
-			fprintf(stderr, " ...");
-		fprintf(stderr, "\n");
+	DEBUG_PROTO("ap_memread @ %" PRIx32 " len %zu:", src, len);
+	const uint8_t *const data = (const uint8_t *)dest;
+	for (size_t offset = 0; offset < len; ++offset) {
+		if (offset == 16U)
+			break;
+		DEBUG_PROTO(" %02x", data[offset]);
 	}
+	if (len > 16U)
+		DEBUG_PROTO(" ...");
+	DEBUG_PROTO("\n");
 }
 
 void adiv5_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
-	if (bmda_debug_flags & BMD_DEBUG_TARGET) {
-		fprintf(stderr, "ap_mem_write_sized @ %" PRIx32 " len %zu, align %d:", dest, len, 1 << align);
-		const uint8_t *const data = (const uint8_t *)src;
-		for (size_t offset = 0; offset < len; ++offset) {
-			if (offset == 16U)
-				break;
-			fprintf(stderr, " %02x", data[offset]);
-		}
-		if (len > 16U)
-			fprintf(stderr, " ...");
-		fprintf(stderr, "\n");
+	DEBUG_PROTO("ap_mem_write_sized @ %" PRIx32 " len %zu, align %d:", dest, len, 1 << align);
+	const uint8_t *const data = (const uint8_t *)src;
+	for (size_t offset = 0; offset < len; ++offset) {
+		if (offset == 16U)
+			break;
+		DEBUG_PROTO(" %02x", data[offset]);
 	}
+	if (len > 16U)
+		DEBUG_PROTO(" ...");
+	DEBUG_PROTO("\n");
 	return ap->dp->mem_write(ap, dest, src, len, align);
 }
 
 void adiv5_dp_abort(adiv5_debug_port_s *dp, uint32_t abort)
 {
-	DEBUG_TARGET("Abort: %08" PRIx32 "\n", abort);
+	DEBUG_PROTO("Abort: %08" PRIx32 "\n", abort);
 	return dp->abort(dp, abort);
 }

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -500,30 +500,26 @@ void platform_target_clk_output_enable(const bool enable)
 
 static void decode_dp_access(const uint8_t addr, const uint8_t rnw)
 {
+	const char *reg = NULL;
 	switch (addr) {
-	case 0x00U: {
-		const char *const reg = rnw ? "DPIDR" : "ABORT";
-		DEBUG_PROTO("%s:", reg);
+	case 0x00U:
+		reg = rnw ? "DPIDR" : "ABORT";
 		break;
-	}
-
 	case 0x04U:
-		DEBUG_PROTO("CTRL/STAT:");
+		reg = "CTRL/STAT";
 		break;
-
-	case 0x08U: {
-		const char *const reg = rnw ? "RESEND" : "SELECT";
-		DEBUG_PROTO("%s:", reg);
+	case 0x08U:
+		reg = rnw ? "RESEND" : "SELECT";
 		break;
-	}
-
 	case 0x0cU:
-		DEBUG_PROTO("RDBUFF:");
+		reg = "RDBUFF";
 		break;
-
-	default:
-		DEBUG_PROTO("Unknown DP register %02x:", addr);
 	}
+
+	if (reg)
+		DEBUG_PROTO("%s:", reg);
+	else
+		DEBUG_PROTO("Unknown DP register %02x:", addr);
 }
 
 static void decode_ap_access(const uint16_t addr)

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -522,54 +522,48 @@ static void decode_dp_access(const uint8_t addr, const uint8_t rnw)
 		DEBUG_PROTO("Unknown DP register %02x:", addr);
 }
 
-static void decode_ap_access(const uint16_t addr)
+static void decode_ap_access(const uint8_t ap, const uint8_t addr)
 {
-	DEBUG_PROTO("AP %u ", addr >> 8U);
+	DEBUG_PROTO("AP %u ", ap);
 
-	switch (addr & 0xffU) {
+	const char *reg = NULL;
+	switch (addr) {
 	case 0x00U:
-		DEBUG_PROTO("CSW:");
+		reg = "CSW";
 		break;
-
 	case 0x04U:
-		DEBUG_PROTO("TAR:");
+		reg = "TAR";
 		break;
-
 	case 0x0cU:
-		DEBUG_PROTO("DRW:");
+		reg = "DRW";
 		break;
-
 	case 0x10U:
-		DEBUG_PROTO("DB0:");
+		reg = "DB0";
 		break;
-
 	case 0x14U:
-		DEBUG_PROTO("DB1:");
+		reg = "DB1";
 		break;
-
 	case 0x18U:
-		DEBUG_PROTO("DB2:");
+		reg = "DB2";
 		break;
-
 	case 0x1cU:
-		DEBUG_PROTO("DB3:");
+		reg = "DB3";
 		break;
-
 	case 0xf8U:
-		DEBUG_PROTO("BASE:");
+		reg = "BASE";
 		break;
-
 	case 0xf4U:
-		DEBUG_PROTO("CFG:");
+		reg = "CFG";
 		break;
-
 	case 0xfcU:
-		DEBUG_PROTO("IDR:");
+		reg = "IDR";
 		break;
-
-	default:
-		DEBUG_PROTO("RSVD%02x:", addr & 0xffU);
 	}
+
+	if (reg)
+		DEBUG_PROTO("%s:", reg);
+	else
+		DEBUG_PROTO("Reserved(%02x):", addr);
 }
 
 static void decode_access(const uint16_t addr, const uint8_t rnw)
@@ -582,7 +576,7 @@ static void decode_access(const uint16_t addr, const uint8_t rnw)
 	if (addr < 0x100U)
 		decode_dp_access(addr & 0xffU, rnw);
 	else
-		decode_ap_access(addr);
+		decode_ap_access(addr >> 8U, addr & 0xffU);
 }
 
 void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value)

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -517,9 +517,9 @@ static void decode_dp_access(const uint8_t addr, const uint8_t rnw)
 	}
 
 	if (reg)
-		DEBUG_PROTO("%s:", reg);
+		DEBUG_PROTO("%s: ", reg);
 	else
-		DEBUG_PROTO("Unknown DP register %02x:", addr);
+		DEBUG_PROTO("Unknown DP register %02x: ", addr);
 }
 
 static void decode_ap_access(const uint8_t ap, const uint8_t addr)
@@ -561,9 +561,9 @@ static void decode_ap_access(const uint8_t ap, const uint8_t addr)
 	}
 
 	if (reg)
-		DEBUG_PROTO("%s:", reg);
+		DEBUG_PROTO("%s: ", reg);
 	else
-		DEBUG_PROTO("Reserved(%02x):", addr);
+		DEBUG_PROTO("Reserved(%02x): ", addr);
 }
 
 static void decode_access(const uint16_t addr, const uint8_t rnw)
@@ -582,7 +582,7 @@ static void decode_access(const uint16_t addr, const uint8_t rnw)
 void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value)
 {
 	decode_access(addr, ADIV5_LOW_WRITE);
-	DEBUG_PROTO(" 0x%08" PRIx32 "\n", value);
+	DEBUG_PROTO("0x%08" PRIx32 "\n", value);
 	dp->low_access(dp, ADIV5_LOW_WRITE, addr, value);
 }
 
@@ -590,7 +590,7 @@ uint32_t adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 {
 	uint32_t ret = dp->dp_read(dp, addr);
 	decode_access(addr, ADIV5_LOW_READ);
-	DEBUG_PROTO(" 0x%08" PRIx32 "\n", ret);
+	DEBUG_PROTO("0x%08" PRIx32 "\n", ret);
 	return ret;
 }
 
@@ -605,7 +605,7 @@ uint32_t adiv5_dp_low_access(adiv5_debug_port_s *dp, uint8_t rnw, uint16_t addr,
 {
 	uint32_t ret = dp->low_access(dp, rnw, addr, value);
 	decode_access(addr, rnw);
-	DEBUG_PROTO(" 0x%08" PRIx32 "\n", rnw ? ret : value);
+	DEBUG_PROTO("0x%08" PRIx32 "\n", rnw ? ret : value);
 	return ret;
 }
 
@@ -613,14 +613,14 @@ uint32_t adiv5_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 {
 	uint32_t ret = ap->dp->ap_read(ap, addr);
 	decode_access(addr, ADIV5_LOW_READ);
-	DEBUG_PROTO(" 0x%08" PRIx32 "\n", ret);
+	DEBUG_PROTO("0x%08" PRIx32 "\n", ret);
 	return ret;
 }
 
 void adiv5_ap_write(adiv5_access_port_s *ap, uint16_t addr, uint32_t value)
 {
 	decode_access(addr, ADIV5_LOW_WRITE);
-	DEBUG_PROTO(" 0x%08" PRIx32 "\n", value);
+	DEBUG_PROTO("0x%08" PRIx32 "\n", value);
 	return ap->dp->ap_write(ap, addr, value);
 }
 

--- a/src/platforms/hosted/probe_info.c
+++ b/src/platforms/hosted/probe_info.c
@@ -132,7 +132,7 @@ void probe_info_to_bmp_info(const probe_info_s *const probe, bmp_info_s *info)
 
 	if (snprintf(info->manufacturer, descriptor_len, "%s (%s)", probe->product, probe->manufacturer) !=
 		(int)descriptor_len - 1) {
-		DEBUG_WARN("Probe descriptor string '%s (%s)' exceeds allowable manufacturer description length\n",
+		DEBUG_ERROR("Probe descriptor string '%s (%s)' exceeds allowable manufacturer description length\n",
 			probe->product, probe->manufacturer);
 	}
 }

--- a/src/platforms/hosted/remote_jtagtap.c
+++ b/src/platforms/hosted/remote_jtagtap.c
@@ -55,7 +55,7 @@ bool remote_jtagtap_init(void)
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	int length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("jtagtap_init failed, error %s\n", length ? buffer + 1 : "unknown");
+		DEBUG_ERROR("jtagtap_init failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 
@@ -69,7 +69,7 @@ bool remote_jtagtap_init(void)
 	platform_buffer_write(REMOTE_HL_CHECK_STR, sizeof(REMOTE_HL_CHECK_STR));
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR || buffer[0] == 1)
-		PRINT_INFO("Firmware does not support newer JTAG commands, please update it.");
+		DEBUG_ERROR("Firmware does not support newer JTAG commands, please update it.");
 	else
 		jtag_proc.jtagtap_cycle = jtagtap_cycle;
 
@@ -84,7 +84,7 @@ static void jtagtap_reset(void)
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	const int length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("jtagtap_reset failed, error %s\n", length ? buffer + 1 : "unknown");
+		DEBUG_ERROR("jtagtap_reset failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 }
@@ -97,7 +97,7 @@ static void jtagtap_tms_seq(uint32_t tms_states, size_t clock_cycles)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("jtagtap_tms_seq failed, error %s\n", length ? buffer + 1 : "unknown");
+		DEBUG_ERROR("jtagtap_tms_seq failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 }
@@ -149,7 +149,7 @@ static void jtagtap_tdi_tdo_seq(
 		/* Receive the response and check if it's an error response */
 		length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 		if (!length || buffer[0] == REMOTE_RESP_ERR) {
-			DEBUG_WARN("jtagtap_tdi_tdo_seq failed, error %s\n", length ? buffer + 1 : "unknown");
+			DEBUG_ERROR("jtagtap_tdi_tdo_seq failed, error %s\n", length ? buffer + 1 : "unknown");
 			exit(-1);
 		}
 		if (data_out) {
@@ -173,7 +173,7 @@ static bool jtagtap_next(const bool tms, const bool tdi)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("jtagtap_next failed, error %s\n", length ? buffer + 1 : "unknown");
+		DEBUG_ERROR("jtagtap_next failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 
@@ -189,7 +189,7 @@ static void jtagtap_cycle(const bool tms, const bool tdi, const size_t clock_cyc
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("jtagtap_cycle failed, error %s\n", length ? buffer + 1 : "unknown");
+		DEBUG_ERROR("jtagtap_cycle failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 }

--- a/src/platforms/hosted/remote_swdptap.c
+++ b/src/platforms/hosted/remote_swdptap.c
@@ -19,7 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* MPSSE bit-banging SW-DP interface over FTDI with loop unrolled.
+/*
+ * MPSSE bit-banging SW-DP interface over FTDI with loop unrolled.
  * Speed is sensible.
  */
 
@@ -44,7 +45,7 @@ bool remote_swdptap_init(void)
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	int length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (!length || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("swdptap_init failed, error %s\n", length ? buffer + 1 : "unknown");
+		DEBUG_ERROR("swdptap_init failed, error %s\n", length ? buffer + 1 : "unknown");
 		exit(-1);
 	}
 
@@ -64,7 +65,7 @@ static bool remote_swd_seq_in_parity(uint32_t *res, size_t clock_cycles)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 2 || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
+		DEBUG_ERROR("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 
@@ -83,7 +84,7 @@ static uint32_t remote_swd_seq_in(size_t clock_cycles)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 2 || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
+		DEBUG_ERROR("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 	uint32_t res = remote_hex_string_to_num(-1, buffer + 1);
@@ -101,7 +102,7 @@ static void remote_swd_seq_out(uint32_t tms_states, size_t clock_cycles)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[0] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
+		DEBUG_ERROR("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
 		exit(-1);
 	}
 }
@@ -116,7 +117,7 @@ static void remote_swd_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 
 	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
 	if (length < 1 || buffer[1] == REMOTE_RESP_ERR) {
-		DEBUG_WARN("%s failed, error %s\n", __func__, length ? buffer + 2 : "short response");
+		DEBUG_ERROR("%s failed, error %s\n", __func__, length ? buffer + 2 : "short response");
 		exit(-1);
 	}
 }

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -42,7 +42,7 @@ static int set_interface_attribs(void)
 	struct termios tty;
 	memset(&tty, 0, sizeof tty);
 	if (tcgetattr(fd, &tty) != 0) {
-		DEBUG_WARN("error %d from tcgetattr", errno);
+		DEBUG_ERROR("error %d from tcgetattr", errno);
 		return -1;
 	}
 
@@ -65,7 +65,7 @@ static int set_interface_attribs(void)
 	tty.c_cflag &= ~CRTSCTS;
 #endif
 	if (tcsetattr(fd, TCSANOW, &tty) != 0) {
-		DEBUG_WARN("error %d from tcsetattr", errno);
+		DEBUG_ERROR("error %d from tcsetattr", errno);
 		return -1;
 	}
 	return 0;
@@ -88,7 +88,7 @@ int serial_open(const bmda_cli_options_s *cl_opts, const char *serial)
 	}
 	fd = open(name, O_RDWR | O_SYNC | O_NOCTTY);
 	if (fd < 0) {
-		DEBUG_WARN("Couldn't open serial port %s\n", name);
+		DEBUG_ERROR("Couldn't open serial port %s\n", name);
 		return -1;
 	}
 	/* BMP only offers an USB-Serial connection with no real serial
@@ -159,7 +159,7 @@ int serial_open(const bmda_cli_options_s *const cl_opts, const char *const seria
 		}
 		closedir(dir);
 		if (total == 0) {
-			DEBUG_WARN("No Black Magic Probes found\n");
+			DEBUG_ERROR("No Black Magic Probes found\n");
 			return -1;
 		}
 		if (matches != 1) {
@@ -175,11 +175,11 @@ int serial_open(const bmda_cli_options_s *const cl_opts, const char *const seria
 				}
 				closedir(dir);
 				if (serial)
-					DEBUG_WARN("No match for (partial) serial number \"%s\"\n", serial);
+					DEBUG_ERROR("No match for (partial) serial number \"%s\"\n", serial);
 				else
 					DEBUG_WARN("Select probe with `-s <(Partial) Serial Number>`\n");
 			} else
-				DEBUG_WARN("Could not scan %s: %s\n", name, strerror(errno));
+				DEBUG_ERROR("Could not scan %s: %s\n", name, strerror(errno));
 			return -1;
 		}
 	} else {
@@ -190,7 +190,7 @@ int serial_open(const bmda_cli_options_s *const cl_opts, const char *const seria
 	}
 	fd = open(name, O_RDWR | O_SYNC | O_NOCTTY);
 	if (fd < 0) {
-		DEBUG_WARN("Couldn't open serial port %s\n", name);
+		DEBUG_ERROR("Couldn't open serial port %s\n", name);
 		return -1;
 	}
 	/* BMP only offers an USB-Serial connection with no real serial
@@ -211,7 +211,7 @@ bool platform_buffer_write(const void *const data, const size_t length)
 	const ssize_t written = write(fd, data, length);
 	if (written < 0) {
 		const int error = errno;
-		DEBUG_WARN("Failed to write (%d): %s\n", errno, strerror(error));
+		DEBUG_ERROR("Failed to write (%d): %s\n", errno, strerror(error));
 		exit(-2);
 	}
 	return (size_t)written == length;
@@ -235,16 +235,16 @@ int platform_buffer_read(void *const data, size_t length)
 
 		const int result = select(FD_SETSIZE, &select_set, NULL, NULL, &timeout);
 		if (result < 0) {
-			DEBUG_WARN("Failed on select\n");
+			DEBUG_ERROR("Failed on select\n");
 			return -3;
 		}
 		if (result == 0) {
-			DEBUG_WARN("Timeout while waiting for BMP response\n");
+			DEBUG_ERROR("Timeout while waiting for BMP response\n");
 			return -4;
 		}
 		if (read(fd, &response, 1) != 1) {
 			const int error = errno;
-			DEBUG_WARN("Failed to read response (%d): %s\n", error, strerror(error));
+			DEBUG_ERROR("Failed to read response (%d): %s\n", error, strerror(error));
 			return -6;
 		}
 	}
@@ -255,16 +255,16 @@ int platform_buffer_read(void *const data, size_t length)
 		FD_SET(fd, &select_set);
 		const int result = select(FD_SETSIZE, &select_set, NULL, NULL, &timeout);
 		if (result < 0) {
-			DEBUG_WARN("Failed on select\n");
+			DEBUG_ERROR("Failed on select\n");
 			exit(-4);
 		}
 		if (result == 0) {
-			DEBUG_WARN("Timeout on read\n");
+			DEBUG_ERROR("Timeout on read\n");
 			return -5;
 		}
 		if (read(fd, data + offset, 1) != 1) {
 			const int error = errno;
-			DEBUG_WARN("Failed to read response (%d): %s\n", error, strerror(error));
+			DEBUG_ERROR("Failed to read response (%d): %s\n", error, strerror(error));
 			return -6;
 		}
 		char *const buffer = (char *)data;
@@ -276,6 +276,6 @@ int platform_buffer_read(void *const data, size_t length)
 		++offset;
 	}
 
-	DEBUG_WARN("Failed to read\n");
+	DEBUG_ERROR("Failed to read\n");
 	return -6;
 }

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -207,7 +207,7 @@ void serial_close(void)
 
 bool platform_buffer_write(const void *const data, const size_t length)
 {
-	DEBUG_WIRE("%s\n", data);
+	DEBUG_WIRE("%s\n", (const char *)data);
 	const ssize_t written = write(fd, data, length);
 	if (written < 0) {
 		const int error = errno;
@@ -270,7 +270,7 @@ int platform_buffer_read(void *const data, size_t length)
 		char *const buffer = (char *)data;
 		if (buffer[offset] == REMOTE_EOM) {
 			buffer[offset] = 0;
-			DEBUG_WIRE("       %s\n", data);
+			DEBUG_WIRE("       %s\n", buffer);
 			return offset;
 		}
 		++offset;

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -216,11 +216,11 @@ static int stlink_usb_error_check(uint8_t *data, bool verbose)
 		return STLINK_ERROR_OK;
 	case STLINK_DEBUG_ERR_FAULT:
 		if (verbose)
-			DEBUG_WARN("SWD fault response (0x%x)\n", STLINK_DEBUG_ERR_FAULT);
+			DEBUG_ERROR("SWD fault response (0x%x)\n", STLINK_DEBUG_ERR_FAULT);
 		return STLINK_ERROR_FAIL;
 	case STLINK_JTAG_UNKNOWN_JTAG_CHAIN:
 		if (verbose)
-			DEBUG_WARN("Unknown JTAG chain\n");
+			DEBUG_ERROR("Unknown JTAG chain\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_NO_DEVICE_CONNECTED:
 		if (verbose)
@@ -228,15 +228,15 @@ static int stlink_usb_error_check(uint8_t *data, bool verbose)
 		return STLINK_ERROR_FAIL;
 	case STLINK_JTAG_COMMAND_ERROR:
 		if (verbose)
-			DEBUG_WARN("Command error\n");
+			DEBUG_ERROR("Command error\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_JTAG_GET_IDCODE_ERROR:
 		if (verbose)
-			DEBUG_WARN("Failure reading IDCODE\n");
+			DEBUG_ERROR("Failure reading IDCODE\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_JTAG_DBG_POWER_ERROR:
 		if (verbose)
-			DEBUG_WARN("Failure powering DBG\n");
+			DEBUG_ERROR("Failure powering DBG\n");
 		return STLINK_ERROR_WAIT;
 	case STLINK_SWD_AP_WAIT:
 		if (verbose)
@@ -248,11 +248,11 @@ static int stlink_usb_error_check(uint8_t *data, bool verbose)
 		return STLINK_ERROR_WAIT;
 	case STLINK_JTAG_WRITE_ERROR:
 		if (verbose)
-			DEBUG_WARN("Write error\n");
+			DEBUG_ERROR("Write error\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_JTAG_WRITE_VERIF_ERROR:
 		if (verbose)
-			DEBUG_WARN("Write verify error, ignoring\n");
+			DEBUG_ERROR("Write verify error, ignoring\n");
 		return STLINK_ERROR_OK;
 	case STLINK_SWD_AP_FAULT:
 		/* git://git.ac6.fr/openocd commit 657e3e885b9ee10
@@ -262,41 +262,41 @@ static int stlink_usb_error_check(uint8_t *data, bool verbose)
 			 */
 		stlink.ap_error = true;
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_AP_FAULT\n");
+			DEBUG_ERROR("STLINK_SWD_AP_FAULT\n");
 		return STLINK_ERROR_AP_FAULT;
 	case STLINK_SWD_AP_ERROR:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_AP_ERROR\n");
+			DEBUG_ERROR("STLINK_SWD_AP_ERROR\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_SWD_AP_PARITY_ERROR:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_AP_PARITY_ERROR\n");
+			DEBUG_ERROR("STLINK_SWD_AP_PARITY_ERROR\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_SWD_DP_FAULT:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_DP_FAULT\n");
+			DEBUG_ERROR("STLINK_SWD_DP_FAULT\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_SWD_DP_ERROR:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_DP_ERROR\n");
+			DEBUG_ERROR("STLINK_SWD_DP_ERROR\n");
 		raise_exception(EXCEPTION_ERROR, "STLINK_SWD_DP_ERROR");
 		return STLINK_ERROR_FAIL;
 	case STLINK_SWD_DP_PARITY_ERROR:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_DP_PARITY_ERROR\n");
+			DEBUG_ERROR("STLINK_SWD_DP_PARITY_ERROR\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_SWD_AP_WDATA_ERROR:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_AP_WDATA_ERROR\n");
+			DEBUG_ERROR("STLINK_SWD_AP_WDATA_ERROR\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_SWD_AP_STICKY_ERROR:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_AP_STICKY_ERROR\n");
+			DEBUG_ERROR("STLINK_SWD_AP_STICKY_ERROR\n");
 		stlink.ap_error = true;
 		return STLINK_ERROR_FAIL;
 	case STLINK_SWD_AP_STICKYORUN_ERROR:
 		if (verbose)
-			DEBUG_WARN("STLINK_SWD_AP_STICKYORUN_ERROR\n");
+			DEBUG_ERROR("STLINK_SWD_AP_STICKYORUN_ERROR\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_BAD_AP_ERROR:
 		/* ADIV5 probe 256 APs, most of them are non exisitant.*/
@@ -304,15 +304,15 @@ static int stlink_usb_error_check(uint8_t *data, bool verbose)
 	case STLINK_TOO_MANY_AP_ERROR:
 		/* TI TM4C duplicates AP. Error happens at AP9.*/
 		if (verbose)
-			DEBUG_WARN("STLINK_TOO_MANY_AP_ERROR\n");
+			DEBUG_ERROR("STLINK_TOO_MANY_AP_ERROR\n");
 		return STLINK_ERROR_FAIL;
 	case STLINK_JTAG_UNKNOWN_CMD:
 		if (verbose)
-			DEBUG_WARN("STLINK_JTAG_UNKNOWN_CMD\n");
+			DEBUG_ERROR("STLINK_JTAG_UNKNOWN_CMD\n");
 		return STLINK_ERROR_FAIL;
 	default:
 		if (verbose)
-			DEBUG_WARN("unknown/unexpected ST-Link status code 0x%x\n", data[0]);
+			DEBUG_ERROR("unknown/unexpected ST-Link status code 0x%x\n", data[0]);
 		return STLINK_ERROR_FAIL;
 	}
 }
@@ -340,7 +340,7 @@ static int stlink_send_recv_retry(uint8_t *txbuf, size_t txsize, uint8_t *rxbuf,
 			first_res = res;
 		uint32_t now = platform_time_ms();
 		if (now - start > cortexm_wait_timeout || res != STLINK_ERROR_WAIT) {
-			DEBUG_WARN("send_recv_retry failed.\n");
+			DEBUG_ERROR("send_recv_retry failed.\n");
 			return res;
 		}
 	}
@@ -358,7 +358,7 @@ static int read_retry(uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsi
 			return res;
 		uint32_t now = platform_time_ms();
 		if (now - start > 1000U || res != STLINK_ERROR_WAIT) {
-			DEBUG_WARN("read_retry failed.\n");
+			DEBUG_ERROR("read_retry failed.\n");
 			stlink_usb_get_rw_status(true);
 			return res;
 		}
@@ -414,9 +414,8 @@ static void stlink_version(bmp_info_s *info)
 		memset(cmd, 0, sizeof(cmd));
 		cmd[0] = STLINK_GET_VERSION;
 		int size = send_recv(info->usb_link, cmd, 16, data, 6);
-		if (size == -1) {
+		if (size == -1)
 			DEBUG_WARN("[!] stlink_send_recv STLINK_GET_VERSION_EX\n");
-		}
 		stlink.vid = (data[3] << 8U) | data[2];
 		stlink.pid = (data[5] << 8U) | data[4];
 		uint16_t version = (data[0] << 8U) | data[1]; /* Big endian here!*/
@@ -512,7 +511,7 @@ int stlink_init(bmp_info_s *info)
 	libusb_device **devs = NULL;
 	const ssize_t cnt = libusb_get_device_list(info->libusb_ctx, &devs);
 	if (cnt < 0) {
-		DEBUG_WARN("FATAL: ST-Link libusb_get_device_list failed\n");
+		DEBUG_ERROR("FATAL: ST-Link libusb_get_device_list failed\n");
 		return -1;
 	}
 	bool found = false;
@@ -521,7 +520,7 @@ int stlink_init(bmp_info_s *info)
 		struct libusb_device_descriptor desc;
 		int result = libusb_get_device_descriptor(dev, &desc);
 		if (result != LIBUSB_SUCCESS) {
-			DEBUG_WARN("libusb_get_device_descriptor failed %s\n", libusb_strerror(result));
+			DEBUG_ERROR("libusb_get_device_descriptor failed %s\n", libusb_strerror(result));
 			return -1;
 		}
 		if (desc.idVendor != info->vid || desc.idProduct != info->pid)
@@ -529,7 +528,7 @@ int stlink_init(bmp_info_s *info)
 
 		result = libusb_open(dev, &sl->ul_libusb_device_handle);
 		if (result != LIBUSB_SUCCESS) {
-			DEBUG_WARN("Failed to open ST-Link device %04x:%04x - %s\n", desc.idVendor, desc.idProduct,
+			DEBUG_ERROR("Failed to open ST-Link device %04x:%04x - %s\n", desc.idVendor, desc.idProduct,
 				libusb_strerror(result));
 			DEBUG_WARN("Are you sure the permissions on the device are set correctly?\n");
 			continue;
@@ -587,19 +586,19 @@ int stlink_init(bmp_info_s *info)
 	int config;
 	int r = libusb_get_configuration(sl->ul_libusb_device_handle, &config);
 	if (r) {
-		DEBUG_WARN("FATAL: ST-Link libusb_get_configuration failed %d: %s\n", r, libusb_strerror(r));
+		DEBUG_ERROR("ST-Link libusb_get_configuration failed %d: %s\n", r, libusb_strerror(r));
 		return -1;
 	}
 	if (config != 1) {
 		r = libusb_set_configuration(sl->ul_libusb_device_handle, 0);
 		if (r) {
-			DEBUG_WARN("FATAL: ST-Link libusb_set_configuration failed %d: %s\n", r, libusb_strerror(r));
+			DEBUG_ERROR("ST-Link libusb_set_configuration failed %d: %s\n", r, libusb_strerror(r));
 			return -1;
 		}
 	}
 	r = libusb_claim_interface(sl->ul_libusb_device_handle, 0);
 	if (r) {
-		DEBUG_WARN("FATAL: ST-Link libusb_claim_interface failed %s\n", libusb_strerror(r));
+		DEBUG_ERROR("ST-Link libusb_claim_interface failed %s\n", libusb_strerror(r));
 		return -1;
 	}
 	sl->req_trans = libusb_alloc_transfer(0);
@@ -608,13 +607,13 @@ int stlink_init(bmp_info_s *info)
 	if ((stlink.ver_stlink < 3U && stlink.ver_jtag < 32U) || (stlink.ver_stlink == 3U && stlink.ver_jtag < 3U)) {
 		/* Maybe the adapter is in some strange state. Try to reset */
 		int result = libusb_reset_device(sl->ul_libusb_device_handle);
-		DEBUG_WARN("INFO: Trying ST-Link reset\n");
+		DEBUG_WARN("Trying ST-Link reset\n");
 		if (result == LIBUSB_ERROR_BUSY) { /* Try again */
 			platform_delay(50);
 			result = libusb_reset_device(sl->ul_libusb_device_handle);
 		}
 		if (result != LIBUSB_SUCCESS) {
-			DEBUG_WARN("FATAL: ST-Link libusb_reset_device failed\n");
+			DEBUG_ERROR("ST-Link libusb_reset_device failed\n");
 			return -1;
 		}
 		stlink_version(info);
@@ -716,7 +715,7 @@ uint32_t stlink_dp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 	adiv5_dp_write(dp, ADIV5_DP_ABORT, clr);
 	dp->fault = 0;
 	if (err)
-		DEBUG_WARN("stlink_dp_error %u\n", err);
+		DEBUG_ERROR("stlink_dp_error %u\n", err);
 	err |= stlink.ap_error;
 	stlink.ap_error = false;
 	return err;
@@ -746,7 +745,7 @@ static int stlink_read_dp_register(uint16_t port, uint16_t addr, uint32_t *reg)
 	if (result == STLINK_ERROR_OK)
 		*reg = data[4] | (data[5] << 8U) | (data[6] << 16U) | (data[7] << 24U);
 	else
-		DEBUG_WARN("%s error %d\n", __func__, result);
+		DEBUG_ERROR("%s error %d\n", __func__, result);
 	return result;
 }
 
@@ -876,7 +875,7 @@ static void stlink_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, s
 		 * Approach taken:
 		 * Fill the memory with some fixed pattern so hopefully
 		 * the caller notices the error*/
-		DEBUG_WARN("stlink_mem_read from  %" PRIx32 " to %p, len %zu failed\n", src, dest, len);
+		DEBUG_ERROR("stlink_mem_read from  %" PRIx32 " to %p, len %zu failed\n", src, dest, len);
 		memset(dest, 0xff, len);
 	}
 	DEBUG_PROBE("stlink_mem_read from %" PRIx32 " to %p, len %zu\n", src, dest, len);
@@ -1089,7 +1088,7 @@ uint32_t stlink_swdp_scan(void)
 
 	adiv5_debug_port_s *dp = calloc(1, sizeof(*dp));
 	if (!dp) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return 0;
 	}
 
@@ -1191,7 +1190,7 @@ void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq)
 		uint8_t data[2];
 		send_recv(info->usb_link, cmd, 16, data, 2);
 		if (stlink_usb_error_check(data, false))
-			DEBUG_WARN("Set frequency failed!\n");
+			DEBUG_ERROR("Set frequency failed!\n");
 	}
 }
 

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -43,7 +43,7 @@ void adiv5_jtag_dp_handler(const uint8_t dev_index)
 {
 	adiv5_debug_port_s *dp = calloc(1, sizeof(*dp));
 	if (!dp) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -100,14 +100,14 @@ uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_
 	} while (!platform_timeout_is_expired(&timeout) && ack == JTAGDP_ACK_WAIT);
 
 	if (ack == JTAGDP_ACK_WAIT) {
-		DEBUG_WARN("JTAG access resulted in wait, aborting\n");
+		DEBUG_ERROR("JTAG access resulted in wait, aborting\n");
 		dp->abort(dp, ADIV5_DP_ABORT_DAPABORT);
 		dp->fault = 1;
 		return 0;
 	}
 
 	if (ack != JTAGDP_ACK_OK) {
-		DEBUG_WARN("JTAG access resulted in: %" PRIx32 ":%x\n", result, ack);
+		DEBUG_ERROR("JTAG access resulted in: %" PRIx32 ":%x\n", result, ack);
 		raise_exception(EXCEPTION_ERROR, "JTAG-DP invalid ACK");
 	}
 

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -470,7 +470,7 @@ bool cortexa_probe(adiv5_access_port_s *apb, uint32_t debug_base)
 	adiv5_ap_ref(apb);
 	cortexa_priv_s *priv = calloc(1, sizeof(*priv));
 	if (!priv) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1230,8 +1230,8 @@ bool cortexm_run_stub(target_s *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, 
 			DEBUG_WARN("Stub hangs\n");
 			uint32_t arm_regs[t->regs_size];
 			target_regs_read(t, arm_regs);
-			for (size_t i = 0; i < 20U; i++)
-				DEBUG_WARN("%2d: %08" PRIx32 ", %08" PRIx32 "\n", i, arm_regs_start[i], arm_regs[i]);
+			for (uint32_t i = 0; i < 20U; ++i)
+				DEBUG_WARN("%2" PRIu32 ": %08" PRIx32 ", %08" PRIx32 "\n", i, arm_regs_start[i], arm_regs[i]);
 #endif
 			return false;
 		}

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -580,7 +580,7 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 
 	cortexm_priv_s *priv = calloc(1, sizeof(*priv));
 	if (!priv) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 
@@ -825,7 +825,7 @@ bool cortexm_attach(target_s *t)
 			if (!(reset_status & CORTEXM_DHCSR_S_RESET_ST))
 				break;
 			if (platform_timeout_is_expired(&timeout)) {
-				DEBUG_WARN("Error releasing from reset\n");
+				DEBUG_ERROR("Error releasing from reset\n");
 				return false;
 			}
 		}
@@ -1227,7 +1227,7 @@ bool cortexm_run_stub(target_s *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, 
 		if (platform_timeout_is_expired(&timeout)) {
 			cortexm_halt_request(t);
 #if defined(PLATFORM_HAS_DEBUG)
-			DEBUG_WARN("Stub hangs\n");
+			DEBUG_WARN("Stub hung\n");
 			uint32_t arm_regs[t->regs_size];
 			target_regs_read(t, arm_regs);
 			for (uint32_t i = 0; i < 20U; ++i)

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -498,7 +498,7 @@ static void efm32_add_flash(target_s *t, target_addr_t addr, size_t length, size
 {
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -89,7 +89,7 @@ uint32_t jtag_scan(const uint8_t *const ir_lengths, const size_t lengths_count)
 	DEBUG_INFO("Resetting TAP\n");
 #if PC_HOSTED == 1
 	if (!platform_jtagtap_init()) {
-		DEBUG_WARN("JTAG not available\n");
+		DEBUG_ERROR("JTAG not available\n");
 		return 0;
 	}
 #else
@@ -182,7 +182,7 @@ static bool jtag_read_idcodes(void)
 			break;
 		/* Check if the max suported chain length is exceeded */
 		if (device == JTAG_MAX_DEVS) {
-			DEBUG_WARN("jtag_scan: Maximum chain length exceeded\n");
+			DEBUG_ERROR("jtag_scan: Maximum chain length exceeded\n");
 			jtag_dev_count = 0;
 			return false;
 		}
@@ -244,7 +244,7 @@ static bool jtag_read_irs(void)
 		const bool next_bit = jtag_proc.jtagtap_next(false, true);
 		/* If we have quirks, validate the bit against the expected IR */
 		if (ir_quirks.ir_length && ((ir_quirks.ir_value >> ir_len) & 1U) != next_bit) {
-			DEBUG_WARN("jtag_scan: IR does not match the expected value, bailing out\n");
+			DEBUG_ERROR("jtag_scan: IR does not match the expected value, bailing out\n");
 			jtag_dev_count = 0;
 			return false;
 		}
@@ -285,7 +285,7 @@ static bool jtag_read_irs(void)
 
 	/* Sanity check that we didn't get an over-long IR */
 	if (ir_len > JTAG_MAX_IR_LEN) {
-		DEBUG_WARN("jtag_scan: Maximum IR length exceeded\n");
+		DEBUG_ERROR("jtag_scan: Maximum IR length exceeded\n");
 		jtag_dev_count = 0;
 		return 0;
 	}
@@ -310,12 +310,12 @@ static bool jtag_validate_irs(const uint8_t *const ir_lengths, const size_t leng
 	for (size_t device = 0; device < lengths_count; ++device) {
 		/* Validate the next ir_lengths value */
 		if (ir_lengths[device] > JTAG_MAX_IR_LEN) {
-			DEBUG_WARN("jtag_scan: Maximum IR length exceeded\n");
+			DEBUG_ERROR("jtag_scan: Maximum IR length exceeded\n");
 			jtag_dev_count = 0U;
 			return false;
 		}
 		if (ir_lengths[device] == 0) {
-			DEBUG_WARN("jtag_scan: IR length must be at least 1\n");
+			DEBUG_ERROR("jtag_scan: IR length must be at least 1\n");
 			jtag_dev_count = 0U;
 			return false;
 		}
@@ -354,7 +354,7 @@ static bool jtag_sanity_check(void)
 
 	/* If the device count gleaned above does not match the device count, error out */
 	if (device != jtag_dev_count) {
-		DEBUG_WARN("jtag_scan: Sanity check failed: BYPASS dev count doesn't match IR scan\n");
+		DEBUG_ERROR("jtag_scan: Sanity check failed: BYPASS dev count doesn't match IR scan\n");
 		jtag_dev_count = 0;
 		return false;
 	}

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -126,7 +126,7 @@ static void kinetis_add_flash(
 {
 	kinetis_flash_s *kf = calloc(1, sizeof(*kf));
 	if (!kf) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -76,7 +76,7 @@ static void lmi_add_flash(target_s *t, size_t length)
 {
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -90,16 +90,16 @@ bool lpc17xx_probe(target_s *target)
 		return false;
 
 	/*
-		* Now that we're sure it's a Cortex-M3, we need to halt the
-		* target and make an IAP call to get the part number.
-		* There appears to have no other method of reading the part number.
-		*/
+	 * Now that we're sure it's a Cortex-M3, we need to halt the
+	 * target and make an IAP call to get the part number.
+	 * There appears to have no other method of reading the part number.
+	 */
 	target_halt_request(target);
 
 	/* Allocate private storage so the flash mode entry/exit routines can save state */
 	lpc17xx_priv_s *priv = calloc(1, sizeof(*priv));
 	if (!priv) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 	target->target_storage = priv;
@@ -114,9 +114,9 @@ bool lpc17xx_probe(target_s *target)
 	target_halt_resume(target, false);
 
 	/*
-		* If we got an error response, it cannot be a LPC17xx as the only response
-		* a real device gives is IAP_STATUS_CMD_SUCCESS.
-		*/
+	 * If we got an error response, it cannot be a LPC17xx as the only response
+	 * a real device gives is IAP_STATUS_CMD_SUCCESS.
+	 */
 	if (result.return_code) {
 		free(priv);
 		target->target_storage = NULL;
@@ -180,19 +180,19 @@ static bool lpc17xx_mass_erase(target_s *target)
 
 	if (lpc17xx_iap_call(target, &result, IAP_CMD_PREPARE, 0, FLASH_NUM_SECTOR - 1U)) {
 		lpc17xx_exit_flash_mode(target);
-		DEBUG_WARN("lpc17xx_cmd_erase: prepare failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("lpc17xx_cmd_erase: prepare failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 
 	if (lpc17xx_iap_call(target, &result, IAP_CMD_ERASE, 0, FLASH_NUM_SECTOR - 1U, CPU_CLK_KHZ)) {
 		lpc17xx_exit_flash_mode(target);
-		DEBUG_WARN("lpc17xx_cmd_erase: erase failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("lpc17xx_cmd_erase: erase failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 
 	if (lpc17xx_iap_call(target, &result, IAP_CMD_BLANKCHECK, 0, FLASH_NUM_SECTOR - 1U)) {
 		lpc17xx_exit_flash_mode(target);
-		DEBUG_WARN("lpc17xx_cmd_erase: blankcheck failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("lpc17xx_cmd_erase: blankcheck failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 

--- a/src/target/lpc40xx.c
+++ b/src/target/lpc40xx.c
@@ -91,16 +91,16 @@ bool lpc40xx_probe(target_s *target)
 		return false;
 
 	/*
-		* Now that we're sure it's a Cortex-M3, we need to halt the
-		* target and make an IAP call to get the part number.
-		* There appears to have no other method of reading the part number.
-		*/
+	 * Now that we're sure it's a Cortex-M3, we need to halt the
+	 * target and make an IAP call to get the part number.
+	 * There appears to have no other method of reading the part number.
+	 */
 	target_halt_request(target);
 
 	/* Allocate private storage so the flash mode entry/exit routines can save state */
 	lpc40xx_priv_s *priv = calloc(1, sizeof(*priv));
 	if (!priv) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 	target->target_storage = priv;
@@ -115,9 +115,9 @@ bool lpc40xx_probe(target_s *target)
 	target_halt_resume(target, false);
 
 	/*
-		* If we got an error response, it cannot be a LPC40xx as the only response
-		* a real device gives is IAP_STATUS_CMD_SUCCESS.
-		*/
+	 * If we got an error response, it cannot be a LPC40xx as the only response
+	 * a real device gives is IAP_STATUS_CMD_SUCCESS.
+	 */
 	if (result.return_code) {
 		free(priv);
 		target->target_storage = NULL;
@@ -172,19 +172,19 @@ static bool lpc40xx_mass_erase(target_s *target)
 
 	if (lpc40xx_iap_call(target, &result, IAP_CMD_PREPARE, 0, FLASH_NUM_SECTOR - 1U)) {
 		lpc40xx_exit_flash_mode(target);
-		DEBUG_WARN("lpc40xx_cmd_erase: prepare failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("lpc40xx_cmd_erase: prepare failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 
 	if (lpc40xx_iap_call(target, &result, IAP_CMD_ERASE, 0, FLASH_NUM_SECTOR - 1U, CPU_CLK_KHZ)) {
 		lpc40xx_exit_flash_mode(target);
-		DEBUG_WARN("lpc40xx_cmd_erase: erase failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("lpc40xx_cmd_erase: erase failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 
 	if (lpc40xx_iap_call(target, &result, IAP_CMD_BLANKCHECK, 0, FLASH_NUM_SECTOR - 1U)) {
 		lpc40xx_exit_flash_mode(target);
-		DEBUG_WARN("lpc40xx_cmd_erase: blankcheck failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("lpc40xx_cmd_erase: blankcheck failed %" PRIu32 "\n", result.return_code);
 		return false;
 	}
 

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -411,7 +411,7 @@ static void lpc43x0_add_spi_flash(target_s *const t, const size_t length)
 {
 	lpc43xx_spi_flash_s *const flash = calloc(1, sizeof(*flash));
 	if (!flash) {
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 	lpc43x0_priv_s *const priv = (lpc43x0_priv_s *)t->target_storage;
@@ -511,7 +511,7 @@ bool lpc43xx_probe(target_s *const t)
 
 		lpc43xx_priv_s *priv = calloc(1, sizeof(lpc43xx_priv_s));
 		if (!priv) { /* calloc failed: heap exhaustion */
-			DEBUG_WARN("calloc: failed in %s\n", __func__);
+			DEBUG_ERROR("calloc: failed in %s\n", __func__);
 			return false;
 		}
 		t->target_storage = priv;
@@ -647,7 +647,7 @@ static bool lpc43x0_attach(target_s *const t)
 	if (!t->target_storage) {
 		lpc43x0_priv_s *priv = calloc(1, sizeof(lpc43x0_priv_s));
 		if (!priv) { /* calloc failed: heap exhaustion */
-			DEBUG_WARN("calloc: failed in %s\n", __func__);
+			DEBUG_ERROR("calloc: failed in %s\n", __func__);
 			return false;
 		}
 		t->target_storage = priv;

--- a/src/target/lpc55xx.c
+++ b/src/target/lpc55xx.c
@@ -275,7 +275,7 @@ static lpc55xx_iap_status_e iap_call_raw(target_s *target, lpc55xx_iap_cmd_e cmd
 		regs[REG_PC] = lpc55xx_get_ffr_get_uuid_address(target);
 		break;
 	default:
-		DEBUG_WARN("LPC55xx: bad IAP command\n");
+		DEBUG_ERROR("LPC55xx: bad IAP command\n");
 		return IAP_STATUS_FLASH_INVALID_ARGUMENT;
 	}
 
@@ -344,7 +344,7 @@ static bool lpc55xx_flash_init(target_s *target, lpc55xx_flash_config_s *config)
 	lpc55xx_iap_status_e status = iap_call_raw(target, IAP_CMD_FLASH_INIT, 0, 0, 0);
 
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_WARN("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
 		goto exit;
 	}
 
@@ -375,21 +375,21 @@ static bool lpc55xx_get_uuid(target_s *target, uint8_t *uuid)
 	lpc55xx_iap_status_e status = iap_call_raw(target, IAP_CMD_FLASH_INIT, 0, 0, 0);
 
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_WARN("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
 		goto exit;
 	}
 
 	status = iap_call_raw(target, IAP_CMD_FFR_INIT, 0, 0, 0);
 
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_WARN("LPC55xx: IAP error: FFR_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: FFR_INIT (%d)\n", status);
 		goto exit;
 	}
 
 	status = iap_call_raw(target, IAP_CMD_FFR_GET_UUID, LPC55xx_UUID_ADDRESS, 0, 0);
 
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_WARN("LPC55xx: IAP error: FFR_GET_UUID (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: FFR_GET_UUID (%d)\n", status);
 		goto exit;
 	}
 
@@ -442,7 +442,7 @@ static bool lpc55xx_flash_prepare(target_flash_s *flash)
 	lpc55xx_iap_status_e status = iap_call_raw(flash->t, IAP_CMD_FLASH_INIT, 0, 0, 0);
 
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_WARN("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
 		return false;
 	}
 
@@ -454,7 +454,7 @@ static bool lpc55xx_flash_erase(target_flash_s *flash, target_addr_t addr, size_
 	lpc55xx_iap_status_e status = iap_call_raw(flash->t, IAP_CMD_FLASH_ERASE, addr, (uint32_t)len, LPC55xx_ERASE_KEY);
 
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_WARN("LPC55xx: IAP error: FLASH_ERASE (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: FLASH_ERASE (%d)\n", status);
 		return false;
 	}
 
@@ -469,7 +469,7 @@ static bool lpc55xx_flash_write(target_flash_s *flash, target_addr_t dest, const
 		iap_call_raw(flash->t, IAP_CMD_FLASH_PROGRAM, dest, LPC55xx_WRITE_BUFFER_ADDRESS, (uint32_t)len);
 
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_WARN("LPC55xx: IAP error: FLASH_PROGRAM (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: FLASH_PROGRAM (%d)\n", status);
 		return false;
 	}
 
@@ -481,7 +481,7 @@ static target_flash_s *lpc55xx_add_flash(target_s *target)
 	target_flash_s *flash = calloc(1, sizeof(*flash));
 
 	if (!flash) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return NULL;
 	}
 
@@ -668,7 +668,7 @@ static bool lpc55_dmap_cmd(adiv5_access_port_s *const ap, const uint32_t cmd)
 		if (value == 0)
 			return true;
 		if (platform_timeout_is_expired(&timeout)) {
-			DEBUG_WARN("LPC55 cmd %" PRIx32 " failed\n", cmd);
+			DEBUG_ERROR("LPC55 cmd %" PRIx32 " failed\n", cmd);
 			return false;
 		}
 	}

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -80,7 +80,7 @@ lpc_flash_s *lpc_add_flash(
 {
 	lpc_flash_s *const lpc_flash = calloc(1, sizeof(*lpc_flash));
 	if (!lpc_flash) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return NULL;
 	}
 
@@ -229,7 +229,7 @@ static bool lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *
 	/* Prepare... */
 	const uint32_t sector = lpc_sector_for_addr(f, dest);
 	if (lpc_iap_call(f, NULL, IAP_CMD_PREPARE, sector, sector, f->bank)) {
-		DEBUG_WARN("Prepare failed\n");
+		DEBUG_ERROR("Prepare failed\n");
 		return false;
 	}
 	const uint32_t bufaddr = ALIGN(f->iap_ram + sizeof(flash_param_s), 4);
@@ -249,7 +249,7 @@ static bool lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *
 		 */
 		for (size_t offset = 0; offset < len - (0x40U * f->reserved_pages); offset += LPX80X_PAGE_SIZE) {
 			if (lpc_iap_call(f, NULL, IAP_CMD_PREPARE, sector, sector, f->bank)) {
-				DEBUG_WARN("Prepare failed\n");
+				DEBUG_ERROR("Prepare failed\n");
 				return false;
 			}
 			/* Set the destination address and program */

--- a/src/target/msp432.c
+++ b/src/target/msp432.c
@@ -144,7 +144,7 @@ static void msp432_add_flash(target_s *t, uint32_t addr, size_t length, target_a
 	msp432_flash_s *mf = calloc(1, sizeof(*mf));
 	target_flash_s *f;
 	if (!mf) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -107,7 +107,7 @@ static void nrf51_add_flash(target_s *t, uint32_t addr, size_t length, size_t er
 {
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 

--- a/src/target/nxpke04.c
+++ b/src/target/nxpke04.c
@@ -221,7 +221,7 @@ bool ke04_probe(target_s *t)
 	/* Add flash, all KE04 have same write and erase size */
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 

--- a/src/target/renesas.c
+++ b/src/target/renesas.c
@@ -762,24 +762,24 @@ bool renesas_probe(target_s *t)
 		 */
 
 		if (renesas_pnr_read(t, RENESAS_FIXED2_PNR, pnr)) {
-			DEBUG_WARN("Found renesas chip (%.*s) with pnr location RENESAS_FIXED2_PNR and unsupported Part ID %" PRIx16
-					   " please report it\n",
-				sizeof(pnr), pnr, t->part_id);
+			DEBUG_WARN("Found renesas chip (%.*s) with pnr location RENESAS_FIXED2_PNR and unsupported Part ID %x "
+					   "please report it\n",
+				(int)sizeof(pnr), pnr, t->part_id);
 			break;
 		}
 
 		if (renesas_pnr_read(t, RENESAS_FIXED1_PNR, pnr)) {
-			DEBUG_WARN("Found renesas chip (%.*s) with pnr location RENESAS_FIXED1_PNR and unsupported Part ID "
-					   "0x%" PRIx16 " please report it\n",
-				sizeof(pnr), pnr, t->part_id);
+			DEBUG_WARN("Found renesas chip (%.*s) with pnr location RENESAS_FIXED1_PNR and unsupported Part ID 0x%x "
+					   "please report it\n",
+				(int)sizeof(pnr), pnr, t->part_id);
 			break;
 		}
 
 		flash_root_table = renesas_fmifrt_read(t);
 		if (renesas_pnr_read(t, RENESAS_FMIFRT_PNR(flash_root_table), pnr)) {
-			DEBUG_WARN("Found renesas chip (%.*s) with Flash Root Table and unsupported Part ID 0x%" PRIx16 " "
+			DEBUG_WARN("Found renesas chip (%.*s) with Flash Root Table and unsupported Part ID 0x%x "
 					   "please report it\n",
-				sizeof(pnr), pnr, t->part_id);
+				(int)sizeof(pnr), pnr, t->part_id);
 			break;
 		}
 

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -244,7 +244,7 @@ static void rp_add_flash(target_s *target)
 {
 	rp_flash_s *spi_flash = calloc(1, sizeof(*spi_flash));
 	if (!spi_flash) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -290,7 +290,7 @@ bool rp_probe(target_s *target)
 	/* Check bootrom magic*/
 	uint32_t boot_magic = target_mem_read32(target, BOOTROM_MAGIC_ADDR);
 	if ((boot_magic & BOOTROM_MAGIC_MASK) != BOOTROM_MAGIC) {
-		DEBUG_WARN("Wrong Bootmagic %08" PRIx32 " found!\n", boot_magic);
+		DEBUG_ERROR("Wrong Bootmagic %08" PRIx32 " found!\n", boot_magic);
 		return false;
 	}
 
@@ -301,7 +301,7 @@ bool rp_probe(target_s *target)
 
 	rp_priv_s *priv_storage = calloc(1, sizeof(rp_priv_s));
 	if (!priv_storage) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 	target->target_storage = (void *)priv_storage;

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -195,7 +195,7 @@ static void sam3_add_flash(target_s *t, uint32_t eefc_base, uint32_t addr, size_
 {
 	sam_flash_s *sf = calloc(1, sizeof(*sf));
 	if (!sf) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -215,7 +215,7 @@ static void sam_add_flash(target_s *t, uint32_t eefc_base, uint32_t addr, size_t
 {
 	sam_flash_s *sf = calloc(1, sizeof(*sf));
 	if (!sf) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -391,7 +391,7 @@ bool samx7x_probe(target_s *t)
 
 	sam_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
 	if (!priv_storage) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 	t->target_storage = priv_storage;

--- a/src/target/sam4l.c
+++ b/src/target/sam4l.c
@@ -189,7 +189,7 @@ static void sam4l_add_flash(target_s *t, uint32_t addr, size_t length)
 {
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -233,7 +233,7 @@ bool sam4l_probe(target_s *t)
 	/* Enable SMAP if not, check for HCR and reset if set */
 	sam4l_extended_reset(t);
 	if (target_check_error(t))
-		DEBUG_WARN("SAM4L: target_check_error returned true\n");
+		DEBUG_ERROR("SAM4L: target_check_error returned true\n");
 	return true;
 }
 

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -474,7 +474,7 @@ static void samd_add_flash(target_s *t, uint32_t addr, size_t length)
 {
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 

--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -492,7 +492,7 @@ static bool samx5x_flash_erase(target_flash_s *f, target_addr_t addr, size_t len
 		}
 
 		if (target_check_error(t) || samx5x_check_nvm_error(t)) {
-			DEBUG_WARN("Error\n");
+			DEBUG_ERROR("Error\n");
 			return false;
 		}
 
@@ -534,7 +534,7 @@ static bool samx5x_flash_write(target_flash_s *f, target_addr_t dest, const void
 	}
 
 	if (error || target_check_error(t) || samx5x_check_nvm_error(t)) {
-		DEBUG_WARN("Error writing flash page at 0x%08" PRIx32 " (len 0x%08" PRIx32 ")\n", dest, (uint32_t)len);
+		DEBUG_ERROR("Error writing flash page at 0x%08" PRIx32 " (len 0x%08" PRIx32 ")\n", dest, (uint32_t)len);
 		return false;
 	}
 

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -110,7 +110,7 @@ static void stm32f1_add_flash(target_s *target, uint32_t addr, size_t length, si
 {
 	target_flash_s *flash = calloc(1, sizeof(*flash));
 	if (!flash) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -323,7 +323,7 @@ bool mm32l0xx_probe(target_s *target)
 
 	const uint32_t mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32L0);
 	if (target_check_error(target)) {
-		DEBUG_WARN("mm32l0xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32L0);
+		DEBUG_ERROR("mm32l0xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32L0);
 		return false;
 	}
 	switch (mm32_id) {
@@ -366,7 +366,7 @@ bool mm32f3xx_probe(target_s *target)
 
 	mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32F3);
 	if (target_check_error(target)) {
-		DEBUG_WARN("mm32f3xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32F3);
+		DEBUG_ERROR("mm32f3xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32F3);
 		return false;
 	}
 	switch (mm32_id) {
@@ -505,7 +505,7 @@ static bool stm32f1_flash_unlock(target_s *target, uint32_t bank_offset)
 	target_mem_write32(target, FLASH_KEYR + bank_offset, KEY2);
 	uint32_t ctrl = target_mem_read32(target, FLASH_CR);
 	if (ctrl & FLASH_CR_LOCK)
-		DEBUG_WARN("unlock failed, cr: 0x%08" PRIx32 "\n", ctrl);
+		DEBUG_ERROR("unlock failed, cr: 0x%08" PRIx32 "\n", ctrl);
 	return !(ctrl & FLASH_CR_LOCK);
 }
 
@@ -530,14 +530,14 @@ static bool stm32f1_flash_busy_wait(
 	while (!(status & SR_EOP) && (status & FLASH_SR_BSY)) {
 		status = target_mem_read32(target, FLASH_SR + bank_offset);
 		if (target_check_error(target)) {
-			DEBUG_WARN("Lost communications with target");
+			DEBUG_ERROR("Lost communications with target");
 			return false;
 		}
 		if (timeout)
 			target_print_progress(timeout);
 	};
 	if (status & SR_ERROR_MASK)
-		DEBUG_WARN("stm32f1 flash error 0x%" PRIx32 "\n", status);
+		DEBUG_ERROR("stm32f1 flash error 0x%" PRIx32 "\n", status);
 	return !(status & SR_ERROR_MASK);
 }
 

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -148,7 +148,7 @@ static void stm32f4_add_flash(target_s *const t, const uint32_t addr, const size
 
 	stm32f4_flash_s *sf = calloc(1, sizeof(*sf));
 	if (!sf) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -351,7 +351,7 @@ static bool stm32f4_attach(target_s *t)
 	/* Allocate target-specific storage */
 	stm32f4_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
 	if (!priv_storage) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 	t->target_storage = priv_storage;
@@ -469,7 +469,7 @@ static bool stm32f4_flash_busy_wait(target_s *const t, platform_timeout_s *const
 	while (status & FLASH_SR_BSY) {
 		status = target_mem_read32(t, FLASH_SR);
 		if ((status & SR_ERROR_MASK) || target_check_error(t)) {
-			DEBUG_WARN("stm32f4 flash error 0x%" PRIx32 "\n", status);
+			DEBUG_ERROR("stm32f4 flash error 0x%" PRIx32 "\n", status);
 			return false;
 		}
 		if (timeout)

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -195,7 +195,7 @@ static void stm32g0_add_flash(target_s *t, uint32_t addr, size_t length, size_t 
 {
 	target_flash_s *f = calloc(1, sizeof(*f));
 	if (!f) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -424,7 +424,7 @@ static bool stm32g0_flash_erase(target_flash_s *f, const target_addr_t addr, con
 	/* Check for error */
 	const uint32_t status = target_mem_read32(t, FLASH_SR);
 	if (status & FLASH_SR_ERROR_MASK)
-		DEBUG_WARN("stm32g0 flash erase error: sr 0x%" PRIx32 "\n", status);
+		DEBUG_ERROR("stm32g0 flash erase error: sr 0x%" PRIx32 "\n", status);
 	stm32g0_flash_op_finish(t);
 	return !(status & FLASH_SR_ERROR_MASK);
 }
@@ -453,14 +453,14 @@ static bool stm32g0_flash_write(target_flash_s *f, target_addr_t dest, const voi
 	target_mem_write(t, dest, src, len);
 	/* Wait for completion or an error */
 	if (!stm32g0_wait_busy(t, NULL)) {
-		DEBUG_WARN("stm32g0 flash write: comm error\n");
+		DEBUG_ERROR("stm32g0 flash write: comm error\n");
 		stm32g0_flash_op_finish(t);
 		return false;
 	}
 
 	const uint32_t status = target_mem_read32(t, FLASH_SR);
 	if (status & FLASH_SR_ERROR_MASK) {
-		DEBUG_WARN("stm32g0 flash write error: sr 0x%" PRIx32 "\n", status);
+		DEBUG_ERROR("stm32g0 flash write error: sr 0x%" PRIx32 "\n", status);
 		stm32g0_flash_op_finish(t);
 		return false;
 	}

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -158,7 +158,7 @@ static void stm32h7_add_flash(target_s *t, uint32_t addr, size_t length, size_t 
 {
 	stm32h7_flash_s *sf = calloc(1, sizeof(*sf));
 	if (!sf) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -241,7 +241,7 @@ static bool stm32h7_flash_busy_wait(target_s *const t, const uint32_t regbase)
 	while (status & (FLASH_SR_BSY | FLASH_SR_QW)) {
 		status = target_mem_read32(t, regbase + FLASH_SR);
 		if ((status & FLASH_SR_ERROR_MASK) || target_check_error(t)) {
-			DEBUG_WARN("stm32h7_flash_write: error status %08" PRIx32 "\n", status);
+			DEBUG_ERROR("stm32h7_flash_write: error status %08" PRIx32 "\n", status);
 			target_mem_write32(t, regbase + FLASH_CCR, status & FLASH_SR_ERROR_MASK);
 			return false;
 		}
@@ -333,7 +333,7 @@ static bool stm32h7_erase_bank(
 	target_s *const t, const align_e psize, const uint32_t start_addr, const uint32_t reg_base)
 {
 	if (!stm32h7_flash_unlock(t, start_addr)) {
-		DEBUG_WARN("Bank erase: Unlock bank failed\n");
+		DEBUG_ERROR("Bank erase: Unlock bank failed\n");
 		return false;
 	}
 	/* BER and start can be merged (§3.3.10). */
@@ -347,7 +347,7 @@ static bool stm32h7_wait_erase_bank(target_s *const t, platform_timeout_s *const
 {
 	while (target_mem_read32(t, reg_base + FLASH_SR) & FLASH_SR_QW) {
 		if (target_check_error(t)) {
-			DEBUG_WARN("mass erase bank: comm failed\n");
+			DEBUG_ERROR("mass erase bank: comm failed\n");
 			return false;
 		}
 		target_print_progress(timeout);
@@ -359,7 +359,7 @@ static bool stm32h7_check_bank(target_s *const t, const uint32_t reg_base)
 {
 	uint32_t status = target_mem_read32(t, reg_base + FLASH_SR);
 	if (status & FLASH_SR_ERROR_MASK)
-		DEBUG_WARN("mass erase bank: error sr %" PRIx32 "\n", status);
+		DEBUG_ERROR("mass erase bank: error sr %" PRIx32 "\n", status);
 	return !(status & FLASH_SR_ERROR_MASK);
 }
 
@@ -437,11 +437,11 @@ static bool stm32h7_crc_bank(target_s *t, uint32_t addr)
 	while (status & FLASH_SR_CRC_BUSY) {
 		status = target_mem_read32(t, reg_base + FLASH_SR);
 		if (target_check_error(t)) {
-			DEBUG_WARN("CRC bank %u: comm failed\n", bank);
+			DEBUG_ERROR("CRC bank %u: comm failed\n", bank);
 			return false;
 		}
 		if (status & FLASH_SR_ERROR_READ) {
-			DEBUG_WARN("CRC bank %u: error status %08" PRIx32 "\n", bank, status);
+			DEBUG_ERROR("CRC bank %u: error status %08" PRIx32 "\n", bank, status);
 			return false;
 		}
 	}

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -187,7 +187,7 @@ static void stm32l_add_flash(target_s *const target, const uint32_t addr, const 
 {
 	target_flash_s *flash = calloc(1, sizeof(*flash));
 	if (!flash) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -204,7 +204,7 @@ static void stm32l_add_eeprom(target_s *const target, const uint32_t addr, const
 {
 	target_flash_s *flash = calloc(1, sizeof(*flash));
 	if (!flash) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -249,7 +249,7 @@ bool stm32l0_probe(target_s *const target)
 
 	stm32l_priv_t *priv_storage = calloc(1, sizeof(*priv_storage));
 	if (!priv_storage) {
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
 	target->target_storage = (void *)priv_storage;

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -467,7 +467,7 @@ static void stm32l4_add_flash(
 {
 	stm32l4_flash_s *sf = calloc(1, sizeof(*sf));
 	if (!sf) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -680,7 +680,7 @@ static bool stm32l4_flash_busy_wait(target_s *const t, platform_timeout_s *timeo
 	while (status & FLASH_SR_BSY) {
 		status = stm32l4_flash_read32(t, FLASH_SR);
 		if ((status & FLASH_SR_ERROR_MASK) || target_check_error(t)) {
-			DEBUG_WARN("stm32l4 Flash error: status 0x%" PRIx32 "\n", status);
+			DEBUG_ERROR("stm32l4 Flash error: status 0x%" PRIx32 "\n", status);
 			return false;
 		}
 		if (timeout)

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -43,7 +43,7 @@ target_s *target_new(void)
 {
 	target_s *t = calloc(1, sizeof(*t));
 	if (!t) { /* calloc failed: heap exhaustion */
-		DEBUG_WARN("calloc: failed in %s\n", __func__);
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return NULL;
 	}
 
@@ -128,7 +128,7 @@ void target_add_commands(target_s *t, const command_s *cmds, const char *name)
 {
 	target_command_s *tc = malloc(sizeof(*tc));
 	if (!tc) { /* malloc failed: heap exhaustion */
-		DEBUG_WARN("malloc: failed in %s\n", __func__);
+		DEBUG_ERROR("malloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -176,7 +176,7 @@ void target_add_ram(target_s *t, target_addr_t start, uint32_t len)
 {
 	target_ram_s *ram = malloc(sizeof(*ram));
 	if (!ram) { /* malloc failed: heap exhaustion */
-		DEBUG_WARN("malloc: failed in %s\n", __func__);
+		DEBUG_ERROR("malloc: failed in %s\n", __func__);
 		return;
 	}
 
@@ -392,7 +392,7 @@ int target_breakwatch_set(target_s *t, target_breakwatch_e type, target_addr_t a
 		/* Success, make a heap copy */
 		breakwatch_s *bwm = malloc(sizeof(bw));
 		if (!bwm) { /* malloc failed: heap exhaustion */
-			DEBUG_WARN("malloc: failed in %s\n", __func__);
+			DEBUG_ERROR("malloc: failed in %s\n", __func__);
 			return 1;
 		}
 		memcpy(bwm, &bw, sizeof(bw));

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -130,7 +130,7 @@ bool target_flash_erase(target_s *t, target_addr_t addr, size_t len)
 	while (len) {
 		target_flash_s *f = target_flash_for_addr(t, addr);
 		if (!f) {
-			DEBUG_WARN("Requested address is outside the valid range 0x%06" PRIx32 "\n", addr);
+			DEBUG_ERROR("Requested address is outside the valid range 0x%06" PRIx32 "\n", addr);
 			return false;
 		}
 
@@ -148,7 +148,7 @@ bool target_flash_erase(target_s *t, target_addr_t addr, size_t len)
 
 		ret &= f->erase(f, local_start_addr, f->blocksize);
 		if (!ret) {
-			DEBUG_WARN("Erase failed at %" PRIx32 "\n", local_start_addr);
+			DEBUG_ERROR("Erase failed at %" PRIx32 "\n", local_start_addr);
 			break;
 		}
 
@@ -165,7 +165,7 @@ bool flash_buffer_alloc(target_flash_s *flash)
 	/* Allocate buffer */
 	flash->buf = malloc(flash->writebufsize);
 	if (!flash->buf) { /* malloc failed: heap exhaustion */
-		DEBUG_WARN("malloc: failed in %s\n", __func__);
+		DEBUG_ERROR("malloc: failed in %s\n", __func__);
 		return false;
 	}
 	flash->buf_addr_base = UINT32_MAX;
@@ -274,7 +274,7 @@ bool target_flash_write(target_s *t, target_addr_t dest, const void *src, size_t
 
 		ret &= flash_buffered_write(f, dest, src, local_length);
 		if (!ret) {
-			DEBUG_WARN("Write failed at %" PRIx32 "\n", dest);
+			DEBUG_ERROR("Write failed at %" PRIx32 "\n", dest);
 			break;
 		}
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Debug logging in BMDA was entirely implemented by the header general.h, providing no API or proper interface and causing massive code duplication in the compiled binary. Additionally, two logging levels were not present - a level for errors and a level for protocol logging - causing other levels to be used and shoehorned with these kinds of messages. This has landed trouble more than once w/ people misunderstanding errors as warnings, and causing getting logging specifically of target behaviour not protocol behaviour to be at best very difficult.

This PR addresses this by introducing `DEBUG_ERROR` and `DEBUG_PROTO` and rearchitecting BMDAs logging infrastructure with two new files (debug.c, debug.h) in the BMDA sources which provide implementations for the logging API and introducing a proper API into general.h.

In a future PR we will look to prepend a message tag to output lines which indicates which level the message is coming from to help make BMDA logs even more readable.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
