### PR TITLE
Fix: STM32F1 load regression

### DIFF
--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -34,6 +34,7 @@ ifeq ($(ASAN), 1)
         CFLAGS += -Wno-format-truncation
     endif
     LDFLAGS += -fsanitize=address
+    OPT_FLAGS += -g
 endif
 
 HIDAPILIB = hidapi

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -120,9 +120,9 @@ static void stm32f1_add_flash(target_s *target, uint32_t addr, size_t length, si
 	flash->start = addr;
 	flash->length = length;
 	flash->blocksize = erasesize;
+	flash->writesize = 1024U;
 	flash->erase = stm32f1_flash_erase;
 	flash->write = stm32f1_flash_write;
-	flash->writesize = erasesize;
 	flash->erased = 0xff;
 	target_add_flash(target, flash);
 }

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -363,12 +363,10 @@ bool at32fxx_probe(target_s *target)
 }
 
 /*
-   mm32l0 flash write
-   On stm32, 16-bit writes use bits 0:15 for even halfwords; bits 16:31 for odd halfwords.
-   On mm32 cortex-m0, 16-bit writes always use bits 0:15.
-   Set both halfwords to the same value, works on both stm32 and mm32.
-*/
-
+ * On STM32, 16-bit writes use bits 0:15 for even halfwords; bits 16:31 for odd halfwords.
+ * On MM32 cortex-m0, 16-bit writes always use bits 0:15.
+ * Set both halfwords to the same value, works on both STM32 and NN32.
+ */
 void mm32l0_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {
 	uint32_t odest = dest;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -652,6 +652,7 @@ static bool stm32f1_flash_erase(target_flash_s *flash, target_addr_t addr, size_
 {
 	target_s *target = flash->t;
 	target_addr_t end = addr + length - 1U;
+	DEBUG_TARGET("%s: at %08" PRIx32 "\n", __func__, addr);
 
 	/* Unlocked an appropriate flash bank */
 	if ((target->part_id == 0x430U && end >= FLASH_BANK_SPLIT && !stm32f1_flash_unlock(target, FLASH_BANK2_OFFSET)) ||
@@ -685,6 +686,7 @@ static bool stm32f1_flash_write(target_flash_s *flash, target_addr_t dest, const
 {
 	target_s *target = flash->t;
 	const size_t offset = stm32f1_bank1_length(dest, len);
+	DEBUG_TARGET("%s: at %08" PRIx32 " for %zu bytes\n", __func__, dest, len);
 
 	/* Start by writing any bank 1 data */
 	if (offset) {

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -333,7 +333,7 @@ static bool at32f43_detect(target_s *target, const uint16_t part_id)
 	 * Out of 640 KB SRAM present on silicon, at least 128 KB are always
 	 * dedicated to "zero-wait-state Flash". ZW region is limited by
 	 * specific part flash capacity (for 256, 448 KB) or at 512 KB.
-	 * AT32F435ZMT default EOPB0=0xffff05fa, 
+	 * AT32F435ZMT default EOPB0=0xffff05fa,
 	 * EOPB[0:2]=0b010 for 384 KB SRAM + 256 KB zero-wait-state flash.
 	 */
 	target->driver = "AT32F435";
@@ -460,14 +460,13 @@ bool mm32l0xx_probe(target_s *target)
 /* Identify MM32 devices (Cortex-M3, Star-MC1) */
 bool mm32f3xx_probe(target_s *target)
 {
-	uint32_t mm32_id;
-	const char *name = "?";
+	const char *name;
 	size_t flash_kbyte = 0;
 	size_t ram1_kbyte = 0; /* ram at 0x20000000 */
 	size_t ram2_kbyte = 0; /* ram at 0x30000000 */
 	size_t block_size = 0x400U;
 
-	mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32F3);
+	const uint32_t mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32F3);
 	if (target_check_error(target)) {
 		DEBUG_ERROR("mm32f3xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32F3);
 		return false;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -468,7 +468,7 @@ bool mm32f3xx_probe(target_s *target)
 
 	const uint32_t mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32F3);
 	if (target_check_error(target)) {
-		DEBUG_ERROR("mm32f3xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32F3);
+		DEBUG_ERROR("%s: read error at 0x%" PRIx32 "\n", __func__, (uint32_t)DBGMCU_IDCODE_MM32F3);
 		return false;
 	}
 	switch (mm32_id) {
@@ -487,7 +487,7 @@ bool mm32f3xx_probe(target_s *target)
 	case 0xffffffffU:
 		return false;
 	default:
-		DEBUG_WARN("mm32f3xx_probe: unknown mm32 dev_id 0x%" PRIx32 "\n", mm32_id);
+		DEBUG_WARN("%s: unknown mm32 ID code 0x%" PRIx32 "\n", __func__, mm32_id);
 		return false;
 	}
 	target->part_id = mm32_id & 0xfffU;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -426,7 +426,7 @@ bool mm32l0xx_probe(target_s *target)
 
 	const uint32_t mm32_id = target_mem_read32(target, DBGMCU_IDCODE_MM32L0);
 	if (target_check_error(target)) {
-		DEBUG_ERROR("mm32l0xx_probe: read error at 0x%" PRIx32 "\n", (uint32_t)DBGMCU_IDCODE_MM32L0);
+		DEBUG_ERROR("%s: read error at 0x%" PRIx32 "\n", __func__, (uint32_t)DBGMCU_IDCODE_MM32L0);
 		return false;
 	}
 	switch (mm32_id) {
@@ -444,7 +444,7 @@ bool mm32l0xx_probe(target_s *target)
 	case 0xffffffffU:
 		return false;
 	default:
-		DEBUG_WARN("mm32l0xx_probe: unknown mm32 dev_id 0x%" PRIx32 "\n", mm32_id);
+		DEBUG_WARN("%s: unknown mm32 dev_id 0x%" PRIx32 "\n", __func__, mm32_id);
 		return false;
 	}
 	target->part_id = mm32_id & 0xfffU;

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -64,7 +64,6 @@ static bool target_enter_flash_mode(target_s *target)
 
 	if (result == true)
 		target->flash_mode = true;
-
 	return result;
 }
 
@@ -81,7 +80,6 @@ static bool target_exit_flash_mode(target_s *target)
 		target_reset(target);
 
 	target->flash_mode = false;
-
 	return result;
 }
 
@@ -130,7 +128,6 @@ static bool flash_done(target_flash_s *flash)
 
 	/* Mark the Flash as idle again */
 	flash->operation = FLASH_OPERATION_NONE;
-
 	return result;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR does some cleanup and addresses a regression found while trying to debug dragonBoot on BMP.

When attempting to `load` firmware in GDB on a target and the firmware winds up containing 0x04 somewhere, the revised GDB packet handling from #1361, the packet state machine incorrectly interprets this as a GDB end of transmission packet, and aborts, causing the BMD GDB main loop to run target_detach() and enter idle mode.

The packet handling should only be considering 0x04 characters received while in the idle state for being EOT packets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
