### PR TITLE
gd32f2xx: add support detection of GD32F2XX microcontrollers

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -131,7 +131,7 @@ static uint16_t stm32f1_read_idcode(target_s *const target)
 	return target_mem_read32(target, DBGMCU_IDCODE) & 0xfffU;
 }
 
-/* Identify GD32F1 and GD32F3 chips */
+/* Identify GD32F1, GD32F2 and GD32F3 chips */
 bool gd32f1_probe(target_s *target)
 {
 	const uint16_t device_id = stm32f1_read_idcode(target);
@@ -139,6 +139,9 @@ bool gd32f1_probe(target_s *target)
 	case 0x414U: /* Gigadevice gd32f303 */
 	case 0x430U:
 		target->driver = "GD32F3";
+		break;
+	case 0x418U:
+		target->driver = "GD32F2";
 		break;
 	case 0x410U: /* Gigadevice gd32f103, gd32e230 */
 		if ((target->cpuid & CPUID_PARTNO_MASK) == CORTEX_M23)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

1. This is a new feature with add support with gd32f2xx chip decection.
2. I have a board with GD32F205RKT6 chip,and I try debug the board with blackmagic, but I found I couldn't recongise the chip correctly, so I try to add support with this feature.
3. I found gd32f1x series chip has supported with blackmagic, and gd32f2xx is compatiled with gd32f1xx in a sense.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
