### PR TITLE
Feature: Refactored LPC546xx device identification using a LUT

### DIFF
--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -90,17 +90,17 @@ typedef struct lpc546xx_device {
  * Part type number encoding: LPC546xxJyyy, where yyy is flash size, KiB
  */
 static const lpc546xx_device_s lpc546xx_devices_lut[] = {
-	{0x7f954605U, "LPC54605J256", 256, 32},
-	{0x7f954606U, "LPC54606J256", 256, 32},
-	{0x7f954607U, "LPC54607J256", 256, 32},
-	{0x7f954616U, "LPC54616J256", 256, 32},
-	{0xfff54605U, "LPC54605J512", 512, 96},
-	{0xfff54606U, "LPC54606J512", 512, 96},
-	{0xfff54607U, "LPC54607J512", 512, 96},
-	{0xfff54608U, "LPC54608J512", 512, 96},
-	{0xfff54616U, "LPC54616J512", 512, 96},
-	{0xfff54618U, "LPC54618J512", 512, 96},
-	{0xfff54628U, "LPC54628J512", 512, 96},
+	{0x7f954605U, "LPC546xxJ256", 256, 32},
+	{0x7f954606U, "LPC546xxJ256", 256, 32},
+	{0x7f954607U, "LPC546xxJ256", 256, 32},
+	{0x7f954616U, "LPC546xxJ256", 256, 32},
+	{0xfff54605U, "LPC546xxJ512", 512, 96},
+	{0xfff54606U, "LPC546xxJ512", 512, 96},
+	{0xfff54607U, "LPC546xxJ512", 512, 96},
+	{0xfff54608U, "LPC546xxJ512", 512, 96},
+	{0xfff54616U, "LPC546xxJ512", 512, 96},
+	{0xfff54618U, "LPC546xxJ512", 512, 96},
+	{0xfff54628U, "LPC546xxJ512", 512, 96},
 };
 
 /* Look up device parameters */
@@ -138,6 +138,7 @@ bool lpc546xx_probe(target_s *t)
 	uint32_t flash_size = 0;
 	uint32_t sram123_size = 0;
 
+	DEBUG_INFO("LPC546xx: Part ID 0x%08" PRIu32 "\n", chipid);
 	const lpc546xx_device_s *device = lpc546xx_get_device(chipid);
 	if (!device)
 		return false;


### PR DESCRIPTION
## Detailed description

* I noticed a long switch-case in the lpc546xx_probe with relatively low entropy: to me, it seemed inefficient, as the branches only differed in part name string. All 11 chips have either 256k or 512k flash. Moreover, SRAM123 size difference was not handled.
* I took inspiration from efm32 detection code and hoisted all part-specific data into a .rodata LUT/array. I also stored known flash & ram sizes there and used these in target_add_ram/flash calls.
* ~In case the LUT is deemed unnecessary, I tried dropping most of name strings for a 192 byte flash reduction.~
* upd: I reduced the name strings from 11 to 2 distinct. Exact Part ID goes into DEBUG_INFO logs.

The LUT approach should be more efficient and readable, ~but in fact results only in -4 bytes flash footprint.~ First squashed commit wins -20 bytes. However, it still preserves all previous information and removes the jumptable.
Second commit adds SRAM logic.
Third commit drops exact Part IDs, and GCC folds the identical constant literals.

Testing with LPC546xx targets is necessary, I don't have any of those.
## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
