### PR TITLE
Fix: Refactor LPC43xx target sram detection code

### DIFF
--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -414,39 +414,48 @@ static void lpc43x0_add_spi_flash(target_s *const target, const size_t length)
 
 static void lpc43x0_detect(target_s *const t, const lpc43xx_partid_s part_id)
 {
+	uint32_t sram1_size;
+	uint32_t sram2_size;
+	uint32_t sram_ahb_size;
 	target_add_ram(t, LPC43xx_SHADOW_BASE, LPC43xx_SHADOW_SIZE);
 	switch (part_id.part) {
 	case LPC43xx_PARTID_LPC4310:
 		t->driver = "LPC4310";
-		target_add_ram(t, LPC43xx_LOCAL_SRAM1_BASE, LPC4310_LOCAL_SRAM1_SIZE);
-		target_add_ram(t, LPC43xx_LOCAL_SRAM2_BASE, LPC43xx_LOCAL_SRAM2_SIZE);
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x2_AHB_SRAM_SIZE);
+		sram1_size = LPC4310_LOCAL_SRAM1_SIZE;
+		sram2_size = LPC43xx_LOCAL_SRAM2_SIZE;
+		sram_ahb_size = LPC43x2_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC4320:
 		t->driver = "LPC4320";
-		target_add_ram(t, LPC43xx_LOCAL_SRAM1_BASE, LPC4310_LOCAL_SRAM1_SIZE);
-		target_add_ram(t, LPC43xx_LOCAL_SRAM2_BASE, LPC43xx_LOCAL_SRAM2_SIZE);
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x5_AHB_SRAM_SIZE);
+		sram1_size = LPC4310_LOCAL_SRAM1_SIZE;
+		sram2_size = LPC43xx_LOCAL_SRAM2_SIZE;
+		sram_ahb_size = LPC43x5_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC4330:
 	case LPC43xx_PARTID_LPC4350:
 		t->driver = "LPC4330/50";
-		target_add_ram(t, LPC43xx_LOCAL_SRAM1_BASE, LPC4330_LOCAL_SRAM1_SIZE);
-		target_add_ram(t, LPC43xx_LOCAL_SRAM2_BASE, LPC43x0_LOCAL_SRAM2_SIZE);
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x5_AHB_SRAM_SIZE);
+		sram1_size = LPC4330_LOCAL_SRAM1_SIZE;
+		sram2_size = LPC43x0_LOCAL_SRAM2_SIZE;
+		sram_ahb_size = LPC43x5_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC4370:
 	case LPC43xx_PARTID_LPC4370_ERRATA:
 		t->driver = "LPC4370";
-		target_add_ram(t, LPC43xx_LOCAL_SRAM1_BASE, LPC4330_LOCAL_SRAM1_SIZE);
-		target_add_ram(t, LPC43xx_LOCAL_SRAM2_BASE, LPC43x0_LOCAL_SRAM2_SIZE);
+		sram1_size = LPC4330_LOCAL_SRAM1_SIZE;
+		sram2_size = LPC43x0_LOCAL_SRAM2_SIZE;
+		sram_ahb_size = LPC43x5_AHB_SRAM_SIZE;
 		target_add_ram(t, LPC4370_M0_SRAM_BASE, LPC4370_M0_SRAM_SIZE);
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x5_AHB_SRAM_SIZE);
 		break;
 	default:
 		DEBUG_WARN("Probable LPC43x0 with ID errata: %08" PRIx32 "\n", part_id.part);
-		break;
+		t->attach = lpc43x0_attach;
+		t->detach = lpc43x0_detach;
+		return;
 	}
+	/* Finally, call these once to append the linked list of ram */
+	target_add_ram(t, LPC43xx_LOCAL_SRAM1_BASE, sram1_size);
+	target_add_ram(t, LPC43xx_LOCAL_SRAM2_BASE, sram2_size);
+	target_add_ram(t, LPC43xx_AHB_SRAM_BASE, sram_ahb_size);
 	t->attach = lpc43x0_attach;
 	t->detach = lpc43x0_detach;
 }

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -312,33 +312,35 @@ static void lpc43xx_detect(target_s *const t, const lpc43xx_partid_s part_id)
 {
 	lpc43xx_priv_s *const priv = (lpc43xx_priv_s *)t->target_storage;
 	const uint32_t iap_entry = target_mem_read32(t, IAP_ENTRYPOINT_LOCATION);
+	uint32_t sram_ahb_size = 0;
 
 	switch (part_id.part) {
 	case LPC43xx_PARTID_LPC4312:
 		t->driver = "LPC4312/3";
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x2_AHB_SRAM_SIZE);
+		sram_ahb_size = LPC43x2_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC4315:
 		t->driver = "LPC4315/7";
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x5_AHB_SRAM_SIZE);
+		sram_ahb_size = LPC43x5_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC4322:
 		t->driver = "LPC4322/3";
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x2_AHB_SRAM_SIZE);
+		sram_ahb_size = LPC43x2_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC4325:
 		t->driver = "LPC4325/7";
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x5_AHB_SRAM_SIZE);
+		sram_ahb_size = LPC43x5_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC433x:
 		t->driver = "LPC433x";
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x5_AHB_SRAM_SIZE);
+		sram_ahb_size = LPC43x5_AHB_SRAM_SIZE;
 		break;
 	case LPC43xx_PARTID_LPC435x:
 		t->driver = "LPC435x";
-		target_add_ram(t, LPC43xx_AHB_SRAM_BASE, LPC43x5_AHB_SRAM_SIZE);
+		sram_ahb_size = LPC43x5_AHB_SRAM_SIZE;
 		break;
 	}
+	target_add_ram(t, LPC43xx_AHB_SRAM_BASE, sram_ahb_size);
 	target_add_ram(t, LPC43xx_SHADOW_BASE, LPC43xx_SHADOW_SIZE);
 	target_add_ram(t, LPC43xx_LOCAL_SRAM1_BASE, LPC43xx_LOCAL_SRAM1_SIZE);
 	target_add_ram(t, LPC43xx_LOCAL_SRAM2_BASE, LPC43xx_LOCAL_SRAM2_SIZE);


### PR DESCRIPTION
## Detailed description

* No new features implemented.
* The pull request is aimed at flash size/footprint reduction.
* I propose to change lpc43x0_detect and lpc43xx_detect logic to use local stack variables and fewer calls, which leads to measurable firmware .text shrink.

Disclaimer: I don't have NXP LPC43xx targets and hence cannot test the change on them. But this approach is already present in other targets code and improves readability by removing duplication/syntactic noise. +12b stack usage (if spilled) should not be a problem.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do