### PR TITLE
Fix: cmsis_dap: error when writing long buffers to DAP (>59 bytes)

### DIFF
--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -193,7 +193,7 @@ bool perform_dap_transfer_block_write(
 
 	dap_transfer_block_response_write_s response;
 	/* Run the request having set up the request buffer */
-	if (!dap_run_cmd(&request, 5U + (block_count * 4U), &response, sizeof(response)))
+	if (!dap_run_cmd(&request, DAP_CMD_BLOCK_WRITE_HDR_LEN + (block_count * 4U), &response, sizeof(response)))
 		return false;
 
 	/* Check the response over */

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -117,11 +117,15 @@ typedef struct dap_transfer_block_request_write {
 	uint8_t data[256][4];
 } dap_transfer_block_request_write_s;
 
+#define DAP_CMD_BLOCK_WRITE_HDR_LEN offsetof(dap_transfer_block_request_write_s, data)
+
 typedef struct dap_transfer_block_response_read {
 	uint8_t count[2];
 	uint8_t status;
 	uint8_t data[256][4];
 } dap_transfer_block_response_read_s;
+
+#define DAP_CMD_BLOCK_READ_HDR_LEN offsetof(dap_transfer_block_response_read_s, data)
 
 typedef struct dap_transfer_block_response_write {
 	uint8_t count[2];


### PR DESCRIPTION
## Detailed description

Without this fix, dap_mem_write() accounts for write buffer header size incorrectly when calculating `blocks_per_transfer`. Long transfers (via HID) fail with error "Attempted to make over-long request of 66 bytes, max length is 65".

Sample stack trace from where this error is triggered:

<details><summary>Click for a a sample stack trace where this error is triggered.</summary>

```
0  dbg_dap_cmd_hid (request_data=request_data@entry=0x7fffffffc103 "\006", request_length=request_length@entry=65, 
    response_data=response_data@entry=0x7fffffffc077 "", response_length=65) at platforms/hosted/cmsis_dap.c:383
#1  0x000055555557930d in dap_run_cmd_raw (response_length=3, response_data=0x7fffffffc100 "\377\377\377\006", request_length=65, 
    request_data=0x7fffffffc103 "\006") at platforms/hosted/cmsis_dap.c:447
#2  dap_run_cmd (request_data=0x7fffffffc103, request_length=request_length@entry=65, response_data=response_data@entry=0x7fffffffc100, 
    response_length=response_length@entry=3) at platforms/hosted/cmsis_dap.c:469
#3  0x000055555557a322 in perform_dap_transfer_block_write (target_dp=0x5555555cd260, reg=reg@entry=13 '\r', 
    block_count=block_count@entry=15, blocks=blocks@entry=0x7fffffffc568) at platforms/hosted/dap_command.c:196
#4  0x0000555555579aac in dap_write_block (target_ap=target_ap@entry=0x5555555cc570, dest=dest@entry=536870916, src=<optimized out>, 
    src@entry=0x5555555e0100, len=len@entry=60, align=align@entry=ALIGN_WORD) at platforms/hosted/dap.c:299
#5  0x0000555555578761 in dap_mem_write (align=ALIGN_WORD, len=256, src=0x5555555e0100, dest=536870916, ap=0x5555555cc570)
    at platforms/hosted/cmsis_dap.c:540
#6  dap_mem_write (ap=0x5555555cc570, dest=536870916, src=0x5555555e0100, len=256, align=ALIGN_WORD) at platforms/hosted/cmsis_dap.c:513
#7  0x00005555555773fa in target_mem_write (t=t@entry=0x5555555d7a50, dest=<optimized out>, src=src@entry=0x5555555e0100, 
    len=len@entry=256) at target/target.c:282
#8  0x000055555556cab1 in rp_spi_xfer (target=0x5555555d7a50, command=<optimized out>, address=0, wr_buf=0x5555555e0100 "", wr_len=256, 
    rd_buf=rd_buf@entry=0x0, rd_len=0) at target/rp.c:459
#9  0x000055555556cb6e in rp_spi_write (target=<optimized out>, command=<optimized out>, address=<optimized out>, buffer=<optimized out>, 
    length=<optimized out>) at target/rp.c:550
#10 0x000055555556fd45 in bmp_spi_flash_write (flash=0x5555555cd7c0, dest=<optimized out>, src=0x5555555e0100, length=4096)
    at target/spi.c:198
#11 0x0000555555577c5c in flash_buffered_flush (flash=0x5555555cd7c0) at target/target_flash.c:206
#12 flash_buffered_flush (flash=0x5555555cd7c0) at target/target_flash.c:191
#13 0x0000555555577f44 in flash_buffered_write (len=64, src=0x5555555a34b5 <pbuf+917>, dest=268439552, flash=0x5555555cd7c0)
    at target/target_flash.c:224
#14 target_flash_write (target=0x5555555d7a50, dest=268438656, src=0x5555555a3135 <pbuf+21>, len=len@entry=960)
    at target/target_flash.c:288
#15 0x0000555555564030 in handle_v_packet (plen=1024, packet=0x5555555a3120 <pbuf> "vFlashWrite:10000c80:\233\030\006\232bD\232B")
    at gdb_main.c:678
#16 gdb_main_loop (tc=tc@entry=0x5555555a23e0 <gdb_controller>, 
    pbuf=pbuf@entry=0x5555555a3120 <pbuf> "vFlashWrite:10000c80:\233\030\006\232bD\232B", pbuf_size=pbuf_size@entry=1024, 
    size=<optimized out>, in_syscall=in_syscall@entry=false) at gdb_main.c:358
#17 0x0000555555564156 in gdb_main (pbuf=pbuf@entry=0x5555555a3120 <pbuf> "vFlashWrite:10000c80:\233\030\006\232bD\232B", 
    pbuf_size=pbuf_size@entry=1024, size=<optimized out>) at gdb_main.c:735
#18 0x000055555555b842 in bmp_poll_loop () at main.c:69
#19 main (argc=<optimized out>, argv=<optimized out>) at main.c:85
```

(Note the calling rp.c target here is different code to "main", but the trigger is just calling `target_mem_write` with a large-ish length value.)

</details>

Includes some refactoring to try and wrap these header sizes in constants.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

Thanks for all your work on the Black Magic project! :)