### PR TITLE
Fix: BMDA ST-Link v2 crash

### DIFF
--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -99,7 +99,7 @@ SRC += protocol_v1.c protocol_v1_adiv5.c protocol_v2.c
 SRC += protocol_v3.c protocol_v3_adiv5.c
 SRC += bmp_remote.c
 ifneq ($(HOSTED_BMP_ONLY), 1)
-    SRC += bmp_libusb.c stlinkv2.c stlinkv2_jtag.c
+    SRC += bmp_libusb.c stlinkv2.c stlinkv2_jtag.c stlinkv2_swd.c
     SRC += ftdi_bmp.c libftdi_swdptap.c libftdi_jtagtap.c
     SRC += jlink.c jlink_adiv5_swdp.c jlink_jtagtap.c
 else

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -99,7 +99,7 @@ SRC += protocol_v1.c protocol_v1_adiv5.c protocol_v2.c
 SRC += protocol_v3.c protocol_v3_adiv5.c
 SRC += bmp_remote.c
 ifneq ($(HOSTED_BMP_ONLY), 1)
-    SRC += bmp_libusb.c stlinkv2.c
+    SRC += bmp_libusb.c stlinkv2.c stlinkv2_jtag.c
     SRC += ftdi_bmp.c libftdi_swdptap.c libftdi_jtagtap.c
     SRC += jlink.c jlink_adiv5_swdp.c jlink_jtagtap.c
 else

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -53,19 +53,16 @@ typedef struct libusb_config_descriptor libusb_config_descriptor_s;
 typedef struct libusb_interface_descriptor libusb_interface_descriptor_s;
 typedef struct libusb_endpoint_descriptor libusb_endpoint_descriptor_s;
 typedef struct libusb_interface libusb_interface_s;
-typedef struct libusb_transfer libusb_transfer_s;
 typedef enum libusb_error libusb_error_e;
 
 typedef struct ftdi_context ftdi_context_s;
 
 typedef struct usb_link {
-	libusb_context *ul_libusb_ctx;
-	libusb_device_handle *ul_libusb_device_handle;
+	libusb_context *context;
+	libusb_device_handle *device_handle;
 	uint8_t interface;
 	uint8_t ep_tx;
 	uint8_t ep_rx;
-	libusb_transfer_s *req_trans;
-	libusb_transfer_s *rep_trans;
 	void *priv;
 } usb_link_s;
 #endif

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -100,7 +100,7 @@ void libusb_exit_function(bmp_info_s *info);
 #if HOSTED_BMP_ONLY == 1
 bool device_is_bmp_gdb_port(const char *device);
 #else
