### PR TITLE
Feature: Remove the JTAG scan IR lengths mechanism

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -198,17 +198,11 @@ bool cmd_help(target_s *t, int argc, const char **argv)
 static bool cmd_jtag_scan(target_s *target, int argc, const char **argv)
 {
 	(void)target;
-	uint8_t ir_lengths[JTAG_MAX_DEVS];
-	const volatile size_t lengths_count = MIN((size_t)argc - 1U, JTAG_MAX_DEVS);
+	(void)argc;
+	(void)argv;
 
 	if (platform_target_voltage())
 		gdb_outf("Target voltage: %s\n", platform_target_voltage());
-
-	if (lengths_count) {
-		/* Accept a list of IR lengths on command line */
-		for (size_t offset = 0; offset < lengths_count; ++offset)
-			ir_lengths[offset] = strtoul(argv[offset + 1U], NULL, 0);
-	}
 
 	if (connect_assert_nrst)
 		platform_nrst_set_val(true); /* will be deasserted after attach */
@@ -217,9 +211,9 @@ static bool cmd_jtag_scan(target_s *target, int argc, const char **argv)
 	volatile exception_s e;
 	TRY_CATCH (e, EXCEPTION_ALL) {
 #if PC_HOSTED == 1
-		devs = platform_jtag_scan(ir_lengths, lengths_count);
+		devs = platform_jtag_scan();
 #else
-		devs = jtag_scan(ir_lengths, lengths_count);
+		devs = jtag_scan();
 #endif
 	}
 	switch (e.type) {
@@ -302,9 +296,9 @@ bool cmd_auto_scan(target_s *t, int argc, const char **argv)
 	volatile exception_s e;
 	TRY_CATCH (e, EXCEPTION_ALL) {
 #if PC_HOSTED == 1
-		devs = platform_jtag_scan(NULL, 0U);
+		devs = platform_jtag_scan();
 #else
-		devs = jtag_scan(NULL, 0U);
+		devs = jtag_scan();
 #endif
 		if (devs > 0)
 			break;

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -36,10 +36,10 @@ typedef struct target_controller target_controller_s;
 
 #if PC_HOSTED == 1
 uint32_t platform_adiv5_swdp_scan(uint32_t targetid);
-uint32_t platform_jtag_scan(const uint8_t *ir_lengths, size_t lengths_count);
+uint32_t platform_jtag_scan(void);
 #endif
 uint32_t adiv5_swdp_scan(uint32_t targetid);
-uint32_t jtag_scan(const uint8_t *ir_lengths, size_t lengths_count);
+uint32_t jtag_scan(void);
 
 int target_foreach(void (*cb)(int i, target_s *t, void *context), void *context);
 void target_list_free(void);

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -417,10 +417,10 @@ static void display_target(int i, target_s *t, void *context)
 uint32_t scan_for_targets(const bmda_cli_options_s *const opt)
 {
 	if (opt->opt_scanmode == BMP_SCAN_JTAG)
-		return platform_jtag_scan(NULL, 0);
+		return platform_jtag_scan();
 	if (opt->opt_scanmode == BMP_SCAN_SWD)
 		return platform_adiv5_swdp_scan(opt->opt_targetid);
-	uint32_t num_targets = platform_jtag_scan(NULL, 0);
+	uint32_t num_targets = platform_jtag_scan();
 	if (num_targets)
 		return num_targets;
 	DEBUG_WARN("JTAG scan found no devices, trying SWD.\n");

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -201,7 +201,7 @@ void platform_add_jtag_dev(uint32_t i, const jtag_dev_s *jtag_dev)
 		remote_add_jtag_dev(i, jtag_dev);
 }
 
-uint32_t platform_jtag_scan(const uint8_t *ir_lengths, const size_t lengths_count)
+uint32_t platform_jtag_scan(void)
 {
 	info.is_jtag = true;
 
@@ -212,12 +212,10 @@ uint32_t platform_jtag_scan(const uint8_t *ir_lengths, const size_t lengths_coun
 	case BMP_TYPE_LIBFTDI:
 	case BMP_TYPE_JLINK:
 	case BMP_TYPE_CMSIS_DAP:
-		return jtag_scan(ir_lengths, lengths_count);
+		return jtag_scan();
 
 #if HOSTED_BMP_ONLY == 0
 	case BMP_TYPE_STLINKV2:
-		if (lengths_count)
-			gdb_outf("Manually specified IR lengths is not supported when using a ST-Link adaptor\n");
 		return stlink_jtag_scan();
 #endif
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This pull request removes the old IR lengths system, where a user would manually specify the expected IR lengths as part of doing a JTAG scan monitor command. This has been done in preference for the IR quirks system which allows specifying not just expected IR lengths but also expected values, making it a considerably more flexible system.

This results in a ~220 byte saving in Flash, which might be enough for #1474 to then fit.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes: blackmagic-debug/black-magic-org#1
