### PR TITLE
Fix: `load` -> `kill` crash

### DIFF
--- a/src/target/adiv5_swdp.c
+++ b/src/target/adiv5_swdp.c
@@ -185,10 +185,11 @@ uint32_t adiv5_swdp_scan(uint32_t targetid)
 				i << ADIV5_DP_TARGETSEL_TINSTANCE_OFFSET |
 					(dp_targetid & (ADIV5_DP_TARGETID_TDESIGNER_MASK | ADIV5_DP_TARGETID_TPARTNO_MASK)) | 1U);
 
+			volatile uint32_t target_id = 0;
 			TRY_CATCH (e, EXCEPTION_ALL) {
-				adiv5_dp_read(initial_dp, ADIV5_DP_DPIDR);
+				target_id = adiv5_dp_read(initial_dp, ADIV5_DP_DPIDR);
 			}
-			if (e.type || initial_dp->fault)
+			if (e.type || initial_dp->fault || !target_id)
 				continue;
 		}
 

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -403,6 +403,7 @@ static bool rp_flash_resume(target_s *const target)
 	/* Flush the cache and resume XIP */
 	rp_flash_flush_cache(target);
 	rp_flash_enter_xip(target);
+	target_mem_write32(target, CORTEXM_AIRCR, CORTEXM_AIRCR_VECTKEY | CORTEXM_AIRCR_SYSRESETREQ);
 	return true;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As part of #1364 it was identified that when running `load` followed immediately by `kill` in GDB on a RP2040, the result would be the target instantly crashing. This PR fixes that by fixing the behaviour of the Flash mode exit routine so the core's put back into a good state on exit ready to go.

This PR also improves the handling of unused DPs in a multi-drop system to reduce the number of protocol recoveries and failures to deal with and speed up SWD scan.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
