### PR TITLE
pre-commit/mirrors-clang-format: update from v15.0.4 to v16.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^upgrade/|^scripts/'  # don't run hooks on scripts/ and upgrade/
 
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v15.0.4
+  rev: v16.0.2
   hooks:
   - id: clang-format
     args: [-Werror]  # change formatting warnings to errors, hook includes -i (Inplace edit) by default

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -57,7 +57,7 @@ int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 }
 #elif defined(__WIN32__) || defined(__CYGWIN__)
 
-	/* This source has been used as an example:
+/* This source has been used as an example:
  * https://stackoverflow.com/questions/3438366/setupdigetdeviceproperty-usage-example */
 
 #include <windows.h>

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1840,8 +1840,8 @@ static int cortexm_hostio_request(target_s *t)
 		ret = -1;
 		uint32_t fio_stat[16]; /* same size as fio_stat in gdb/include/gdb/fileio.h */
 		//DEBUG("SYS_FLEN fio_stat addr %p\n", fio_stat);
-		void (*saved_mem_read)(target_s * t, void *dest, target_addr_t src, size_t len);
-		void (*saved_mem_write)(target_s * t, target_addr_t dest, const void *src, size_t len);
+		void (*saved_mem_read)(target_s *t, void *dest, target_addr_t src, size_t len);
+		void (*saved_mem_write)(target_s *t, target_addr_t dest, const void *src, size_t len);
 		saved_mem_read = t->mem_read;
 		saved_mem_write = t->mem_write;
 		t->mem_read = probe_mem_read;
@@ -1872,8 +1872,8 @@ static int cortexm_hostio_request(target_s *t)
 		} fio_timeval;
 
 		//DEBUG("SYS_TIME fio_timeval addr %p\n", &fio_timeval);
-		void (*saved_mem_read)(target_s * t, void *dest, target_addr_t src, size_t len);
-		void (*saved_mem_write)(target_s * t, target_addr_t dest, const void *src, size_t len);
+		void (*saved_mem_read)(target_s *t, void *dest, target_addr_t src, size_t len);
+		void (*saved_mem_write)(target_s *t, target_addr_t dest, const void *src, size_t len);
 		saved_mem_read = t->mem_read;
 		saved_mem_write = t->mem_write;
 		t->mem_read = probe_mem_read;
@@ -1904,8 +1904,8 @@ static int cortexm_hostio_request(target_s *t)
 	case SEMIHOSTING_SYS_READC: { /* readc */
 		uint8_t ch = '?';
 		//DEBUG("SYS_READC ch addr %p\n", &ch);
-		void (*saved_mem_read)(target_s * t, void *dest, target_addr_t src, size_t len);
-		void (*saved_mem_write)(target_s * t, target_addr_t dest, const void *src, size_t len);
+		void (*saved_mem_read)(target_s *t, void *dest, target_addr_t src, size_t len);
+		void (*saved_mem_write)(target_s *t, target_addr_t dest, const void *src, size_t len);
 		saved_mem_read = t->mem_read;
 		saved_mem_write = t->mem_write;
 		t->mem_read = probe_mem_read;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
This pull request fixes issue #1469, where a pre-commit error was encountered on macOS using Apple Silicon, as `libzstd` was not found.

`pre-commit` uses a mirror of `clang-format`, which is located at https://github.com/pre-commit/mirrors-clang-format and defined in the `.pre-commit-config.yaml` file.

Upgrading from clang-format v15.0.4 to v16.0.2 fixes the issue.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
#1469
<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
