### PR TITLE
Fix DWT mask calculation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,7 @@ SRC =              \
 	lpc55xx.c      \
 	kinetis.c      \
 	main.c         \
+	maths_utils.c  \
 	morse.c        \
 	msp432.c       \
 	nrf51.c        \

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -39,6 +39,7 @@
 #include <inttypes.h>
 #include <sys/types.h>
 
+#include "maths_utils.h"
 #include "platform.h"
 #include "platform_support.h"
 

--- a/src/include/maths_utils.h
+++ b/src/include/maths_utils.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef INCLUDE_MATHS_UTILS_H
+#define INCLUDE_MATHS_UTILS_H
+
+#include <stdint.h>
+
+uint8_t ulog2(uint32_t value);
+
+#endif /* INCLUDE_MATHS_UTILS_H */

--- a/src/maths_utils.c
+++ b/src/maths_utils.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* 
+ * Mathematical helper functions
+ */
+
+#include "maths_utils.h"
+
+#ifdef __GNUC__
+#define unlikely(x) __builtin_expect(x, 0)
+#else
+#define unlikely(x) x
+#endif
+
+uint8_t ulog2(uint32_t value)
+{
+	if (unlikely(!value))
+		return UINT8_MAX;
+#if defined(__GNUC__)
+	return (uint8_t)((sizeof(uint32_t) * 8U) - (uint8_t)__builtin_clz(value));
+#elif defined(_MSC_VER)
+	return (uint8_t)((sizeof(uint32_t) * 8U) - (uint8_t)__lzcnt(value));
+#else
+	uint8_t result = 0U;
+	if (value <= UINT32_C(0x0000ffff)) {
+		result += 16;
+		value <<= 16U;
+	}
+	if (value <= UINT32_C(0x00ffffff)) {
+		result += 8;
+		value <<= 8U;
+	}
+	if (value <= UINT32_C(0x0fffffff)) {
+		result += 4;
+		value <<= 4U;
+	}
+	if (value <= UINT32_C(0x3fffffff)) {
+		result += 2;
+		value <<= 2U;
+	}
+	if (value <= UINT32_C(0x7fffffff))
+		++result;
+	return (sizeof(uint8_t) * 8U) - result;
+#endif
+}

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1261,22 +1261,22 @@ bool cortexm_run_stub(target_s *t, uint32_t loadaddr, uint32_t r0, uint32_t r1, 
 	return bkpt_instr & 0xffU;
 }
 
-/* The following routines implement hardware breakpoints and watchpoints.
+/*
+ * The following routines implement hardware breakpoints and watchpoints.
  * The Flash Patch and Breakpoint (FPB) and Data Watch and Trace (DWT)
- * systems are used. */
+ * systems are used.
+ */
 
+/*
+ * DWT only supports powers of two as size. Convert length in bytes to
+ * number of least-significant bits of the address to ignore during
+ * match (maximum 31).
+ */
 static uint32_t dwt_mask(size_t len)
 {
-	switch (len) {
-	case 1:
-		return CORTEXM_DWT_MASK_BYTE;
-	case 2:
-		return CORTEXM_DWT_MASK_HALFWORD;
-	case 4:
-		return CORTEXM_DWT_MASK_WORD;
-	default:
-		return -1;
-	}
+	if (len < 2)
+		return 0;
+	return MIN(ulog2(len - 1), 31);
 }
 
 static uint32_t dwt_func(target_s *t, target_breakwatch_e type)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

DWT can match power-of-two sized memory regions up to an implementation-defined limit. Properly calculate the mask length for region sizes of more then 4 bytes rather than writing reserved bits.

Factored out `stlink_ulog2()` from [`src/platforms/hosted/stlinkv2.c`](https://github.com/blackmagic-debug/blackmagic/blob/5a925ee79c36a2a3f13d32570fd48b890b4a4f4e/src/platforms/hosted/stlinkv2.c) as `ulog2()` into a new source file `src/compat.c` so we can use it in `src/target/cortexm.c`. I didn't find a good location for this function (the closest match I could find was `hex_utils.c`) so I created a new file.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
