### PR TITLE
Fix: BMDA CMSIS-DAP v2 selection

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -529,7 +529,7 @@ int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 			DEBUG_WARN(" %2zu. %-20s %-25s %-25s %s\n", position, probe->product, probe->serial, probe->manufacturer,
 				probe->version);
 		probe_info_list_free(probe_list);
-		return 1; // false;
+		return cl_opts->opt_list_only ? 0 : 1; // false;
 	}
 
 	/* We found a matching probe, populate bmp_info_s and signal success */

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -472,7 +472,6 @@ int find_debuggers(bmda_cli_options_s *cl_opts, bmp_info_s *info)
 	}
 
 	/* We found a matching probe, populate bmp_info_s and signal success */
-	DEBUG_WARN("Using: %-20s %-20s %-25s %s\n", probe->product, probe->serial, probe->manufacturer, probe->version);
 	probe_info_to_bmp_info(probe, info);
 	/* If the selected probe is an FTDI adapter try to resolve the adaptor type */
 	if (probe->vid == VENDOR_ID_FTDI && !ftdi_lookup_adaptor_descriptor(cl_opts, probe)) {

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -135,7 +135,7 @@ void bmp_read_product_version(libusb_device_descriptor_s *device_descriptor, lib
 			--start_of_version;
 		start_of_version[1] = '\0';
 		start_of_version += 2;
-		while (start_of_version[0] == ' ' && start_of_version[0] != '\0')
+		while (start_of_version[0] == ' ')
 			++start_of_version;
 		*version = strdup(start_of_version);
 	}

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -112,6 +112,9 @@ void platform_init(int argc, char **argv)
 	else if (find_debuggers(&cl_opts, &info))
 		exit(1);
 
+	if (cl_opts.opt_list_only)
+		exit(0);
+
 	bmp_ident(&info);
 
 	switch (info.bmp_type) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a small regression introduced in https://github.com/blackmagic-debug/blackmagic/pull/1502 which causes CMSIS-DAP probes to be assumed to be v1 even when they might be v2 or support both.

We fix this by re-checking the descriptors of the probe if it's a CMSIS-DAP probe, once it's been selected by the probe discovery code. We then check for the v2 descriptors and extract the correct endpoints to allow the backend to do the right thing.

The way this is done also ensures that we should always pick up the proper interfaces no matter what order they appear in.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes https://github.com/blackmagic-debug/blackmagic/issues/959
