### PR TITLE
riscv: Check if hw reset worked, if not do a DM reset

### DIFF
--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -848,6 +848,7 @@ static void riscv_reset(target_s *const target)
 	}
 	/* Acknowledge the reset */
 	riscv_dm_write(hart->dbg_module, RV_DM_CONTROL, hart->hartsel | RV_DM_CTRL_HART_ACK_RESET);
+	riscv_halt_request(target);
 	target_check_error(target);
 }
 


### PR DESCRIPTION
## Detailed description

If the board does not have a hw reset pin (or  misconfigured or does not work), and without RV_TOPT_INHIBIT_NRST,
the riscv_reset relies entirely on the hw reset and ignores errors.

As a result the board can be not reset and behave weirdly.

The MR tries to detect the HW reset failed (riscv_dm_poll_state timeout) and if so, tries to do a system reset through DM.

With that MR i can use the "r" gdb command to restart the system properly without explicitly disabling the HW reset
(i dont have it on my board)


## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

