### PR TITLE
imxrt: ungate boot_mode even on non-hosted

### DIFF
--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -172,7 +172,7 @@ bool imxrt_probe(target_s *const target)
 	target->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 	target->driver = "i.MXRT10xx";
 
-#if defined(ENABLE_DEBUG) && PC_HOSTED == 1
+#if defined(ENABLE_DEBUG) || (PC_HOSTED == 1 || defined(ESP_LOGD))
 	const uint8_t boot_mode = (target_mem_read32(target, IMXRT_SRC_BOOT_MODE2) >> 24U) & 3U;
 #endif
 	DEBUG_TARGET("i.MXRT boot mode is %x\n", boot_mode);


### PR DESCRIPTION
## Detailed description

When building debug mode for hardware, the `boot_mode` flag is consulted. However, the `boot_mode` flag is only present when debug mode is enabled on PC_HOSTED.

Remove the requirement for this to be built on PC_HOSTED in order to fix compiling when built on native hardware with debug mode enabled.

## Your checklist for this pull request

* [√] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [√] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [√] It builds for hardware native (`make PROBE_HOST=native`)
* [√] It builds as BMDA (`make PROBE_HOST=hosted`)
* [√] I've tested it to the best of my ability
* [√] My commit messages provide a useful short description of what the commits do