### PR TITLE
make: Don't delete version.h in archives.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -144,10 +144,18 @@ endif
 
 .PHONY:	clean host_clean all_platforms clang-format FORCE
 
+
+GIT_VERSION := $(shell if [ -d "../.git" ]; then git describe --always --dirty --tags; fi)
+
 clean:	host_clean
 	$(Q)echo "  CLEAN"
 	-$(Q)$(RM) *.o *.d *.elf *~ $(TARGET) $(HOSTFILES)
-	-$(Q)$(RM) platforms/*/*.o platforms/*/*.d mapfile include/version.h
+	-$(Q)$(RM) platforms/*/*.o platforms/*/*.d mapfile
+ifeq ($(GIT_VERSION),)
+	@echo Git not found, not deleting include/version.h
+else
+	-$(Q)$(RM) include/version.h
+endif
 
 all_platforms:
 	$(Q)if [ ! -f ../libopencm3/Makefile ]; then \
@@ -191,7 +199,6 @@ all_platforms:
 
 command.c: include/version.h
 
-GIT_VERSION := $(shell git describe --always --dirty --tags)
 VERSION_HEADER := \#define FIRMWARE_VERSION "$(GIT_VERSION)"
 
 include/version.h: FORCE


### PR DESCRIPTION
## Detailed description

Together with releases we also provide sourcecode archives. The archives contain the `version.h` file but no `.git` as it is not an active git repository. When the code is cleaned in a source archive the version.h should not be deleted. Also we should not require `git` to be installed so we check if it is in the path before running `git desscribe`.

This patch checks if git exists in the PATH and is executable, and makes cleaning of `version.h` optional.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

