### PR TITLE
Fix: GCC -fanalyzer lints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ blackmagic_upgrade
 src/artifacts/
 
 src/ftd2xx.dll
+
+scripts/swolisten

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -566,6 +566,10 @@ bool efm32_probe(target_s *t)
 	uint32_t flash_page_size = device->flash_page_size;
 
 	efm32_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
+	if (!priv_storage) { /* calloc failed: heap exhaustion */
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
+		return false;
+	}
 	t->target_storage = (void *)priv_storage;
 
 	priv_storage->di_version = di_version;

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -475,16 +475,15 @@ static uint16_t efm32_read_radio_part_number(target_s *t, uint8_t di_version)
 /* Reads the EFM32 Misc. Chip definitions */
 static efm32_v2_di_miscchip_s efm32_v2_read_miscchip(target_s *t, uint8_t di_version)
 {
-	uint32_t meminfo;
-	efm32_v2_di_miscchip_s miscchip;
-	memset(&miscchip, 0, sizeof(efm32_v2_di_miscchip_s) / sizeof(char));
+	efm32_v2_di_miscchip_s miscchip = {0};
 
 	switch (di_version) {
-	case 2:
-		meminfo = target_mem_read32(t, EFM32_V2_DI_MEMINFO);
+	case 2: {
+		const uint32_t meminfo = target_mem_read32(t, EFM32_V2_DI_MEMINFO);
 		miscchip.pincount = (meminfo >> 16U) & 0xffU;
 		miscchip.pkgtype = (meminfo >> 8U) & 0xffU;
 		miscchip.tempgrade = (meminfo >> 0U) & 0xffU;
+	}
 	}
 
 	return miscchip;

--- a/src/target/lpc43xx.c
+++ b/src/target/lpc43xx.c
@@ -204,6 +204,7 @@
 #define LPC43x0_SPIFI_FRAME_OPCODE_3B_ADDR (4U << 21U)
 #define LPC43x0_SPIFI_FRAME_OPCODE_4B_ADDR (5U << 21U)
 #define LPC43x0_SPIFI_FRAME_MASK           0x00e00000U
+#define LPC43x0_SPIFI_FRAME_SHIFT          21U
 #define LPC43x0_SPIFI_OPCODE_SHIFT         24U
 #define LPC43x0_SPIFI_STATUS_CMD_ACTIVE    (1U << 1U)
 #define LPC43x0_SPIFI_STATUS_RESET         (1U << 4U)
@@ -834,7 +835,7 @@ static void lpc43x0_ssp0_setup_command(target_s *const t, const uint32_t command
 	/* Start by sending the command opcode byte */
 	lpc43x0_ssp0_transfer(t, (command >> 24U) & 0xffU);
 	/* Next, if the command has an address, deal with that */
-	const uint8_t address_bytes = ((command & LPC43x0_SPIFI_FRAME_MASK) >> 21U) - 1U;
+	const uint8_t address_bytes = (command & SPI_FLASH_OPCODE_MODE_MASK) == SPI_FLASH_OPCODE_3B_ADDR ? 3U : 0U;
 	for (size_t i = 0; i < address_bytes; ++i) {
 		const size_t shift = (address_bytes - (i + 1U)) * 8U;
 		lpc43x0_ssp0_transfer(t, (address >> shift) & 0xffU);

--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -267,6 +267,10 @@ static bool lpc546xx_cmd_write_sector(target_s *t, int argc, const char **argv)
 			return false;
 
 		uint8_t *buf = calloc(1, sector_size);
+		if (!buf) { /* calloc failed: heap exhaustion */
+			DEBUG_ERROR("calloc: failed in %s\n", __func__);
+			return false;
+		}
 		for (uint32_t i = 0; i < sector_size; i++)
 			buf[i] = i & 0xffU;
 

--- a/src/target/sfdp.c
+++ b/src/target/sfdp.c
@@ -72,7 +72,7 @@ static spi_parameters_s sfdp_read_basic_parameter_table(
 	const size_t table_length = MIN(sizeof(sfdp_basic_parameter_table_s), length);
 	spi_read(target, SPI_FLASH_CMD_READ_SFDP, address, &parameter_table, table_length);
 
-	spi_parameters_s result;
+	spi_parameters_s result = {0};
 	result.capacity = sfdp_memory_density_to_capacity_bits(parameter_table.memory_density) >> 3U;
 	for (size_t i = 0; i < SFDP_ERASE_TYPES; ++i) {
 		erase_parameters_s *erase_type = &parameter_table.erase_types[i];

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -280,6 +280,10 @@ bool stm32g0_probe(target_s *t)
 
 	/* Save private storage */
 	stm32g0_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
+	if (!priv_storage) { /* calloc failed: heap exhaustion */
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
+		return false;
+	}
 	t->target_storage = priv_storage;
 	priv_storage->irreversible_enabled = false;
 

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -199,6 +199,10 @@ bool stm32h7_probe(target_s *target)
 
 	/* Save private storage */
 	stm32h7_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
+	if (!priv_storage) { /* calloc failed: heap exhaustion */
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
+		return false;
+	}
 	priv_storage->dbg_cr = target_mem_read32(target, DBGMCU_CR);
 	target->target_storage = priv_storage;
 

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -283,7 +283,7 @@ bool target_flash_write(target_s *target, target_addr_t dest, const void *src, s
 
 		/* Early exit if any of the flushing and cleanup steps above failed */
 		if (!result)
-			break;
+			return false;
 
 		const target_addr_t local_end_addr = MIN(dest + len, flash->start + flash->length);
 		const target_addr_t local_length = local_end_addr - dest;
@@ -291,7 +291,7 @@ bool target_flash_write(target_s *target, target_addr_t dest, const void *src, s
 		result &= flash_buffered_write(flash, dest, src, local_length);
 		if (!result) {
 			DEBUG_ERROR("Write failed at %" PRIx32 "\n", dest);
-			break;
+			return false;
 		}
 
 		dest = local_end_addr;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR came about by trying `-fanalyzer` on BMDA and seeing what fell out. In this PR we fix several missing pieces of error handling around allocations, and some logic errors the analyser found resulting in buggy behaviour on a couple of targets and some UB.

While we have not been able to test all of the results, this should be a low-risk set of changes, and definitely solves an issue seen with LPC43x0 targets.

We did not address /all/ lints this compiler option produces yet as a couple of the lints being produced are rather complicated to address. This means there will be a follow-up PR at some future point to look into the remaining lints.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
