### PR TITLE
Fix: warning pedantic range expr

### DIFF
--- a/src/include/target.h
+++ b/src/include/target.h
@@ -69,8 +69,8 @@ size_t target_regs_size(target_s *target);
 const char *target_regs_description(target_s *target);
 void target_regs_read(target_s *target, void *data);
 void target_regs_write(target_s *target, const void *data);
-ssize_t target_reg_read(target_s *target, int reg, void *data, size_t max);
-ssize_t target_reg_write(target_s *target, int reg, const void *data, size_t size);
+ssize_t target_reg_read(target_s *target, uint32_t reg, void *data, size_t max);
+ssize_t target_reg_write(target_s *target, uint32_t reg, const void *data, size_t size);
 
 /* Halt/resume functions */
 typedef enum target_halt_reason {

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -279,32 +279,36 @@ static const char *adiv5_arm_ap_type_string(const uint8_t ap_type, const uint8_t
 	 * table C1-2 "AP Identification types for an AP designed by Arm"
 	 */
 
-	switch (ap_type) {
-	case 0x1U:
-		return "AHB3-AP";
-	case 0x2U:
-		return "APB2/3-AP";
-	/* 0x3 is not defined */
-	case 0x4U:
-		return "AXI3/4-AP";
-	case 0x5U:
-		return "AHB5-AP";
-	case 0x6U:
-		return "APB4/5-AP";
-	case 0x7U:
-		return "AXI5-AP";
-	case 0x8U:
-		return "AHB5-AP";
-	case 0U:
-		/* Type 0 APs are determined by the class code */
-		if (ap_class == 0U)
-			return "JTAG-AP";
-		if (ap_class == 1U)
-			return "COM-AP";
-	/* fall through */
-	default:
-		return "Unknown";
+	/* All types except 0 are only valid for ap_class == 0x8 */
+	if (ap_class == 0x8U || ap_type == 0U) {
+		switch (ap_type) {
+		case 0U:
+			/* Type 0 APs are determined by the class code */
+			if (ap_class == 0U)
+				return "JTAG-AP";
+			if (ap_class == 1U)
+				return "COM-AP";
+			break;
+		case 0x1U:
+			return "AHB3-AP";
+		case 0x2U:
+			return "APB2/3-AP";
+		/* 0x3 is not defined */
+		case 0x4U:
+			return "AXI3/4-AP";
+		case 0x5U:
+			return "AHB5-AP";
+		case 0x6U:
+			return "APB4/5-AP";
+		case 0x7U:
+			return "AXI5-AP";
+		case 0x8U:
+			return "AHB5-AP";
+		default:
+			break;
+		}
 	}
+	return "Unknown";
 }
 
 static const char *adiv5_cid_class_string(const cid_class_e cid_class)

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -48,8 +48,8 @@ static void cortexa_regs_read(target_s *t, void *data);
 static void cortexa_regs_write(target_s *t, const void *data);
 static void cortexa_regs_read_internal(target_s *t);
 static void cortexa_regs_write_internal(target_s *t);
-static ssize_t cortexa_reg_read(target_s *t, int reg, void *data, size_t max);
-static ssize_t cortexa_reg_write(target_s *t, int reg, const void *data, size_t max);
+static ssize_t cortexa_reg_read(target_s *t, uint32_t reg, void *data, size_t max);
+static ssize_t cortexa_reg_write(target_s *t, uint32_t reg, const void *data, size_t max);
 
 static void cortexa_reset(target_s *t);
 static target_halt_reason_e cortexa_halt_poll(target_s *t, target_addr_t *watch);
@@ -607,28 +607,26 @@ static void cortexa_regs_write(target_s *t, const void *data)
 	memcpy(&priv->reg_cache, data, t->regs_size);
 }
 
-static ssize_t ptr_for_reg(target_s *t, int reg, void **r)
+static ssize_t ptr_for_reg(target_s *t, uint32_t reg, void **r)
 {
 	cortexa_priv_s *priv = (cortexa_priv_s *)t->priv;
-	switch (reg) {
-	case 0 ... 15:
+	if (reg <= 15U) { /* 0 .. 15 */
 		*r = &priv->reg_cache.r[reg];
-		return 4;
-	case 16:
+		return 4U;
+	} else if (reg == 16U) { /* 16 */
 		*r = &priv->reg_cache.cpsr;
-		return 4;
-	case 17:
+		return 4U;
+	} else if (reg == 17U) { /* 17 */
 		*r = &priv->reg_cache.fpscr;
-		return 4;
-	case 18 ... 33:
-		*r = &priv->reg_cache.d[reg - 18];
-		return 8;
-	default:
-		return -1;
+		return 4U;
+	} else if (reg <= 33U) { /* 18 .. 33 */
+		*r = &priv->reg_cache.d[reg - 18U];
+		return 8U;
 	}
+	return -1;
 }
 
-static ssize_t cortexa_reg_read(target_s *t, int reg, void *data, size_t max)
+static ssize_t cortexa_reg_read(target_s *t, uint32_t reg, void *data, size_t max)
 {
 	void *r = NULL;
 	size_t s = ptr_for_reg(t, reg, &r);
@@ -638,7 +636,7 @@ static ssize_t cortexa_reg_read(target_s *t, int reg, void *data, size_t max)
 	return s;
 }
 
-static ssize_t cortexa_reg_write(target_s *t, int reg, const void *data, size_t max)
+static ssize_t cortexa_reg_write(target_s *t, uint32_t reg, const void *data, size_t max)
 {
 	void *r = NULL;
 	size_t s = ptr_for_reg(t, reg, &r);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -90,8 +90,8 @@ static const char *cortexm_regs_description(target_s *t);
 static void cortexm_regs_read(target_s *t, void *data);
 static void cortexm_regs_write(target_s *t, const void *data);
 static uint32_t cortexm_pc_read(target_s *t);
-static ssize_t cortexm_reg_read(target_s *t, int reg, void *data, size_t max);
-static ssize_t cortexm_reg_write(target_s *t, int reg, const void *data, size_t max);
+static ssize_t cortexm_reg_read(target_s *t, uint32_t reg, void *data, size_t max);
+static ssize_t cortexm_reg_write(target_s *t, uint32_t reg, const void *data, size_t max);
 
 static void cortexm_reset(target_s *t);
 static target_halt_reason_e cortexm_halt_poll(target_s *t, target_addr_t *watch);
@@ -996,7 +996,7 @@ static int dcrsr_regnum(target_s *t, unsigned reg)
 	return -1;
 }
 
-static ssize_t cortexm_reg_read(target_s *t, int reg, void *data, size_t max)
+static ssize_t cortexm_reg_read(target_s *t, uint32_t reg, void *data, size_t max)
 {
 	if (max < 4U)
 		return -1;
@@ -1006,7 +1006,7 @@ static ssize_t cortexm_reg_read(target_s *t, int reg, void *data, size_t max)
 	return 4U;
 }
 
-static ssize_t cortexm_reg_write(target_s *t, int reg, const void *data, size_t max)
+static ssize_t cortexm_reg_write(target_s *t, uint32_t reg, const void *data, size_t max)
 {
 	if (max < 4U)
 		return -1;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -293,14 +293,14 @@ bool target_mem_access_needs_halt(target_s *t)
 }
 
 /* Register access functions */
-ssize_t target_reg_read(target_s *t, int reg, void *data, size_t max)
+ssize_t target_reg_read(target_s *t, uint32_t reg, void *data, size_t max)
 {
 	if (t->reg_read)
 		return t->reg_read(t, reg, data, max);
 	return 0;
 }
 
-ssize_t target_reg_write(target_s *t, int reg, const void *data, size_t size)
+ssize_t target_reg_write(target_s *t, uint32_t reg, const void *data, size_t size)
 {
 	if (t->reg_write)
 		return t->reg_write(t, reg, data, size);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -117,8 +117,8 @@ struct target {
 	const char *(*regs_description)(target_s *target);
 	void (*regs_read)(target_s *target, void *data);
 	void (*regs_write)(target_s *target, const void *data);
-	ssize_t (*reg_read)(target_s *target, int reg, void *data, size_t max);
-	ssize_t (*reg_write)(target_s *target, int reg, const void *data, size_t size);
+	ssize_t (*reg_read)(target_s *target, uint32_t reg, void *data, size_t max);
+	ssize_t (*reg_write)(target_s *target, uint32_t reg, const void *data, size_t size);
 
 	/* Halt/resume functions */
 	void (*reset)(target_s *target);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This one was missed from the initial batch

Fix (some) warnings for `-Wpedantic`

See #1590 for context

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
