### PR TITLE
Fix: target: Deduplicate message strings

### DIFF
--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -648,7 +648,7 @@ static bool samx5x_cmd_lock_flash(target_s *t, int argc, const char **argv)
 		tc_printf(t, "Error writing NVM page\n");
 		return false;
 	}
-	tc_printf(t, "Flash locked. The target must be reset for this to take effect.\n");
+	tc_printf(t, "%s. The target must be reset for this to take effect.\n", "Flash locked");
 	return true;
 }
 
@@ -660,7 +660,7 @@ static bool samx5x_cmd_unlock_flash(target_s *t, int argc, const char **argv)
 		tc_printf(t, "Error writing NVM page\n");
 		return false;
 	}
-	tc_printf(t, "Flash unlocked. The target must be reset for this to take effect.\n");
+	tc_printf(t, "%s. The target must be reset for this to take effect.\n", "Flash unlocked");
 	return true;
 }
 
@@ -696,7 +696,7 @@ static bool samx5x_cmd_lock_bootprot(target_s *t, int argc, const char **argv)
 		tc_printf(t, "Error writing NVM page\n");
 		return false;
 	}
-	tc_printf(t, "Bootprot locked. The target must be reset for this to take effect.\n");
+	tc_printf(t, "%s. The target must be reset for this to take effect.\n", "Bootprot locked");
 	return true;
 }
 
@@ -708,7 +708,7 @@ static bool samx5x_cmd_unlock_bootprot(target_s *t, int argc, const char **argv)
 		tc_printf(t, "Error writing NVM page\n");
 		return false;
 	}
-	tc_printf(t, "Bootprot unlocked. The target must be reset for this to take effect.\n");
+	tc_printf(t, "%s. The target must be reset for this to take effect.\n", "Bootprot unlocked");
 	return true;
 }
 

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -752,7 +752,7 @@ static bool stm32l4_cmd_erase_bank1(target_s *const t, const int argc, const cha
 {
 	(void)argc;
 	(void)argv;
-	gdb_out("Erasing bank 1: ");
+	gdb_outf("Erasing bank %u: ", 1);
 	const bool result = stm32l4_cmd_erase(t, FLASH_CR_MER1);
 	gdb_out("done\n");
 	return result;
@@ -762,7 +762,7 @@ static bool stm32l4_cmd_erase_bank2(target_s *const t, const int argc, const cha
 {
 	(void)argc;
 	(void)argv;
-	gdb_out("Erasing bank 2: ");
+	gdb_outf("Erasing bank %u: ", 2);
 	const bool result = stm32l4_cmd_erase(t, FLASH_CR_MER2);
 	gdb_out("done\n");
 	return result;
@@ -863,15 +863,15 @@ static stm32l4_option_bytes_info_s stm32l4_get_opt_bytes_info(const uint16_t par
 static bool stm32l4_cmd_option(target_s *t, int argc, const char **argv)
 {
 	if (t->part_id == ID_STM32L55) {
-		tc_printf(t, "STM32L5 options not implemented!\n");
+		tc_printf(t, "%s options not implemented!\n", "STM32L5");
 		return false;
 	}
 	if (t->part_id == ID_STM32WBXX || t->part_id == ID_STM32WB1X) {
-		tc_printf(t, "STM32WBxx options not implemented!\n");
+		tc_printf(t, "%s options not implemented!\n", "STM32WBxx");
 		return false;
 	}
 	if (t->part_id == ID_STM32WLXX) {
-		tc_printf(t, "STM32WLxx options not implemented!\n");
+		tc_printf(t, "%s options not implemented!\n", "STM32WLxx");
 		return false;
 	}
 


### PR DESCRIPTION
## Detailed description

* No new feature implemented.
* This pull request is aimed at flash size/footprint reduction.
* Repeated parts of message strings in stm32l4 & samx5x could be output via `%s` of tc_printf/gdb_voutf/vasprintf, and this allows GCC to fold string literal constants, saving 200 bytes in `.rodata`.

Disclaimer: I don't have targets handled by stm32l4 code available (and certainly not samx5x), so I can't runtime-test whether the probe now crashes at this stack depth etc.
Additionally, I didn't find a `tc_puts()` or something similar to print simple `\n\0`-terminated string literals. GCC is known to optimise such calls of `printf("...\n")` to `puts("...")` (see `gimple_fold_builtin_printf()`). Some of the changes could be alternatively split into two print statements, the second printing the common/folded message part.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