-int send_recv(usb_link_s *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
+int bmda_usb_transfer(usb_link_s *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
 #endif
 
 #endif /* PLATFORMS_HOSTED_BMP_HOSTED_H */

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -100,7 +100,7 @@ void libusb_exit_function(bmp_info_s *info);
 #if HOSTED_BMP_ONLY == 1
 bool device_is_bmp_gdb_port(const char *device);
 #else
-int bmda_usb_transfer(usb_link_s *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
+int bmda_usb_transfer(usb_link_s *link, const void *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
 #endif
 
 #endif /* PLATFORMS_HOSTED_BMP_HOSTED_H */

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -100,7 +100,7 @@ void libusb_exit_function(bmp_info_s *info);
 #if HOSTED_BMP_ONLY == 1
 bool device_is_bmp_gdb_port(const char *device);
 #else
-int bmda_usb_transfer(usb_link_s *link, const void *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize);
+int bmda_usb_transfer(usb_link_s *link, const void *tx_buffer, size_t tx_len, void *rx_buffer, size_t rx_len);
 #endif
 
 #endif /* PLATFORMS_HOSTED_BMP_HOSTED_H */

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -393,7 +393,7 @@ static int submit_wait(usb_link_s *link, libusb_transfer_s *transfer)
 }
 
 /* One USB transaction */
-int send_recv(usb_link_s *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize)
+int bmda_usb_transfer(usb_link_s *link, uint8_t *txbuf, size_t txsize, uint8_t *rxbuf, size_t rxsize)
 {
 	int res = 0;
 	if (txsize) {

--- a/src/platforms/hosted/ftdi_bmp.h
+++ b/src/platforms/hosted/ftdi_bmp.h
@@ -4,6 +4,8 @@
  * Copyright (C) 2011  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
  * Copyright (C) 2018  Uwe Bonnes (non@elektron.ikp.physik.tu-darmstadt.de)
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +23,8 @@
 
 #ifndef PLATFORMS_HOSTED_FTDI_BMP_H
 #define PLATFORMS_HOSTED_FTDI_BMP_H
+
+#include <ftdi.h>
 
 #include "cli.h"
 #include "jtagtap.h"
@@ -99,84 +103,6 @@ typedef struct cable_desc {
 	char *name;
 } cable_desc_s;
 
-#define libftdi_buffer_write_arr(array) libftdi_buffer_write(array, sizeof(array))
-#define libftdi_buffer_write_val(value) libftdi_buffer_write(&(value), sizeof(value))
-#define libftdi_buffer_read_arr(array)  libftdi_buffer_read(array, sizeof(array))
-#define libftdi_buffer_read_val(value)  libftdi_buffer_read(&(value), sizeof(value))
-
-#if HOSTED_BMP_ONLY == 1
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
-bool ftdi_bmp_init(bmda_cli_options_s *cl_opts)
-{
-	return false;
-}
-
-bool ftdi_swd_init(void)
-{
-	return false;
-}
-
-bool ftdi_jtag_init(void)
-{
-	return false;
-}
-
-void libftdi_buffer_flush(void)
-{
-}
-
-size_t libftdi_buffer_write(const uint8_t *data, size_t size)
-{
-	return size;
-}
-
-size_t libftdi_buffer_read(uint8_t *data, size_t size)
-{
-	return size;
-}
-
-const char *libftdi_target_voltage(void)
-{
-	return "ERROR";
-}
-
-void ftdi_jtag_tdi_tdo_seq(
-	uint8_t *const data_out, const bool final_tms, const uint8_t *const data_in, const size_t ticks)
-{
-}
-
-bool ftdi_swd_possible(void)
-{
-	return false;
-}
-
-void libftdi_max_frequency_set(uint32_t freq)
-{
-}
-
-uint32_t libftdi_max_frequency_get(void)
-{
-	return 0;
-}
-
-void libftdi_nrst_set_val(bool assert)
-{
-}
-
-bool libftdi_nrst_get_val(void)
-{
-	return false;
-}
-
-#pragma GCC diagnostic pop
-#else
-#include <ftdi.h>
-extern const cable_desc_s cable_desc[];
-extern cable_desc_s active_cable;
-extern data_desc_s active_state;
-
 typedef struct ftdi_mpsse_cmd {
 	uint8_t command;
 	uint8_t length[2];
@@ -186,6 +112,15 @@ typedef struct ftdi_mpsse_cmd_bits {
 	uint8_t command;
 	uint8_t length;
 } ftdi_mpsse_cmd_bits_s;
+
+extern const cable_desc_s cable_desc[];
+extern cable_desc_s active_cable;
+extern data_desc_s active_state;
+
+#define libftdi_buffer_write_arr(array) libftdi_buffer_write(array, sizeof(array))
+#define libftdi_buffer_write_val(value) libftdi_buffer_write(&(value), sizeof(value))
+#define libftdi_buffer_read_arr(array)  libftdi_buffer_read(array, sizeof(array))
+#define libftdi_buffer_read_val(value)  libftdi_buffer_read(&(value), sizeof(value))
 
 bool ftdi_bmp_init(bmda_cli_options_s *cl_opts);
 bool ftdi_swd_init(void);
@@ -200,7 +135,6 @@ void libftdi_max_frequency_set(uint32_t freq);
 uint32_t libftdi_max_frequency_get(void);
 void libftdi_nrst_set_val(bool assert);
 bool libftdi_nrst_get_val(void);
-#endif
 
 #define MPSSE_SK 1
 #define PIN0     1

--- a/src/platforms/hosted/jlink_adiv5_swdp.c
+++ b/src/platforms/hosted/jlink_adiv5_swdp.c
@@ -58,8 +58,8 @@ static bool line_reset(bmp_info_s *const info)
 	data[13] = 0xa5U;
 
 	uint8_t res[19];
-	send_recv(info->usb_link, cmd, 42U, res, 19U);
-	send_recv(info->usb_link, NULL, 0U, res, 1U);
+	bmda_usb_transfer(info->usb_link, cmd, 42U, res, 19U);
+	bmda_usb_transfer(info->usb_link, NULL, 0U, res, 1U);
 
 	if (res[0] != 0) {
 		DEBUG_ERROR("Line reset failed\n");
@@ -75,13 +75,13 @@ static bool jlink_swdptap_init(bmp_info_s *const info)
 		JLINK_IF_GET_AVAILABLE,
 	};
 	uint8_t res[4];
-	send_recv(info->usb_link, cmd, 2, res, sizeof(res));
+	bmda_usb_transfer(info->usb_link, cmd, 2, res, sizeof(res));
 
 	if (!(res[0] & JLINK_IF_SWD))
 		return false;
 
 	cmd[1] = SELECT_IF_SWD;
-	send_recv(info->usb_link, cmd, 2, res, sizeof(res));
+	bmda_usb_transfer(info->usb_link, cmd, 2, res, sizeof(res));
 
 	platform_delay(10);
 	/* SWD speed is fixed. Do not set it here*/
@@ -109,8 +109,8 @@ uint32_t jlink_swdp_scan(bmp_info_s *const info)
 	memset(data + 9U, 0xffU, 6U);
 
 	uint8_t res[18];
-	send_recv(info->usb_link, cmd, 38U, res, 17U);
-	send_recv(info->usb_link, NULL, 0U, res, 1U);
+	bmda_usb_transfer(info->usb_link, cmd, 38U, res, 17U);
+	bmda_usb_transfer(info->usb_link, NULL, 0U, res, 1U);
 
 	if (res[0] != 0) {
 		DEBUG_ERROR("Line reset failed\n");
@@ -164,8 +164,8 @@ static bool jlink_adiv5_swdp_write_nocheck(const uint16_t addr, const uint32_t d
 	uint8_t result[3];
 	uint8_t request[8];
 	jlink_adiv5_swdp_make_packet_request(request, sizeof(request), ADIV5_LOW_WRITE, addr & 0xfU);
-	send_recv(info.usb_link, request, 8U, result, 2U);
-	send_recv(info.usb_link, NULL, 0U, result + 2U, 1U);
+	bmda_usb_transfer(info.usb_link, request, 8U, result, 2U);
+	bmda_usb_transfer(info.usb_link, NULL, 0U, result + 2U, 1U);
 	const uint8_t ack = result[1] & 7U;
 
 	uint8_t response[16];
@@ -179,8 +179,8 @@ static bool jlink_adiv5_swdp_write_nocheck(const uint16_t addr, const uint32_t d
 	const uint8_t bit_count = __builtin_popcount(data);
 	response[14] = bit_count & 1U;
 
-	send_recv(info.usb_link, response, 16, result, 6);
-	send_recv(info.usb_link, NULL, 0, result, 1);
+	bmda_usb_transfer(info.usb_link, response, 16, result, 6);
+	bmda_usb_transfer(info.usb_link, NULL, 0, result, 1);
 	if (result[0] != 0)
 		raise_exception(EXCEPTION_ERROR, "Low access write failed");
 	return ack != SWDP_ACK_OK;
@@ -191,8 +191,8 @@ static uint32_t jlink_adiv5_swdp_read_nocheck(const uint16_t addr)
 	uint8_t result[6];
 	uint8_t request[8];
 	jlink_adiv5_swdp_make_packet_request(request, sizeof(request), ADIV5_LOW_READ, addr & 0xfU);
-	send_recv(info.usb_link, request, 8U, result, 2U);
-	send_recv(info.usb_link, NULL, 0U, result + 2U, 1U);
+	bmda_usb_transfer(info.usb_link, request, 8U, result, 2U);
+	bmda_usb_transfer(info.usb_link, NULL, 0U, result + 2U, 1U);
 	const uint8_t ack = result[1] & 7U;
 
 	uint8_t response[14];
@@ -200,8 +200,8 @@ static uint32_t jlink_adiv5_swdp_read_nocheck(const uint16_t addr)
 	response[0] = CMD_HW_JTAG3;
 	response[2] = 33U + 2U; /* 2 idle cycles */
 	response[8] = 0xfe;
-	send_recv(info.usb_link, response, 14, result, 5);
-	send_recv(info.usb_link, NULL, 0, result + 5U, 1);
+	bmda_usb_transfer(info.usb_link, response, 14, result, 5);
+	bmda_usb_transfer(info.usb_link, NULL, 0, result + 5U, 1);
 	if (result[5] != 0)
 		raise_exception(EXCEPTION_ERROR, "Low access read failed");
 	const uint32_t data = result[0] | result[1] << 8U | result[2] << 16U | result[3] << 24U;
@@ -244,8 +244,8 @@ static uint32_t jlink_adiv5_swdp_low_read(adiv5_debug_port_s *const dp)
 	cmd[0] = CMD_HW_JTAG3;
 	cmd[2] = 33U + 2U; /* 2 idle cycles */
 	cmd[8] = 0xfe;
-	send_recv(info.usb_link, cmd, 14, result, 5);
-	send_recv(info.usb_link, NULL, 0, result + 5U, 1);
+	bmda_usb_transfer(info.usb_link, cmd, 14, result, 5);
+	bmda_usb_transfer(info.usb_link, NULL, 0, result + 5U, 1);
 
 	if (result[5] != 0)
 		raise_exception(EXCEPTION_ERROR, "Low access read failed");
@@ -277,8 +277,8 @@ static void jlink_adiv5_swdp_low_write(const uint32_t value)
 	const uint8_t bit_count = __builtin_popcount(value);
 	cmd[14] = bit_count & 1U;
 
-	send_recv(info.usb_link, cmd, 16, result, 6);
-	send_recv(info.usb_link, NULL, 0, result, 1);
+	bmda_usb_transfer(info.usb_link, cmd, 16, result, 6);
+	bmda_usb_transfer(info.usb_link, NULL, 0, result, 1);
 
 	if (result[0] != 0)
 		raise_exception(EXCEPTION_ERROR, "Low access write failed");
@@ -298,8 +298,8 @@ static uint32_t jlink_adiv5_swdp_low_access(
 	platform_timeout_set(&timeout, 2000);
 	uint8_t ack = SWDP_ACK_WAIT;
 	while (ack == SWDP_ACK_WAIT && !platform_timeout_is_expired(&timeout)) {
-		send_recv(info.usb_link, cmd, 8U, res, 2U);
-		send_recv(info.usb_link, NULL, 0U, res + 2U, 1U);
+		bmda_usb_transfer(info.usb_link, cmd, 8U, res, 2U);
+		bmda_usb_transfer(info.usb_link, NULL, 0U, res + 2U, 1U);
 
 		if (res[2] != 0)
 			raise_exception(EXCEPTION_ERROR, "Low access setup failed");

--- a/src/platforms/hosted/jlink_jtagtap.c
+++ b/src/platforms/hosted/jlink_jtagtap.c
@@ -64,13 +64,13 @@ bool jlink_jtagtap_init(bmp_info_s *const info)
 		JLINK_IF_GET_AVAILABLE,
 	};
 	uint8_t res[4];
-	send_recv(info->usb_link, cmd_switch, 2, res, sizeof(res));
+	bmda_usb_transfer(info->usb_link, cmd_switch, 2, res, sizeof(res));
 	if (!(res[0] & JLINK_IF_JTAG)) {
 		DEBUG_ERROR("JTAG not available\n");
 		return false;
 	}
 	cmd_switch[1] = SELECT_IF_JTAG;
-	send_recv(info->usb_link, cmd_switch, 2, res, sizeof(res));
+	bmda_usb_transfer(info->usb_link, cmd_switch, 2, res, sizeof(res));
 	platform_delay(10);
 	/* Set speed 256 kHz*/
 	const uint16_t speed = 2000;
@@ -79,7 +79,7 @@ bool jlink_jtagtap_init(bmp_info_s *const info)
 		speed & 0xffU,
 		speed >> 8U,
 	};
-	send_recv(info->usb_link, jtag_speed, 3, NULL, 0);
+	bmda_usb_transfer(info->usb_link, jtag_speed, 3, NULL, 0);
 	uint8_t cmd[22];
 	memset(cmd, 0, 22);
 	cmd[0] = CMD_HW_JTAG3;
@@ -88,8 +88,8 @@ bool jlink_jtagtap_init(bmp_info_s *const info)
 	memset(cmd + 4U, 0xffU, 7);
 	cmd[11] = 0x3c;
 	cmd[12] = 0xe7;
-	send_recv(info->usb_link, cmd, 22, cmd, 9);
-	send_recv(info->usb_link, NULL, 0, res, 1);
+	bmda_usb_transfer(info->usb_link, cmd, 22, cmd, 9);
+	bmda_usb_transfer(info->usb_link, NULL, 0, res, 1);
 
 	if (res[0] != 0) {
 		DEBUG_ERROR("Switch to JTAG failed\n");
@@ -125,8 +125,8 @@ static void jtagtap_tms_seq(const uint32_t tms_states, const size_t clock_cycles
 		cmd[index + total_chunks] = cmd[index];
 	}
 	uint8_t result[4];
-	send_recv(info.usb_link, cmd, 4U + (total_chunks * 2U), result, len);
-	send_recv(info.usb_link, NULL, 0, result, 1);
+	bmda_usb_transfer(info.usb_link, cmd, 4U + (total_chunks * 2U), result, len);
+	bmda_usb_transfer(info.usb_link, NULL, 0, result, 1);
 	if (result[0] != 0)
 		raise_exception(EXCEPTION_ERROR, "tagtap_tms_seq failed");
 }
@@ -157,8 +157,8 @@ static void jtagtap_tdi_tdo_seq(
 		}
 	}
 	uint8_t result[4];
-	send_recv(info.usb_link, cmd, cmd_len, data_out ? data_out : result, total_chunks);
-	send_recv(info.usb_link, NULL, 0, result, 1);
+	bmda_usb_transfer(info.usb_link, cmd, cmd_len, data_out ? data_out : result, total_chunks);
+	bmda_usb_transfer(info.usb_link, NULL, 0, result, 1);
 	free(cmd);
 	if (result[0] != 0)
 		raise_exception(EXCEPTION_ERROR, "jtagtap_tdi_tdi failed");
@@ -191,9 +191,9 @@ static bool jtagtap_next(bool tms, bool tdi)
 	if (tdi)
 		cmd[5] = 1;
 	uint8_t tdo;
-	send_recv(info.usb_link, cmd, 6, &tdo, 1);
+	bmda_usb_transfer(info.usb_link, cmd, 6, &tdo, 1);
 	uint8_t result;
-	send_recv(info.usb_link, NULL, 0, &result, 1);
+	bmda_usb_transfer(info.usb_link, NULL, 0, &result, 1);
 	if (result != 0)
 		raise_exception(EXCEPTION_ERROR, "jtagtap_next failed");
 	return tdo & 1U;

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -102,7 +102,7 @@ void platform_init(int argc, char **argv)
 		break;
 
 	case BMP_TYPE_STLINKV2:
-		if (!stlink_init(&info))
+		if (!stlink_init())
 			exit(-1);
 		break;
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -420,12 +420,14 @@ void platform_max_frequency_set(uint32_t freq)
 		break;
 	}
 
-	uint32_t max_freq = platform_max_frequency_get();
-	if (max_freq == FREQ_FIXED)
+	const uint32_t actual_freq = platform_max_frequency_get();
+	if (actual_freq == FREQ_FIXED)
 		DEBUG_INFO("Device has fixed frequency for %s\n", (info.is_jtag) ? "JTAG" : "SWD");
-	else
-		DEBUG_INFO(
-			"Speed set to %7.4f MHz for %s\n", platform_max_frequency_get() / 1000000.0, info.is_jtag ? "JTAG" : "SWD");
+	else {
+		const uint16_t freq_mhz = actual_freq / 1000000U;
+		const uint16_t freq_khz = (actual_freq / 1000U) - (freq_mhz * 1000U);
+		DEBUG_INFO("Speed set to %u.%03uMHz for %s\n", freq_mhz, freq_khz, info.is_jtag ? "JTAG" : "SWD");
+	}
 }
 
 uint32_t platform_max_frequency_get(void)

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -218,7 +218,7 @@ uint32_t platform_jtag_scan(const uint8_t *ir_lengths, const size_t lengths_coun
 	case BMP_TYPE_STLINKV2:
 		if (lengths_count)
 			gdb_outf("Manually specified IR lengths is not supported when using a ST-Link adaptor\n");
-		return jtag_scan_stlinkv2();
+		return stlink_jtag_scan();
 #endif
 
 	default:

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -102,7 +102,7 @@ void platform_init(int argc, char **argv)
 		break;
 
 	case BMP_TYPE_STLINKV2:
-		if (stlink_init(&info))
+		if (!stlink_init(&info))
 			exit(-1);
 		break;
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -317,7 +317,7 @@ void platform_nrst_set_val(bool assert)
 {
 	switch (info.bmp_type) {
 	case BMP_TYPE_STLINKV2:
-		return stlink_nrst_set_val(&info, assert);
+		return stlink_nrst_set_val(assert);
 
 	case BMP_TYPE_BMP:
 		return remote_nrst_set_val(assert);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -300,7 +300,7 @@ const char *platform_target_voltage(void)
 		return remote_target_voltage();
 
 	case BMP_TYPE_STLINKV2:
-		return stlink_target_voltage(&info);
+		return stlink_target_voltage();
 
 	case BMP_TYPE_LIBFTDI:
 		return libftdi_target_voltage();

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -407,7 +407,7 @@ void platform_max_frequency_set(uint32_t freq)
 		break;
 
 	case BMP_TYPE_STLINKV2:
-		stlink_max_frequency_set(&info, freq);
+		stlink_max_frequency_set(freq);
 		break;
 
 	case BMP_TYPE_JLINK:
@@ -416,7 +416,7 @@ void platform_max_frequency_set(uint32_t freq)
 #endif
 
 	default:
-		DEBUG_WARN("Setting max SWJ frequency not yet implemented\n");
+		DEBUG_WARN("Setting max SWD/JTAG frequency not yet implemented\n");
 		break;
 	}
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -158,7 +158,7 @@ uint32_t platform_adiv5_swdp_scan(uint32_t targetid)
 
 #if HOSTED_BMP_ONLY == 0
 	case BMP_TYPE_STLINKV2:
-		return stlink_swdp_scan();
+		return stlink_swd_scan();
 
 	case BMP_TYPE_JLINK:
 		return jlink_swdp_scan(&info);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -442,7 +442,7 @@ uint32_t platform_max_frequency_get(void)
 		return libftdi_max_frequency_get();
 
 	case BMP_TYPE_STLINKV2:
-		return stlink_max_frequency_get(&info);
+		return stlink_max_frequency_get();
 
 	case BMP_TYPE_JLINK:
 		return jlink_max_frequency_get(&info);

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -882,12 +882,12 @@ void stlink_max_frequency_set(const uint32_t freq)
 		stlink_v2_set_frequency(freq);
 }
 
-uint32_t stlink_max_frequency_get(bmp_info_s *info)
+uint32_t stlink_max_frequency_get(void)
 {
 	if (stlink.ver_hw == 30U)
-		return stlink_v3_freq[info->is_jtag ? STLINK_MODE_JTAG : STLINK_MODE_SWD];
-	const uint32_t result = STLINK_V2_CLOCK_RATE;
-	if (info->is_jtag)
-		return result / (2U * stlink_v2_divisor);
-	return result / (STLINK_V2_USED_SWD_CYCLES + (STLINK_V2_CYCLES_PER_CNT * stlink_v2_divisor));
+		return stlink_v3_freq[info.is_jtag ? STLINK_MODE_JTAG : STLINK_MODE_SWD];
+
+	if (info.is_jtag)
+		return STLINK_V2_CLOCK_RATE / (2U * stlink_v2_divisor);
+	return STLINK_V2_CLOCK_RATE / (STLINK_V2_USED_SWD_CYCLES + (STLINK_V2_CYCLES_PER_CNT * stlink_v2_divisor));
 }

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -499,13 +499,10 @@ static bool stlink_leave_state(void)
 	return false;
 }
 
-const char *stlink_target_voltage(bmp_info_s *info)
+const char *stlink_target_voltage(void)
 {
-	uint8_t cmd[16];
 	uint8_t data[8];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_GET_TARGET_VOLTAGE;
-	bmda_usb_transfer(info->usb_link, cmd, 16, data, 8);
+	stlink_simple_query(STLINK_GET_TARGET_VOLTAGE, 0, data, sizeof(data));
 	uint16_t adc[2];
 	adc[0] = data[0] | (data[1] << 8U); /* Calibration value? */
 	adc[1] = data[4] | (data[5] << 8U); /* Measured value?*/

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -614,11 +614,11 @@ static int stlink_write_dp_register(uint16_t port, uint16_t addr, uint32_t val)
 	return stlink_usb_error_check(data, true);
 }
 
-uint32_t stlink_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
+uint32_t stlink_raw_access(adiv5_debug_port_s *dp, uint8_t rnw, uint16_t addr, uint32_t value)
 {
 	uint32_t response = 0;
 	int res;
-	if (RnW)
+	if (rnw)
 		res = stlink_read_dp_register(addr < 0x100U ? STLINK_DEBUG_PORT_ACCESS : 0, addr, &response);
 	else
 		res = stlink_write_dp_register(addr < 0x100U ? STLINK_DEBUG_PORT_ACCESS : 0, addr, value);

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -76,6 +76,10 @@ int debug_level = 0;
 #define STLINK_ERROR_DP_FAULT (-2)
 #define STLINK_ERROR_AP_FAULT (-3)
 
+#define V2_USED_SWD_CYCLES 20U
+#define V2_CYCLES_PER_CNT  20U
+#define V2_CLOCK_RATE      (72U * 1000U * 1000U)
+
 static stlink_mem_command_s stlink_memory_access(
 	const uint8_t operation, const uint32_t address, const uint16_t length, const uint8_t apsel)
 {
@@ -809,9 +813,6 @@ void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->mem_write = stlink_mem_write;
 }
 
-#define V2_USED_SWD_CYCLES 20U
-#define V2_CYCLES_PER_CNT  20U
-#define V2_CLOCK_RATE      (72U * 1000U * 1000U)
 /* Above values reproduce the known values for V2
 #include <stdio.h>
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -228,10 +228,10 @@ static stlink_mem_command_s stlink_memory_access(
 	return command;
 }
 
-/**
-    Converts an STLINK status code held in the first byte of a response to
-	readable error
-*/
+/*
+ * Converts an ST-Link status code held in the first byte of a response to
+ * readable error
+ */
 static int stlink_usb_error_check(uint8_t *data, bool verbose)
 {
 	switch (data[0]) {

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -682,13 +682,9 @@ int stlink_hwversion(void)
 static int stlink_enter_debug_jtag(void)
 {
 	stlink_leave_state();
-	uint8_t cmd[16];
 	uint8_t data[2];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_DEBUG_COMMAND;
-	cmd[1] = STLINK_DEBUG_APIV2_ENTER;
-	cmd[2] = STLINK_DEBUG_ENTER_JTAG_NO_RESET;
-	bmda_usb_transfer(info.usb_link, cmd, 16, data, 2);
+	stlink_simple_request(
+		STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_ENTER, STLINK_DEBUG_ENTER_JTAG_NO_RESET, data, sizeof(data));
 	return stlink_usb_error_check(data, true);
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -913,16 +913,12 @@ static void stlink_mem_write(
 
 static void stlink_regs_read(adiv5_access_port_s *ap, void *data)
 {
-	uint8_t cmd[16];
-	uint8_t res[88];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_DEBUG_COMMAND;
-	cmd[1] = STLINK_DEBUG_APIV2_READALLREGS;
-	cmd[2] = ap->apsel;
-	DEBUG_PROBE("AP %hhu: Read all core registers\n", ap->apsel);
-	bmda_usb_transfer(info.usb_link, cmd, 16, res, 88);
-	stlink_usb_error_check(res, true);
-	memcpy(data, res + 4U, 84);
+	uint8_t result[88];
+	DEBUG_PROBE("%s: AP %u\n", __func__, ap->apsel);
+	stlink_simple_request(STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_READALLREGS, ap->apsel, result, sizeof(result));
+	stlink_usb_error_check(result, true);
+	/* Ignore the first 4 bytes as protocol overhead */
+	memcpy(data, result + 4U, sizeof(result) - 4U);
 }
 
 static uint32_t stlink_reg_read(adiv5_access_port_s *ap, int num)

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -71,12 +71,6 @@ typedef struct stlink {
 	bool ap_error;
 } stlink_s;
 
-stlink_s stlink;
-
-static int stlink_usb_get_rw_status(bool verbose);
-
-int debug_level = 0;
-
 #define STLINK_ERROR_DP_FAULT (-2)
 #define STLINK_ERROR_AP_FAULT (-3)
 
@@ -93,6 +87,13 @@ int debug_level = 0;
 #else
 #define unlikely(x) x
 #endif
+
+static stlink_s stlink;
+
+static uint32_t stlink_v2_divisor;
+static unsigned int stlink_v3_freq[2];
+
+static int stlink_usb_get_rw_status(bool verbose);
 
 static stlink_mem_command_s stlink_memory_access(
 	const uint8_t operation, const uint32_t address, const uint16_t length, const uint8_t apsel)
@@ -817,9 +818,6 @@ void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 	dp->mem_read = stlink_mem_read;
 	dp->mem_write = stlink_mem_write;
 }
-
-static uint32_t stlink_v2_divisor;
-static unsigned int stlink_v3_freq[2];
 
 static uint8_t stlink_ulog2(uint32_t value)
 {

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -688,24 +688,10 @@ static int stlink_enter_debug_jtag(void)
 	return stlink_usb_error_check(data, true);
 }
 
-// static uint32_t stlink_read_coreid(void)
-// {
-// 	uint8_t cmd[16] = {STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_READ_IDCODES};
-// 	uint8_t data[12];
-// 	bmda_usb_transfer(info.usb_link, cmd, 16, data, 12);
-// 	uint32_t id =  data[4] | data[5] << 8 | data[6] << 16 | data[7] << 24;
-// 	DEBUG_INFO("Read Core ID: 0x%08" PRIx32 "\n", id);
-// 	return id;
-// }
-
 static size_t stlink_read_idcodes(uint32_t *idcodes)
 {
-	uint8_t cmd[16];
 	uint8_t data[12];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_DEBUG_COMMAND;
-	cmd[1] = STLINK_DEBUG_APIV2_READ_IDCODES;
-	bmda_usb_transfer(info.usb_link, cmd, 16, data, 12);
+	stlink_simple_query(STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_READ_IDCODES, data, sizeof(data));
 	if (stlink_usb_error_check(data, true))
 		return 0;
 	idcodes[0] = data[4] | (data[5] << 8U) | (data[6] << 16U) | (data[7] << 24U);

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -514,14 +514,10 @@ const char *stlink_target_voltage(void)
 	return res;
 }
 
-static void stlink_resetsys(void)
+static void stlink_reset_adaptor(void)
 {
-	uint8_t cmd[16];
 	uint8_t data[2];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_DEBUG_COMMAND;
-	cmd[1] = STLINK_DEBUG_APIV2_RESETSYS;
-	bmda_usb_transfer(info.usb_link, cmd, 16, data, 2);
+	stlink_simple_query(STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_RESETSYS, data, sizeof(data));
 }
 
 bool stlink_init(void)
@@ -647,7 +643,7 @@ bool stlink_init(void)
 		DEBUG_WARN("ST-Link board was in DFU mode. Restart\n");
 		return false;
 	}
-	stlink_resetsys();
+	stlink_reset_adaptor();
 	return true;
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -847,15 +847,13 @@ uint32_t stlink_swdp_scan(void)
 
 	stlink_leave_state();
 
-	uint8_t cmd[16];
+	const stlink_simple_request_s command = {
+		.command = STLINK_DEBUG_COMMAND,
+		.operation = STLINK_DEBUG_APIV2_ENTER,
+		.param = STLINK_DEBUG_ENTER_SWD_NO_RESET,
+	};
 	uint8_t data[2];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_DEBUG_COMMAND;
-	cmd[1] = STLINK_DEBUG_APIV2_ENTER;
-	cmd[2] = STLINK_DEBUG_ENTER_SWD_NO_RESET;
-
-	stlink_send_recv_retry(cmd, 16, data, 2);
-
+	stlink_send_recv_retry(&command, sizeof(command), data, sizeof(data));
 	if (stlink_usb_error_check(data, true))
 		return 0;
 
@@ -871,9 +869,7 @@ uint32_t stlink_swdp_scan(void)
 	dp->abort = stlink_dp_abort;
 
 	adiv5_dp_error(dp);
-
 	adiv5_dp_init(dp, 0);
-
 	return target_list ? 1U : 0U;
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -796,13 +796,6 @@ static uint32_t stlink_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 	return ret;
 }
 
-void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
-{
-	dp->error = stlink_dp_error;
-	dp->low_access = stlink_dp_low_access;
-	dp->abort = stlink_dp_abort;
-}
-
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
 {
 	dp->ap_regs_read = stlink_regs_read;

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -831,12 +831,8 @@ static void stlink_ap_cleanup(const uint8_t ap)
 
 static int stlink_usb_get_rw_status(bool verbose)
 {
-	uint8_t cmd[16];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_DEBUG_COMMAND;
-	cmd[1] = STLINK_DEBUG_APIV2_GETLASTRWSTATUS2;
 	uint8_t data[12];
-	bmda_usb_transfer(info.usb_link, cmd, 16, data, 12);
+	stlink_simple_query(STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_GETLASTRWSTATUS2, data, sizeof(data));
 	return stlink_usb_error_check(data, verbose);
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -409,17 +409,18 @@ static int stlink_write_retry(const void *req_buffer, size_t req_len, const void
 	return res;
 }
 
-/* Version data is at 0x080103f8 with STLINKV3 bootloader flashed with
+/*
+ * Version data is at 0x080103f8 with STLINKV3 bootloader flashed with
  * STLinkUpgrade_v3[3|5].jar
  */
-static void stlink_version(bmp_info_s *info)
+static void stlink_version(void)
 {
 	if (stlink.ver_hw == 30) {
 		uint8_t cmd[16];
 		uint8_t data[12];
 		memset(cmd, 0, sizeof(cmd));
 		cmd[0] = STLINK_APIV3_GET_VERSION_EX;
-		int size = bmda_usb_transfer(info->usb_link, cmd, 16, data, 12);
+		int size = bmda_usb_transfer(info.usb_link, cmd, 16, data, 12);
 		if (size == -1)
 			DEBUG_WARN("[!] stlink_send_recv STLINK_APIV3_GET_VERSION_EX\n");
 
@@ -436,7 +437,7 @@ static void stlink_version(bmp_info_s *info)
 		uint8_t data[6];
 		memset(cmd, 0, sizeof(cmd));
 		cmd[0] = STLINK_GET_VERSION;
-		int size = bmda_usb_transfer(info->usb_link, cmd, 16, data, 6);
+		int size = bmda_usb_transfer(info.usb_link, cmd, 16, data, 6);
 		if (size == -1)
 			DEBUG_WARN("[!] stlink_send_recv STLINK_GET_VERSION_EX\n");
 		stlink.vid = (data[3] << 8U) | data[2];
@@ -514,14 +515,14 @@ const char *stlink_target_voltage(bmp_info_s *info)
 	return res;
 }
 
-static void stlink_resetsys(bmp_info_s *info)
+static void stlink_resetsys(void)
 {
 	uint8_t cmd[16];
 	uint8_t data[2];
 	memset(cmd, 0, sizeof(cmd));
 	cmd[0] = STLINK_DEBUG_COMMAND;
 	cmd[1] = STLINK_DEBUG_APIV2_RESETSYS;
-	bmda_usb_transfer(info->usb_link, cmd, 16, data, 2);
+	bmda_usb_transfer(info.usb_link, cmd, 16, data, 2);
 }
 
 bool stlink_init(bmp_info_s *info)
@@ -626,7 +627,7 @@ bool stlink_init(bmp_info_s *info)
 	}
 	sl->req_trans = libusb_alloc_transfer(0);
 	sl->rep_trans = libusb_alloc_transfer(0);
-	stlink_version(info);
+	stlink_version();
 	if ((stlink.ver_stlink < 3U && stlink.ver_jtag < 32U) || (stlink.ver_stlink == 3U && stlink.ver_jtag < 3U)) {
 		/* Maybe the adapter is in some strange state. Try to reset */
 		int result = libusb_reset_device(sl->ul_libusb_device_handle);
@@ -639,7 +640,7 @@ bool stlink_init(bmp_info_s *info)
 			DEBUG_ERROR("ST-Link libusb_reset_device failed\n");
 			return false;
 		}
-		stlink_version(info);
+		stlink_version();
 	}
 	if ((stlink.ver_stlink < 3U && stlink.ver_jtag < 32U) || (stlink.ver_stlink == 3U && stlink.ver_jtag < 3U)) {
 		DEBUG_WARN("Please update the firmware on your ST-Link\n");
@@ -649,7 +650,7 @@ bool stlink_init(bmp_info_s *info)
 		DEBUG_WARN("ST-Link board was in DFU mode. Restart\n");
 		return false;
 	}
-	stlink_resetsys(info);
+	stlink_resetsys();
 	return true;
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -578,7 +578,7 @@ bool stlink_init(void)
 		found = true;
 		break;
 	}
-	libusb_free_device_list(devs, cnt);
+	libusb_free_device_list(devs, (int)cnt);
 	if (!found)
 		return false;
 	if (info.vid != VENDOR_ID_STLINK)
@@ -880,14 +880,14 @@ static void stlink_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, s
 	stlink_mem_command_s command = stlink_memory_access(type, src, len, ap->apsel);
 	int res = 0;
 	if (len > 1)
-		res = stlink_read_retry(&command.command, sizeof(command), dest, len);
+		res = stlink_read_retry(&command, sizeof(command), dest, len);
 	else {
 		/*
 		 * Due to an artefact of how the ST-Link protocol works (minimum read size is 2),
 		 * a single byte read must be done into a 2 byte buffer
 		 */
 		uint8_t buffer[2];
-		res = stlink_read_retry(&command.command, sizeof(command), buffer, sizeof(buffer));
+		res = stlink_read_retry(&command, sizeof(command), buffer, sizeof(buffer));
 		/* But we only want and need to keep a single byte from this */
 		memcpy(dest, buffer, 1);
 	}
@@ -930,7 +930,7 @@ static void stlink_mem_write(
 			break;
 		}
 		/* And perform the block write */
-		stlink_write_retry(&command.command, sizeof(command), data + offset, amount);
+		stlink_write_retry(&command, sizeof(command), data + offset, amount);
 	}
 }
 

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -821,16 +821,11 @@ static bool stlink_ap_setup(const uint8_t ap)
 	return !res;
 }
 
-static void stlink_ap_cleanup(int ap)
+static void stlink_ap_cleanup(const uint8_t ap)
 {
-	uint8_t cmd[16];
-	memset(cmd, 0, sizeof(cmd));
-	cmd[0] = STLINK_DEBUG_COMMAND;
-	cmd[1] = STLINK_DEBUG_APIV2_CLOSE_AP_DBG;
-	cmd[2] = ap;
 	uint8_t data[2];
-	bmda_usb_transfer(info.usb_link, cmd, 16, data, 2);
-	DEBUG_PROBE("Close AP %d\n", ap);
+	stlink_simple_request(STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_CLOSE_AP_DBG, ap, data, sizeof(data));
+	DEBUG_PROBE("%s: AP %u\n", __func__, ap);
 	stlink_usb_error_check(data, true);
 }
 

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -42,7 +42,7 @@ int stlink_hwversion(void)
 	return -1;
 }
 
-const char *stlink_target_voltage(bmp_info_s *info)
+const char *stlink_target_voltage(void)
 {
 	return "ERROR";
 }
@@ -92,7 +92,7 @@ uint32_t stlink_max_frequency_get(bmp_info_s *info)
 #else
 bool stlink_init(void);
 int stlink_hwversion(void);
-const char *stlink_target_voltage(bmp_info_s *info);
+const char *stlink_target_voltage(void);
 void stlink_nrst_set_val(bmp_info_s *info, bool assert);
 bool stlink_nrst_get_val(void);
 uint32_t stlink_swdp_scan(void);

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -31,14 +31,14 @@
 #define STLINK_DEBUG_PORT_ACCESS 0xffffU
 
 bool stlink_init(void);
+uint32_t stlink_swdp_scan(void);
+uint32_t stlink_jtag_scan(void);
 int stlink_hwversion(void);
 const char *stlink_target_voltage(void);
 void stlink_nrst_set_val(bool assert);
 bool stlink_nrst_get_val(void);
-uint32_t stlink_swdp_scan(void);
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp);
 void stlink_jtag_dp_init(adiv5_debug_port_s *dp);
-uint32_t jtag_scan_stlinkv2(void);
 void stlink_exit_function(bmp_info_s *info);
 void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq);
 uint32_t stlink_max_frequency_get(bmp_info_s *info);

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -2,6 +2,8 @@
  * This file is part of the Black Magic Debug project.
  *
  * Copyright (C) 2019 Uwe Bonnes
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,69 +30,6 @@
 
 #define STLINK_DEBUG_PORT_ACCESS 0xffffU
 
-#if HOSTED_BMP_ONLY == 1
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-
-bool stlink_init(void)
-{
-	return false;
-}
-
-int stlink_hwversion(void)
-{
-	return -1;
-}
-
-const char *stlink_target_voltage(void)
-{
-	return "ERROR";
-}
-
-void stlink_nrst_set_val(bool assert)
-{
-	(void)assert;
-}
-
-bool stlink_nrst_get_val(void)
-{
-	return true;
-}
-
-uint32_t stlink_swdp_scan(void)
-{
-	return 0;
-}
-
-void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp)
-{
-}
-
-void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
-{
-	(void)dp;
-}
-
-uint32_t jtag_scan_stlinkv2(void)
-{
-	return 0;
-}
-
-void stlink_exit_function(bmp_info_s *info)
-{
-}
-
-void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq)
-{
-}
-
-uint32_t stlink_max_frequency_get(bmp_info_s *info)
-{
-	return 0;
-}
-
-#pragma GCC diagnostic pop
-#else
 bool stlink_init(void);
 int stlink_hwversion(void);
 const char *stlink_target_voltage(void);
