### PR TITLE
Fix: CMSIS-DAP transfer failure handling

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -351,9 +351,14 @@ uint32_t dap_dp_low_access(
 
 uint32_t dap_dp_read_reg(adiv5_debug_port_s *const target_dp, const uint16_t addr)
 {
-	uint32_t res = dap_dp_low_access(target_dp, ADIV5_LOW_READ, addr, 0);
-	DEBUG_PROBE("dp_read %04x %08" PRIx32 "\n", addr, res);
-	return res;
+	uint32_t result = dap_dp_low_access(target_dp, ADIV5_LOW_READ, addr, 0);
+	if (target_dp->fault == DAP_TRANSFER_NO_RESPONSE) {
+		DEBUG_WARN("Recovering and re-trying access\n");
+		target_dp->error(target_dp, true);
+		result = dap_dp_low_access(target_dp, ADIV5_LOW_READ, addr, 0);
+	}
+	DEBUG_PROBE("dp_read %04x %08" PRIx32 "\n", addr, result);
+	return result;
 }
 
 void dap_exit_function(void)

--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -133,6 +133,7 @@ bool perform_dap_transfer_recoverable(adiv5_debug_port_s *const target_dp,
 	/* If all went well, or we can't recover, we get to early return */
 	if (result || target_dp->fault != DAP_TRANSFER_NO_RESPONSE)
 		return result;
+	DEBUG_WARN("Recovering and re-trying access\n");
 	/* Otherwise clear the error and try again as our best and final answer */
 	target_dp->error(target_dp, true);
 	return perform_dap_transfer(target_dp, transfer_requests, requests, response_data, responses);

--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -227,7 +227,7 @@ bool perform_dap_swj_sequence(size_t clock_cycles, const uint8_t *data)
 	/* Calculate the number of bytes needed to represent the requested number of clock cycles */
 	const size_t bytes = (clock_cycles + 7U) >> 3U;
 	/* And copy the data into the buffer */
-	memcpy(request + 2, data, bytes);
+	memcpy(request + 2U, data, bytes);
 
 	/* Sequence response is a single byte */
 	uint8_t response = DAP_RESPONSE_OK;
@@ -268,8 +268,8 @@ bool perform_dap_jtag_sequence(
 	};
 	/* Copy in a suitable amount of data from the source buffer */
 	const size_t sequence_length = (cycles + 7U) >> 3U;
-	memcpy(request + 3, data_in, sequence_length);
-	size_t offset = 3 + sequence_length;
+	memcpy(request + 3U, data_in, sequence_length);
+	size_t offset = 3U + sequence_length;
 	/* Figure out where the final bit is */
 	const uint8_t final_byte = cycles >> 3U;
 	const uint8_t final_bit = cycles & 7U;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

While helping Sid debug some really curious target behaviour from the Ambiq Apollo SoC's, he ran into an issue where ORBTrace would report the device gave a no-response response to a DAP_TRANSFER and BMDA would fail to pick up on that, pretending the DP register read worked just fine and gave a response of 0.

This PR corrects this behaviour by improving the perform_dap_transfer() error handling, allowing the detection of sequences such as
```
-> dap_transfer (1 requests)
 command: 05 00 01 06
response: 05 01 01 00 00 00 f4
dap_read_reg: 04 -> f4000000
dp_read 0004 f4000000
Read CTRL/STAT: 0xf4000000
-> dap_transfer (1 requests)
 command: 05 00 01 06
response: 05 01 07
dp_read 0004 00000000
Read CTRL/STAT: 0x00000000
```

With this change, the request will by noted as having triggered no-response and dap_dp_reg_read() will attempt to perform protocol recovery and re-try the read.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
