### PR TITLE
Fix: Windows debug output

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -22,12 +22,15 @@
 #define INCLUDE_GENERAL_H
 
 #ifndef _GNU_SOURCE
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #define _GNU_SOURCE
 #endif
 #ifndef _DEFAULT_SOURCE
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #define _DEFAULT_SOURCE
 #endif
 #if !defined(__USE_MINGW_ANSI_STDIO)
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #define __USE_MINGW_ANSI_STDIO 1
 #endif
 #include <stdint.h>
@@ -93,17 +96,6 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #else
 #include "debug.h"
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#define DEBUG_WIDEN(fmt)       L##fmt
-#define DEBUG_ERROR(fmt, ...)  debug_error(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#define DEBUG_WARN(fmt, ...)   debug_warning(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#define DEBUG_INFO(fmt, ...)   debug_info(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#define DEBUG_GDB(fmt, ...)    debug_gdb(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#define DEBUG_TARGET(fmt, ...) debug_target(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#define DEBUG_PROTO(fmt, ...)  debug_protocol(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#define DEBUG_PROBE(fmt, ...)  debug_probe(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#define DEBUG_WIRE(fmt, ...)   debug_wire(DEBUG_WIDEN(fmt), ##__VA_ARGS__)
-#else
 #define DEBUG_ERROR(...)  debug_error(__VA_ARGS__)
 #define DEBUG_WARN(...)   debug_warning(__VA_ARGS__)
 #define DEBUG_INFO(...)   debug_info(__VA_ARGS__)
@@ -112,7 +104,6 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #define DEBUG_PROTO(...)  debug_protocol(__VA_ARGS__)
 #define DEBUG_PROBE(...)  debug_probe(__VA_ARGS__)
 #define DEBUG_WIRE(...)   debug_wire(__VA_ARGS__)
-#endif
 #endif
 
 #define ALIGN(x, n) (((x) + (n)-1) & ~((n)-1))

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -115,7 +115,7 @@ print_probes_info:
 				(BYTE *)busReportedDeviceSesc, sizeof busReportedDeviceSesc, &dwSize, 0)) {
 			probes_found++;
 			if (is_printing_probes_info) {
-				DEBUG_WARN("%2d: %s, %ls\n", probes_found, serial_number, busReportedDeviceSesc);
+				DEBUG_WARN("%2zu: %s, %ls\n", probes_found, serial_number, busReportedDeviceSesc);
 			} else {
 				bool probe_identified = true;
 				if ((cl_opts->opt_serial && strstr(serial_number, cl_opts->opt_serial)) ||
@@ -152,7 +152,7 @@ print_probes_info:
 	 * and no probe was identified as selected by the user.
 	 * Restart the identification loop, this time printing the probe information,
 	 * and then return. */
-	DEBUG_WARN("%d debuggers found!\nSelect with -P <pos>, or "
+	DEBUG_WARN("%zu debuggers found!\nSelect with -P <pos>, or "
 			   "-s <(partial)serial no.>\n",
 		probes_found);
 	probes_found = 0;

--- a/src/platforms/hosted/debug.c
+++ b/src/platforms/hosted/debug.c
@@ -31,20 +31,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <wchar.h>
-#define PRINT_FN vfwprintf
-#else
-#include <stdio.h>
-#define PRINT_FN vfprintf
-#endif
 #include <stdarg.h>
 #include "general.h"
 #include "debug.h"
 
 uint16_t bmda_debug_flags = BMD_DEBUG_ERROR | BMD_DEBUG_WARNING;
 
-static void debug_print(const uint16_t level, const debug_str_t format, va_list args)
+static void debug_print(const uint16_t level, const char *format, va_list args)
 {
 	/* Check if the required level is enabled */
 	if (!(bmda_debug_flags & level))
@@ -52,7 +45,7 @@ static void debug_print(const uint16_t level, const debug_str_t format, va_list 
 	/* Check to see which of stderr and stdout the message should go to */
 	FILE *const where = bmda_debug_flags & BMD_DEBUG_USE_STDERR ? stderr : stdout;
 	/* And shoot the message to the correct place */
-	(void)PRINT_FN(where, format, args);
+	(void)vfprintf(where, format, args);
 	/* Note: we have no useful way to use the output of the above call, so we ignore it. */
 }
 
@@ -62,42 +55,42 @@ static void debug_print(const uint16_t level, const debug_str_t format, va_list 
 	debug_print((level), format, args); \
 	va_end(args)
 
-void debug_error(const debug_str_t format, ...)
+void debug_error(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_ERROR);
 }
 
-void debug_warning(const debug_str_t format, ...)
+void debug_warning(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_WARNING);
 }
 
-void debug_info(const debug_str_t format, ...)
+void debug_info(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_INFO);
 }
 
-void debug_gdb(const debug_str_t format, ...)
+void debug_gdb(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_GDB);
 }
 
-void debug_target(const debug_str_t format, ...)
+void debug_target(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_TARGET);
 }
 
-void debug_protocol(const debug_str_t format, ...)
+void debug_protocol(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_PROTO);
 }
 
