### PR TITLE
Fix: Remote protocol write length alignment error

### DIFF
--- a/src/platforms/hosted/remote/protocol_v0_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v0_adiv5.c
@@ -49,7 +49,12 @@ static bool remote_adiv5_check_error(const char *const func, const char *const b
 		const uint64_t response_code = remote_decode_response(buffer + 1, (size_t)length - 1U);
 		const uint8_t error = response_code & 0xffU;
 		DEBUG_ERROR("%s: Unexpected error %u\n", func, error);
-	}
+	} /* Check if the remote is reporting a parameter error*/
+	else if (buffer[0] == REMOTE_RESP_PARERR)
+		DEBUG_ERROR("%s: !BUG! Firmware reported a parameter error\n", func);
+	/* Check if the firmware is reporting some other kind of error */
+	else if (buffer[0] != REMOTE_RESP_OK)
+		DEBUG_ERROR("%s: Firmware reported unexpected error: %c\n", func, buffer[0]);
 	/* Return whether the remote indicated the request was successfull */
 	return buffer[0] == REMOTE_RESP_OK;
 }

--- a/src/platforms/hosted/remote/protocol_v0_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v0_adiv5.c
@@ -174,7 +174,8 @@ void remote_v0_adiv5_mem_write_bytes(adiv5_access_port_s *const ap, const uint32
 	/* + 1 for terminating NUL character */
 	char buffer[REMOTE_MAX_MSG_SIZE + 1U];
 	/* As we do, calculate how large a transfer we can do to the firmware */
-	const size_t blocksize = (REMOTE_MAX_MSG_SIZE - REMOTE_ADIv5_MEM_WRITE_LENGTH) / 2U;
+	const size_t alignment_mask = ~((1U << align) - 1U);
+	const size_t blocksize = ((REMOTE_MAX_MSG_SIZE - REMOTE_ADIv5_MEM_WRITE_LENGTH) / 2U) & alignment_mask;
 	/* For each transfer block size, ask the firmware to write that block of bytes */
 	for (size_t offset = 0; offset < write_length; offset += blocksize) {
 		/* Pick the amount left to write or the block size, whichever is smaller */

--- a/src/platforms/hosted/remote/protocol_v1_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v1_adiv5.c
@@ -49,7 +49,12 @@ static bool remote_adiv5_check_error(const char *const func, const char *const b
 		const uint64_t response_code = remote_decode_response(buffer + 1, (size_t)length - 1U);
 		const uint8_t error = response_code & 0xffU;
 		DEBUG_ERROR("%s: Unexpected error %u\n", func, error);
-	}
+	} /* Check if the remote is reporting a parameter error*/
+	else if (buffer[0] == REMOTE_RESP_PARERR)
+		DEBUG_ERROR("%s: !BUG! Firmware reported a parameter error\n", func);
+	/* Check if the firmware is reporting some other kind of error */
+	else if (buffer[0] != REMOTE_RESP_OK)
+		DEBUG_ERROR("%s: Firmware reported unexpected error: %c\n", func, buffer[0]);
 	/* Return whether the remote indicated the request was successfull */
 	return buffer[0] == REMOTE_RESP_OK;
 }

--- a/src/platforms/hosted/remote/protocol_v1_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v1_adiv5.c
@@ -176,7 +176,8 @@ void remote_v1_adiv5_mem_write_bytes(adiv5_access_port_s *const ap, const uint32
 	/* + 1 for terminating NUL character */
 	char buffer[REMOTE_MAX_MSG_SIZE + 1U];
 	/* As we do, calculate how large a transfer we can do to the firmware */
-	const size_t blocksize = (REMOTE_MAX_MSG_SIZE - REMOTE_ADIv5_MEM_WRITE_LENGTH) / 2U;
+	const size_t alignment_mask = ~((1U << align) - 1U);
+	const size_t blocksize = ((REMOTE_MAX_MSG_SIZE - REMOTE_ADIv5_MEM_WRITE_LENGTH) / 2U) & alignment_mask;
 	/* For each transfer block size, ask the firmware to write that block of bytes */
 	for (size_t offset = 0; offset < write_length; offset += blocksize) {
 		/* Pick the amount left to write or the block size, whichever is smaller */

--- a/src/platforms/hosted/remote/protocol_v3_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v3_adiv5.c
@@ -59,7 +59,12 @@ static bool remote_adiv5_check_error(
 		/* Otherwise it's an unexpected error */
 		else
 			DEBUG_ERROR("%s: Unexpected error %u\n", func, error);
-	}
+	} /* Check if the remote is reporting a parameter error*/
+	else if (buffer[0] == REMOTE_RESP_PARERR)
+		DEBUG_ERROR("%s: !BUG! Firmware reported a parameter error\n", func);
+	/* Check if the firmware is reporting some other kind of error */
+	else if (buffer[0] != REMOTE_RESP_OK)
+		DEBUG_ERROR("%s: Firmware reported unexpected error: %c\n", func, buffer[0]);
 	/* Return whether the remote indicated the request was successfull */
 	return buffer[0] == REMOTE_RESP_OK;
 }

--- a/src/platforms/hosted/remote/protocol_v3_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v3_adiv5.c
@@ -186,7 +186,8 @@ void remote_v3_adiv5_mem_write_bytes(adiv5_access_port_s *const ap, const uint32
 	/* + 1 for terminating NUL character */
 	char buffer[REMOTE_MAX_MSG_SIZE + 1U];
 	/* As we do, calculate how large a transfer we can do to the firmware */
-	const size_t blocksize = (REMOTE_MAX_MSG_SIZE - REMOTE_ADIv5_MEM_WRITE_LENGTH) / 2U;
+	const size_t alignment_mask = ~((1U << align) - 1U);
+	const size_t blocksize = ((REMOTE_MAX_MSG_SIZE - REMOTE_ADIv5_MEM_WRITE_LENGTH) / 2U) & alignment_mask;
 	/* For each transfer block size, ask the firmware to write that block of bytes */
 	for (size_t offset = 0; offset < write_length; offset += blocksize) {
 		/* Pick the amount left to write or the block size, whichever is smaller */

--- a/src/remote.c
+++ b/src/remote.c
@@ -435,7 +435,7 @@ static void remote_packet_process_adiv5(const char *const packet, const size_t p
 		remote_adiv5_respond(data, length);
 		break;
 	}
-	case REMOTE_MEM_WRITE: { /* Am = Write to memory */
+	case REMOTE_MEM_WRITE: { /* AM = Write to memory */
 		/* Grab the CSW value to use in the access */
 		remote_ap.csw = remote_hex_string_to_num(8, packet + 6);
 		/* Grab the alignment for the access */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a regression caused by #1459 where BMDA can calculate a memory write transfer length inappropriate to the alignment required for that write. In the process, this also improves the error reporting of the BMDA remote protocol implementation to make debugging in the future easier.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1492