### PR TITLE
Feature: probe scan cleanup

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -143,15 +143,16 @@ void bmp_read_product_version(libusb_device_descriptor_s *device_descriptor, lib
 	char *start_of_version = strrchr(*product, ' ');
 	if (start_of_version == NULL) {
 		*version = NULL;
-	} else {
-		while (start_of_version[0] == ' ' && start_of_version != *product)
-			--start_of_version;
-		start_of_version[1] = '\0';
-		start_of_version += 2;
-		while (start_of_version[0] == ' ')
-			++start_of_version;
-		*version = strdup(start_of_version);
+		return;
 	}
+
+	while (start_of_version[0] == ' ' && start_of_version != *product)
+		--start_of_version;
+	start_of_version[1] = '\0';
+	start_of_version += 2;
+	while (start_of_version[0] == ' ')
+		++start_of_version;
+	*version = strdup(start_of_version);
 }
 
 /*

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -138,11 +138,11 @@ void bmp_read_product_version(libusb_device_descriptor_s *device_descriptor, lib
 	(void)device;
 	(void)serial;
 	(void)manufacturer;
-	char *start_of_version;
 	*product = get_device_descriptor_string(handle, device_descriptor->iProduct);
-	start_of_version = strrchr(*product, ' ');
+
+	char *start_of_version = strrchr(*product, ' ');
 	if (start_of_version == NULL) {
-		version = NULL;
+		*version = NULL;
 	} else {
 		while (start_of_version[0] == ' ' && start_of_version != *product)
 			--start_of_version;

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -5,7 +5,7 @@
  * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
  * Written by Sid Price <sid@sidprice.com>
  * Written by Rachel Mant <git@dragonmux.network>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -96,9 +96,8 @@ bmp_type_t get_type_from_vid_pid(const uint16_t probe_vid, const uint16_t probe_
 
 void bmp_ident(bmp_info_s *info)
 {
-	DEBUG_INFO("Black Magic Debug App %s\n for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP, "
-			   "J-Link and FTDI (MPSSE)\n",
-		FIRMWARE_VERSION);
+	DEBUG_INFO("Black Magic Debug App " FIRMWARE_VERSION "\n for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP, "
+			   "J-Link and FTDI (MPSSE)\n");
 	if (info && info->vid && info->pid) {
 		DEBUG_INFO("Using %04x:%04x %s %s\n %s %s\n", info->vid, info->pid,
 			(info->serial[0]) ? info->serial : NO_SERIAL_NUMBER, info->manufacturer, info->product, info->version);

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -117,8 +117,13 @@ void libusb_exit_function(bmp_info_s *info)
 static char *get_device_descriptor_string(libusb_device_handle *handle, uint16_t string_index)
 {
 	char read_string[128] = {0};
-	if (string_index != 0)
-		libusb_get_string_descriptor_ascii(handle, string_index, (uint8_t *)read_string, sizeof(read_string));
+	if (string_index != 0) {
+		const int result =
+			libusb_get_string_descriptor_ascii(handle, string_index, (uint8_t *)read_string, sizeof(read_string));
+		if (result < LIBUSB_SUCCESS)
+			DEBUG_ERROR(
+				"%s: Failed to read string from device (%d): %s\n", __func__, result, libusb_error_name(result));
+	}
 	return strdup(read_string);
 }
 

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -100,8 +100,8 @@ void bmp_ident(bmp_info_s *info)
 			   "J-Link and FTDI (MPSSE)\n",
 		FIRMWARE_VERSION);
 	if (info && info->vid && info->pid) {
-		DEBUG_INFO("Using %04x:%04x %s %s\n %s\n", info->vid, info->pid,
-			(info->serial[0]) ? info->serial : NO_SERIAL_NUMBER, info->manufacturer, info->product);
+		DEBUG_INFO("Using %04x:%04x %s %s\n %s %s\n", info->vid, info->pid,
+			(info->serial[0]) ? info->serial : NO_SERIAL_NUMBER, info->manufacturer, info->product, info->version);
 	}
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

While testing an unrelated change set, we realised that the BMDA identification banner that's displayed was showing a duff output for the probe selected. This PR addresses this by properly sorting out how that output is generated and cleaning up some loose ends in the BMD firmware product and version string handling to help identify when things are going wrong.

The result changes
```
❯ src/blackmagic -s 8BB20695 -tv 1
Black Magic Debug App v1.9.0-1056-g95e768be
 for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP, J-Link and FTDI (MPSSE)
Using 1d50:6018 8BB20695 Black Magic Probe (Black Magic Debug)

```
to displaying
```
❯ src/blackmagic -s 8BB20695 -tv 1
Black Magic Debug App v1.9.0-1062-gf35b2403
 for Black Magic Probe, ST-Link v2 and v3, CMSIS-DAP, J-Link and FTDI (MPSSE)
Using 1d50:6018 8BB20695 Black Magic Debug
 Black Magic Probe v1.9.0-1023-g717ace3f-dirty
```

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
