### PR TITLE
Fix: threads-induced IDE hangups

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -183,7 +183,8 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 			gdb_putpacketz("OK");
 		break;
 	}
-	/* '[m|M|g|G|c][thread-id]' : Set the thread ID for the given subsequent operation
+	/*
+	 * '[m|M|g|G|c][thread-id]' : Set the thread ID for the given subsequent operation
 	 * (we don't actually care which as we only care about the TID for whether to send OK or an error)
 	 */
 	case 'H': {
@@ -254,7 +255,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 			int n;
 			sscanf(pbuf, "P%" SCNx32 "=%n", &reg, &n);
 			// TODO: FIXME, VLAs considered harmful.
-			uint8_t val[strlen(&pbuf[n]) / 2U];
+			uint8_t val[strlen(pbuf + n) / 2U];
 			unhexify(val, pbuf + n, sizeof(val));
 			if (target_reg_write(cur_target, reg, val, sizeof(val)) > 0)
 				gdb_putpacketz("OK");
@@ -276,10 +277,11 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 		break;
 
 	case '!': /* Enable Extended GDB Protocol. */
-		/* This doesn't do anything, we support the extended
-			 * protocol anyway, but GDB will never send us a 'R'
-			 * packet unless we answer 'OK' here.
-			 */
+		/*
+		 * This doesn't do anything, we support the extended
+		 * protocol anyway, but GDB will never send us a 'R'
+		 * packet unless we answer 'OK' here.
+		 */
 		gdb_putpacketz("OK");
 		break;
 
@@ -655,8 +657,10 @@ static void handle_v_packet(char *packet, const size_t plen)
 			gdb_putpacketz("OK");
 
 	} else {
-		/* The vMustReplyEmpty is used as a feature test to check how gdbserver handles unknown packets */
-		/* print only actually unknown packets */
+		/*
+		 * The vMustReplyEmpty is used as a feature test to check how gdbserver handles
+		 * unknown packets print only actually unknown packets
+		 */
 		if (strcmp(packet, "vMustReplyEmpty") != 0)
 			DEBUG_GDB("*** Unsupported packet: %s\n", packet);
 		gdb_putpacket("", 0);

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -497,7 +497,7 @@ static void exec_q_c(const char *packet, const size_t length)
 static void exec_q_thread_info(const char *packet, const size_t length)
 {
 	(void)length;
-	if (packet[-11] == 'f')
+	if (packet[-11] == 'f' && cur_target)
 		gdb_putpacketz("m1");
 	else
 		gdb_putpacketz("l");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Back in v1.8.2 we introduced fake threads support to allow modern GDBs to work with the project. As part of that we had to report to GDB that there's always and forever one thread to match the 1 core no OS reality of debugging bare-metal. Unfortunately a consequence of that was that IDEs that don't properly gate checking for threads against being presently attached to a target would then ask, after detaching, if there were any threads, get told yes, and then go sulk due to their impaired logic.

This PR addresses this by gating our telling GDB there are threads, behind being attached to a target. This means we report an empty thread list when detached, preventing the logic issue in those IDEs. It technically also means we're being more correct in our handling of the request which is why we've marked it as a bug in BMD, but it is papering over a bug in particularly Eclipse-based IDEs like STM32CubeIDE, Eclipse Embedded CDT and AT32IDE.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
