### PR TITLE
Fix: Replace strtol with strtoul

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -245,7 +245,7 @@ bool cmd_swdp_scan(target_s *t, int argc, const char **argv)
 	(void)t;
 	volatile uint32_t targetid = 0;
 	if (argc > 1)
-		targetid = strtol(argv[1], NULL, 0);
+		targetid = strtoul(argv[1], NULL, 0);
 	if (platform_target_voltage())
 		gdb_outf("Target voltage: %s\n", platform_target_voltage());
 

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -125,7 +125,7 @@ size_t gdb_getpacket(char *const packet, const size_t size)
 		recv_csum[2] = 0;
 
 		/* Return packet if checksum matches */
-		if (csum == strtol(recv_csum, NULL, 16))
+		if (csum == strtoul(recv_csum, NULL, 16))
 			break;
 
 		/* Get here if checksum fails */

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -790,8 +790,8 @@ static bool stm32f1_cmd_option(target_s *target, int argc, const char **argv)
 			return false;
 	} else if (argc == 3) {
 		/* If 3 arguments are given, assume the second is an address, and the third a value */
-		const uint32_t addr = strtol(argv[1], NULL, 0);
-		const uint32_t val = strtol(argv[2], NULL, 0);
+		const uint32_t addr = strtoul(argv[1], NULL, 0);
+		const uint32_t val = strtoul(argv[2], NULL, 0);
 		/* Try and program the new option value to the requested option byte */
 		if (!stm32f1_option_write(target, addr, val))
 			return false;


### PR DESCRIPTION
## Detailed description

* The PR tries to optimise flash size by slightly reducing the set of functions required from libc.
* Precisely, I've identified the three places where `strtol` is called in firmware with help of Puncover. `strtoul` seems to be sufficient to store into uint32_t results in all three cases, and the `base` argument is 16 or 0 (for hexadecimal) anyway.

man 3 strtoul: 
>Negative values are considered valid input and are silently converted to the equivalent unsigned long value.

Even though newlib provides `_strtol_r` & `_strtoul_r` as different implementations (not calling each other, unlike atoi()/atol() wrappers), the resulting program ends up referencing both functions via (si)scanf implementation anyway (newlib & newlib-nano). There is only an effectively 20-40-byte .text reduction from dropping the `strtol` wrapper.
Still offering this PR in the event siscanf (1.5k with deps) from newlib-nano somehow gets replaced with an optimized version.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None known.
Testing would involve fiddling with option bytes of stm32f1 and issuing a swdp_scan of a given TARGETID.