### PR TITLE
Fix: TraceSWO Async improvements

### DIFF
--- a/src/platforms/common/blackpill-f4/Makefile.inc
+++ b/src/platforms/common/blackpill-f4/Makefile.inc
@@ -49,7 +49,7 @@ VPATH +=                          \
 SRC +=               \
 	blackpill-f4.c   \
 	traceswodecode.c \
-	traceswo.c       \
+	traceswoasync.c  \
 	serialno.c       \
 	timing.c         \
 	timing_stm32.c

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -27,7 +27,9 @@
 #include "timing.h"
 #include "timing_stm32.h"
 
-#define PLATFORM_HAS_TRACESWO
+#define PLATFORM_HAS_TRACESWO 1
+#define NUM_TRACE_PACKETS     512U /* 32K buffer */
+//#define TRACESWO_PROTOCOL     2U   /* 1 = RZ/Manchester, 2 = NRZ/async/uart */
 
 /* Error handling for ALTERNATIVE_PINOUT
  * If ALTERNATIVE_PINOUT has a value >= 4 (undefined), or <= 0, an error is thrown.
@@ -202,11 +204,27 @@
 #define IRQ_PRI_USBUSART     (2U << 4U)
 #define IRQ_PRI_USBUSART_DMA (2U << 4U)
 #define IRQ_PRI_TRACE        (0U << 4U)
+#define IRQ_PRI_SWO_DMA      (0U << 4U)
 
 #define TRACE_TIM          TIM3
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR(x)       tim3_isr(x)
+
+/* On F411 use USART1 remapped to PB7 for async capture */
+#define SWO_UART        USBUSART1
+#define SWO_UART_CLK    USBUSART1_CLK
+#define SWO_UART_DR     USBUSART1_DR
+#define SWO_UART_PORT   GPIOB
+#define SWO_UART_RX_PIN GPIO7
+
+/* Bind to the same DMA Rx channel */
+#define SWO_DMA_BUS    USBUSART1_DMA_BUS
+#define SWO_DMA_CLK    USBUSART1_DMA_CLK
+#define SWO_DMA_CHAN   USBUSART1_DMA_RX_CHAN
+#define SWO_DMA_IRQ    USBUSART1_DMA_RX_IRQ
+#define SWO_DMA_ISR(x) USBUSART1_DMA_RX_ISRx(x)
+#define SWO_DMA_TRG    DMA_SxCR_CHSEL_4
 
 #define SET_RUN_STATE(state)      \
 	{                             \

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -29,7 +29,7 @@
 
 #define PLATFORM_HAS_TRACESWO 1
 #define NUM_TRACE_PACKETS     512U /* 32K buffer */
-//#define TRACESWO_PROTOCOL     2U   /* 1 = RZ/Manchester, 2 = NRZ/async/uart */
+#define TRACESWO_PROTOCOL     2U   /* 1 = RZ/Manchester, 2 = NRZ/async/uart */
 
 /* Error handling for ALTERNATIVE_PINOUT
  * If ALTERNATIVE_PINOUT has a value >= 4 (undefined), or <= 0, an error is thrown.

--- a/src/platforms/common/stm32/traceswoasync.c
+++ b/src/platforms/common/stm32/traceswoasync.c
@@ -42,6 +42,20 @@
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/stm32/dma.h>
 
+#if defined(DMA_STREAM0)
+#define dma_channel_reset(dma, channel)   dma_stream_reset(dma, channel)
+#define dma_enable_channel(dma, channel)  dma_enable_stream(dma, channel)
+#define dma_disable_channel(dma, channel) dma_disable_stream(dma, channel)
+
+#define DMA_PSIZE_8BIT DMA_SxCR_PSIZE_8BIT
+#define DMA_MSIZE_8BIT DMA_SxCR_MSIZE_8BIT
+#define DMA_PL_HIGH    DMA_SxCR_PL_HIGH
+#else
+#define DMA_PSIZE_8BIT DMA_CCR_PSIZE_8BIT
+#define DMA_MSIZE_8BIT DMA_CCR_MSIZE_8BIT
+#define DMA_PL_HIGH    DMA_CCR_PL_HIGH
+#endif
+
 #define TRACESWOASYNC_ALLOCS
 //#define TRACESWOASYNC_DEALLOCS
 
@@ -96,11 +110,18 @@ void traceswo_setspeed(uint32_t baudrate)
 	/* Set up DMA channel */
 	dma_channel_reset(SWO_DMA_BUS, SWO_DMA_CHAN);
 	dma_set_peripheral_address(SWO_DMA_BUS, SWO_DMA_CHAN, (uint32_t)&SWO_UART_DR);
+#if defined(DMA_STREAM0)
+	dma_set_transfer_mode(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_SxCR_DIR_PERIPHERAL_TO_MEM);
+	dma_channel_select(SWO_DMA_BUS, SWO_DMA_CHAN, SWO_DMA_TRG);
+	dma_set_dma_flow_control(SWO_DMA_BUS, SWO_DMA_CHAN);
+	dma_enable_direct_mode(SWO_DMA_BUS, SWO_DMA_CHAN);
+#else
 	dma_set_read_from_peripheral(SWO_DMA_BUS, SWO_DMA_CHAN);
+#endif
 	dma_enable_memory_increment_mode(SWO_DMA_BUS, SWO_DMA_CHAN);
-	dma_set_peripheral_size(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_CCR_PSIZE_8BIT);
-	dma_set_memory_size(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_CCR_MSIZE_8BIT);
-	dma_set_priority(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_CCR_PL_HIGH);
+	dma_set_peripheral_size(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_PSIZE_8BIT);
+	dma_set_memory_size(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_MSIZE_8BIT);
+	dma_set_priority(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_PL_HIGH);
 	dma_enable_transfer_complete_interrupt(SWO_DMA_BUS, SWO_DMA_CHAN);
 	dma_enable_half_transfer_interrupt(SWO_DMA_BUS, SWO_DMA_CHAN);
 	dma_enable_circular_mode(SWO_DMA_BUS, SWO_DMA_CHAN);
@@ -114,20 +135,37 @@ void traceswo_setspeed(uint32_t baudrate)
 	usart_enable_rx_dma(SWO_UART);
 }
 
