### PR TITLE
Reset pulse length, fix ST-Link v2 clone nRST pin

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -91,7 +91,7 @@ const command_s cmd_list[] = {
 	{"morse", cmd_morse, "Display morse error message"},
 	{"halt_timeout", cmd_halt_timeout, "Timeout (ms) to wait until Cortex-M is halted: (Default 2000)"},
 	{"connect_rst", cmd_connect_reset, "Configure connect under reset: (enable|disable)"},
-	{"reset", cmd_reset, "Pulse the nRST line - disconnects target"},
+	{"reset", cmd_reset, "Pulse the nRST line - disconnects target: (pulse_len_ms, default 0)"},
 	{"tdi_low_reset", cmd_tdi_low_reset,
 		"Pulse nRST with TDI set low to attempt to wake certain targets up (eg LPC82x)"},
 #ifdef PLATFORM_HAS_POWER_SWITCH
@@ -454,10 +454,12 @@ static bool cmd_halt_timeout(target_s *t, int argc, const char **argv)
 static bool cmd_reset(target_s *t, int argc, const char **argv)
 {
 	(void)t;
-	(void)argc;
-	(void)argv;
+	uint32_t pulse_len_ms = 0;
+	if (argc > 1)
+		pulse_len_ms = strtoul(argv[1], NULL, 0);
 	target_list_free();
 	platform_nrst_set_val(true);
+	platform_delay(pulse_len_ms);
 	platform_nrst_set_val(false);
 	return true;
 }

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -51,12 +51,19 @@ void platform_init(void)
 	led_idle_run = GPIO13;
 	nrst_pin = NRST_PIN_V1;
 #else
-	if (rev == 0) {
+	switch (rev) {
+	case 0:
 		led_idle_run = GPIO8;
 		nrst_pin = NRST_PIN_V1;
-	} else {
+		break;
+	case 0x101:
+		led_idle_run = GPIO9;
+		nrst_pin = NRST_PIN_CLONE;
+		break;
+	default:
 		led_idle_run = GPIO9;
 		nrst_pin = NRST_PIN_V2;
+		break;
 	}
 #endif
 	/* Setup GPIO ports */
@@ -73,7 +80,7 @@ void platform_init(void)
 	SCB_VTOR = (uintptr_t)&vector_table;
 
 	platform_timing_init();
-	if (rev > 1U) /* Reconnect USB */
+	if ((rev & 0xff) > 1U) /* Reconnect USB */
 		gpio_set(GPIOA, GPIO15);
 	blackmagic_usb_init();
 

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -53,9 +53,10 @@ extern bool debug_bmp;
 #define SWDIO_PIN  TMS_PIN
 #define SWCLK_PIN  TCK_PIN
 
-#define NRST_PORT   GPIOB
-#define NRST_PIN_V1 GPIO1
-#define NRST_PIN_V2 GPIO0
+#define NRST_PORT      GPIOB
+#define NRST_PIN_V1    GPIO1
+#define NRST_PIN_V2    GPIO0
+#define NRST_PIN_CLONE GPIO6
 
 #ifdef BLUEPILL
 #define LED_PORT GPIOC

--- a/src/platforms/stlink/stlink_common.c
+++ b/src/platforms/stlink/stlink_common.c
@@ -49,7 +49,7 @@ uint32_t detect_rev(void)
 	 * First, get the board revision by pulling PC13/14 up then reading them.
 	 * This gives us the following table of values for these pins:
 	 *  11 for ST-Link v1, e.g. on VL Discovery, tag as rev 0
-	 *  11 for "Baite" clones, PB11 pulled high, tag as rev 1
+	 *  11 for "Baite" clones, PB11 pulled high, tag as rev 257 (0x101)
 	 *  00 for ST-Link v2, e.g. on F4 Discovery, tag as rev 1
 	 *  01 for ST-Link v2, else,                 tag as rev 1
 	 */
@@ -60,7 +60,7 @@ uint32_t detect_rev(void)
 
 	uint32_t revision = 0;
 	if (stlink_stable_read(GPIOC, GPIO13))
-		revision = gpio_get(GPIOB, GPIO11) ? 1 : 0;
+		revision = gpio_get(GPIOB, GPIO11) ? 0x101 : 0;
 	else {
 		/*
 		 * Check for ST-Link v2.1 boards.
@@ -89,7 +89,7 @@ uint32_t detect_rev(void)
 		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO8);
 	}
 	/* Clean up after ourself on boards that aren't identified as ST-Link v2.1's */
-	if (revision < 2U) {
+	if ((revision & 0xff) < 2U) {
 		gpio_clear(GPIOA, GPIO12);
 		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_OPENDRAIN, GPIO12);
 	}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This patch series fixes two issues I had using the BMP firmware on an ST-Link v2 clone with a target that requires using SRST:
- The nRST pulse length is too short and didn't trigger a target reset at all in my case.

  This is addressed by adding an optional parameter to `cmd_reset` specifying the pulse length in milliseconds, defaulting to the previous behaviour of no delay (0ms).
- Unlike the original ST-Link v2 hardware which has nRST connected to PB0 or PB1, the "clones" use PB6.

  Despite having completely different PCB layouts and ICs, all three different types of "clones" I examined don't have nRST hooked up to PB0 or PB1 but rather to PB6. Some have PB6 and PB7 connected together.
  The clones are now assigned their own hardware revision (0x101 to leave plenty of room for more variations of the original hardware). Based on this hardware revision, BMP will now use PB6 as nRST for the clones.

*N.B.*: Building the BMP firmware for ST-Link clones currently requires disabling some of the targets as otherwise it's too large to fit into the 128KiB flash of the clones (build time error). This requires manual changes to `src/Makefile`. For testing this patch series I disabled the `lpc*` targets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md) that has no contact method filled in.
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None.
<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
