### PR TITLE
Feature: reduced JTAG devices table Fflash usage

### DIFF
--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -28,9 +28,12 @@ const jtag_dev_descr_s dev_descr[] = {
 	{
 		.idcode = 0x0ba00477U,
 		.idmask = 0x0fff0fffU,
+#ifdef ENABLE_DEBUG
 		.descr = "ADIv5 JTAG-DP port.",
+#endif
 		.handler = adiv5_jtag_dp_handler,
 	},
+#ifdef ENABLE_DEBUG
 	{
 		.idcode = 0x00000477U,
 		.idmask = 0x00000fffU,
@@ -101,16 +104,20 @@ const jtag_dev_descr_s dev_descr[] = {
 		.idmask = 0xffffffffU,
 		.descr = "NXP: LPC17xx family.",
 	},
+#endif
 	{
 		.idcode = 0x00000093U,
 		.idmask = 0x00000fffU,
+#ifdef ENABLE_DEBUG
 		.descr = "Xilinx.",
+#endif
 		.ir_quirks =
 			{
 				.ir_length = 6U,
 				.ir_value = 1U,
 			},
 	},
+#ifdef ENABLE_DEBUG
 	{
 		.idcode = 0x0000063dU,
 		.idmask = 0x00000fffU,
@@ -147,9 +154,12 @@ const jtag_dev_descr_s dev_descr[] = {
 		.idmask = 0xffffffffU,
 		.descr = "BCM2836.",
 	},
+#endif
 	{
 		.idcode = 0U,
 		.idmask = 0U,
+#ifdef ENABLE_DEBUG
 		.descr = "Unknown",
+#endif
 	},
 };

--- a/src/target/jtag_devs.h
+++ b/src/target/jtag_devs.h
@@ -31,7 +31,9 @@ typedef struct jtag_ir_quirks {
 typedef struct jtag_dev_descr {
 	uint32_t idcode;
 	uint32_t idmask;
+#ifdef ENABLE_DEBUG
 	const char *descr;
+#endif
 	void (*handler)(uint8_t jd_index);
 	jtag_ir_quirks_s ir_quirks;
 } jtag_dev_descr_s;

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -142,8 +142,6 @@ bool jtag_scan(void)
 	for (size_t device = 0; device < jtag_dev_count; device++) {
 		for (size_t descr = 0; dev_descr[descr].idcode; descr++) {
 			if ((jtag_devs[device].jd_idcode & dev_descr[descr].idmask) == dev_descr[descr].idcode) {
-				/* Save description in table */
-				jtag_devs[device].jd_descr = dev_descr[descr].descr;
 				/* Call handler to initialise/probe device further */
 				if (dev_descr[descr].handler)
 					dev_descr[descr].handler(device);

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -30,7 +30,6 @@
 #define JTAG_MAX_IR_LEN 16U
 
 typedef struct jtag_dev {
-	const char *jd_descr;
 	uint32_t jd_idcode;
 	uint32_t current_ir;
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR seeks to improve the Flash usage of the firmware by cutting down on the amount of data in one of the largest tables built in - the JTAG devices descriptor table.

It does this in two ways: It makes the description strings (which are only used in ENABLE_DEBUG=1 builds) optional; It makes all entries in the table that are there for description purposes only, optional.

This saves 800 bytes of Flash.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
