### PR TITLE
imxrt: use %u for formatting status code

### DIFF
--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -463,8 +463,8 @@ static void imxrt_spi_wait_complete(target_s *const target)
 #ifdef ENABLE_DEBUG
 		/* Read out the status code and display it */
 		const uint32_t status = target_mem_read32(target, IMXRT_FLEXSPI1_STAT1);
-		DEBUG_TARGET("Error executing sequence, offset %" PRIu8 ", error code %" PRIu8 "\n",
-			(uint8_t)(status >> 16U) & 0xfU, (uint8_t)(status >> 24U) & 0xfU);
+		DEBUG_TARGET("Error executing sequence, offset %u, error code %u\n", (uint8_t)(status >> 16U) & 0xfU,
+			(uint8_t)(status >> 24U) & 0xfU);
 #endif
 		/* Now clear the error (this clears the status field bits too) */
 		target_mem_write32(target, IMXRT_FLEXSPI1_INT, IMXRT_FLEXSPI1_INT_CMD_ERR);


### PR DESCRIPTION
This fixes the build on macos, after it was discovered that `PRIu8` didn't work due to integer promotion rules.

## Detailed description

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
