### PR TITLE
cortexm: Avoid long division for non-hosted

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1894,8 +1894,9 @@ static int cortexm_hostio_request(target_s *t)
 			if (time0_sec > sec)
 				time0_sec = sec; /* set sys_clock time origin */
 			sec -= time0_sec;
-			uint64_t csec64 = (sec * UINT64_C(1000000) + usec) / UINT64_C(10000);
-			uint32_t csec = csec64 & 0x7fffffffU;
+			/* Cast down microseconds to avoid u64 division */
+			uint32_t csec32 = ((uint32_t)usec / 10000U) + (sec * 100U);
+			int32_t csec = csec32 & 0x7fffffffU;
 			ret = csec;
 		}
 		break;


### PR DESCRIPTION
## Detailed description

* The only place in firmware involving long division is in `cortexm_hostio_request` with a `uint64_t csec64` intermediate, as analyzed by Puncover.
* This PR reorders expression terms to stay in uint32_t type.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Indirectly affects issues with FTBFS for flash-constrained platforms (native/stlink/swlink).
Impact: users of on-probe Semihosting. Testing required (esp. BMP vs BMDA-processed semihosting).
When building with gcc-{10,11,12}, code size decreases by ~780 bytes by dropping `__aeabi_uldivmod`.