### PR TITLE
Fix: Decouple headers general.h/platform.h

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -25,6 +25,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "exception.h"
 #include "command.h"
 #include "gdb_packet.h"

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -25,6 +25,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "ctype.h"
 #include "hex_utils.h"
 #include "gdb_if.h"

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -40,7 +40,7 @@
 #include <sys/types.h>
 
 #include "maths_utils.h"
-#include "platform.h"
+#include "timing.h"
 #include "platform_support.h"
 
 #ifndef ARRAY_LENGTH

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -121,11 +121,4 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #undef MAX
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 
-#if !defined(SYSTICKHZ)
-#define SYSTICKHZ 100U
-#endif
-
-#define SYSTICKMS (1000U / SYSTICKHZ)
-#define MORSECNT  ((SYSTICKHZ / 10U) - 1U)
-
 #endif /* INCLUDE_GENERAL_H */

--- a/src/include/timing.h
+++ b/src/include/timing.h
@@ -23,6 +23,10 @@
 
 #include <stdint.h>
 
+#if PC_HOSTED == 1
+#define SYSTICKHZ 1000U
+#endif
+
 #if !defined(SYSTICKHZ)
 #define SYSTICKHZ 100U
 #endif

--- a/src/include/timing.h
+++ b/src/include/timing.h
@@ -23,6 +23,13 @@
 
 #include <stdint.h>
 
+#if !defined(SYSTICKHZ)
+#define SYSTICKHZ 100U
+#endif
+
+#define SYSTICKMS (1000U / SYSTICKHZ)
+#define MORSECNT  ((SYSTICKHZ / 10U) - 1U)
+
 struct platform_timeout {
 	uint32_t time;
 };

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@
 /* Provides main entry point. Initialise subsystems and enter GDB protocol loop. */
 
 #include "general.h"
+#include "platform.h"
 #include "gdb_if.h"
 #include "gdb_main.h"
 #include "target.h"

--- a/src/platforms/96b_carbon/platform.c
+++ b/src/platforms/96b_carbon/platform.c
@@ -36,6 +36,11 @@
 
 jmp_buf fatal_error_jmpbuf;
 
+int platform_hwversion(void)
+{
+	return 0;
+}
+
 void platform_init(void)
 {
 	rcc_clock_setup_pll(&rcc_hse_16mhz_3v3[RCC_CLOCK_3V3_84MHZ]);

--- a/src/platforms/96b_carbon/platform.c
+++ b/src/platforms/96b_carbon/platform.c
@@ -21,6 +21,7 @@
 /* This file implements the platform specific functions for the 96Boards Carbon implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "morse.h"

--- a/src/platforms/96b_carbon/platform.h
+++ b/src/platforms/96b_carbon/platform.h
@@ -145,11 +145,6 @@
 		gpio_set_val(LED_PORT_ERROR, LED_ERROR, state); \
 	}
 
-static inline int platform_hwversion(void)
-{
-	return 0;
-}
-
 /* Use newlib provided integer-only stdio functions */
 
 #ifdef sscanf

--- a/src/platforms/common/aux_serial.c
+++ b/src/platforms/common/aux_serial.c
@@ -32,6 +32,7 @@
 #include <libopencm3/cm3/nvic.h>
 
 #include "general.h"
+#include "platform.h"
 #include "usb_serial.h"
 #include "aux_serial.h"
 

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -194,3 +194,8 @@ uint8_t platform_spi_xfer(const spi_bus_e bus, const uint8_t value)
 	(void)bus;
 	return value;
 }
+
+int platform_hwversion(void)
+{
+	return 0;
+}

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -21,6 +21,7 @@
 /* This file implements the platform specific functions for the blackpill-f4 implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "morse.h"

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -221,11 +221,6 @@
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-static inline int platform_hwversion(void)
-{
-	return 0;
-}
-
 /* Use newlib provided integer-only stdio functions */
 
 #ifdef sscanf

--- a/src/platforms/common/jtagtap.c
+++ b/src/platforms/common/jtagtap.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 
 #include "general.h"
+#include "platform.h"
 #include "jtagtap.h"
 
 jtag_proc_s jtag_proc;

--- a/src/platforms/common/stm32/dfucore.c
+++ b/src/platforms/common/stm32/dfucore.c
@@ -18,6 +18,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "version.h"
 #include "serialno.h"
 #include <string.h>

--- a/src/platforms/common/stm32/gdb_if.c
+++ b/src/platforms/common/stm32/gdb_if.c
@@ -27,6 +27,7 @@
 #include <libopencmsis/core_cm3.h>
 
 #include "general.h"
