### PR TITLE
Feature: CDC GET_LINE_CODING support

### DIFF
--- a/src/platforms/common/aux_serial.h
+++ b/src/platforms/common/aux_serial.h
@@ -44,6 +44,7 @@ typedef struct usb_cdc_line_coding usb_cdc_line_coding_s;
 
 void aux_serial_init(void);
 void aux_serial_set_encoding(const usb_cdc_line_coding_s *coding);
+void aux_serial_get_encoding(usb_cdc_line_coding_s *coding);
 
 #if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
 typedef enum aux_serial_led {

--- a/src/platforms/common/aux_serial.h
+++ b/src/platforms/common/aux_serial.h
@@ -40,8 +40,10 @@
 #define AUX_UART_BUFFER_SIZE 128U
 #endif
 
+typedef struct usb_cdc_line_coding usb_cdc_line_coding_s;
+
 void aux_serial_init(void);
-void aux_serial_set_encoding(usb_cdc_line_coding_s *coding);
+void aux_serial_set_encoding(const usb_cdc_line_coding_s *coding);
 
 #if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
 typedef enum aux_serial_led {

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -153,6 +153,11 @@ static usbd_request_return_codes_e debug_serial_control_request(usbd_device *dev
 			return USBD_REQ_NOTSUPP;
 		aux_serial_set_encoding((usb_cdc_line_coding_s *)*buf);
 		return USBD_REQ_HANDLED;
+	case USB_CDC_REQ_GET_LINE_CODING:
+		if (*len < sizeof(usb_cdc_line_coding_s))
+			return USBD_REQ_NOTSUPP;
+		aux_serial_get_encoding((usb_cdc_line_coding_s *)*buf);
+		return USBD_REQ_HANDLED;
 	}
 	return USBD_REQ_NOTSUPP;
 }

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -109,6 +109,17 @@ static usbd_request_return_codes_e gdb_serial_control_request(usbd_device *dev, 
 		if (*len < sizeof(usb_cdc_line_coding_s))
 			return USBD_REQ_NOTSUPP;
 		return USBD_REQ_HANDLED; /* Ignore on GDB Port */
+	case USB_CDC_REQ_GET_LINE_CODING: {
+		if (*len < sizeof(usb_cdc_line_coding_s))
+			return USBD_REQ_NOTSUPP;
+		usb_cdc_line_coding_s *line_coding = (usb_cdc_line_coding_s *)*buf;
+		/* This tells the host that we talk 1MBaud, 8-bit no parity w/ 1 stop bit */
+		line_coding->dwDTERate = 1 * 1000 * 1000;
+		line_coding->bCharFormat = USB_CDC_1_STOP_BITS;
+		line_coding->bParityType = USB_CDC_NO_PARITY;
+		line_coding->bDataBits = 8;
+		return USBD_REQ_HANDLED;
+	}
 	}
 	return USBD_REQ_NOTSUPP;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR implements support for the USB CDC ACM control request "GET_LINE_CODING" which is used by Windows and Linux most notably to ensure they're in step with the firmware for things like baud rate, control signalling state, etc.

With this PR, the reliability of GDB to BMP connectivity should be improved as are various ancillary things to do with the AUX serial to USB serial bridge.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
