### PR TITLE
Invalid sector_num fixed for dfu erase stm32f4

### DIFF
--- a/src/platforms/common/stm32/dfu_f4.c
+++ b/src/platforms/common/stm32/dfu_f4.c
@@ -60,6 +60,7 @@ static void get_sector_num(uint32_t addr)
 
 	if (!sector_addr[i])
 		return;
+	--i;
 	sector_num = i & 0x1fU;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

I think I found bug in Black Magic DFU bootloader for stm32f4 platform, where I'm testing BMP firmware.
I've encountered with DFU not erasing flash memory, where after manually erased chip, dfu bootloader successfully loaded BMP firmware. The commit where erase flow was changed  SHA:
3647a627bf1f2d42560a007085e7c06d1a82cb28
![02_bmp](https://github.com/blackmagic-debug/blackmagic/assets/17275900/e55057f4-326b-4cfe-8220-84eb64ecfcb4)

After the changes I've made I was able to download BMP firmware with DFU bootloader successfully.
## Your checklist for this pull request

* [* ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [*] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [* ] It builds for hardware native (`make PROBE_HOST=native`)
* [* ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [* ] I've tested it to the best of my ability
* [* ] My commit messages provide a useful short description of what the commits do

## Closing issues