@@ -103,6 +42,5 @@ uint32_t jtag_scan_stlinkv2(void);
 void stlink_exit_function(bmp_info_s *info);
 void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq);
 uint32_t stlink_max_frequency_get(bmp_info_s *info);
-#endif
 
 #endif /* PLATFORMS_HOSTED_STLINKV2_H */

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -32,7 +32,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-bool stlink_init(bmp_info_s *info)
+bool stlink_init(void)
 {
 	return false;
 }
@@ -90,7 +90,7 @@ uint32_t stlink_max_frequency_get(bmp_info_s *info)
 
 #pragma GCC diagnostic pop
 #else
-bool stlink_init(bmp_info_s *info);
+bool stlink_init(void);
 int stlink_hwversion(void);
 const char *stlink_target_voltage(bmp_info_s *info);
 void stlink_nrst_set_val(bmp_info_s *info, bool assert);

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -28,8 +28,6 @@
 #define STLINK_ERROR_OK   0
 #define STLINK_ERROR_WAIT 1
 
-#define STLINK_DEBUG_PORT_ACCESS 0xffffU
-
 bool stlink_init(void);
 uint32_t stlink_swd_scan(void);
 uint32_t stlink_jtag_scan(void);

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -31,7 +31,7 @@
 #define STLINK_DEBUG_PORT_ACCESS 0xffffU
 
 bool stlink_init(void);
