### PR TITLE
imxrt: correct logic of debug guard

### DIFF
--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -172,7 +172,7 @@ bool imxrt_probe(target_s *const target)
 	target->target_options |= CORTEXM_TOPT_INHIBIT_NRST;
 	target->driver = "i.MXRT10xx";
 
-#if defined(ENABLE_DEBUG) || (PC_HOSTED == 1 || defined(ESP_LOGD))
+#if defined(ENABLE_DEBUG) && (PC_HOSTED == 1 || defined(ESP_LOGD))
 	const uint8_t boot_mode = (target_mem_read32(target, IMXRT_SRC_BOOT_MODE2) >> 24U) & 3U;
 #endif
 	DEBUG_TARGET("i.MXRT boot mode is %x\n", boot_mode);


### PR DESCRIPTION
## Detailed description

Patch a674dff2495a78cd4b87a091ad5c7ef10bd94daf accidentally had `||` rather than `&&`, resulting in build errors when enabling debug mode on certain hardware targets. Correct this logic in order to fix builds with certain other platforms.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