+#if defined(DMA_STREAM0)
 void SWO_DMA_ISR(void)
 {
-	if (DMA_ISR(SWO_DMA_BUS) & DMA_ISR_HTIF(SWO_DMA_CHAN)) {
-		DMA_IFCR(SWO_DMA_BUS) |= DMA_ISR_HTIF(SWO_DMA_CHAN);
+	if (dma_get_interrupt_flag(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_HTIF)) {
+		dma_clear_interrupt_flags(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_HTIF);
 		memcpy(&trace_rx_buf[write_index * TRACE_ENDPOINT_SIZE], pingpong_buf, TRACE_ENDPOINT_SIZE);
 	}
-	if (DMA_ISR(SWO_DMA_BUS) & DMA_ISR_TCIF(SWO_DMA_CHAN)) {
-		DMA_IFCR(SWO_DMA_BUS) |= DMA_ISR_TCIF(SWO_DMA_CHAN);
+	if (dma_get_interrupt_flag(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_TCIF)) {
+		dma_clear_interrupt_flags(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_TCIF);
 		memcpy(
 			&trace_rx_buf[write_index * TRACE_ENDPOINT_SIZE], &pingpong_buf[TRACE_ENDPOINT_SIZE], TRACE_ENDPOINT_SIZE);
 	}
 	write_index = (write_index + 1U) % NUM_TRACE_PACKETS;
 	trace_buf_drain(usbdev, TRACE_ENDPOINT | USB_REQ_TYPE_IN);
 }
+#else
+void SWO_DMA_ISR(void)
+{
+	if (dma_get_interrupt_flag(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_HTIF)) {
+		dma_clear_interrupt_flags(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_HTIF);
+		memcpy(&trace_rx_buf[write_index * TRACE_ENDPOINT_SIZE], pingpong_buf, TRACE_ENDPOINT_SIZE);
+	}
+	if (dma_get_interrupt_flag(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_TCIF)) {
+		dma_clear_interrupt_flags(SWO_DMA_BUS, SWO_DMA_CHAN, DMA_TCIF);
+		memcpy(
+			&trace_rx_buf[write_index * TRACE_ENDPOINT_SIZE], &pingpong_buf[TRACE_ENDPOINT_SIZE], TRACE_ENDPOINT_SIZE);
+	}
+	write_index = (write_index + 1U) % NUM_TRACE_PACKETS;
+	trace_buf_drain(usbdev, TRACE_ENDPOINT | USB_REQ_TYPE_IN);
+}
+#endif
 
 void traceswo_init(uint32_t baudrate, uint32_t swo_chan_bitmask)
 {
@@ -148,9 +186,16 @@ void traceswo_init(uint32_t baudrate, uint32_t swo_chan_bitmask)
 	rcc_periph_clock_enable(SWO_UART_CLK);
 	rcc_periph_clock_enable(SWO_DMA_CLK);
 
+#if defined(STM32F1)
 	gpio_set_mode(SWO_UART_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, SWO_UART_RX_PIN);
 	/* Pull SWO pin high to keep open SWO line ind uart idle state! */
 	gpio_set(SWO_UART_PORT, SWO_UART_RX_PIN);
+#else
+	gpio_mode_setup(SWO_UART_PORT, GPIO_MODE_AF, GPIO_PUPD_PULLUP, SWO_UART_RX_PIN);
+	gpio_set_output_options(SWO_UART_PORT, GPIO_OTYPE_OD, GPIO_OSPEED_100MHZ, SWO_UART_RX_PIN);
+	gpio_set_af(SWO_UART_PORT, GPIO_AF7, SWO_UART_RX_PIN);
+#endif
+
 	nvic_set_priority(SWO_DMA_IRQ, IRQ_PRI_SWO_DMA);
 	nvic_enable_irq(SWO_DMA_IRQ);
 	traceswo_setspeed(baudrate);

--- a/src/platforms/common/stm32/traceswoasync.c
+++ b/src/platforms/common/stm32/traceswoasync.c
@@ -29,6 +29,8 @@
 /* TDO/TRACESWO signal comes into the SWOUSART RX pin. */
 
 #include <stdatomic.h>
+#include <malloc.h>
+#include <errno.h>
 #include "general.h"
 #include "usb.h"
 #include "traceswo.h"
@@ -40,10 +42,17 @@
 #include <libopencm3/stm32/usart.h>
 #include <libopencm3/stm32/dma.h>
 
+#define TRACESWOASYNC_ALLOCS
+//#define TRACESWOASYNC_DEALLOCS
+
 static volatile uint32_t write_index; /* Packet currently received via UART */
 static volatile uint32_t read_index;  /* Packet currently waiting to transmit to USB */
 /* Packets arrived from the SWO interface */
+#ifdef TRACESWOASYNC_ALLOCS
+static uint8_t *trace_rx_buf = NULL;
+#else
 static uint8_t trace_rx_buf[NUM_TRACE_PACKETS * TRACE_ENDPOINT_SIZE];
+#endif
 /* Packet pingpong buffer used for receiving packets */
 static uint8_t pingpong_buf[2 * TRACE_ENDPOINT_SIZE];
 /* SWO decoding */
@@ -122,6 +131,17 @@ void SWO_DMA_ISR(void)
 
 void traceswo_init(uint32_t baudrate, uint32_t swo_chan_bitmask)
 {
+#ifdef TRACESWOASYNC_ALLOCS
+	if (trace_rx_buf == NULL) {
+		uint8_t *newbuf = memalign(TRACE_ENDPOINT_SIZE, NUM_TRACE_PACKETS * TRACE_ENDPOINT_SIZE);
+		if (newbuf == NULL) {
+			DEBUG_ERROR("%s: memalign failed, errno=%d\n", __func__, errno);
+			return;
+		}
+		trace_rx_buf = newbuf;
+	}
+#endif
+
 	if (!baudrate)
 		baudrate = SWO_DEFAULT_BAUD;
 
@@ -136,4 +156,24 @@ void traceswo_init(uint32_t baudrate, uint32_t swo_chan_bitmask)
 	traceswo_setspeed(baudrate);
 	traceswo_setmask(swo_chan_bitmask);
 	decoding = (swo_chan_bitmask != 0);
+}
+
+void traceswo_deinit(void)
+{
+	/* Stop peripherals servicing */
+	nvic_disable_irq(SWO_DMA_IRQ);
+	dma_disable_channel(SWO_DMA_BUS, SWO_DMA_CHAN);
+	usart_disable(SWO_UART);
+	/* Dump the buffered remains */
+	trace_buf_drain(usbdev, TRACE_ENDPOINT | USB_REQ_TYPE_IN);
+#ifdef TRACESWOASYNC_DEALLOCS
+	/* Release this chunk of precious SRAM. FIXME: does heap shrink after free/malloc_trim? */
+	if (trace_rx_buf != NULL) {
+		mallopt(M_TRIM_THRESHOLD, 4 * 1024);
+		free(trace_rx_buf);
+		trace_rx_buf = NULL;
+		/* Trim manually in case free() didn't. This returns 1 on newlib, or fails to link on newlib-nano. */
+		malloc_trim(0);
+	}
+#endif
 }


### PR DESCRIPTION
## Detailed description

* This is kinda a new feature -- this provides traceswoasync for STM32F4 and similar (newer than F1 chip-based) platforms. 
* This PR has two changes and tries to solve two problems. 
* Problem F4. STM32F4 platforms had only timer-based RZ/Manchester traceswo available.
* Solution F4. The PR extends logic in traceswoasync with F4-specific macros to properly support newer DMA IP (and maybe GPIO) like aux_serial.
* Problem F1. The only two known users of traceswoasync are stlink and swlink platforms (stlinkv3 has a forked traceswoasync_f723), and they become very RAM-constrained after permanently assigning 8k of 20k to `trace_rx_buf[]`. (4k static .data/.bss, 8k trace_rx_buf, ~-4k stack, and only like 4k left for newlib-nano heap)
* Solution F1. The first commit in PR adds a `memalign()` call and makes the trace_rx_buf a dynamic buffer allocated on heap only when requested.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) -- no change as async not supported yet
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) -- no change to hosted
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

should fix issues triggered by heap exhaustion on stlink & swlink platforms. Can't find exact issue numbers.

## Miscellaneous notes

The new `traceswo_deinit()` is there to a) allow switching between RZ & NRZ in the future (after refactoring both); b) remind developers to possibly free the buffer. This does NOT shrink the heap on newlib-nano, because malloc_trim is unimplemented, but MAY on newlib after adjusting mallopt or manually calling malloc_trim. At the moment `nano.specs` is used by native, stlink, swlink, f072, f3, stlinkv3.

The alloc and blackpil-f4 changesets may be split into a second PR, but I needed a way to test the unified traceswoasync unit on the two platforms I own (bluepill & blackpill-f4) against regressions. I did not test anything of this yet besides building `all_platforms`. I tried `posix_memalign`, it does not exist in newlib.