### PR TITLE
github: Replaced run-action with direct call of pre-commit in lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,5 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3.0.2
 
+    - name: Install pre-commit
+      run: pip install pre-commit
+
     - name: Run pre-commit
-      uses: before-commit/run-action@v2.0.3
+      run: pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

There are some warnings going on in the action runs, see https://github.com/blackmagic-debug/blackmagic/actions/runs/4802501164 for example:

```
Annotations
4 warnings
pre-commit
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: before-commit/run-action@v2.0.3. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
pre-commit
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
pre-commit
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
pre-commit
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

This can not be fixed with a version bump because there are no new releases/tags being made since Apr 21, 2021 in [before-commit/run-action](https://github.com/before-commit/run-action/tags). We can install and call `pre-commit` directly though instead as we see what options are used in [this run](https://github.com/blackmagic-debug/blackmagic/actions/runs/4802501164/jobs/8546036072):

```
/home/runner/.local/bin/pre-commit run --show-diff-on-failure --color=always --all-files
```

Compare these 2 runs and you can see they are identical:

before (this repo): https://github.com/blackmagic-debug/blackmagic/actions/runs/4802501164/jobs/8546036072
after (my forked repo): https://github.com/gemesa/blackmagic/actions/runs/4809530379/jobs/8560906932

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
