### PR TITLE
Fix: ADIv5 debug bringup reliability

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -714,7 +714,7 @@ adiv5_access_port_s *adiv5_new_ap(adiv5_debug_port_s *dp, uint8_t apsel)
 		return NULL;
 	tmpap.csw = adiv5_ap_read(&tmpap, ADIV5_AP_CSW);
 	// XXX: We might be able to use the type field in ap->idr to determine if the AP supports TrustZone
-	tmpap.csw &= ~(ADIV5_AP_CSW_SIZE_MASK | ADIV5_AP_CSW_ADDRINC_MASK | ADIV5_AP_CSW_HNOSEC);
+	tmpap.csw &= ~(ADIV5_AP_CSW_SIZE_MASK | ADIV5_AP_CSW_ADDRINC_MASK | ADIV5_AP_CSW_MTE | ADIV5_AP_CSW_HNOSEC);
 	tmpap.csw |= ADIV5_AP_CSW_DBGSWENABLE;
 
 	if (tmpap.csw & ADIV5_AP_CSW_TRINPROG) {

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -49,10 +49,7 @@
  * "AP Identification types for an AP designed by Arm"
  * §C1.3 pg146. This defines a AHB3 AP when the class value is 8
  */
-#define ARM_AP_TYPE_AHB  1U
-#define ARM_AP_TYPE_APB  3U
-#define ARM_AP_TYPE_AXI  4U
-#define ARM_AP_TYPE_AHB5 5U
+#define ARM_AP_TYPE_AHB3 1U
 
 /* ROM table CIDR values */
 #define CIDR0_OFFSET 0xff0U /* DBGCID0 */
@@ -971,7 +968,7 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp, const uint32_t idcode)
 		lpc55_dmap_probe(ap);
 
 		/* Try to prepare the AP if it seems to be a AHB (memory) AP */
-		if (!ap->apsel && (ap->idr & 0xfU) == ARM_AP_TYPE_AHB) {
+		if (!ap->apsel && ADIV5_AP_IDR_CLASS(ap->idr) == 8U && ADIV5_AP_IDR_TYPE(ap->idr) == ARM_AP_TYPE_AHB3) {
 			if (!cortexm_prepare(ap))
 				DEBUG_WARN("adiv5: Failed to prepare AP, results may be unpredictable\n");
 		}

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -46,7 +46,7 @@
 #define ADIV5_SWD_TO_JTAG_SELECT_SEQUENCE 0xe73cU /* 16 bits, LSB (MSB: 0x3ce7) */
 #define ADIV5_JTAG_TO_SWD_SELECT_SEQUENCE 0xe79eU /* 16 bits, LSB (MSB: 0x79e7) */
 
-/* 
+/*
  * ADIv5 Selection Alert sequence
  * This sequence is sent MSB first and can be represented as either:
  * - 0x49cf9046 a9b4a161 97f5bbc7 45703d98 transmitted MSB first
@@ -156,7 +156,10 @@
 #define ADIV5_AP_CSW_MASTERTYPE_DEBUG (1U << 29U)
 #define ADIV5_AP_CSW_HPROT1           (1U << 25U)
 #define ADIV5_AP_CSW_SPIDEN           (1U << 23U)
-/* Bits 22:12 - Reserved */
+/* Bits 22:16 - Reserved */
+/* Bit 15 - MTE (Memory Tagging Enable) for AXI busses */
+#define ADIV5_AP_CSW_MTE (1U << 15U)
+/* Bits 14:12 - Reserved */
 /* Bits 11:8 - Mode, must be zero */
 #define ADIV5_AP_CSW_TRINPROG       (1U << 7U)
 #define ADIV5_AP_CSW_DEVICEEN       (1U << 6U)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

During the process of building target support for the Ambiq Apollo 3, Sid wound up hitting and issue where the debug reset code in the ADIv5 implementation would cause the target to quit talking SWD or JTAG till power cycled, preventing scan from working.

After working with zyp, mubes and Sid and reading the ADIv5 spec closely, we have come to the conclusion that we can get the effect of the reset sequence logic by instead powering down the debug engine on the target, then powering it back up. This is guaranteed by the spec for targets that actually implement power control on the APs and debug bus to cause the APs and debug bus to come back up via a reset, getting the same net effect as the prior logic.

This has been tested on a couple of different targets including the STM32F411, LPC4370 and Apollo 3, and appears to be reliable, with the AP bringup code mopping up the only potential stale values this can cause for targets that don't implement power control.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
