### PR TITLE
Fix: ADIv5 DPv0 ID Codes

### DIFF
--- a/src/platforms/hosted/stlinkv2_swd.c
+++ b/src/platforms/hosted/stlinkv2_swd.c
@@ -52,7 +52,7 @@ bool stlink_swd_scan(void)
 	dp->abort = stlink_dp_abort;
 
 	adiv5_dp_error(dp);
-	adiv5_dp_init(dp, 0);
+	adiv5_dp_init(dp);
 
 	return target_list != NULL;
 }

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -813,7 +813,7 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp, const uint32_t idcode)
 	 *
 	 * for SWD-DP, we are guaranteed to be DP v1 or later.
 	 */
-	if (idcode != JTAG_IDCODE_ARM_DPv0) {
+	if ((idcode & (JTAG_IDCODE_DESIGNER_MASK | JTAG_IDCODE_PARTNO_MASK)) != JTAG_IDCODE_ARM_DPv0) {
 		const uint32_t dpidr = adiv5_dp_read_dpidr(dp);
 		if (!dpidr) {
 			DEBUG_ERROR("Failed to read DPIDR\n");

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -791,7 +791,7 @@ uint32_t adiv5_dp_read_dpidr(adiv5_debug_port_s *const dp)
 	return dpidr;
 }
 
-void adiv5_dp_init(adiv5_debug_port_s *const dp, const uint32_t idcode)
+void adiv5_dp_init(adiv5_debug_port_s *const dp)
 {
 	/*
 	 * We have to initialse the DP routines up front before any adiv5_* functions are called or
@@ -804,29 +804,6 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp, const uint32_t idcode)
 #if PC_HOSTED == 1
 	bmda_adiv5_dp_init(dp);
 #endif
-
-	/* Check if we have a JTAG ID code and that it's a valid one */
-	if (idcode & 1U) {
-		/*
-		 * We do, so this is a JTAG DP. Let's pull out the designer and part codes then.
-		 *
-		 * Start by pulling out the designer code which will be used to attempt to
-		 * detect a DPv0 DP. This will get overriden later by DPIDR if the DP turns out
-		 * to be DPv1+.
-		 */
-		const uint16_t designer = (idcode & JTAG_IDCODE_DESIGNER_MASK) >> JTAG_IDCODE_DESIGNER_OFFSET;
-		/*
-		 * Now extract the part number and sort out the designer code.
-		 * The JTAG ID code designer is in the form:
-		 * Bits 10:7 - JEP-106 Continuation Code
-		 * Bits 6:0 - JEP-106 Identity Code
-		 * So here we convert that into our internal representation.
-		 * See the JEP-106 code list (jep106.h) for more on that.
-		 */
-		dp->designer_code =
-			((designer & ADIV5_DP_DESIGNER_JEP106_CONT_MASK) << 1U) | (designer & ADIV5_DP_DESIGNER_JEP106_CODE_MASK);
-		dp->partno = (idcode & JTAG_IDCODE_PARTNO_MASK) >> JTAG_IDCODE_PARTNO_OFFSET;
-	}
 
 	/*
 	 * Start by assuming DP v1 or later.

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -784,7 +784,7 @@ uint32_t adiv5_dp_read_dpidr(adiv5_debug_port_s *const dp)
 	volatile uint32_t dpidr = 0;
 	volatile exception_s e;
 	TRY_CATCH (e, EXCEPTION_ALL) {
-		dpidr = adiv5_dp_read(dp, ADIV5_DP_DPIDR);
+		dpidr = adiv5_dp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_DPIDR, 0U);
 	}
 	if (e.type)
 		return 0;

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -894,14 +894,21 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp, const uint32_t idcode)
 		return;
 	}
 
+	platform_timeout_s timeout;
+	platform_timeout_set(&timeout, 250);
+
 	/* Start by resetting the DP contol state so the debug domain powers down */
 	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, 0U);
 	uint32_t status = ADIV5_DP_CTRLSTAT_CSYSPWRUPACK | ADIV5_DP_CTRLSTAT_CDBGPWRUPACK;
 	/* Wait for the acknowledgements to go low */
-	while (status & (ADIV5_DP_CTRLSTAT_CSYSPWRUPACK | ADIV5_DP_CTRLSTAT_CDBGPWRUPACK))
+	while (status & (ADIV5_DP_CTRLSTAT_CSYSPWRUPACK | ADIV5_DP_CTRLSTAT_CDBGPWRUPACK)) {
 		status = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT);
+		if (platform_timeout_is_expired(&timeout)) {
+			DEBUG_WARN("adiv5: power-down failed\n");
+			break;
+		}
+	}
 
-	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 201);
 	/* Write request for system and debug power up */
 	adiv5_dp_write(dp, ADIV5_DP_CTRLSTAT, ADIV5_DP_CTRLSTAT_CSYSPWRUPREQ | ADIV5_DP_CTRLSTAT_CDBGPWRUPREQ);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -208,7 +208,7 @@
 #define JTAG_IDCODE_DESIGNER_OFFSET 1U
 #define JTAG_IDCODE_DESIGNER_MASK   (0x7ffU << JTAG_IDCODE_DESIGNER_OFFSET)
 