-void debug_probe(const debug_str_t format, ...)
+void debug_probe(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_PROBE);
 }
 
-void debug_wire(const debug_str_t format, ...)
+void debug_wire(const char *format, ...)
 {
 	DEBUG_PRINT(BMD_DEBUG_WIRE);
 }

--- a/src/platforms/hosted/debug.h
+++ b/src/platforms/hosted/debug.h
@@ -34,12 +34,16 @@
 #ifndef PLATFORMS_HOSTED_DEBUG_H
 #define PLATFORMS_HOSTED_DEBUG_H
 
+#if !defined(__USE_MINGW_ANSI_STDIO)
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define __USE_MINGW_ANSI_STDIO 1
+#endif
 #include <stdint.h>
-#if defined(_WIN32) || defined(__CYGWIN__)
-typedef const wchar_t *debug_str_t;
-#define DEBUG_FORMAT_ATTR /*__attribute__((format(__wprintf__, 1, 2)))*/
-#else
+#include <stdio.h>
 typedef const char *debug_str_t;
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define DEBUG_FORMAT_ATTR __attribute__((format(__MINGW_PRINTF_FORMAT, 1, 2)))
+#else
 #define DEBUG_FORMAT_ATTR __attribute__((format(printf, 1, 2)))
 #endif
 
@@ -59,13 +63,13 @@ typedef const char *debug_str_t;
 
 extern uint16_t bmda_debug_flags;
 
-void debug_error(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
-void debug_warning(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
-void debug_info(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
-void debug_gdb(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
-void debug_target(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
-void debug_protocol(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
-void debug_probe(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
-void debug_wire(debug_str_t format, ...) DEBUG_FORMAT_ATTR;
+void debug_error(const char *format, ...) DEBUG_FORMAT_ATTR;
+void debug_warning(const char *format, ...) DEBUG_FORMAT_ATTR;
+void debug_info(const char *format, ...) DEBUG_FORMAT_ATTR;
+void debug_gdb(const char *format, ...) DEBUG_FORMAT_ATTR;
+void debug_target(const char *format, ...) DEBUG_FORMAT_ATTR;
+void debug_protocol(const char *format, ...) DEBUG_FORMAT_ATTR;
+void debug_probe(const char *format, ...) DEBUG_FORMAT_ATTR;
+void debug_wire(const char *format, ...) DEBUG_FORMAT_ATTR;
 
 #endif /*PLATFORMS_HOSTED_DEBUG_H*/

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -33,6 +33,7 @@
 #include <winsock2.h>
 
 typedef SOCKET socket_t;
+#define PRI_SOCKET "zu"
 #ifndef __CYGWIN__
 typedef signed long long ssize_t;
 #endif
@@ -46,6 +47,7 @@ typedef signed long long ssize_t;
 #include <fcntl.h>
 
 typedef int32_t socket_t;
+#define PRI_SOCKET     "d"
 #define INVALID_SOCKET (-1)
 #endif
 
@@ -170,7 +172,7 @@ static void display_socket_error(const int error, const socket_t socket, const c
 #else
 	const char *message = strerror(error);
 #endif
-	DEBUG_ERROR("Error %s %d, got error %d: %s\n", operation, socket, error, message);
+	DEBUG_ERROR("Error %s %" PRI_SOCKET ", got error %d: %s\n", operation, socket, error, message);
 #if defined(_WIN32) || defined(__CYGWIN__)
 	LocalFree(message);
 #endif

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -19,8 +19,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* Handle different BMP pc-hosted platforms/
- */
+/* Implements core platform-specific functionality for BMDA */
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
 
 #include "general.h"
 #include "platform.h"
@@ -90,6 +95,9 @@ static void sigterm_handler(int sig)
 
 void platform_init(int argc, char **argv)
 {
+#if defined(_WIN32) || defined(__CYGWIN__)
+	SetConsoleOutputCP(CP_UTF8);
+#endif
 	cl_init(&cl_opts, argc, argv);
 	atexit(exit_function);
 	signal(SIGTERM, sigterm_handler);

--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -57,7 +57,7 @@ static void display_error(const LSTATUS error, const char *const operation, cons
 	char *message = NULL;
 	FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
 		error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (char *)&message, 0, NULL);
-	DEBUG_ERROR("Error %s %s, got error %08x: %s\n", operation, path, error, message);
+	DEBUG_ERROR("Error %s %s, got error %08lx: %s\n", operation, path, error, message);
 	LocalFree(message);
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a regression introduced in https://github.com/blackmagic-debug/blackmagic/pull/1452 which saw the output on Windows get munged by a standards conformity issue in `wprintf()` on that OS. With the [help of Microsoft](https://developercommunity.visualstudio.com/t/wprintf-has-non-conforming-string-format/10386390), we have come to a compromise involving switching the output code page to try and guarantee correct operation.

This change also introduces `printf()` format string warnings for Windows, consistent with Linux and macOS compilation.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
