### PR TITLE
Fix: reword vMustReplyEmpty comment

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -698,7 +698,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 	} else {
 		/*
 		 * The vMustReplyEmpty is used as a feature test to check how gdbserver handles
-		 * unknown packets print only actually unknown packets
+		 * unknown packets, don't print an error message for it.
 		 */
 		if (strcmp(packet, "vMustReplyEmpty") != 0)
 			DEBUG_GDB("*** Unsupported packet: %s\n", packet);


### PR DESCRIPTION
In a recent commit this comment got auto formatted, making it make slightly less sense, reword it

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] ~~It builds for hardware native (`make PROBE_HOST=native`)~~
* [ ] ~~It builds as BMDA (`make PROBE_HOST=hosted`)~~
* [ ] ~~I've tested it to the best of my ability~~
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