-uint32_t stlink_swdp_scan(void);
+uint32_t stlink_swd_scan(void);
 uint32_t stlink_jtag_scan(void);
 int stlink_hwversion(void);
 const char *stlink_target_voltage(void);

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -47,8 +47,9 @@ const char *stlink_target_voltage(void)
 	return "ERROR";
 }
 
-void stlink_nrst_set_val(bmp_info_s *info, bool assert)
+void stlink_nrst_set_val(bool assert)
 {
+	(void)assert;
 }
 
 bool stlink_nrst_get_val(void)
@@ -93,7 +94,7 @@ uint32_t stlink_max_frequency_get(bmp_info_s *info)
 bool stlink_init(void);
 int stlink_hwversion(void);
 const char *stlink_target_voltage(void);
-void stlink_nrst_set_val(bmp_info_s *info, bool assert);
+void stlink_nrst_set_val(bool assert);
 bool stlink_nrst_get_val(void);
 uint32_t stlink_swdp_scan(void);
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp);

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -38,7 +38,7 @@ bool stlink_nrst_get_val(void);
 void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp);
 void stlink_jtag_dp_init(adiv5_debug_port_s *dp);
 void stlink_exit_function(bmp_info_s *info);
-void stlink_max_frequency_set(bmp_info_s *info, uint32_t freq);
+void stlink_max_frequency_set(uint32_t freq);
 uint32_t stlink_max_frequency_get(bmp_info_s *info);
 
 #endif /* PLATFORMS_HOSTED_STLINKV2_H */

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -39,6 +39,6 @@ void stlink_adiv5_dp_defaults(adiv5_debug_port_s *dp);
 void stlink_jtag_dp_init(adiv5_debug_port_s *dp);
 void stlink_exit_function(bmp_info_s *info);
 void stlink_max_frequency_set(uint32_t freq);
