### PR TITLE
Feature: Implement SPI support for blackpill-f4

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -111,7 +111,16 @@
 #define LED_PORT_UART GPIOA
 #define LED_UART      PINOUT_SWITCH(GPIO4, GPIO1)
 
-/* SPI2: PA4/5/6/7 to onboard w25q64 */
+/* SPI2: PB12/13/14/15 to external chips */
+#define EXT_SPI         SPI2
+#define EXT_SPI_PORT    GPIOB
+#define EXT_SPI_SCLK    GPIO13
+#define EXT_SPI_MISO    GPIO14
+#define EXT_SPI_MOSI    GPIO15
+#define EXT_SPI_CS_PORT GPIOB
+#define EXT_SPI_CS      GPIO12
+
+/* SPI1: PA4/5/6/7 to onboard w25q64 */
 #define OB_SPI         SPI1
 #define OB_SPI_PORT    GPIOA
 #define OB_SPI_SCLK    GPIO5

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -111,6 +111,15 @@
 #define LED_PORT_UART GPIOA
 #define LED_UART      PINOUT_SWITCH(GPIO4, GPIO1)
 
+/* SPI2: PA4/5/6/7 to onboard w25q64 */
+#define OB_SPI         SPI1
+#define OB_SPI_PORT    GPIOA
+#define OB_SPI_SCLK    GPIO5
+#define OB_SPI_MISO    GPIO6
+#define OB_SPI_MOSI    GPIO7
+#define OB_SPI_CS_PORT GPIOA
+#define OB_SPI_CS      GPIO4
+
 /* USART2 with PA2 and PA3 is selected as USBUSART. Alternatively USART1 with PB6 and PB7 can be used. */
 #define USBUSART               USBUSART2
 #define USBUSART_CR1           USBUSART2_CR1


### PR DESCRIPTION
## Detailed description
This PR implements support for the internal (on-board) SPI Flash found on the Blackpill series boards, mirroring the work done for "native" (BMP).
* A new feature was implemented in #1499 for accessing probe-attached SPI flash chips via BMP remote protocol (and desktop cross-platform bmpflash client).
* However, it only implements SPI platform code for `native` hardware, providing no-op stubs for all the other platforms.
* I propose implementing platform_spi_init/deinit/chip_select/xfer for `blackpill-f4` hardware, which I own and test on.

This change results in ~~+320~~ +448 bytes flash footprint for `blackpill-f4x1cx`. Testing included `sfdp` and `read` from onboard w25q64 to desktop dualboot host (Linux Mint 21.1, Windows 11) using latest manually compiled bmpflash/substrate/fmt/libusb-1.0.
Read speed of 8MiB flash chip: Linux 200KiB/s, Win11 175KiB/s. File seems to match remains of NuttX SmartFS I kept there from previous development tests.

Misc. notes:
* At APB2=96MHz and SPI1 DIV8, line clock frequency should be 12MHz which is reasonable (`native`/F1 uses APB1=36;/8=4.5MHz for EXT SPI1 and APB2=72;/8=9Mhz for AUX SPI2).
* w25q64 datasheet states the chip supports accesses at clock frequency, when powered from 3.3v, in Standard SPI mode, `03h Read Data` up to 50MHz and `0Bh Fast Read` up to 104MHz.
* ~~I might add SPI2 on PB12/13/14/15 (F4 APB1=48Mhz) later as external/aux/etc. bus, these pins are not claimed yet.~~ Added SPI2 with same divisor, 48/8=6MHz.
* Other WeAct Studios designed hardware (BluePill Plus) also has SOIC-8 footprints on the bottom of PCB, so this PR might be useful in case somebody implements SPI support for that hardware later. It even maps that to the same GPIOs and HW SPI.
## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) -- changes another platform
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) -- not applicable
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
No issues raised on SPI functionality by users of blackpill-f4 boards, because it was absent from platform code.