### PR TITLE
Fix selecting between multiple identical CMSIS-DAP devices

### DIFF
--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -77,6 +77,7 @@ typedef struct bmp_info {
 	bool is_jtag;
 #if HOSTED_BMP_ONLY != 1
 	libusb_context *libusb_ctx;
+	libusb_device *libusb_dev;
 	ftdi_context_s *ftdi_ctx;
 	usb_link_s *usb_link;
 	uint16_t vid;

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -296,6 +296,7 @@ rescan:
 			DEBUG_WARN("%2zu: %s, %s, %s\n", found_debuggers + 1U, serial[0] ? serial : NO_SERIAL_NUMBER, manufacturer,
 				product);
 
+		info->libusb_dev = dev;
 		info->vid = desc.idVendor;
 		info->pid = desc.idProduct;
 		info->bmp_type = type;
@@ -327,6 +328,8 @@ rescan:
 	}
 	if (!found_debuggers && access_problems)
 		DEBUG_ERROR("No debugger found. Please check access rights to USB devices!\n");
+	if (info->libusb_dev)
+		libusb_ref_device(info->libusb_dev);
 	libusb_free_device_list(devs, 1);
 	return found_debuggers == 1U ? 0 : -1;
 }

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -199,9 +199,9 @@ static bool dap_init_hid(const bmp_info_s *const info)
 static bool dap_init_bulk(const bmp_info_s *const info)
 {
 	DEBUG_INFO("Using bulk transfer\n");
-	usb_handle = libusb_open_device_with_vid_pid(info->libusb_ctx, info->vid, info->pid);
-	if (!usb_handle) {
-		DEBUG_ERROR("libusb_open_device_with_vid_pid() failed\n");
+	int res = libusb_open(info->libusb_dev, &usb_handle);
+	if (res != LIBUSB_SUCCESS) {
+		DEBUG_ERROR("libusb_open() failed (%d): %s\n", res, libusb_error_name(res));
 		return false;
 	}
 	if (libusb_claim_interface(usb_handle, info->interface_num) < 0) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Unlike ST-Link and JLink's init functions, CMSIS-DAP's `dap_init_bulk()` uses `libusb_open_device_with_vid_pid()` which just grabs the first matching device without filtering by serial, which makes it impossible to select other devices than the first.

Rather than transplanting the opening/filtering code from one of the other interfaces, this PR leverages the fact that we've already found and decided on which USB device we want to use in `find_debuggers()`, so all we have to do is to keep a reference to the selected `libusb_device` so that the interface drivers can pass that to `libusb_open()` without having to do a new scan.

The natural next step would be to simplify the ST-Link and JLink interface drivers to also make use of this, but I'm not able to test those right now, so I've left those out of the scope for this PR.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
