### PR TITLE
Fix: Increase SysTick frequency to 1kHz

### DIFF
--- a/src/include/timing.h
+++ b/src/include/timing.h
@@ -23,12 +23,8 @@
 
 #include <stdint.h>
 
-#if PC_HOSTED == 1
-#define SYSTICKHZ 1000U
-#endif
-
 #if !defined(SYSTICKHZ)
-#define SYSTICKHZ 100U
+#define SYSTICKHZ 1000U
 #endif
 
 #define SYSTICKMS (1000U / SYSTICKHZ)


### PR DESCRIPTION
## Detailed description

* No new features.
* The pull request solves the problem of relatively slow RTT streaming speed of BMF.
* The pull request solves the problem by making it possible to poll faster than every 10ms. This requires raising the SysTick interrupt frequency from historically 100Hz to 1000Hz.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

No known to me issues solved by this PR.

## Testing

I conducted tests of RTT streaming from @koendv 's Arduino sketch running on NUCLEO-G071RB (and some tests were repeated on a WeAct Studio BluePIll-Plus with genuine stm32f103cbt6). Here are the results in chars/s as reported by DUT measuring a hardware timer prescaled to 1ms ticks:
* `blackpill-f411ce` before: 34000..51000, after: 87000..102400;
* `swlink` before: 32000..34000, after: 78000;
* `f072rb` before: untested, after: 42000. This is on a 32F072B-DISCO just to check on the slowest (48MHz) supported platform.

If dropping the PC_HOSTED separation is wrong, I will rebase it out. For reference `hosted` uses `usleep(ms * 1000U)` or `Sleep(ms)` for delays but `gettimeofday()` for timestamping.