-uint32_t stlink_max_frequency_get(bmp_info_s *info);
+uint32_t stlink_max_frequency_get(void);
 
 #endif /* PLATFORMS_HOSTED_STLINKV2_H */

--- a/src/platforms/hosted/stlinkv2.h
+++ b/src/platforms/hosted/stlinkv2.h
@@ -32,9 +32,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-int stlink_init(bmp_info_s *info)
+bool stlink_init(bmp_info_s *info)
 {
-	return -1;
+	return false;
 }
 
 int stlink_hwversion(void)
@@ -90,7 +90,7 @@ uint32_t stlink_max_frequency_get(bmp_info_s *info)
 
 #pragma GCC diagnostic pop
 #else
-int stlink_init(bmp_info_s *info);
+bool stlink_init(bmp_info_s *info);
 int stlink_hwversion(void);
 const char *stlink_target_voltage(bmp_info_s *info);
 void stlink_nrst_set_val(bmp_info_s *info, bool assert);

--- a/src/platforms/hosted/stlinkv2_jtag.c
+++ b/src/platforms/hosted/stlinkv2_jtag.c
@@ -73,3 +73,10 @@ static size_t stlink_read_idcodes(uint32_t *idcodes)
 	idcodes[1] = data[8] | (data[9] << 8U) | (data[10] << 16U) | (data[11] << 24U);
 	return STLINK_JTAG_MAX_DEVS;
 }
