### PR TITLE
stm32l4.c: Fix RAM size argument to some target_add_ram()

### DIFF
--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -584,9 +584,9 @@ static bool stm32l4_attach(target_s *const t)
 	target_mem_map_free(t);
 	/* And rebuild the RAM map */
 	if (device->family == STM32L4_FAMILY_L55x)
-		target_add_ram(t, 0x0a000000, device->sram1 + device->sram2);
+		target_add_ram(t, 0x0a000000, (device->sram1 + device->sram2) * 1024U);
 	else
-		target_add_ram(t, 0x10000000, device->sram2);
+		target_add_ram(t, 0x10000000, device->sram2 * 1024U);
 	target_add_ram(t, 0x20000000, stm32l4_main_sram_length(t));
 
 	const uint16_t flash_len = stm32l4_flash_read16(t, FLASHSIZE);


### PR DESCRIPTION
The device->sram1 and device->sram2 are in kilobyte. A multiplication by 1024 is required when used as an argument to target_add_ram()

<!-- Filling this template is mandatory -->

## Detailed description
Discord 2023-07-26:
@jcamdr: The patch multiply some RAM size by 1024U, because I can't understand how it can possibly work without that.
@dragonmux: ah, that is indeed a bug re the missing `* 1024U`'s

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
