### PR TITLE
hosted: Correct copyright notices

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -1,8 +1,11 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright(C) 2020 - 2022 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
- *
+ * Copyright (C) 2020 - 2022 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
+ * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Written by Sid Price <sid@sidprice.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/src/platforms/hosted/windows/ftdi.c
+++ b/src/platforms/hosted/windows/ftdi.c
@@ -1,8 +1,8 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
- * Copyright (C) 2023 Sid Price <sid@sidprice.com>
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by Sid Price <sid@sidprice.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/platforms/hosted/windows/ftdi.h
+++ b/src/platforms/hosted/windows/ftdi.h
@@ -1,11 +1,8 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2011  Black Sphere Technologies Ltd.
- * Copyright (C) 2018  Uwe Bonnes(bon@elektron.ikp.physik.tu-darmstadt.de)
- * Written by Gareth McMullin <gareth@blacksphere.co.nz>
- * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
- * Originated by Sid Price <sid@sidprice.com>
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by Sid Price <sid@sidprice.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
The copyright notices on a couple of BMDA related files were not up-to-date

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

