### PR TITLE
Fix morse new null msg

### DIFF
--- a/src/include/morse.h
+++ b/src/include/morse.h
@@ -23,7 +23,7 @@
 
 #include <stdbool.h>
 
-extern const char *morse_msg;
+extern volatile const char *morse_msg;
 
 void morse(const char *msg, bool repeat);
 bool morse_update(void);

--- a/src/morse.c
+++ b/src/morse.c
@@ -53,9 +53,9 @@ static const struct {
 	{0b0000010101110111, 14}, // 'Z' --..
 };
 
-const char *morse_msg = NULL;
+volatile const char *morse_msg = NULL;
 static volatile size_t msg_index = SIZE_MAX;
-static bool morse_repeat = false;
+static volatile bool morse_repeat = false;
 
 void morse(const char *const msg, const bool repeat)
 {

--- a/src/morse.c
+++ b/src/morse.c
@@ -65,7 +65,7 @@ void morse(const char *const msg, const bool repeat)
 	(void)repeat;
 #else
 	morse_msg = msg;
-	msg_index = 0;
+	msg_index = msg ? 0 : SIZE_MAX;
 	morse_repeat = repeat;
 #endif
 }

--- a/src/morse.c
+++ b/src/morse.c
@@ -64,9 +64,9 @@ void morse(const char *const msg, const bool repeat)
 		DEBUG_WARN("%s\n", msg);
 	(void)repeat;
 #else
-	morse_msg = msg;
-	msg_index = msg ? 0 : SIZE_MAX;
 	morse_repeat = repeat;
+	msg_index = msg ? 0 : SIZE_MAX;
+	morse_msg = msg;
 #endif
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
Discord 2023-08-02
jcamdr: I can't understand how a morse(NULL, false) can work without dereferencing a NULL pointer inside morse_update() after a morse() with a string.
dragonmux: good catch, that's because it does dereference NULL under that circumstance
jcamdr: Is there any possible atomic issue with morse_msg and morse_index between morse() and morse_update() on some plateform?
dragonmux: technically, yes. morse() should update those 3 variables in exactly the opposite order to how they are currently
that is, morse_repeat, then msg_index then morse_msg. that'll guarantee the update, while not atomic, will apply correctly and do sensible things
jcamdr: Fully agree. All 3 variables probably need to be volatile AFAIK.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
