### PR TITLE
Fix: Use reentrant strtok_r

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -141,7 +141,9 @@ int command_process(target_s *t, char *cmd)
 
 	/* Tokenize cmd to find argv */
 	argc = 0;
-	for (const char *part = strtok(cmd, " \t"); part; part = strtok(NULL, " \t"))
+	/* Reentrant strtok needs a state pointer to the unprocessed part */
+	char *token_state = NULL;
+	for (const char *part = strtok_r(cmd, " \t", &token_state); part; part = strtok_r(NULL, " \t", &token_state))
 		argv[argc++] = part;
 
 	/* Look for match and call handler */


### PR DESCRIPTION
## Detailed description

* The strtok in newlib pulls in assert, fiprintf and other FILE*/reentrant stuff which is a code size problem.
* This PR rewrites the sole caller (`command_process()`) to manage the state (`char* saveptr`) and use the reentrant `strtok_r`.

Caveats: `-DNDEBUG` for disabling asserts doesn't influence this, as this is a special `__reent_assert`;
any introduction of assert() or direct fiprintf() usage will pull the dropped functions (`_vfiprintf_r` and friends) back into firmware binary.

Build-tests for native,stlink,blackpill-f4 show 1.5 kilobyte flash size reduction.
Now even `make PROBE_HOST=stlink ST_BOOTLOADER=1` produces 7524 + 114424 binaries (131072-8192=114688 limit) which fits both a 16k ST DFU and a 112k BMP firmware into 128k adapter flash.
This is (helped by and) a follow-up to #1511, #1512.
Additionally, this is a one malloc less (for `struct _misc_reent`, so might help with heap usage.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Indirectly helps issues arisen due to `native` flash constraints without having to drop targets support. Closes #1510.

Runtime testing should exercise long remote monitor commands with multiple arguments, maybe even against BMDA (hosted).