### PR TITLE
Feature: SWD error handling deduplication

### DIFF
--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -78,9 +78,9 @@ bool dap_swd_init(adiv5_debug_port_s *target_dp)
 
 	/* If we have SWD sequences available, make use of them */
 	if (dap_has_swd_sequence)
-		target_dp->dp_low_write = dap_write_reg_no_check;
+		target_dp->write_no_check = dap_write_reg_no_check;
 	else
-		target_dp->dp_low_write = NULL;
+		target_dp->write_no_check = NULL;
 	/* Set up the accelerated SWD functions for basic target operations */
 	target_dp->dp_read = dap_dp_read_reg;
 	target_dp->error = dap_swd_clear_error;
@@ -190,7 +190,7 @@ static void dap_line_reset(void)
 		DEBUG_ERROR("line reset failed\n");
 }
 
-static bool dap_write_reg_no_check(uint16_t addr, const uint32_t data)
+static bool dap_write_reg_no_check(const uint16_t addr, const uint32_t data)
 {
 	DEBUG_PROBE("dap_write_reg_no_check %04x <- %08" PRIx32 "\n", addr, data);
 	/* Setup the sequences */

--- a/src/platforms/hosted/jlink_swd.c
+++ b/src/platforms/hosted/jlink_swd.c
@@ -101,6 +101,7 @@ bool jlink_swd_init(adiv5_debug_port_s *dp)
 
 	/* Set up the accelerated SWD functions for basic target operations */
 	dp->write_no_check = jlink_adiv5_raw_write_no_check;
+	dp->read_no_check = jlink_adiv5_raw_read_no_check;
 	dp->dp_read = firmware_swdp_read;
 	dp->error = jlink_adiv5_clear_error;
 	dp->low_access = jlink_adiv5_raw_access;

--- a/src/platforms/hosted/jlink_swd.c
+++ b/src/platforms/hosted/jlink_swd.c
@@ -100,7 +100,7 @@ bool jlink_swd_init(adiv5_debug_port_s *dp)
 	swd_proc.seq_out_parity = jlink_swd_seq_out_parity;
 
 	/* Set up the accelerated SWD functions for basic target operations */
-	dp->dp_low_write = jlink_adiv5_raw_write_no_check;
+	dp->write_no_check = jlink_adiv5_raw_write_no_check;
 	dp->dp_read = firmware_swdp_read;
 	dp->error = jlink_adiv5_clear_error;
 	dp->low_access = jlink_adiv5_raw_access;

--- a/src/platforms/hosted/jlink_swd.c
+++ b/src/platforms/hosted/jlink_swd.c
@@ -96,7 +96,6 @@ bool jlink_swd_init(adiv5_debug_port_s *dp)
 	/* Set up the accelerated SWD functions for basic target operations */
 	dp->write_no_check = jlink_adiv5_raw_write_no_check;
 	dp->read_no_check = jlink_adiv5_raw_read_no_check;
-	dp->dp_read = firmware_swdp_read;
 	dp->low_access = jlink_adiv5_raw_access;
 	return true;
 }

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -679,6 +679,21 @@ static void decode_access(const uint16_t addr, const uint8_t rnw, const uint32_t
 		decode_ap_access(addr >> 8U, addr & 0xffU);
 }
 
