### PR TITLE
target/stm32h7: fix checking result from bank erase while mass erasing

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -377,7 +377,8 @@ static bool stm32h7_mass_erase(target_s *t)
 			psize = ((struct stm32h7_flash *)flash)->psize;
 	}
 	/* Send mass erase Flash start instruction */
-	if (!stm32h7_erase_bank(t, psize, BANK1_START, FPEC1_BASE) || stm32h7_erase_bank(t, psize, BANK2_START, FPEC2_BASE))
+	if (!stm32h7_erase_bank(t, psize, BANK1_START, FPEC1_BASE) ||
+		!stm32h7_erase_bank(t, psize, BANK2_START, FPEC2_BASE))
 		return false;
 
 	platform_timeout_s timeout;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
Fixes a wrong check on the result from second bank erase. This was resulting in prematurely exiting the mass erase call.

## Your checklist for this pull request

* [ ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [ ] My commit messages provide a useful short description of what the commits do