+
+void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
+{
+	dp->error = stlink_dp_error;
+	dp->low_access = stlink_dp_low_access;
+	dp->abort = stlink_dp_abort;
+}

--- a/src/platforms/hosted/stlinkv2_jtag.c
+++ b/src/platforms/hosted/stlinkv2_jtag.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "general.h"
+#include "stlinkv2.h"
+#include "stlinkv2_protocol.h"
+#include "jtag_devs.h"
+
+#define STLINK_JTAG_MAX_DEVS 2U
+
+static int stlink_enter_debug_jtag(void);
+static size_t stlink_read_idcodes(uint32_t *idcodes);
+
+uint32_t jtag_scan_stlinkv2(void)
+{
+	uint32_t idcodes[STLINK_JTAG_MAX_DEVS];
+	target_list_free();
+
+	jtag_dev_count = 0;
+	memset(jtag_devs, 0, sizeof(jtag_devs));
+	if (stlink_enter_debug_jtag())
+		return 0;
+	jtag_dev_count = stlink_read_idcodes(idcodes);
+	/* Check for known devices and handle accordingly */
+	for (uint32_t i = 0; i < jtag_dev_count; ++i)
+		jtag_devs[i].jd_idcode = idcodes[i];
+
+	for (uint32_t i = 0; i < jtag_dev_count; ++i) {
+		for (size_t j = 0; dev_descr[j].idcode; ++j) {
+			if ((jtag_devs[i].jd_idcode & dev_descr[j].idmask) == dev_descr[j].idcode) {
+				if (dev_descr[j].handler)
+					dev_descr[j].handler(i);
+				break;
+			}
+		}
+	}
+	return jtag_dev_count;
+}
+
+static int stlink_enter_debug_jtag(void)
+{
+	stlink_leave_state();
+	uint8_t data[2];
+	stlink_simple_request(
+		STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_ENTER, STLINK_DEBUG_ENTER_JTAG_NO_RESET, data, sizeof(data));
+	return stlink_usb_error_check(data, true);
+}
+
+static size_t stlink_read_idcodes(uint32_t *idcodes)
+{
+	uint8_t data[12];
+	stlink_simple_query(STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_READ_IDCODES, data, sizeof(data));
+	if (stlink_usb_error_check(data, true))
+		return 0;
+	idcodes[0] = data[4] | (data[5] << 8U) | (data[6] << 16U) | (data[7] << 24U);
+	idcodes[1] = data[8] | (data[9] << 8U) | (data[10] << 16U) | (data[11] << 24U);
+	return STLINK_JTAG_MAX_DEVS;
+}

--- a/src/platforms/hosted/stlinkv2_jtag.c
+++ b/src/platforms/hosted/stlinkv2_jtag.c
@@ -28,7 +28,7 @@
 static int stlink_enter_debug_jtag(void);
 static size_t stlink_read_idcodes(uint32_t *idcodes);
 
