### PR TITLE
Fix: remote protocol SWD hangs

### DIFF
--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -69,12 +69,12 @@ static void swdptap_turnaround(const swdio_status_t dir)
 		SWDIO_MODE_FLOAT();
 	} else {
 		gpio_clear(SWCLK_PORT, SWCLK_PIN);
-		for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
+		for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 			continue;
 	}
 
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
-	for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
+	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 
 	if (dir == SWDIO_STATUS_DRIVE) {
@@ -127,14 +127,14 @@ static uint32_t swdptap_seq_in(size_t clock_cycles)
 static bool swdptap_seq_in_parity(uint32_t *ret, size_t clock_cycles)
 {
 	const uint32_t result = swdptap_seq_in(clock_cycles);
-	for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
+	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 
 	size_t parity = __builtin_popcount(result);
 	parity += gpio_get(SWDIO_IN_PORT, SWDIO_IN_PIN) ? 1U : 0U;
 
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
-	for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
+	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 
 	*ret = result;
@@ -185,10 +185,10 @@ static void swdptap_seq_out_parity(const uint32_t tms_states, const size_t clock
 	int parity = __builtin_popcount(tms_states);
 	swdptap_seq_out(tms_states, clock_cycles);
 	gpio_set_val(SWDIO_PORT, SWDIO_PIN, parity & 1U);
-	for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
+	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
-	for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
+	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 	gpio_clear(SWCLK_PORT, SWCLK_PIN);
 }

--- a/src/remote.c
+++ b/src/remote.c
@@ -130,11 +130,11 @@ static adiv5_debug_port_s remote_dp = {
 	.mem_write = adiv5_mem_write_bytes,
 };
 
-static void remote_packet_process_swd(unsigned i, char *packet)
+static void remote_packet_process_swd(const char *const packet, const size_t packet_len)
 {
 	switch (packet[1]) {
 	case REMOTE_INIT: /* SS = initialise =============================== */
-		if (i == 2) {
+		if (packet_len == 2) {
 			remote_dp.dp_read = firmware_swdp_read;
 			remote_dp.low_access = firmware_swdp_low_access;
 			remote_dp.abort = firmware_swdp_abort;
@@ -588,7 +588,7 @@ void remote_packet_process(unsigned i, char *packet)
 {
 	switch (packet[0]) {
 	case REMOTE_SWDP_PACKET:
-		remote_packet_process_swd(i, packet);
+		remote_packet_process_swd(packet, i);
 		break;
 
 	case REMOTE_JTAG_PACKET:

--- a/src/remote.c
+++ b/src/remote.c
@@ -198,8 +198,8 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 		break;
 
 	case REMOTE_TMS: { /* JT = TMS Sequence ============================ */
-		const size_t clock_cycles = remote_hex_string_to_num(2, &packet[2]);
-		const uint32_t tms_states = remote_hex_string_to_num(2, &packet[4]);
+		const size_t clock_cycles = remote_hex_string_to_num(2, packet + 2);
+		const uint32_t tms_states = remote_hex_string_to_num(2, packet + 4);
 
 		if (packet_len < 4U)
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
@@ -211,7 +211,7 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 	}
 
 	case REMOTE_CYCLE: { /* JC = clock cycle ============================ */
-		const size_t clock_cycles = remote_hex_string_to_num(8, &packet[4]);
+		const size_t clock_cycles = remote_hex_string_to_num(8, packet + 4);
 		const bool tms = packet[2] != '0';
 		const bool tdi = packet[3] != '0';
 		jtag_proc.jtagtap_cycle(tms, tdi, clock_cycles);
@@ -224,8 +224,8 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 		if (packet_len < 5U)
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		else {
-			const size_t clock_cycles = remote_hex_string_to_num(2, &packet[2]);
-			const uint64_t data_in = remote_hex_string_to_num(-1, &packet[4]);
+			const size_t clock_cycles = remote_hex_string_to_num(2, packet + 2);
+			const uint64_t data_in = remote_hex_string_to_num(-1, packet + 4);
 			uint64_t data_out = 0;
 			jtag_proc.jtagtap_tdi_tdo_seq(
 				(uint8_t *)&data_out, packet[1] == REMOTE_TDITDO_TMS, (const uint8_t *)&data_in, clock_cycles);

--- a/src/remote.c
+++ b/src/remote.c
@@ -155,11 +155,12 @@ static void remote_packet_process_swd(unsigned i, char *packet)
 		break;
 	}
 
-	case REMOTE_IN: /* Si = In ======================================= */
-		ticks = remote_hex_string_to_num(2, &packet[2]);
-		param = swd_proc.seq_in(ticks);
-		remote_respond(REMOTE_RESP_OK, param);
+	case REMOTE_IN: { /* Si = In ======================================= */
+		const size_t clock_cycles = remote_hex_string_to_num(2, packet + 2);
+		const uint32_t result = swd_proc.seq_in(clock_cycles);
+		remote_respond(REMOTE_RESP_OK, result);
 		break;
+	}
 
 	case REMOTE_OUT: /* So= Out ====================================== */
 		ticks = remote_hex_string_to_num(2, &packet[2]);

--- a/src/remote.c
+++ b/src/remote.c
@@ -144,9 +144,8 @@ static void remote_packet_process_swd(unsigned i, char *packet)
 			remote_dp.abort = firmware_swdp_abort;
 			swdptap_init();
 			remote_respond(REMOTE_RESP_OK, 0);
-		} else {
+		} else
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
-		}
 		break;
 
 	case REMOTE_IN_PAR: /* SI = In parity ============================= */

--- a/src/remote.c
+++ b/src/remote.c
@@ -132,9 +132,6 @@ static adiv5_debug_port_s remote_dp = {
 
 static void remote_packet_process_swd(unsigned i, char *packet)
 {
-	uint8_t ticks;
-	uint32_t param;
-
 	switch (packet[1]) {
 	case REMOTE_INIT: /* SS = initialise =============================== */
 		if (i == 2) {
@@ -170,12 +167,13 @@ static void remote_packet_process_swd(unsigned i, char *packet)
 		break;
 	}
 
-	case REMOTE_OUT_PAR: /* SO = Out parity ========================== */
-		ticks = remote_hex_string_to_num(2, &packet[2]);
-		param = remote_hex_string_to_num(-1, &packet[4]);
-		swd_proc.seq_out_parity(param, ticks);
+	case REMOTE_OUT_PAR: { /* SO = Out parity ========================== */
+		const size_t clock_cycles = remote_hex_string_to_num(2, packet + 2);
+		const uint32_t data = remote_hex_string_to_num(-1, packet + 4);
+		swd_proc.seq_out_parity(data, clock_cycles);
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
+	}
 
 	default:
 		remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_UNRECOGNISED);

--- a/src/remote.c
+++ b/src/remote.c
@@ -162,12 +162,13 @@ static void remote_packet_process_swd(unsigned i, char *packet)
 		break;
 	}
 
-	case REMOTE_OUT: /* So= Out ====================================== */
-		ticks = remote_hex_string_to_num(2, &packet[2]);
-		param = remote_hex_string_to_num(-1, &packet[4]);
-		swd_proc.seq_out(param, ticks);
+	case REMOTE_OUT: { /* So = Out ====================================== */
+		const size_t clock_cycles = remote_hex_string_to_num(2, packet + 2);
+		const uint32_t data = remote_hex_string_to_num(-1, packet + 4);
+		swd_proc.seq_out(data, clock_cycles);
 		remote_respond(REMOTE_RESP_OK, 0);
 		break;
+	}
 
 	case REMOTE_OUT_PAR: /* SO = Out parity ========================== */
 		ticks = remote_hex_string_to_num(2, &packet[2]);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a regression introduced in PR #1531 which forgot that the SWD bitbanging code needs to deal with target_clk_divider = UINT32_MAX fully. The effect of this mistake was that SWD would "hang" and soft-crash the probe.

We've also taken the opportunity to clean up the SWD remote protocol implementation the same as we did the JTAG implementation, saving a couple of bytes of Flash from that routine.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