-#define JTAG_IDCODE_ARM_DPv0 UINT32_C(0x4ba00477)
+#define JTAG_IDCODE_ARM_DPv0 UINT32_C(0x0ba00476)
 
 /* Constants to make RnW parameters more clear in code */
 #define ADIV5_LOW_WRITE 0

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -208,7 +208,8 @@
 #define JTAG_IDCODE_DESIGNER_OFFSET 1U
 #define JTAG_IDCODE_DESIGNER_MASK   (0x7ffU << JTAG_IDCODE_DESIGNER_OFFSET)
 
-#define JTAG_IDCODE_ARM_DPv0 UINT32_C(0x0ba00476)
+#define JTAG_IDCODE_ARM_DPv0    UINT32_C(0x0ba00476)
+#define JTAG_IDCODE_PARTNO_DPv0 0xba00U
 
 /* Constants to make RnW parameters more clear in code */
 #define ADIV5_LOW_WRITE 0

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -208,7 +208,6 @@
 #define JTAG_IDCODE_DESIGNER_OFFSET 1U
 #define JTAG_IDCODE_DESIGNER_MASK   (0x7ffU << JTAG_IDCODE_DESIGNER_OFFSET)
 
-#define JTAG_IDCODE_ARM_DPv0    UINT32_C(0x0ba00476)
 #define JTAG_IDCODE_PARTNO_DPv0 0xba00U
 
 /* Constants to make RnW parameters more clear in code */
@@ -368,7 +367,7 @@ static inline uint32_t adiv5_dp_recoverable_access(adiv5_debug_port_s *dp, uint8
 	return result;
 }
 
-void adiv5_dp_init(adiv5_debug_port_s *dp, uint32_t idcode);
+void adiv5_dp_init(adiv5_debug_port_s *dp);
 void bmda_adiv5_dp_init(adiv5_debug_port_s *dp);
 adiv5_access_port_s *adiv5_new_ap(adiv5_debug_port_s *dp, uint8_t apsel);
 void remote_jtag_dev(const jtag_dev_s *jtag_dev);

--- a/src/target/adiv5_jtag.c
+++ b/src/target/adiv5_jtag.c
@@ -57,7 +57,8 @@ void adiv5_jtag_dp_handler(const uint8_t dev_index)
 	bmda_jtag_dp_init(dp);
 #endif
 
