### PR TITLE
Fix: ST-Link v2 serial number readout

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -383,16 +383,8 @@ static bool process_vid_pid_table_probe(
 			product = get_device_descriptor_string(handle, device_descriptor->iProduct);
 		if (manufacturer == NULL)
 			manufacturer = get_device_descriptor_string(handle, device_descriptor->iManufacturer);
-		if (serial == NULL) {
-			/*
-			 * If this is a ST-Link v2, it does not report its serial number correctly,
-			 * bypass trying to read it.
-			 */
-			if (device_descriptor->idVendor == VENDOR_ID_STLINK && device_descriptor->idProduct == PRODUCT_ID_STLINKV2)
-				serial = strdup("---");
-			else
-				serial = get_device_descriptor_string(handle, device_descriptor->iSerialNumber);
-		}
+		if (serial == NULL)
+			serial = get_device_descriptor_string(handle, device_descriptor->iSerialNumber);
 
 		if (version == NULL)
 			version = strdup("---");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

The original ST-Link v2 has a firmware bug that remains unfixed which means that instead of the serial number being properly hex encoded UTF-16 returned to the host, the serial number is returned raw as a series of uint16_t's that must then be converted to hex for display and which must bypass and side-step libusb's libusb_get_string_descriptor_ascii() function due to it converting any character with numerical value >= 0x80 to '?'.

This PR addresses this long standing problem, allowing the serial number matching mechanics to work properly with ST-Link v2 serial numbers. This builds on the new probe scanning engine which already stopped us from displaying garbage on the user's console.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
