### PR TITLE
hosted/bmp_libusb: Work around missing char16_t typedef in Darwin

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -31,7 +31,13 @@
 #include <libusb.h>
 #include <ftdi.h>
 #endif
+#if (defined __has_include && __has_include(<uchar.h>)) || !defined(__APPLE__)
 #include <uchar.h>
+#else
+//https://sourceware.org/bugzilla/show_bug.cgi?id=17979
+#include <stdint.h>
+typedef int_least16_t char16_t;
+#endif
 #include "cli.h"
 #include "ftdi_bmp.h"
 #include "version.h"


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In #1551, @dragonmux used char16_t to safely deal with the readout of ST-Link v2 serial numbers. However, what she didn't know was that Apple Clang *still* does not ship that particular bit of the C11 standard: https://stackoverflow.com/questions/24608832/uchar-h-file-not-found-on-os-x-10-9

This can be easily remedied as described in the following glibc bug: https://sourceware.org/bugzilla/show_bug.cgi?id=17979

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1557