-	if (jtag_devs[dev_index].jd_idcode == JTAG_IDCODE_ARM_DPv0)
+	if ((jtag_devs[dev_index].jd_idcode & (JTAG_IDCODE_PARTNO_MASK | JTAG_IDCODE_DESIGNER_MASK)) ==
+		JTAG_IDCODE_ARM_DPv0)
 		adiv5_dp_error(dp);
 	else
 		adiv5_dp_abort(dp, ADIV5_DP_ABORT_STKERRCLR);

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -55,7 +55,7 @@ uint8_t make_packet_request(uint8_t RnW, uint16_t addr)
 
 static void swd_line_reset_sequence(const bool idle_cycles)
 {
-	/* 
+	/*
 	 * A line reset is achieved by holding the SWDIOTMS HIGH for at least 50 SWCLKTCK cycles, followed by at least two idle cycles
 	 * Note: in some non-conformant devices (STM32) at least 51 HIGH cycles and/or 3/4 idle cycles are required
 	 *
@@ -82,12 +82,12 @@ static void dormant_to_swd_sequence()
 	swd_proc.seq_out(ADIV5_SELECTION_ALERT_SEQUENCE_1, 32U);
 	swd_proc.seq_out(ADIV5_SELECTION_ALERT_SEQUENCE_2, 32U);
 	swd_proc.seq_out(ADIV5_SELECTION_ALERT_SEQUENCE_3, 32U);
-	/* 
+	/*
 	 * We combine the last two sequences in a single seq_out as an optimization
 	 *
 	 * Send 4 SWCLKTCK cycles with SWDIOTMS LOW
 	 * Send the required 8 bit activation code sequence on SWDIOTMS
-	 * 
+	 *
 	 * The bits are shifted out to the right, so we shift the second sequence left by the size of the first sequence
 	 * The first sequence is 4 bits and the second 8 bits, totaling 12 bits in the combined sequence
 	 */
@@ -180,7 +180,7 @@ bool adiv5_swd_scan(const uint32_t targetid)
 		 * ARM Debug Interface Architecture Specification, ADIv5.0 to ADIv5.2. ARM IHI 0031C
 		 *
 		 * §4.2.6 Limitations of multi-drop
-		 * 
+		 *
 		 * It is not possible to interrogate a multi-drop Serial Wire Debug system that includes multiple devices to establish
 		 * which devices are connected. Because all devices are selected on coming out of a line reset, no communication with
 		 * a device is possible without prior selection of that target using its target ID. Therefore, connection to a multi-drop
@@ -244,7 +244,7 @@ bool adiv5_swd_scan(const uint32_t targetid)
 		adiv5_swd_multidrop_scan(dp, dp_targetid);
 	else {
 		adiv5_dp_abort(dp, ADIV5_DP_ABORT_STKERRCLR);
-		adiv5_dp_init(dp, 0);
+		adiv5_dp_init(dp);
 	}
 
 	return target_list != NULL;
@@ -254,12 +254,12 @@ bool adiv5_swd_scan(const uint32_t targetid)
  * ARM Debug Interface Architecture Specification, ADIv5.0 to ADIv5.2. ARM IHI 0031C
  *
  * §4.2.6 Limitations of multi-drop
- * 
+ *
  * Each device must be configured with a unique target ID, that includes a 4-bit instance ID, to differentiate between
  * otherwise identical targets. This places a limit of 16 such targets in any system, and means that identical devices
  * must be configured before they are connected together to ensure that their instance IDs do not conflict.
  * Auto-detection of the target
- * 
+ *
  * It is not possible to interrogate a multi-drop Serial Wire Debug system that includes multiple devices to establish
  * which devices are connected. Because all devices are selected on coming out of a line reset, no communication with
  * a device is possible without prior selection of that target using its target ID. Therefore, connection to a multi-drop
@@ -267,7 +267,7 @@ bool adiv5_swd_scan(const uint32_t targetid)
  * - The host has prior knowledge of the devices in the system and is configured before target connection.
  * - The host attempts auto-detection by issuing a target select command for each of the devices it has been
  * configured to support.
- * 
+ *
  * This means that debug tools cannot connect seamlessly to targets in a multi-drop Serial Wire Debug system that they
  * have never seen before. However, if the debug tools can be provided with the target ID of such targets by the user
  * then the contents of the target can be auto-detected as normal.
@@ -286,7 +286,7 @@ void adiv5_swd_multidrop_scan(adiv5_debug_port_s *const dp, const uint32_t targe
 		 * conditions are met:
 		 * Bits [31:28] match bits [31:28] in the DLPIDR. (i.e. the instance ID matches)
 		 * Bits [27:0] match bits [27:0] in the TARGETID register.
-		 * Writing any other value deselects the target. 
+		 * Writing any other value deselects the target.
 		 * During the response phase of a write to the TARGETSEL register, the target does not drive the line
 		 */
 
@@ -317,7 +317,7 @@ void adiv5_swd_multidrop_scan(adiv5_debug_port_s *const dp, const uint32_t targe
 
 		/* Yield the target DP to adiv5_dp_init */
 		adiv5_dp_abort(target_dp, ADIV5_DP_ABORT_STKERRCLR);
-		adiv5_dp_init(target_dp, 0);
+		adiv5_dp_init(target_dp);
 	}
 
 	/* free the initial DP */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the STM32MP15x having a JTAG ID of 0x6ba00477 indicating a DPv0 TAP, and an ADIv5 non-compliance issue the part has which results in it hanging in the new power down code in adiv5_dp_init().

The latter is caused by the control and status register hanging at the value 0xa0000000 forever contrary to how the acknowledgement bits are supposed to work according to the ADIv5 spec.

@Perigoso given your experience with ADIv5, please check our logic regarding the ID code part of this fix.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
