### PR TITLE
Feature: Flash state tracking

### DIFF
--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -38,116 +38,118 @@
 #include "general.h"
 #include "target_internal.h"
 
-target_flash_s *target_flash_for_addr(target_s *t, uint32_t addr)
+static bool flash_done(target_flash_s *flash);
+
+target_flash_s *target_flash_for_addr(target_s *target, uint32_t addr)
 {
-	for (target_flash_s *f = t->flash; f; f = f->next) {
-		if (f->start <= addr && addr < f->start + f->length)
-			return f;
+	for (target_flash_s *flash = target->flash; flash; flash = flash->next) {
+		if (flash->start <= addr && addr < flash->start + flash->length)
+			return flash;
 	}
 	return NULL;
 }
 
-static bool target_enter_flash_mode(target_s *t)
+static bool target_enter_flash_mode(target_s *target)
 {
-	if (t->flash_mode)
+	if (target->flash_mode)
 		return true;
 
-	bool ret = true;
-	if (t->enter_flash_mode)
-		ret = t->enter_flash_mode(t);
+	bool result = true;
+	if (target->enter_flash_mode)
+		result = target->enter_flash_mode(target);
 	else
 		/* Reset target on flash command */
 		/* This saves us if we're interrupted in IRQ context */
-		target_reset(t);
+		target_reset(target);
 
-	if (ret == true)
-		t->flash_mode = true;
+	if (result == true)
+		target->flash_mode = true;
 
-	return ret;
+	return result;
 }
 
-static bool target_exit_flash_mode(target_s *t)
+static bool target_exit_flash_mode(target_s *target)
 {
-	if (!t->flash_mode)
+	if (!target->flash_mode)
 		return true;
 
-	bool ret = true;
-	if (t->exit_flash_mode)
-		ret = t->exit_flash_mode(t);
+	bool result = true;
+	if (target->exit_flash_mode)
+		result = target->exit_flash_mode(target);
 	else
 		/* Reset target to known state when done flashing */
-		target_reset(t);
+		target_reset(target);
 
-	t->flash_mode = false;
+	target->flash_mode = false;
 
-	return ret;
+	return result;
 }
 
-static bool flash_prepare(target_flash_s *f)
+static bool flash_prepare(target_flash_s *flash)
 {
-	if (f->ready)
+	if (flash->ready)
 		return true;
 
-	bool ret = true;
-	if (f->prepare)
-		ret = f->prepare(f);
+	bool result = true;
+	if (flash->prepare)
+		result = flash->prepare(flash);
 
-	if (ret == true)
-		f->ready = true;
+	if (result == true)
+		flash->ready = true;
 
-	return ret;
+	return result;
 }
 
-static bool flash_done(target_flash_s *f)
+static bool flash_done(target_flash_s *flash)
 {
-	if (!f->ready)
+	if (!flash->ready)
 		return true;
 
-	bool ret = true;
-	if (f->done)
-		ret = f->done(f);
+	bool result = true;
+	if (flash->done)
+		result = flash->done(flash);
 
-	if (f->buf) {
-		free(f->buf);
-		f->buf = NULL;
+	if (flash->buf) {
+		free(flash->buf);
+		flash->buf = NULL;
 	}
 
-	f->ready = false;
+	flash->ready = false;
 
-	return ret;
+	return result;
 }
 
-bool target_flash_erase(target_s *t, target_addr_t addr, size_t len)
+bool target_flash_erase(target_s *target, target_addr_t addr, size_t len)
 {
-	if (!target_enter_flash_mode(t))
+	if (!target_enter_flash_mode(target))
 		return false;
 
-	target_flash_s *active_flash = target_flash_for_addr(t, addr);
+	target_flash_s *active_flash = target_flash_for_addr(target, addr);
 	if (!active_flash)
 		return false;
 
-	bool ret = true; /* Catch false returns with &= */
+	bool result = true; /* Catch false returns with &= */
 	while (len) {
-		target_flash_s *f = target_flash_for_addr(t, addr);
-		if (!f) {
+		target_flash_s *flash = target_flash_for_addr(target, addr);
+		if (!flash) {
 			DEBUG_ERROR("Requested address is outside the valid range 0x%06" PRIx32 "\n", addr);
 			return false;
 		}
 
 		/* Terminate flash operations if we're not in the same target flash */
-		if (f != active_flash) {
-			ret &= flash_done(active_flash);
-			active_flash = f;
+		if (flash != active_flash) {
+			result &= flash_done(active_flash);
+			active_flash = flash;
 		}
 
-		const target_addr_t local_start_addr = addr & ~(f->blocksize - 1U);
-		const target_addr_t local_end_addr = local_start_addr + f->blocksize;
+		const target_addr_t local_start_addr = addr & ~(flash->blocksize - 1U);
+		const target_addr_t local_end_addr = local_start_addr + flash->blocksize;
 
-		if (!flash_prepare(f))
+		if (!flash_prepare(flash))
 			return false;
 
-		ret &= f->erase(f, local_start_addr, f->blocksize);
-		if (!ret) {
+		result &= flash->erase(flash, local_start_addr, flash->blocksize);
+		if (!result) {
 			DEBUG_ERROR("Erase failed at %" PRIx32 "\n", local_start_addr);
 			break;
 		}
@@ -156,8 +158,8 @@ bool target_flash_erase(target_s *t, target_addr_t addr, size_t len)
 		addr = local_end_addr;
 	}
 	/* Issue flash done on last operation */
-	ret &= flash_done(active_flash);
-	return ret;
+	result &= flash_done(active_flash);
+	return result;
 }
 
 bool flash_buffer_alloc(target_flash_s *flash)
@@ -174,106 +176,105 @@ bool flash_buffer_alloc(target_flash_s *flash)
 	return true;
 }
 
-static bool flash_buffered_flush(target_flash_s *f)
+static bool flash_buffered_flush(target_flash_s *flash)
 {
-	bool ret = true; /* Catch false returns with &= */
-	if (f->buf && f->buf_addr_base != UINT32_MAX && f->buf_addr_low != UINT32_MAX &&
-		f->buf_addr_low < f->buf_addr_high) {
+	bool result = true; /* Catch false returns with &= */
+	if (flash->buf && flash->buf_addr_base != UINT32_MAX && flash->buf_addr_low != UINT32_MAX &&
+		flash->buf_addr_low < flash->buf_addr_high) {
 		/* Write buffer to flash */
 
-		if (!flash_prepare(f))
+		if (!flash_prepare(flash))
 			return false;
 
-		target_addr_t aligned_addr = f->buf_addr_low & ~(f->writesize - 1U);
+		const target_addr_t aligned_addr = flash->buf_addr_low & ~(flash->writesize - 1U);
+		const uint8_t *src = flash->buf + (aligned_addr - flash->buf_addr_base);
+		const uint32_t length = flash->buf_addr_high - aligned_addr;
 
-		const uint8_t *src = f->buf + (aligned_addr - f->buf_addr_base);
-		uint32_t len = f->buf_addr_high - aligned_addr;
+		for (size_t offset = 0; offset < length; offset += flash->writesize)
+			result &= flash->write(flash, aligned_addr + offset, src + offset, flash->writesize);
 
-		for (size_t offset = 0; offset < len; offset += f->writesize)
-			ret &= f->write(f, aligned_addr + offset, src + offset, f->writesize);
-
-		f->buf_addr_base = UINT32_MAX;
-		f->buf_addr_low = UINT32_MAX;
-		f->buf_addr_high = 0;
+		flash->buf_addr_base = UINT32_MAX;
+		flash->buf_addr_low = UINT32_MAX;
+		flash->buf_addr_high = 0;
 	}
 
-	return ret;
+	return result;
 }
 
-static bool flash_buffered_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len)
+static bool flash_buffered_write(target_flash_s *flash, target_addr_t dest, const void *src, size_t len)
 {
-	bool ret = true; /* Catch false returns with &= */
+	bool result = true; /* Catch false returns with &= */
 	while (len) {
-		const target_addr_t base_addr = dest & ~(f->writebufsize - 1U);
+		const target_addr_t base_addr = dest & ~(flash->writebufsize - 1U);
 
 		/* Check for base address change */
-		if (base_addr != f->buf_addr_base) {
-			ret &= flash_buffered_flush(f);
+		if (base_addr != flash->buf_addr_base) {
+			result &= flash_buffered_flush(flash);
 
 			/* Setup buffer */
-			f->buf_addr_base = base_addr;
-			memset(f->buf, f->erased, f->writebufsize);
+			flash->buf_addr_base = base_addr;
+			memset(flash->buf, flash->erased, flash->writebufsize);
 		}
 
-		const size_t offset = dest % f->writebufsize;
-		const size_t local_len = MIN(f->writebufsize - offset, len);
+		const size_t offset = dest % flash->writebufsize;
+		const size_t local_len = MIN(flash->writebufsize - offset, len);
 
 		/* Copy chunk into sector buffer */
-		memcpy(f->buf + offset, src, local_len);
+		memcpy(flash->buf + offset, src, local_len);
 
 		/* This allows for writes smaller than writebufsize when flushing in the future */
-		f->buf_addr_low = MIN(f->buf_addr_low, dest);
-		f->buf_addr_high = MAX(f->buf_addr_high, dest + local_len);
+		flash->buf_addr_low = MIN(flash->buf_addr_low, dest);
+		flash->buf_addr_high = MAX(flash->buf_addr_high, dest + local_len);
 
 		dest += local_len;
 		src += local_len;
 		len -= local_len;
 	}
-	return ret;
+	return result;
 }
 
-bool target_flash_write(target_s *t, target_addr_t dest, const void *src, size_t len)
+bool target_flash_write(target_s *target, target_addr_t dest, const void *src, size_t len)
 {
-	if (!target_enter_flash_mode(t))
+	if (!target_enter_flash_mode(target))
 		return false;
 
-	bool ret = true; /* Catch false returns with &= */
+	bool result = true; /* Catch false returns with &= */
 	target_flash_s *active_flash = NULL;
 
-	for (target_flash_s *f = t->flash; f; f = f->next) {
-		if (f->start <= dest && dest < f->start + f->length)
-			active_flash = f;
-		else if (f->buf) {
-			ret &= flash_buffered_flush(f);
-			ret &= flash_done(f);
+	for (target_flash_s *flash = target->flash; flash; flash = flash->next) {
+		if (flash->start <= dest && dest < flash->start + flash->length)
+			active_flash = flash;
+		else if (flash->buf) {
+			result &= flash_buffered_flush(flash);
+			result &= flash_done(flash);
 		}
 	}
-	if (!active_flash || !ret)
+	if (!active_flash || !result)
 		return false;
 
 	while (len) {
-		target_flash_s *f = target_flash_for_addr(t, dest);
-		if (!f)
+		target_flash_s *flash = target_flash_for_addr(target, dest);
+		if (!flash)
 			return false;
 
 		/* Terminate flash operations if we're not in the same target flash */
-		if (f != active_flash) {
-			ret &= flash_buffered_flush(active_flash);
-			ret &= flash_done(active_flash);
-			active_flash = f;
+		if (flash != active_flash) {
+			result &= flash_buffered_flush(active_flash);
+			result &= flash_done(active_flash);
+			active_flash = flash;
 		}
-		if (!f->buf)
-			ret &= flash_buffer_alloc(f);
+		if (!flash->buf)
+			result &= flash_buffer_alloc(flash);
 
 		/* Early exit if any of the flushing and cleanup steps above failed */
-		if (!ret)
+		if (!result)
 			break;
 
-		const target_addr_t local_end_addr = MIN(dest + len, f->start + f->length);
+		const target_addr_t local_end_addr = MIN(dest + len, flash->start + flash->length);
 		const target_addr_t local_length = local_end_addr - dest;
 
-		ret &= flash_buffered_write(f, dest, src, local_length);
-		if (!ret) {
+		result &= flash_buffered_write(flash, dest, src, local_length);
+		if (!result) {
 			DEBUG_ERROR("Write failed at %" PRIx32 "\n", dest);
 			break;
 		}
@@ -282,20 +283,20 @@ bool target_flash_write(target_s *t, target_addr_t dest, const void *src, size_t
 		src += local_length;
 		len -= local_length;
 	}
-	return ret;
+	return result;
 }
 
-bool target_flash_complete(target_s *t)
+bool target_flash_complete(target_s *target)
 {
-	if (!t->flash_mode)
+	if (!target->flash_mode)
 		return false;
 
-	bool ret = true; /* Catch false returns with &= */
-	for (target_flash_s *f = t->flash; f; f = f->next) {
-		ret &= flash_buffered_flush(f);
-		ret &= flash_done(f);
+	bool result = true; /* Catch false returns with &= */
+	for (target_flash_s *flash = target->flash; flash; flash = flash->next) {
+		result &= flash_buffered_flush(flash);
+		result &= flash_done(flash);
 	}
 
-	target_exit_flash_mode(t);
-	return ret;
+	target_exit_flash_mode(target);
+	return result;
 }

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -30,6 +30,12 @@
 extern target_s *target_list;
 target_s *target_new(void);
 
+typedef enum flash_operation {
+	FLASH_OPERATION_NONE,
+	FLASH_OPERATION_ERASE,
+	FLASH_OPERATION_WRITE,
+} flash_operation_e;
+
 typedef struct target_ram target_ram_s;
 
 struct target_ram {
@@ -53,7 +59,7 @@ struct target_flash {
 	size_t writesize;            /* Write operation size, must be <= blocksize/writebufsize */
 	size_t writebufsize;         /* Size of write buffer, this is calculated and not set in target code */
 	uint8_t erased;              /* Byte erased state */
-	bool ready;                  /* True if flash is in flash mode/prepared */
+	uint8_t operation;           /* Current Flash operation (none means it's idle/unprepared) */
 	flash_prepare_func prepare;  /* Prepare for flash operations */
 	flash_erase_func erase;      /* Erase a range of flash */
 	flash_write_func write;      /* Write to flash */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR splits off from https://github.com/blackmagic-debug/blackmagic/pull/1241 the introduction of Flash region state tracking to allow special behaviour to be introduced based on going into an erase vs write operation. This needs merging ahead of that PR to make things all make sense.

It tries to make the change in a way that creates the least impact possible and prevents targets that don't need the new features, for paying for them.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