+bool adiv5_write_no_check(adiv5_debug_port_s *dp, uint16_t addr, const uint32_t value)
+{
+	decode_access(addr, ADIV5_LOW_WRITE, value);
+	DEBUG_PROTO("0x%08" PRIx32 "\n", value);
+	return dp->write_no_check(addr, value);
+}
+
+uint32_t adiv5_read_no_check(adiv5_debug_port_s *dp, uint16_t addr)
+{
+	uint32_t result = dp->read_no_check(addr);
+	decode_access(addr, ADIV5_LOW_READ, 0U);
+	DEBUG_PROTO("0x%08" PRIx32 "\n", result);
+	return result;
+}
+
 void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value)
 {
 	decode_access(addr, ADIV5_LOW_WRITE, value);

--- a/src/remote.c
+++ b/src/remote.c
@@ -129,7 +129,7 @@ static void remote_respond_string(const char response_code, const char *const st
  * and remote_packet_process_jtag() for use by remote_packet_process_adiv5() so its faked AP can do the right
  * thing.
  *
- * REMOTE_INIT for SWD and JTAG rewrite the dp_low_write, dp_read, error, low_access and abort function
+ * REMOTE_INIT for SWD and JTAG rewrite the write_no_check, dp_read, error, low_access and abort function
  * pointers to reconfigure this structure appropriately.
  */
 static adiv5_debug_port_s remote_dp = {
@@ -144,7 +144,7 @@ static void remote_packet_process_swd(const char *const packet, const size_t pac
 	switch (packet[1]) {
 	case REMOTE_INIT: /* SS = initialise =============================== */
 		if (packet_len == 2) {
-			remote_dp.dp_low_write = firmware_dp_low_write;
+			remote_dp.write_no_check = adiv5_swd_write_no_check;
 			remote_dp.dp_read = firmware_swdp_read;
 			remote_dp.error = adiv5_swd_clear_error;
 			remote_dp.low_access = firmware_swdp_low_access;
@@ -196,7 +196,7 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 {
 	switch (packet[1]) {
 	case REMOTE_INIT: /* JS = initialise ============================= */
-		remote_dp.dp_low_write = NULL;
+		remote_dp.write_no_check = NULL;
 		remote_dp.dp_read = fw_adiv5_jtagdp_read;
 		remote_dp.error = adiv5_jtagdp_error;
 		remote_dp.low_access = fw_adiv5_jtagdp_low_access;

--- a/src/remote.c
+++ b/src/remote.c
@@ -129,7 +129,7 @@ static void remote_respond_string(const char response_code, const char *const st
  * and remote_packet_process_jtag() for use by remote_packet_process_adiv5() so its faked AP can do the right
  * thing.
  *
- * REMOTE_INIT for SWD and JTAG rewrite the write_no_check, dp_read, error, low_access and abort function
+ * REMOTE_INIT for SWD and JTAG rewrite the {read,write}_no_check, dp_read, error, low_access and abort function
  * pointers to reconfigure this structure appropriately.
  */
 static adiv5_debug_port_s remote_dp = {
@@ -145,6 +145,7 @@ static void remote_packet_process_swd(const char *const packet, const size_t pac
 	case REMOTE_INIT: /* SS = initialise =============================== */
 		if (packet_len == 2) {
 			remote_dp.write_no_check = adiv5_swd_write_no_check;
+			remote_dp.read_no_check = adiv5_swd_read_no_check;
 			remote_dp.dp_read = firmware_swdp_read;
 			remote_dp.error = adiv5_swd_clear_error;
 			remote_dp.low_access = firmware_swdp_low_access;
@@ -197,6 +198,7 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 	switch (packet[1]) {
 	case REMOTE_INIT: /* JS = initialise ============================= */
 		remote_dp.write_no_check = NULL;
+		remote_dp.read_no_check = NULL;
 		remote_dp.dp_read = fw_adiv5_jtagdp_read;
 		remote_dp.error = adiv5_jtagdp_error;
 		remote_dp.low_access = fw_adiv5_jtagdp_low_access;

--- a/src/remote.c
+++ b/src/remote.c
@@ -146,7 +146,7 @@ static void remote_packet_process_swd(const char *const packet, const size_t pac
 		if (packet_len == 2) {
 			remote_dp.dp_low_write = firmware_dp_low_write;
 			remote_dp.dp_read = firmware_swdp_read;
-			remote_dp.error = firmware_swdp_error;
+			remote_dp.error = adiv5_swd_clear_error;
 			remote_dp.low_access = firmware_swdp_low_access;
 			remote_dp.abort = firmware_swdp_abort;
 			swdptap_init();

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -228,6 +228,7 @@ struct adiv5_debug_port {
 
 	/* write_no_check returns true if no OK response, but ignores errors */
 	bool (*write_no_check)(uint16_t addr, const uint32_t data);
+	uint32_t (*read_no_check)(uint16_t addr);
 	uint32_t (*dp_read)(adiv5_debug_port_s *dp, uint16_t addr);
 	uint32_t (*error)(adiv5_debug_port_s *dp, bool protocol_recovery);
 	uint32_t (*low_access)(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
@@ -388,6 +389,7 @@ uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 
 bool adiv5_swd_write_no_check(uint16_t addr, uint32_t data);
+uint32_t adiv5_swd_read_no_check(uint16_t addr);
 uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -388,7 +388,7 @@ uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 
 bool firmware_dp_low_write(uint16_t addr, uint32_t data);
-uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
+uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 
 void firmware_swdp_abort(adiv5_debug_port_s *dp, uint32_t abort);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -286,6 +286,16 @@ struct adiv5_access_port {
 uint8_t make_packet_request(uint8_t RnW, uint16_t addr);
 
 #if PC_HOSTED == 0
+static inline bool adiv5_write_no_check(adiv5_debug_port_s *const dp, uint16_t addr, const uint32_t value)
+{
+	return dp->write_no_check(addr, value);
+}
+
+static inline uint32_t adiv5_read_no_check(adiv5_debug_port_s *const dp, uint16_t addr)
+{
+	return dp->read_no_check(addr);
+}
+
 static inline uint32_t adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr)
 {
 	return dp->dp_read(dp, addr);
@@ -333,6 +343,8 @@ static inline void adiv5_dp_write(adiv5_debug_port_s *dp, uint16_t addr, uint32_
 }
 
 #else
+bool adiv5_write_no_check(adiv5_debug_port_s *dp, uint16_t addr, uint32_t value);
+uint32_t adiv5_read_no_check(adiv5_debug_port_s *dp, uint16_t addr);
 uint32_t adiv5_dp_read(adiv5_debug_port_s *dp, uint16_t addr);
 uint32_t adiv5_dp_error(adiv5_debug_port_s *dp);
 uint32_t adiv5_dp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -226,8 +226,8 @@ typedef struct adiv5_debug_port adiv5_debug_port_s;
 struct adiv5_debug_port {
 	int refcnt;
 
-	/* dp_low_write returns true if no OK response, but ignores errors */
-	bool (*dp_low_write)(uint16_t addr, const uint32_t data);
+	/* write_no_check returns true if no OK response, but ignores errors */
+	bool (*write_no_check)(uint16_t addr, const uint32_t data);
 	uint32_t (*dp_read)(adiv5_debug_port_s *dp, uint16_t addr);
 	uint32_t (*error)(adiv5_debug_port_s *dp, bool protocol_recovery);
 	uint32_t (*low_access)(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value);
@@ -387,7 +387,7 @@ uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_
 uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 
-bool firmware_dp_low_write(uint16_t addr, uint32_t data);
+bool adiv5_swd_write_no_check(uint16_t addr, uint32_t data);
 uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -346,11 +346,11 @@ uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *const dp, const bool protocol
 		 */
 		swd_line_reset_sequence(true);
 		if (dp->version >= 2U)
-			adiv5_swd_write_no_check(ADIV5_DP_TARGETSEL, dp->targetsel);
-		adiv5_swd_read_no_check(ADIV5_DP_DPIDR);
+			adiv5_write_no_check(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+		adiv5_read_no_check(dp, ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */
 	}
-	const uint32_t err = adiv5_swd_read_no_check(ADIV5_DP_CTRLSTAT) &
+	const uint32_t err = adiv5_read_no_check(dp, ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 			ADIV5_DP_CTRLSTAT_WDATAERR);
 	uint32_t clr = 0;
@@ -365,7 +365,7 @@ uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *const dp, const bool protocol
 		clr |= ADIV5_DP_ABORT_WDERRCLR;
 
 	if (clr)
-		adiv5_swd_write_no_check(ADIV5_DP_ABORT, clr);
+		adiv5_write_no_check(dp, ADIV5_DP_ABORT, clr);
 	dp->fault = 0;
 	return err;
 }

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -153,7 +153,7 @@ bool adiv5_swd_scan(const uint32_t targetid)
 	}
 
 	dp->dp_low_write = firmware_dp_low_write;
-	dp->error = firmware_swdp_error;
+	dp->error = adiv5_swd_clear_error;
 	dp->dp_read = firmware_swdp_read;
 	dp->low_access = firmware_swdp_low_access;
 	dp->abort = firmware_swdp_abort;
@@ -333,7 +333,7 @@ uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 	return adiv5_dp_recoverable_access(dp, ADIV5_LOW_READ, addr, 0);
 }
 
-uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
+uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *const dp, const bool protocol_recovery)
 {
 	/* Only do the comms reset dance on DPv2+ w/ fault or to perform protocol recovery. */
 	if ((dp->version >= 2U && dp->fault) || protocol_recovery) {

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -121,7 +121,7 @@ static void jtag_to_swd_sequence()
 	swd_line_reset_sequence(true);
 }
 
-bool firmware_dp_low_write(const uint16_t addr, const uint32_t data)
+bool adiv5_swd_write_no_check(const uint16_t addr, const uint32_t data)
 {
 	const uint8_t request = make_packet_request(ADIV5_LOW_WRITE, addr);
 	swd_proc.seq_out(request, 8U);
@@ -152,7 +152,7 @@ bool adiv5_swd_scan(const uint32_t targetid)
 		return false;
 	}
 
-	dp->dp_low_write = firmware_dp_low_write;
+	dp->write_no_check = adiv5_swd_write_no_check;
 	dp->error = adiv5_swd_clear_error;
 	dp->dp_read = firmware_swdp_read;
 	dp->low_access = firmware_swdp_low_access;
@@ -234,7 +234,7 @@ bool adiv5_swd_scan(const uint32_t targetid)
 		bool scan_multidrop = targetid || dp->version >= 2U;
 
 #if PC_HOSTED == 1
-	if (scan_multidrop && !dp->dp_low_write) {
+	if (scan_multidrop && !dp->write_no_check) {
 		DEBUG_WARN("Discovered multi-drop enabled target but CMSIS_DAP < v1.2 cannot handle multi-drop\n");
 		scan_multidrop = false;
 	}
@@ -295,7 +295,7 @@ void adiv5_swd_multidrop_scan(adiv5_debug_port_s *const dp, const uint32_t targe
 		dp->fault = 0;
 
 		/* Select the instance */
-		dp->dp_low_write(ADIV5_DP_TARGETSEL,
+		dp->write_no_check(ADIV5_DP_TARGETSEL,
 			instance << ADIV5_DP_TARGETSEL_TINSTANCE_OFFSET |
 				(targetid & (ADIV5_DP_TARGETID_TDESIGNER_MASK | ADIV5_DP_TARGETID_TPARTNO_MASK)) | 1U);
 
@@ -345,7 +345,7 @@ uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *const dp, const bool protocol
 		 */
 		swd_line_reset_sequence(true);
 		if (dp->version >= 2U)
-			firmware_dp_low_write(ADIV5_DP_TARGETSEL, dp->targetsel);
+			adiv5_swd_write_no_check(ADIV5_DP_TARGETSEL, dp->targetsel);
 		firmware_dp_low_read(ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */
 	}
@@ -364,7 +364,7 @@ uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *const dp, const bool protocol
 		clr |= ADIV5_DP_ABORT_WDERRCLR;
 
 	if (clr)
-		firmware_dp_low_write(ADIV5_DP_ABORT, clr);
+		adiv5_swd_write_no_check(ADIV5_DP_ABORT, clr);
 	dp->fault = 0;
 	return err;
 }

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -131,7 +131,7 @@ bool adiv5_swd_write_no_check(const uint16_t addr, const uint32_t data)
 	return res != SWDP_ACK_OK;
 }
 
-static uint32_t firmware_dp_low_read(const uint16_t addr)
+uint32_t adiv5_swd_read_no_check(const uint16_t addr)
 {
 	const uint8_t request = make_packet_request(ADIV5_LOW_READ, addr);
 	swd_proc.seq_out(request, 8U);
@@ -153,6 +153,7 @@ bool adiv5_swd_scan(const uint32_t targetid)
 	}
 
 	dp->write_no_check = adiv5_swd_write_no_check;
+	dp->read_no_check = adiv5_swd_read_no_check;
 	dp->error = adiv5_swd_clear_error;
 	dp->dp_read = firmware_swdp_read;
 	dp->low_access = firmware_swdp_low_access;
@@ -346,10 +347,10 @@ uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *const dp, const bool protocol
 		swd_line_reset_sequence(true);
 		if (dp->version >= 2U)
 			adiv5_swd_write_no_check(ADIV5_DP_TARGETSEL, dp->targetsel);
-		firmware_dp_low_read(ADIV5_DP_DPIDR);
+		adiv5_swd_read_no_check(ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */
 	}
-	const uint32_t err = firmware_dp_low_read(ADIV5_DP_CTRLSTAT) &
+	const uint32_t err = adiv5_swd_read_no_check(ADIV5_DP_CTRLSTAT) &
 		(ADIV5_DP_CTRLSTAT_STICKYORUN | ADIV5_DP_CTRLSTAT_STICKYCMP | ADIV5_DP_CTRLSTAT_STICKYERR |
 			ADIV5_DP_CTRLSTAT_WDATAERR);
 	uint32_t clr = 0;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Noticed while working on the multi-drop handling, that a couple error handling routines could be replaced by the default error handling routine (J-Link and DAP), but this needs to be tested and validated to be true. 

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
