### PR TITLE
Build - Fix building BMDA due to alloca being undefined.

### DIFF
--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -26,6 +26,12 @@
 #include <unistd.h>
 #include <sys/time.h>
 
+#if defined(_WIN32)
+#include <malloc.h>
+#else
+#include <alloca.h>
+#endif
+
 #include "ftdi_bmp.h"
 #include <ftdi.h>
 


### PR DESCRIPTION
## Detailed description
Fixes the compilation error.

```
$ make -j 30 clean && make -j 30 PROBE_HOST=hosted HOSTED_BMP_ONLY=0 ENABLE_DEBUG=1
...
platforms/hosted/ftdi_bmp.c: In function ‘libftdi_jtagtap_tdi_tdo_seq’:
platforms/hosted/ftdi_bmp.c:694:32: error: implicit declaration of function ‘alloca’; did you mean ‘malloc’? [-Werror=implicit-function-declaration]
  694 |                 uint8_t *tmp = alloca(rsize);
      |                                ^~~~~~
      |                                malloc
platforms/hosted/ftdi_bmp.c:694:32: error: initialization of ‘uint8_t *’ {aka ‘unsigned char *’} from ‘int’ makes pointer from integer without a cast [-Werror=int-conversion]
cc1: all warnings being treated as errors
make[1]: *** [Makefile:125: ftdi_bmp.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:22: all] Error 2
```



## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

