### PR TITLE
Fix: build error for hosted platform on Apple

### DIFF
--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -72,14 +72,14 @@ static bool set_interface_attribs(void)
 }
 
 #ifdef __APPLE__
-int serial_open(const bmda_cli_options_s *cl_opts, const char *serial)
+bool serial_open(const bmda_cli_options_s *cl_opts, const char *serial)
 {
 	char name[4096];
 	if (!cl_opts->opt_device) {
 		/* Try to find some BMP if0*/
 		if (!serial) {
 			DEBUG_WARN("No serial device found\n");
-			return -1;
+			return false;
 		} else {
 			sprintf(name, "/dev/cu.usbmodem%s1", serial);
 		}
@@ -89,7 +89,7 @@ int serial_open(const bmda_cli_options_s *cl_opts, const char *serial)
 	fd = open(name, O_RDWR | O_SYNC | O_NOCTTY);
 	if (fd < 0) {
 		DEBUG_ERROR("Couldn't open serial port %s\n", name);
-		return -1;
+		return false;
 	}
 	/* BMP only offers an USB-Serial connection with no real serial
      * line in between. No need for baudrate or parity.!

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -526,8 +526,7 @@ static void adiv5_component_probe(
 			 * see 'JEP-106 code list' for context, here we are aliasing codes that are non compliant with the
 			 * JEP-106 standard to their expected codes, this is later used to determine the correct probe function.
 			 */
-			DEBUG_WARN(
-				"Patching Designer code 0x%03" PRIx16 " -> 0x%03u\n", designer_code, JEP106_MANUFACTURER_STM);
+			DEBUG_WARN("Patching Designer code 0x%03" PRIx16 " -> 0x%03u\n", designer_code, JEP106_MANUFACTURER_STM);
 			designer_code = JEP106_MANUFACTURER_STM;
 		}
 	} else {

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -527,7 +527,7 @@ static void adiv5_component_probe(
 			 * JEP-106 standard to their expected codes, this is later used to determine the correct probe function.
 			 */
 			DEBUG_WARN(
-				"Patching Designer code 0x%03" PRIx16 " -> 0x%03" PRIx16 "\n", designer_code, JEP106_MANUFACTURER_STM);
+				"Patching Designer code 0x%03" PRIx16 " -> 0x%03u\n", designer_code, JEP106_MANUFACTURER_STM);
 			designer_code = JEP106_MANUFACTURER_STM;
 		}
 	} else {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
This pull requested fixes two compiler errors encountered when compiling for `PROBE_HOST=hosted` on Apple (macOS). These were reported in #1466.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
#1466 
