### PR TITLE
Fix: CMSIS-DAP versioning identification

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -290,6 +290,9 @@ dap_version_s dap_adaptor_version(const dap_info_e version_kind)
 	const char *begin = version_str;
 	char *end = NULL;
 	dap_version_s version = {};
+	/* If the string starts with a 'v' or 'V', skip over that */
+	if (begin[0] == 'v' || begin[0] == 'V')
+		++begin;
 	/* Now try to parse out the individual parts of the version string */
 	const uint16_t major = strtoul(begin, &end, 10);
 	/* If we fail on the first hurdle, return the bad version */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses an issue that cropped up since the ORBTrace v1.3 gateware was released as that gateware includes a `v` prefix on the version string for the adaptor. This meant that we'd see the thing as version "0.0.0" because of a quirk in how that broke the CMSIS-DAP implementation's version string parsing routine.

With this PR applied, the latest ORBTrace gateware is correctly identified as being v1.3.1 by BMDA and the multi-TAP quirk correctly applied, where before it was always applied.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