-uint32_t jtag_scan_stlinkv2(void)
+uint32_t stlink_jtag_scan(void)
 {
 	uint32_t idcodes[STLINK_JTAG_MAX_DEVS];
 	target_list_free();

--- a/src/platforms/hosted/stlinkv2_jtag.c
+++ b/src/platforms/hosted/stlinkv2_jtag.c
@@ -77,6 +77,6 @@ static size_t stlink_read_idcodes(uint32_t *idcodes)
 void stlink_jtag_dp_init(adiv5_debug_port_s *dp)
 {
 	dp->error = stlink_dp_error;
-	dp->low_access = stlink_dp_low_access;
+	dp->low_access = stlink_raw_access;
 	dp->abort = stlink_dp_abort;
 }

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -212,6 +212,13 @@ typedef struct stlink_mem_command {
 	uint8_t reserved[7];
 } stlink_mem_command_s;
 
+typedef struct stlink_v2_set_freq {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t divisor[2];
+	uint8_t reserved[12];
+} stlink_v2_set_freq_s;
+
 typedef struct stlink_v3_set_freq {
 	uint8_t command;
 	uint8_t operation;

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -154,6 +154,8 @@
 
 #define STLINK_V3_MAX_FREQ_NB 10U
 
+#define STLINK_DEBUG_PORT 0xffffU
+
 typedef struct stlink_simple_command {
 	uint8_t command;
 	uint8_t operation;
@@ -166,6 +168,14 @@ typedef struct stlink_simple_request {
 	uint8_t param;
 	uint8_t reserved[13];
 } stlink_simple_request_s;
+
+typedef struct stlink_adiv5_reg_read {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t apsel[2];
+	uint8_t address[2];
+	uint8_t reserved[10];
+} stlink_adiv5_reg_read_s;
 
 typedef struct stlink_mem_command {
 	uint8_t command;

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -183,7 +183,7 @@ int stlink_send_recv_retry(const void *req_buffer, size_t req_len, void *rx_buff
 bool stlink_leave_state(void);
 int stlink_usb_error_check(uint8_t *data, bool verbose);
 
-uint32_t stlink_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
+uint32_t stlink_raw_access(adiv5_debug_port_s *dp, uint8_t rnw, uint16_t addr, uint32_t value);
 uint32_t stlink_dp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 void stlink_dp_abort(adiv5_debug_port_s *dp, uint32_t abort);
 

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -194,6 +194,15 @@ typedef struct stlink_arm_reg_read {
 	uint8_t reserved[12];
 } stlink_arm_reg_read_s;
 
+typedef struct stlink_arm_reg_write {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t reg_num;
+	uint8_t value[4];
+	uint8_t apsel;
+	uint8_t reserved[8];
+} stlink_arm_reg_write_s;
+
 typedef struct stlink_mem_command {
 	uint8_t command;
 	uint8_t operation;

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include "adiv5.h"
 
 #define STLINK_SWIM_ERR_OK             0x00U
 #define STLINK_SWIM_BUSY               0x01U
@@ -153,10 +154,37 @@
 
 #define STLINK_V3_MAX_FREQ_NB 10U
 
+typedef struct stlink_simple_command {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t reserved[14];
+} stlink_simple_command_s;
+
+typedef struct stlink_simple_request {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t param;
+	uint8_t reserved[13];
+} stlink_simple_request_s;
+
+typedef struct stlink_mem_command {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t address[4];
+	uint8_t length[2];
+	uint8_t apsel;
+	uint8_t reserved[7];
+} stlink_mem_command_s;
+
 int stlink_simple_query(uint8_t command, uint8_t operation, void *rx_buffer, size_t rx_len);
 int stlink_simple_request(uint8_t command, uint8_t operation, uint8_t param, void *rx_buffer, size_t rx_len);
+int stlink_send_recv_retry(const void *req_buffer, size_t req_len, void *rx_buffer, size_t rx_len);
 
 bool stlink_leave_state(void);
 int stlink_usb_error_check(uint8_t *data, bool verbose);
+
+uint32_t stlink_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
+uint32_t stlink_dp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
+void stlink_dp_abort(adiv5_debug_port_s *dp, uint32_t abort);
 
 #endif /*PLATFORMS_HOSTED_STLINKV2_PROTOCOL_H*/

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -186,6 +186,14 @@ typedef struct stlink_adiv5_reg_write {
 	uint8_t reserved[6];
 } stlink_adiv5_reg_write_s;
 
+typedef struct stlink_arm_reg_read {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t reg_num;
+	uint8_t apsel;
+	uint8_t reserved[12];
+} stlink_arm_reg_read_s;
+
 typedef struct stlink_mem_command {
 	uint8_t command;
 	uint8_t operation;

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -1,0 +1,162 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PLATFORMS_HOSTED_STLINKV2_PROTOCOL_H
+#define PLATFORMS_HOSTED_STLINKV2_PROTOCOL_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#define STLINK_SWIM_ERR_OK             0x00U
+#define STLINK_SWIM_BUSY               0x01U
+#define STLINK_DEBUG_ERR_OK            0x80U
+#define STLINK_DEBUG_ERR_FAULT         0x81U
+#define STLINK_JTAG_UNKNOWN_JTAG_CHAIN 0x04U
+#define STLINK_NO_DEVICE_CONNECTED     0x05U
+#define STLINK_JTAG_COMMAND_ERROR      0x08U
+#define STLINK_JTAG_COMMAND_ERROR      0x08U
+#define STLINK_JTAG_GET_IDCODE_ERROR   0x09U
+#define STLINK_JTAG_DBG_POWER_ERROR    0x0bU
+#define STLINK_SWD_AP_WAIT             0x10U
+#define STLINK_SWD_AP_FAULT            0x11U
+#define STLINK_SWD_AP_ERROR            0x12U
+#define STLINK_SWD_AP_PARITY_ERROR     0x13U
+#define STLINK_JTAG_WRITE_ERROR        0x0cU
+#define STLINK_JTAG_WRITE_VERIF_ERROR  0x0dU
+#define STLINK_SWD_DP_WAIT             0x14U
+#define STLINK_SWD_DP_FAULT            0x15U
+#define STLINK_SWD_DP_ERROR            0x16U
+#define STLINK_SWD_DP_PARITY_ERROR     0x17U
+
+#define STLINK_SWD_AP_WDATA_ERROR      0x18U
+#define STLINK_SWD_AP_STICKY_ERROR     0x19U
+#define STLINK_SWD_AP_STICKYORUN_ERROR 0x1aU
+#define STLINK_BAD_AP_ERROR            0x1dU
+#define STLINK_TOO_MANY_AP_ERROR       0x29U
+#define STLINK_JTAG_UNKNOWN_CMD        0x42U
+
+#define STLINK_CORE_RUNNING      0x80U
+#define STLINK_CORE_HALTED       0x81U
+#define STLINK_CORE_STAT_UNKNOWN (-1)
+
+#define STLINK_GET_VERSION        0xf1U
+#define STLINK_DEBUG_COMMAND      0xf2U
+#define STLINK_DFU_COMMAND        0xf3U
+#define STLINK_SWIM_COMMAND       0xf4U
+#define STLINK_GET_CURRENT_MODE   0xf5U
+#define STLINK_GET_TARGET_VOLTAGE 0xf7U
+
+#define STLINK_DEV_DFU_MODE        0x00U
+#define STLINK_DEV_MASS_MODE       0x01U
+#define STLINK_DEV_DEBUG_MODE      0x02U
+#define STLINK_DEV_SWIM_MODE       0x03U
+#define STLINK_DEV_BOOTLOADER_MODE 0x04U
+#define STLINK_DEV_UNKNOWN_MODE    (-1)
+
+#define STLINK_DFU_EXIT 0x07U
+
+#define STLINK_SWIM_ENTER          0x00U
+#define STLINK_SWIM_EXIT           0x01U
+#define STLINK_SWIM_READ_CAP       0x02U
+#define STLINK_SWIM_SPEED          0x03U
+#define STLINK_SWIM_ENTER_SEQ      0x04U
+#define STLINK_SWIM_GEN_RST        0x05U
+#define STLINK_SWIM_RESET          0x06U
+#define STLINK_SWIM_ASSERT_RESET   0x07U
+#define STLINK_SWIM_DEASSERT_RESET 0x08U
+#define STLINK_SWIM_READSTATUS     0x09U
+#define STLINK_SWIM_WRITEMEM       0x0aU
+#define STLINK_SWIM_READMEM        0x0bU
+#define STLINK_SWIM_READBUF        0x0cU
+
+#define STLINK_DEBUG_GETSTATUS           0x01U
+#define STLINK_DEBUG_FORCEDEBUG          0x02U
+#define STLINK_DEBUG_APIV1_RESETSYS      0x03U
+#define STLINK_DEBUG_APIV1_READALLREGS   0x04U
+#define STLINK_DEBUG_APIV1_READREG       0x05U
+#define STLINK_DEBUG_APIV1_WRITEREG      0x06U
+#define STLINK_DEBUG_READMEM_32BIT       0x07U
+#define STLINK_DEBUG_WRITEMEM_32BIT      0x08U
+#define STLINK_DEBUG_RUNCORE             0x09U
+#define STLINK_DEBUG_STEPCORE            0x0aU
+#define STLINK_DEBUG_APIV1_SETFP         0x0bU
+#define STLINK_DEBUG_READMEM_8BIT        0x0cU
+#define STLINK_DEBUG_WRITEMEM_8BIT       0x0dU
+#define STLINK_DEBUG_APIV1_CLEARFP       0x0eU
+#define STLINK_DEBUG_APIV1_WRITEDEBUGREG 0x0fU
+#define STLINK_DEBUG_APIV1_SETWATCHPOINT 0x10U
+
+#define STLINK_DEBUG_ENTER_JTAG_RESET    0x00U
+#define STLINK_DEBUG_ENTER_SWD_NO_RESET  0xa3U
+#define STLINK_DEBUG_ENTER_JTAG_NO_RESET 0xa4U
+
+#define STLINK_DEBUG_APIV1_ENTER 0x20U
+#define STLINK_DEBUG_EXIT        0x21U
+#define STLINK_DEBUG_READCOREID  0x22U
+
+#define STLINK_DEBUG_APIV2_ENTER         0x30U
+#define STLINK_DEBUG_APIV2_READ_IDCODES  0x31U
+#define STLINK_DEBUG_APIV2_RESETSYS      0x32U
+#define STLINK_DEBUG_APIV2_READREG       0x33U
+#define STLINK_DEBUG_APIV2_WRITEREG      0x34U
+#define STLINK_DEBUG_APIV2_WRITEDEBUGREG 0x35U
+#define STLINK_DEBUG_APIV2_READDEBUGREG  0x36U
+
+#define STLINK_DEBUG_APIV2_READALLREGS     0x3aU
+#define STLINK_DEBUG_APIV2_GETLASTRWSTATUS 0x3bU
+#define STLINK_DEBUG_APIV2_DRIVE_NRST      0x3cU
+
+#define STLINK_DEBUG_APIV2_GETLASTRWSTATUS2 0x3eU
+
+#define STLINK_DEBUG_APIV2_START_TRACE_RX 0x40U
+#define STLINK_DEBUG_APIV2_STOP_TRACE_RX  0x41U
+#define STLINK_DEBUG_APIV2_GET_TRACE_NB   0x42U
+#define STLINK_DEBUG_APIV2_SWD_SET_FREQ   0x43U
+#define STLINK_DEBUG_APIV2_JTAG_SET_FREQ  0x44U
+#define STLINK_DEBUG_APIV2_READ_DAP_REG   0x45U
+#define STLINK_DEBUG_APIV2_WRITE_DAP_REG  0x46U
+#define STLINK_DEBUG_APIV2_READMEM_16BIT  0x47U
+#define STLINK_DEBUG_APIV2_WRITEMEM_16BIT 0x48U
+
+#define STLINK_DEBUG_APIV2_INIT_AP      0x4bU
+#define STLINK_DEBUG_APIV2_CLOSE_AP_DBG 0x4cU
+
+#define STLINK_APIV3_SET_COM_FREQ 0x61U
+#define STLINK_APIV3_GET_COM_FREQ 0x62U
+
+#define STLINK_APIV3_GET_VERSION_EX 0xfbU
+
+#define STLINK_DEBUG_APIV2_DRIVE_NRST_LOW   0x00U
+#define STLINK_DEBUG_APIV2_DRIVE_NRST_HIGH  0x01U
+#define STLINK_DEBUG_APIV2_DRIVE_NRST_PULSE 0x02U
+
+#define STLINK_TRACE_SIZE   4096U
+#define STLINK_TRACE_MAX_HZ 2000000U
+
+#define STLINK_V3_MAX_FREQ_NB 10U
+
+int stlink_simple_query(uint8_t command, uint8_t operation, void *rx_buffer, size_t rx_len);
+int stlink_simple_request(uint8_t command, uint8_t operation, uint8_t param, void *rx_buffer, size_t rx_len);
+
+bool stlink_leave_state(void);
+int stlink_usb_error_check(uint8_t *data, bool verbose);
+
+#endif /*PLATFORMS_HOSTED_STLINKV2_PROTOCOL_H*/

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -177,6 +177,15 @@ typedef struct stlink_adiv5_reg_read {
 	uint8_t reserved[10];
 } stlink_adiv5_reg_read_s;
 
+typedef struct stlink_adiv5_reg_write {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t apsel[2];
+	uint8_t address[2];
+	uint8_t value[4];
+	uint8_t reserved[6];
+} stlink_adiv5_reg_write_s;
+
 typedef struct stlink_mem_command {
 	uint8_t command;
 	uint8_t operation;

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -152,7 +152,7 @@
 #define STLINK_TRACE_SIZE   4096U
 #define STLINK_TRACE_MAX_HZ 2000000U
 
-#define STLINK_V3_MAX_FREQ_NB 10U
+#define STLINK_V3_FREQ_ENTRY_COUNT 10U
 
 #define STLINK_DEBUG_PORT 0xffffU
 
@@ -211,6 +211,15 @@ typedef struct stlink_mem_command {
 	uint8_t apsel;
 	uint8_t reserved[7];
 } stlink_mem_command_s;
+
+typedef struct stlink_v3_set_freq {
+	uint8_t command;
+	uint8_t operation;
+	uint8_t mode;
+	uint8_t reserved1;
+	uint8_t frequency[4];
+	uint8_t reserved2[8];
+} stlink_v3_set_freq_s;
 
 int stlink_simple_query(uint8_t command, uint8_t operation, void *rx_buffer, size_t rx_len);
 int stlink_simple_request(uint8_t command, uint8_t operation, uint8_t param, void *rx_buffer, size_t rx_len);

--- a/src/platforms/hosted/stlinkv2_swd.c
+++ b/src/platforms/hosted/stlinkv2_swd.c
@@ -48,7 +48,7 @@ uint32_t stlink_swd_scan(void)
 
 	dp->dp_read = firmware_swdp_read;
 	dp->error = stlink_dp_error;
-	dp->low_access = stlink_dp_low_access;
+	dp->low_access = stlink_raw_access;
 	dp->abort = stlink_dp_abort;
 
 	adiv5_dp_error(dp);

--- a/src/platforms/hosted/stlinkv2_swd.c
+++ b/src/platforms/hosted/stlinkv2_swd.c
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "general.h"
+#include "stlinkv2.h"
+#include "stlinkv2_protocol.h"
+#include "jtag_devs.h"
+#include "target_internal.h"
+
+uint32_t stlink_swd_scan(void)
+{
+	target_list_free();
+
+	stlink_leave_state();
+
+	const stlink_simple_request_s command = {
+		.command = STLINK_DEBUG_COMMAND,
+		.operation = STLINK_DEBUG_APIV2_ENTER,
+		.param = STLINK_DEBUG_ENTER_SWD_NO_RESET,
+	};
+	uint8_t data[2];
+	stlink_send_recv_retry(&command, sizeof(command), data, sizeof(data));
+	if (stlink_usb_error_check(data, true))
+		return 0;
+
+	adiv5_debug_port_s *dp = calloc(1, sizeof(*dp));
+	if (!dp) { /* calloc failed: heap exhaustion */
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
+		return 0;
+	}
+
+	dp->dp_read = firmware_swdp_read;
+	dp->error = stlink_dp_error;
+	dp->low_access = stlink_dp_low_access;
+	dp->abort = stlink_dp_abort;
+
+	adiv5_dp_error(dp);
+	adiv5_dp_init(dp, 0);
+	return target_list ? 1U : 0U;
+}

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -202,7 +202,7 @@ struct adiv5_debug_port {
 
 #if PC_HOSTED == 1
 	bool (*ap_setup)(uint8_t i);
-	void (*ap_cleanup)(int i);
+	void (*ap_cleanup)(uint8_t i);
 	void (*ap_regs_read)(adiv5_access_port_s *ap, void *data);
 	uint32_t (*ap_reg_read)(adiv5_access_port_s *ap, int num);
 	void (*ap_reg_write)(adiv5_access_port_s *ap, int num, uint32_t value);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -205,7 +205,7 @@ struct adiv5_debug_port {
 	void (*ap_cleanup)(uint8_t i);
 	void (*ap_regs_read)(adiv5_access_port_s *ap, void *data);
 	uint32_t (*ap_reg_read)(adiv5_access_port_s *ap, uint8_t reg_num);
-	void (*ap_reg_write)(adiv5_access_port_s *ap, int num, uint32_t value);
+	void (*ap_reg_write)(adiv5_access_port_s *ap, uint8_t num, uint32_t value);
 	void (*read_block)(uint32_t addr, uint8_t *data, int size);
 	void (*dap_write_block_sized)(uint32_t addr, uint8_t *data, int size, align_e align);
 #endif

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -204,7 +204,7 @@ struct adiv5_debug_port {
 	bool (*ap_setup)(uint8_t i);
 	void (*ap_cleanup)(uint8_t i);
 	void (*ap_regs_read)(adiv5_access_port_s *ap, void *data);
-	uint32_t (*ap_reg_read)(adiv5_access_port_s *ap, int num);
+	uint32_t (*ap_reg_read)(adiv5_access_port_s *ap, uint8_t reg_num);
 	void (*ap_reg_write)(adiv5_access_port_s *ap, int num, uint32_t value);
 	void (*read_block)(uint32_t addr, uint8_t *data, int size);
 	void (*dap_write_block_sized)(uint32_t addr, uint8_t *data, int size, align_e align);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -201,7 +201,7 @@ struct adiv5_debug_port {
 	void (*abort)(adiv5_debug_port_s *dp, uint32_t abort);
 
 #if PC_HOSTED == 1
-	bool (*ap_setup)(int i);
+	bool (*ap_setup)(uint8_t i);
 	void (*ap_cleanup)(int i);
 	void (*ap_regs_read)(adiv5_access_port_s *ap, void *data);
 	uint32_t (*ap_reg_read)(adiv5_access_port_s *ap, int num);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes the ST-Lijnk backend for BMDA writing 2 bytes to a single byte of storage when doing a target_mem_read8() and entirely overhauls this backend, bringing it mostly up to speed with the other backends.

A side effect of this PR is that both the ST-Link and J-Link backends should now run considerably faster due to their improved use of libusb Bulk transfers.

Tested against the ST-Link v2.1 that is part of the STM32F411 Nucleo board.

This PR also pre-emptively fixes several other issues including the frequency selection/calculation logic and splits the backend up into JTAG-specific, SWD-specific and general components to match the other backends more closely

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes: #1455
