### PR TITLE
Fix: BMDA J-Link set frequency regression

### DIFF
--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -494,7 +494,7 @@ static bool jlink_set_interface_frequency(const uint8_t interface, const uint32_
 		divisor = interface_frequency->min_divisor;
 
 	/* Get the approximate frequency we'll actually be running at, convert to kHz in the process */
-	const uint16_t frequency_khz = (interface_frequency->base / interface_frequency->current_divisor) / 1000U;
+	const uint16_t frequency_khz = (interface_frequency->base / divisor) / 1000U;
 
 	if (!jlink_simple_request_16(JLINK_CMD_INTERFACE_SET_FREQUENCY_KHZ, frequency_khz, NULL, 0))
 		return false;

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -106,8 +106,8 @@ bool jlink_simple_request_32(
  * In SWD mode, the `tms` buffer represents direction states and
  * the `tdi` buffer represents SWDIO data to send to the device
  *
- * RM08001 Reference manual for J-Link USB Protocol 
- * §5.5.12 EMU_CMD_HW_JTAG3 
+ * RM08001 Reference manual for J-Link USB Protocol
+ * §5.5.12 EMU_CMD_HW_JTAG3
  */
 bool jlink_transfer(const uint16_t clock_cycles, const uint8_t *const tms, const uint8_t *const tdi, uint8_t *const tdo)
 {
@@ -367,7 +367,7 @@ static bool jlink_get_interfaces(void)
 	if (!jlink_simple_request_8(JLINK_CMD_INTERFACE_GET, JLINK_INTERFACE_GET_AVAILABLE, buffer, sizeof(buffer)))
 		return false;
 
-	/* available_interfaces is a 32bit bitfield/mask */
+	/* Available_interfaces is a 32bit bitfield/mask */
 	jlink.available_interfaces = read_le4(buffer, 0);
 
 	/* Print the available interfaces, marking the selected one, and unsuported ones */
@@ -397,7 +397,10 @@ static bool jlink_get_interface_frequency(const uint8_t interface)
 	if (!jlink_interface_available(interface))
 		return false;
 
-	/* If the base frequency is non-zero, we've already read the frequency info for the requested interface and can skip the query */
+	/*
+	 * If the base frequency is non-zero, we've already read the frequency info
+	 * for the requested interface and can skip the query
+	 */
 	if (jlink.interface_frequency[interface].base != 0U)
 		return true;
 
@@ -405,7 +408,10 @@ static bool jlink_get_interface_frequency(const uint8_t interface)
 	const uint8_t selected_interface = jlink_selected_interface();
 
 	if (selected_interface != interface) {
-		/* If the selected interface doesn't match the requested interface, select it, let's hope this doesn't mess something up elsewhere */
+		/*
+		 * If the selected interface doesn't match the requested interface, select it,
+		 * let's hope this doesn't mess something up elsewhere
+		 */
 		DEBUG_WARN("Trying to get frequency for interface %s but it is not selected, selecting it\n",
 			jlink_interface_to_string(interface));
 
@@ -424,7 +430,10 @@ static bool jlink_get_interface_frequency(const uint8_t interface)
 	interface_frequency->base = read_le4(buffer, JLINK_INTERFACE_BASE_FREQUENCY_OFFSET);
 	interface_frequency->min_divisor = read_le2(buffer, JLINK_INTERFACE_MIN_DIV_OFFSET);
 
-	/* This is an assumption, if the J-Link was configured before we started, this may not be true, but we have no way to know */
+	/*
+	 * This is an assumption, if the J-Link was configured before we started,
+	 * this may not be true, but we have no way to know
+	 */
 	interface_frequency->current_divisor = interface_frequency->min_divisor;
 
 	DEBUG_INFO("%s interface frequency:\n\tBase frequency: %uHz\n\tMinimum divisor: %u\n",
@@ -459,7 +468,10 @@ static bool jlink_set_interface_frequency(const uint8_t interface, const uint32_
 	const uint8_t selected_interface = jlink_selected_interface();
 
 	if (selected_interface != interface) {
-		/* If the selected interface doesn't match the requested interface, select it, let's hope this doesn't mess something up elsewhere */
+		/*
+		 * If the selected interface doesn't match the requested interface, select it,
+		 * let's hope this doesn't mess something up elsewhere
+		 */
 		DEBUG_WARN("Trying to set frequency for interface %s but it is not selected, selecting it\n",
 			jlink_interface_to_string(interface));
 
@@ -537,7 +549,7 @@ static bool jlink_kickstart_power(void)
 
 static bool jlink_set_kickstart_power(const bool enable)
 {
-	/* 
+	/*
 	 * Kickstart power is a 5V 300mA supply that can be used to power targets
 	 * Exposed on pin 19 of the J-Link 20 pin connector
 	 */

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -304,7 +304,7 @@ static bool jlink_get_version(void)
 
 		jlink.hw_version = read_le4(buffer, 0);
 
-		DEBUG_INFO("Hardware version: %s v%u.%u.%u\n",
+		DEBUG_INFO("Hardware version: %s v%" PRIu32 ".%" PRIu32 ".%" PRIu32 "\n",
 			jlink_hw_type_to_string(JLINK_HARDWARE_VERSION_TYPE(jlink.hw_version)),
 			JLINK_HARDWARE_VERSION_MAJOR(jlink.hw_version), JLINK_HARDWARE_VERSION_MINOR(jlink.hw_version),
 			JLINK_HARDWARE_VERSION_REVISION(jlink.hw_version));
@@ -436,7 +436,7 @@ static bool jlink_get_interface_frequency(const uint8_t interface)
 	 */
 	interface_frequency->current_divisor = interface_frequency->min_divisor;
 
-	DEBUG_INFO("%s interface frequency:\n\tBase frequency: %uHz\n\tMinimum divisor: %u\n",
+	DEBUG_INFO("%s interface frequency:\n\tBase frequency: %" PRIu32 "Hz\n\tMinimum divisor: %u\n",
 		jlink_interface_to_string(interface), interface_frequency->base, interface_frequency->min_divisor);
 
 #if 0

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -504,7 +504,7 @@ bool platform_target_get_power(void)
 
 uint32_t platform_target_voltage_sense(void)
 {
-	uint32_t targetVoltage = 0;
+	uint32_t target_voltage = 0;
 
 	switch (info.bmp_type) {
 	case BMP_TYPE_BMP: {
@@ -513,14 +513,14 @@ uint32_t platform_target_voltage_sense(void)
 			uint32_t units = 0;
 			uint32_t tenths = 0;
 			sscanf(result, "%" PRIu32 ".%" PRIu32, &units, &tenths);
-			targetVoltage = (units * 10U) + tenths;
+			target_voltage = (units * 10U) + tenths;
 		}
 		break;
 	}
 
 #if HOSTED_BMP_ONLY == 0
 	case BMP_TYPE_JLINK:
-		targetVoltage = jlink_target_voltage_sense();
+		target_voltage = jlink_target_voltage_sense();
 		break;
 #endif
 
@@ -528,7 +528,7 @@ uint32_t platform_target_voltage_sense(void)
 		break;
 	}
 
-	return targetVoltage;
+	return target_voltage;
 }
 
 void platform_buffer_flush(void)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

While testing an unrelated patch set with our LPC-Link 2 running the J-Link firmware, we discovered a firmware-crashing regression from Perigoso's PR #1570 which revolves around how the adaptor frequency is set.

This PR addresses this and a couple of clang-tidy and naming lints spotted along the way.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
