### PR TITLE
platforms/f4discovery: Update README.md

### DIFF
--- a/src/platforms/f4discovery/README.md
+++ b/src/platforms/f4discovery/README.md
@@ -3,7 +3,8 @@
 Allows the use of the STM32F407 Discovery board main cpu as a Black Magic Probe. Historically it was used to program the on board built in debugger before ST-Link bootloader use was possible.
 
 ## Connections
-
+* PD9: UART RX
+* PD8: UART TX
 * PC2: TDI
 * PC4: TMS/SWDIO
 * PC5: TCK/SWCLK


### PR DESCRIPTION
Nothing fancy here. This just updates the README.md of the f4discovery and adds the missing UART pins, which are actually there just not documented. 

Tested on my f4 discovery board. Works just fine.
