### PR TITLE
platforms/blackpill-f4: fix inverted tpwr command

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -96,7 +96,7 @@ void platform_init(void)
 	gpio_mode_setup(LED_PORT_UART, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_UART);
 
 #ifdef PLATFORM_HAS_POWER_SWITCH
-	gpio_set(PWR_BR_PORT, PWR_BR_PIN);
+	gpio_clear(PWR_BR_PORT, PWR_BR_PIN); // Set the pin of the given GPIO port to 0.
 	gpio_mode_setup(PWR_BR_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, PWR_BR_PIN);
 #endif
 
@@ -146,7 +146,7 @@ void platform_request_boot(void)
 #ifdef PLATFORM_HAS_POWER_SWITCH
 bool platform_target_get_power(void)
 {
-	return !gpio_get(PWR_BR_PORT, PWR_BR_PIN);
+	return gpio_get(PWR_BR_PORT, PWR_BR_PIN);
 }
 
 void platform_target_set_power(const bool power)

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -151,7 +151,7 @@ bool platform_target_get_power(void)
 
 void platform_target_set_power(const bool power)
 {
-	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, !power);
+	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, power);
 }
 
 /*


### PR DESCRIPTION
This pull request fixes a bug where the command `monitor tpwr disable` would enable tpwr, and `monitor tpwr enable` would disable tpwr.

With this fix, running `monitor tpwr disable` sets the voltage of the tpwr pin to 0.00 V, and running `monitor tpwr enable` sets the voltage of the tpwr pin to 3.30 V.

> **Note**
> A remaining issue is that tpwr is enabled upon startup, whereas `monitor tpwr` reports `Target Power: disabled`. This was already the case before this pull request, and remains an issue. @dragonmux Do you perhaps know what could cause this, and what could be a fix?

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for all platforms (`make all_platforms`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
