### PR TITLE
Fix: ADIv5 DP init

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -874,15 +874,8 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp, const uint32_t idcode)
 		return;
 	}
 
-	volatile uint32_t ctrlstat = 0;
-	TRY_CATCH (e, EXCEPTION_TIMEOUT) {
-		ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
-	}
-	if (e.type) {
-		DEBUG_WARN("DP not responding! Trying abort sequence...\n");
-		adiv5_dp_abort(dp, ADIV5_DP_ABORT_DAPABORT);
-		ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
-	}
+	/* Read DP Control/Status */
+	uint32_t ctrlstat = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
 
 	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 201);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR does a much needed cleanup in `adiv5_dp_init`, related to the `TRY_CATCH` blocks

`TRY_CATCH` brings clobbering errors, forcing us to volatile certain variables and thus blocking certain optimizations

This contains the problematic code and unblocks optimizations, bringing a small code size saving

Tested with BMDA (J-Link  V8) and native on a RP2040 target

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
