### PR TITLE
Fix: ENABLE_DEBUG=1 build throws -Wunused-variable in imxrt.c

### DIFF
--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -248,7 +248,7 @@ bool imxrt_probe(target_s *const target)
 	target->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 	target->driver = "i.MXRT10xx";
 
-#if ENABLE_DEBUG
+#if defined(ENABLE_DEBUG) && PC_HOSTED == 1
 	const uint8_t boot_mode = (target_mem_read32(target, IMXRT_SRC_BOOT_MODE2) >> 24U) & 3U;
 #endif
 	DEBUG_TARGET("i.MXRT boot mode is %x\n", boot_mode);
@@ -460,7 +460,7 @@ static void imxrt_spi_wait_complete(target_s *const target)
 	target_mem_write32(target, IMXRT_FLEXSPI1_INT, IMXRT_FLEXSPI1_INT_PRG_CMD_DONE);
 	/* Check if any errors occured */
 	if (target_mem_read32(target, IMXRT_FLEXSPI1_INT) & IMXRT_FLEXSPI1_INT_CMD_ERR) {
-#ifdef ENABLE_DEBUG
+#if defined(ENABLE_DEBUG) && PC_HOSTED == 1
 		/* Read out the status code and display it */
 		const uint32_t status = target_mem_read32(target, IMXRT_FLEXSPI1_STAT1);
 		DEBUG_TARGET("Error executing sequence, offset %u, error code %u\n", (uint8_t)(status >> 16U) & 0xfU,


### PR DESCRIPTION
## Detailed description

* Makeflag `ENABLE_DEBUG=1` includes many debugging printf statements into the probe firmware.
* `src/target/imxrt.c` had some funky `DEBUG_TARGET` code/variables partially guarded by `ENABLE_DEBUG`.
* Fix the build by additionally guarding with `PC_HOSTED==1`, as these statements are intended only for BMDA.

This change was introduced/discussed on Discord on June 15th, and I don't see it in PRs against `main`. Will drop/close this PR if the change is going to be included in a larger PR to avoid the trouble of rebasing.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) -- fails to fit at link stage due to +21k of flash footprint.
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) -- no change
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

No issues reporting ENABLE_DEBUG=1 builds were spotted, but I certainly did face this problem.