### PR TITLE
Fix: CRC32 type error

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -138,6 +138,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 }
 #else
 #include <libopencm3/stm32/crc.h>
+#include "buffer_utils.h"
 
 bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_t base, const size_t len)
 {
@@ -160,7 +161,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 		}
 
 		for (size_t i = 0; i < read_len; i += 4U)
-			CRC_DR = __builtin_bswap32(*(uint32_t *)(bytes + i));
+			CRC_DR = read_be4(bytes, i);
 	}
 
 	uint32_t crc = CRC_DR;

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -100,7 +100,7 @@ static uint32_t crc32_calc(const uint32_t crc, const uint8_t data)
 	return (crc << 8U) ^ crc32_table[((crc >> 24U) ^ data) & 0xffU];
 }
 
-bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, size_t len)
+bool generic_crc32(target_s *const target, uint32_t *const crc_res, uint32_t base, size_t len)
 {
 	uint32_t crc = 0xffffffffU;
 #if PC_HOSTED == 1
@@ -124,7 +124,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 			gdb_if_putchar(0, true);
 		}
 		const size_t read_len = MIN(sizeof(bytes), len);
-		if (target_mem_read(t, bytes, base, (read_len + 3U) & ~3U)) {
+		if (target_mem_read(target, bytes, base, (read_len + 3U) & ~3U)) {
 			DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
 			return false;
 		}
@@ -142,7 +142,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 #else
 #include <libopencm3/stm32/crc.h>
 
-bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, size_t len)
+bool generic_crc32(target_s *const target, uint32_t *const crc_res, uint32_t base, size_t len)
 {
 	uint8_t bytes[128];
 
@@ -156,7 +156,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 			gdb_if_putchar(0, true);
 		}
 		const size_t read_len = MIN(sizeof(bytes), len) & ~3U;
-		if (target_mem_read(t, bytes, base, read_len)) {
+		if (target_mem_read(target, bytes, base, read_len)) {
 			DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
 			return false;
 		}
@@ -170,7 +170,7 @@ bool generic_crc32(target_s *const t, uint32_t *const crc_res, uint32_t base, si
 
 	uint32_t crc = CRC_DR;
 
-	if (target_mem_read(t, bytes, base, len)) {
+	if (target_mem_read(target, bytes, base, len)) {
 		DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", base);
 		return false;
 	}

--- a/src/include/buffer_utils.h
+++ b/src/include/buffer_utils.h
@@ -62,4 +62,10 @@ static inline uint32_t read_le4(const uint8_t *const buffer, const size_t offset
 		((uint32_t)buffer[offset + 3U] << 24U);
 }
 
+static inline uint32_t read_be4(const uint8_t *const buffer, const size_t offset)
+{
+	return ((uint32_t)buffer[offset + 0U] << 24U) | ((uint32_t)buffer[offset + 1U] << 16U) |
+		((uint32_t)buffer[offset + 2U] << 8U) | buffer[offset + 3U];
+}
+
 #endif /*INCLUDE_BUFFER_UTILS_H*/

--- a/src/include/crc32.h
+++ b/src/include/crc32.h
@@ -21,6 +21,9 @@
 #ifndef INCLUDE_CRC32_H
 #define INCLUDE_CRC32_H
 
-bool generic_crc32(target_s *t, uint32_t *crc, uint32_t base, int len);
+#include <stdint.h>
+#include <target.h>
+
+bool generic_crc32(target_s *target, uint32_t *crc, uint32_t base, size_t len);
 
 #endif /* INCLUDE_CRC32_H */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

While toying with LTO and doing a BMDA build, GCC warned of a type error in the CRC32 header. On checking it out, the type for the length parameter was indeed mismatched between header and both implementations.

This PR addresses this and does cleanup on the CRC32 implementations to bring them up to standard and make them easier to read and understand. Tested against a LPC4370 on both BMP and using BMDA, this offers no functional change but does fix some undefined behaviour.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