+#include "platform.h"
 #include "usb_serial.h"
 #include "gdb_if.h"
 

--- a/src/platforms/common/stm32/serialno.c
+++ b/src/platforms/common/stm32/serialno.c
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "general.h"
+#include "platform.h"
 #include <libopencm3/stm32/desig.h>
 
 char serial_no[DFU_SERIAL_LENGTH];

--- a/src/platforms/common/stm32/timing_stm32.c
+++ b/src/platforms/common/stm32/timing_stm32.c
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "general.h"
+#include "platform.h"
 #include "morse.h"
 
 #include <libopencm3/cm3/systick.h>

--- a/src/platforms/common/stm32/traceswo.c
+++ b/src/platforms/common/stm32/traceswo.c
@@ -32,6 +32,7 @@
  * The core can then process the buffer to extract the frame.
  */
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "traceswo.h"
 

--- a/src/platforms/common/stm32/traceswoasync.c
+++ b/src/platforms/common/stm32/traceswoasync.c
@@ -30,6 +30,7 @@
 
 #include <stdatomic.h>
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "traceswo.h"
 

--- a/src/platforms/common/stm32/traceswoasync_f723.c
+++ b/src/platforms/common/stm32/traceswoasync_f723.c
@@ -31,6 +31,7 @@
 
 #include <stdatomic.h>
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "traceswo.h"
 

--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -21,6 +21,7 @@
 /* This file implements the SW-DP interface. */
 
 #include "general.h"
+#include "platform.h"
 #include "timing.h"
 #include "swd.h"
 

--- a/src/platforms/common/tm4c/traceswo.c
+++ b/src/platforms/common/tm4c/traceswo.c
@@ -28,6 +28,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 
 #include <libopencm3/cm3/nvic.h>

--- a/src/platforms/common/usb.c
+++ b/src/platforms/common/usb.c
@@ -21,6 +21,7 @@
 #include <libopencm3/cm3/nvic.h>
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "usb_descriptors.h"
 #include "usb_serial.h"

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -47,6 +47,7 @@
 typedef struct stat stat_s;
 #endif
 #include "general.h"
+#include "platform.h"
 #include "gdb_if.h"
 #include "usb_serial.h"
 #ifdef PLATFORM_HAS_TRACESWO

--- a/src/platforms/f072/platform.c
+++ b/src/platforms/f072/platform.c
@@ -121,6 +121,11 @@ void platform_request_boot(void)
 
 #pragma GCC diagnostic pop
 
+int platform_hwversion(void)
+{
+	return 0;
+}
+
 void platform_target_clk_output_enable(bool enable)
 {
 	(void)enable;

--- a/src/platforms/f072/platform.c
+++ b/src/platforms/f072/platform.c
@@ -20,6 +20,7 @@
 /* This file implements the platform specific functions for the STM32F072-IF implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "morse.h"

--- a/src/platforms/f072/platform.h
+++ b/src/platforms/f072/platform.h
@@ -155,11 +155,6 @@ extern bool debug_bmp;
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-static inline int platform_hwversion(void)
-{
-	return 0;
-}
-
 /* Use newlib provided integer-only stdio functions */
 
 #ifdef sscanf

--- a/src/platforms/f3/platform.c
+++ b/src/platforms/f3/platform.c
@@ -34,6 +34,11 @@
 
 extern uint32_t _ebss; // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 
+int platform_hwversion(void)
+{
+	return 0;
+}
+
 void platform_init(void)
 {
 	volatile uint32_t *magic = &_ebss;

--- a/src/platforms/f3/platform.c
+++ b/src/platforms/f3/platform.c
@@ -20,6 +20,7 @@
 /* This file implements the platform specific functions for the STM32F3-IF implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "morse.h"

--- a/src/platforms/f3/platform.h
+++ b/src/platforms/f3/platform.h
@@ -148,11 +148,6 @@ extern bool debug_bmp;
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-static inline int platform_hwversion(void)
-{
-	return 0;
-}
-
 /* Use newlib provided integer-only stdio functions */
 
 #ifdef sscanf

--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -21,6 +21,7 @@
 /* This file implements the platform specific functions for the F4 Discovery implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "morse.h"

--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -39,6 +39,11 @@
 jmp_buf fatal_error_jmpbuf;
 extern uint32_t _ebss; // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 
+int platform_hwversion(void)
+{
+	return 0;
+}
+
 void platform_init(void)
 {
 	volatile uint32_t *magic = &_ebss;

--- a/src/platforms/f4discovery/platform.h
+++ b/src/platforms/f4discovery/platform.h
@@ -144,11 +144,6 @@
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-static inline int platform_hwversion(void)
-{
-	return 0;
-}
-
 /* Use newlib provided integer-only stdio functions */
 
 #ifdef sscanf

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -23,6 +23,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "jtagtap.h"
 #include "swd.h"
 #include "target.h"

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -49,8 +49,6 @@ void platform_buffer_flush(void);
 	} while (0)
 #define PLATFORM_HAS_POWER_SWITCH
 
-#define SYSTICKHZ 1000U
-
 #define VENDOR_ID_BMP     0x1d50U
 #define PRODUCT_ID_BMP_BL 0x6017U
 #define PRODUCT_ID_BMP    0x6018U

--- a/src/platforms/hydrabus/platform.c
+++ b/src/platforms/hydrabus/platform.c
@@ -21,6 +21,7 @@
 /* This file implements the platform specific functions for the Hydrabus implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "morse.h"

--- a/src/platforms/hydrabus/platform.c
+++ b/src/platforms/hydrabus/platform.c
@@ -36,6 +36,11 @@
 
 jmp_buf fatal_error_jmpbuf;
 
+int platform_hwversion(void)
+{
+	return 0;
+}
+
 void platform_init(void)
 {
 	/* Check the USER button */

--- a/src/platforms/hydrabus/platform.h
+++ b/src/platforms/hydrabus/platform.h
@@ -142,11 +142,6 @@
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-static inline int platform_hwversion(void)
-{
-	return 0;
-}
-
 /* Use newlib provided integer-only stdio functions */
 
 #ifdef sscanf

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -48,6 +48,11 @@ uint32_t platform_time_ms(void)
 	return time_ms;
 }
 
