### PR TITLE
Fix: Factor out integer-only stdio into a common header

### DIFF
--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -24,6 +24,9 @@
 #error "Include 'general.h' instead"
 #endif
 
+#if PC_HOSTED == 0
+#include "stdio_newlib.h"
+#endif
 #include "target.h"
 #include "spi_types.h"
 

--- a/src/include/stdio_newlib.h
+++ b/src/include/stdio_newlib.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by ALTracer <tolstov_den@mail.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef STDIO_NEWLIB_H
+#define STDIO_NEWLIB_H
+
+/* Use newlib provided integer-only stdio functions */
+
+#ifdef sscanf
+#undef sscanf
+#endif
+#define sscanf siscanf
+
+#ifdef sprintf
+#undef sprintf
+#endif
+#define sprintf siprintf
+
+#ifdef vasprintf
+#undef vasprintf
+#endif
+#define vasprintf vasiprintf
+
+#ifdef snprintf
+#undef snprintf
+#endif
+#define snprintf sniprintf
+
+#endif /* STDIO_NEWLIB_H */

--- a/src/platforms/96b_carbon/platform.h
+++ b/src/platforms/96b_carbon/platform.h
@@ -145,26 +145,4 @@
 		gpio_set_val(LED_PORT_ERROR, LED_ERROR, state); \
 	}
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_96B_CARBON_PLATFORM_H */

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -221,26 +221,4 @@
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_COMMON_BLACKPILL_F4_H */

--- a/src/platforms/f072/platform.h
+++ b/src/platforms/f072/platform.h
@@ -155,26 +155,4 @@ extern bool debug_bmp;
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_F072_PLATFORM_H */

--- a/src/platforms/f3/platform.h
+++ b/src/platforms/f3/platform.h
@@ -148,26 +148,4 @@ extern bool debug_bmp;
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_F3_PLATFORM_H */

--- a/src/platforms/f4discovery/platform.h
+++ b/src/platforms/f4discovery/platform.h
@@ -144,26 +144,4 @@
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_F4DISCOVERY_PLATFORM_H */

--- a/src/platforms/hydrabus/platform.h
+++ b/src/platforms/hydrabus/platform.h
@@ -142,26 +142,4 @@
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_HYDRABUS_PLATFORM_H */

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -122,26 +122,4 @@ inline static uint8_t gpio_get(uint32_t port, uint8_t pin)
 		nvic_disable_irq(USB_IRQ);  \
 	} while (0)
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_LAUNCHPAD_ICDI_PLATFORM_H */

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -327,26 +327,4 @@ extern bool debug_bmp;
 #define BITBANG_DIVIDER_OFFSET 52U
 #define BITBANG_DIVIDER_FACTOR 30U
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_NATIVE_PLATFORM_H */

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -174,26 +174,4 @@ extern uint16_t led_idle_run;
 
 extern uint32_t detect_rev(void);
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_STLINK_PLATFORM_H */

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -155,26 +155,4 @@ extern void set_idle_state(int state);
 
 extern uint8_t detect_rev(void);
 
-/* Use newlib provided integer-only stdio functions */
-
-#ifdef sscanf
-#undef sscanf
-#endif
-#define sscanf siscanf
-
-#ifdef sprintf
-#undef sprintf
-#endif
-#define sprintf siprintf
-
-#ifdef vasprintf
-#undef vasprintf
-#endif
-#define vasprintf vasiprintf
-
-#ifdef snprintf
-#undef snprintf
-#endif
-#define snprintf sniprintf
-
 #endif /* PLATFORMS_SWLINK_PLATFORM_H */


### PR DESCRIPTION
## Detailed description

* The previous PR #1530 reduced visibility of "newlib integer-only stdio" redefinitions to only those translation units which `#include platform.h` This lead to flash size increase for 7 platforms (all not using newlib-nano) by 37 KiB because of linker pulling float/double capable stdio implementations (and softfp routines for double etc).
* This PR ties these redefinitions back to `platform_support.h` visible via `general.h` to every platform except `hosted`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

## Testing
To reproduce/verify, `make all_platforms` and compare binary sizes of files under `src/artifacts/v1.9.0-...` for relevant revisions.
Also Puncover to check for functions pulled from libc. 
*I don't know yet how to easily automatically perform checks for ENABLE_DEBUG=1 builds without encountering build failures or invoking make per-platform manually, but these binaries are Big anyways.*

## Miscellaneous
If there is a better header to place this in than `platform_support.h`, then I'll edit this branch.
I could also edit the copyright string, author and filename for "stdio_newlib.h" as I'm only reorganizing the header contents and not actually writing implementation code in this PR. The touched `platform.h` headers contain at least three authors in "Written by" strings.