### PR TITLE
blackpillv2/platform: add function platform_target_voltage_sense

### DIFF
--- a/src/platforms/blackpillv2/platform.c
+++ b/src/platforms/blackpillv2/platform.c
@@ -149,6 +149,22 @@ void platform_target_set_power(const bool power)
 {
 	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, !power);
 }
+
+/**
+ * @brief Senses the voltage on the power pin in tenths of a volt (so 33 means 3.3V).
+ * 
+ * However it returns 0 for blackpillv2, as it does not sense the voltage on the power pin.
+ * This function is only needed for implementations that allow the target to be powered
+ * from the debug probe.
+ * 
+ * @param void
+ * @return voltage sensed on the power pin. 0 for blackpillv2.
+ */
+uint32_t platform_target_voltage_sense(void)
+{
+	return 0;
+}
+
 #endif
 
 void platform_target_clk_output_enable(bool enable)

--- a/src/platforms/blackpillv2/platform.c
+++ b/src/platforms/blackpillv2/platform.c
@@ -150,21 +150,16 @@ void platform_target_set_power(const bool power)
 	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, !power);
 }
 
-/**
- * @brief Senses the voltage on the power pin in tenths of a volt (so 33 means 3.3V).
- * 
- * However it returns 0 for blackpillv2, as it does not sense the voltage on the power pin.
- * This function is only needed for implementations that allow the target to be powered
- * from the debug probe.
- * 
- * @param void
- * @return voltage sensed on the power pin. 0 for blackpillv2.
+/*
+ * A dummy implementation of platform_target_voltage_sense as the
+ * blackpillv2 has no ability to sense the voltage on the power pin.
+ * This function is only needed for implementations that allow the target
+ * to be powered from the debug probe.
  */
 uint32_t platform_target_voltage_sense(void)
 {
 	return 0;
 }
-
 #endif
 
 void platform_target_clk_output_enable(bool enable)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
This pull request fixes the compiler error ```undefined reference to `platform_target_voltage_sense'``` when PLATFORM_HAS_POWER_SWITCH is defined for the blackpillv2.

It fixes the error by adding the function platform_target_voltage_sense as it was previously undefined.

As the blackpillv2 does not sense the voltage on the power pin, the function is implemented by returning a 0.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] It builds for hardware blackpillv2 (`make PROBE_HOST=blackpillv2`)
* [x] It builds for all platforms (`make all_platforms`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

<!-- ## Closing issues -->

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
