### PR TITLE
Fix: CMSIS-DAP WAIT handling

### DIFF
--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -67,8 +67,6 @@ static void dap_dispatch_status(adiv5_debug_port_s *const dp, const dap_transfer
 	case DAP_TRANSFER_OK:
 		break;
 	case DAP_TRANSFER_WAIT:
-		DEBUG_ERROR("Access resulted in wait, aborting\n");
-		dp->abort(dp, ADIV5_DP_ABORT_DAPABORT);
 		dp->fault = status;
 		break;
 	case DAP_TRANSFER_FAULT:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a bug found while tracing another bug in the GD32F1/STM32F1 handling. We encountered this issue while using ORBTrace.

With the `dp->abort()` call present, it screws up state on CMSIS-DAP and results in a no-scan situation due to the target generating FAULT and getting angry at us.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
