### PR TITLE
Fix: platforms/blackpill-f4: fix typo in readme

### DIFF
--- a/src/platforms/common/blackpill-f4/README.md
+++ b/src/platforms/common/blackpill-f4/README.md
@@ -58,7 +58,7 @@ make PROBE_HOST=blackpill-f4x1cx ALTERNATIVE_PINOUT=1
   - Release BOOT0
 - Upload the firmware:
 ```
-./dfu-util -a 0 --dfuse-address 0x08000000:leave -R -D blackmagic-blackpillv2.bin
+./dfu-util -a 0 --dfuse-address 0x08000000:leave -R -D blackmagic.bin
 ```
 - Exit dfu mode: press and release nRST. The newly flashed Black Magic Probe should boot and enumerate.
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This pull request fixes a typo in the readme of the common blackpill-f4 code.

The typo is a remaining `blackpillv2` entry in the command to upload the firmware. This is updated in this pull request.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
