### PR TITLE
clang-tidy: Additions for case checking in source code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,6 +28,22 @@ CheckOptions:
     value: '2'
   - key:   readability-identifier-length.MinimumVariableNameLength
     value: '2'
+  - key:   readability-identifier-naming.VariableCase
+    value: 'lower_case'
+  - key:   readability-identifier-naming.FunctionCase
+    value: 'lower_case'
+  - key:   readability-identifier-naming.ConstantCase
+    value: 'lower_case'
+  - key:   readability-identifier-naming.EnumCase
+  value: 'lower_case'
+   - key:   readability-identifier-naming.StructCase
+  value: 'lower_case'
+   - key:   readability-identifier-naming.UnionCase
+  value: 'lower_case'
+   - key:   readability-identifier-naming.TypedefCase
+  value: 'lower_case'
+  - key:   readability-identifier-naming.MacroDefinitionCase
+    value: 'UPPER_CASE'
   - key:   readability-identifier-length.MinimumParameterNameLength
     value: '2'
 ...


### PR DESCRIPTION
This PR adds case checking for various elements of the source code.

These checks were added to assist contributors in checking their submissions against the project contribution requirements.

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
