### PR TITLE
gdb_packet: include stdbool.h

### DIFF
--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -23,6 +23,7 @@
 
 #include <stddef.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #define GDB_PACKET_START              '$'
 #define GDB_PACKET_END                '#'


### PR DESCRIPTION
## Detailed description

A recent change to gdb_set_noackmode() caused it to get a `bool` as an argument. However, in order to use this in a standard C compiler, you must include <stdbool.h>.

Add this include file.

This fixes the build for Farpatch.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
