### PR TITLE
Fix git detection when using blackmagic as a submodule.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -145,7 +145,7 @@ endif
 .PHONY:	clean host_clean all_platforms clang-format FORCE
 
 
-GIT_VERSION := $(shell if [ -d "../.git" ]; then git describe --always --dirty --tags; fi)
+GIT_VERSION := $(shell if [ -e "../.git" ]; then git describe --always --dirty --tags; fi)
 
 clean:	host_clean
 	$(Q)echo "  CLEAN"


### PR DESCRIPTION


## Detailed description

When the `blackmagic` repository is used as a submodule of another repository the .git is a file redirecting to where the directory is instead of being the directory itself. We need to test for "a file" existing not for a directory.

I have tested this by creating a mockup repository using this repository as a submodule. Now building within the submodule works again as intended.

Not sure if we need to backport this patch to the v1.9 branch and include in the next point release. It depends on what the liklyhood` is of anyone using the stable branch or any of the tags instead of `main` as submodule.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Fixes #1483
<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
