### PR TITLE
Fix: LPC43x0 Flash detection failure mishandling

### DIFF
--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -680,10 +680,12 @@ static bool lpc43x0_attach(target_s *const target)
 static void lpc43x0_detach(target_s *const target)
 {
 	lpc43x0_priv_s *const priv = (lpc43x0_priv_s *)target->target_storage;
-	free(priv->flash->flash_high);
-	free(priv->flash);
-	priv->flash = NULL;
-	target->flash = NULL;
+	if (priv->flash) {
+		free(priv->flash->flash_high);
+		free(priv->flash);
+		priv->flash = NULL;
+		target->flash = NULL;
+	}
 	cortexm_detach(target);
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR address a bug in the LPC43x0 support found via ASAN in which when Flash detection fails, the Flash structure is never allocated.

This leads to `lpc43x0_detach()` trying to dereference a NULL pointer in `priv->flash`and so crash. Checking for the possible NULL pointer and guarding the whole Flash structure freeing operation avoids this.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