+int platform_hwversion(void)
+{
+	return 0;
+}
+
 void platform_init(void)
 {
 	for (volatile size_t i = 0; i < 1000000U; ++i)

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -16,6 +16,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "gdb_if.h"
 #include "usb.h"
 #include "aux_serial.h"

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -123,11 +123,6 @@ inline static uint8_t gpio_get(uint32_t port, uint8_t pin)
 		nvic_disable_irq(USB_IRQ);  \
 	} while (0)
 
-static inline int platform_hwversion(void)
-{
-	return 0;
-}
-
 /* Use newlib provided integer-only stdio functions */
 
 #ifdef sscanf

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -21,6 +21,7 @@
 /* This file implements the platform specific functions for the native implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "morse.h"

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -21,6 +21,7 @@
 /* This file implements the platform specific functions for the ST-Link implementation. */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 

--- a/src/platforms/stlinkv3/platform.c
+++ b/src/platforms/stlinkv3/platform.c
@@ -23,6 +23,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 #include "gdb_if.h"

--- a/src/platforms/stlinkv3/usbdfu.c
+++ b/src/platforms/stlinkv3/usbdfu.c
@@ -27,6 +27,7 @@
 
 #include "usbdfu.h"
 #include "general.h"
+#include "platform.h"
 
 uintptr_t app_address = APP_START;
 

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -24,6 +24,7 @@
  */
 
 #include "general.h"
+#include "platform.h"
 #include "usb.h"
 #include "aux_serial.h"
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -23,6 +23,7 @@
 
 #include <stdarg.h>
 #include "general.h"
+#include "platform.h"
 #include "remote.h"
 #include "gdb_main.h"
 #include "gdb_packet.h"


### PR DESCRIPTION
## Detailed description

* This is not a feature.
* Incremental builds after touching `platform.h` on my laptop take >10s (`user` time over ~3 of 4 Tremont N6000 CPU cores) because of `target/*.c` rebuilds. Not using ccache.
* The PR solves this problem by breaking the include-dependency of `target/` drivers on `platform.h` header and by propagating that into its actual users, with inclusion order `general.h` then `platform.h` as before. There also are a couple related/required/revealed codebase cleanup changes.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) -- fixed encountered breakage
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) -- fixed encountered breakage
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

No issues were reported on incremental build times by foreign platform developers yet, I'm the only one complaining.

## Miscellaneous notes

This reduces incremental build times from 10s for 64 translation units to 3s for 16 units. CI full builds are not affected.
This PR is aimed specifically at the old/current Makefile build system, but future Kconfig or meson systems may benefit from this as well. I can't say whether other major PRs will need rebasing.