### PR TITLE
target: Add missing braces to array of struct initializers.

### DIFF
--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -322,7 +322,7 @@ static uint8_t imxrt_spi_build_insn_sequence(target_s *const target, const uint1
 		slot = 0;
 
 	/* Build a new microcode sequence to run */
-	imxrt_flexspi_lut_insn_s sequence[8] = {0};
+	imxrt_flexspi_lut_insn_s sequence[8] = {{0}};
 	/* Start by writing the command opcode to the Flash */
 	sequence[0].opcode_mode = IMXRT_FLEXSPI_LUT_OPCODE(IMXRT_FLEXSPI_LUT_OP_COMMAND) | IMXRT_FLEXSPI_LUT_MODE_SERIAL;
 	sequence[0].value = command & SPI_FLASH_OPCODE_MASK;

--- a/src/target/stm32g0.c
+++ b/src/target/stm32g0.c
@@ -691,7 +691,7 @@ static void stm32g0_display_registers(target_s *t)
  */
 static bool stm32g0_cmd_option(target_s *t, int argc, const char **argv)
 {
-	option_register_s options_req[OPT_REG_COUNT] = {0};
+	option_register_s options_req[OPT_REG_COUNT] = {{0}};
 
 	if (argc == 2 && strcasecmp(argv[1], "erase") == 0) {
 		if (t->part_id == STM32C011 || t->part_id == STM32C031)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Two of the targets are using single braces to initialize arrays of structs, and this fails on my compiler:

```
  CC      target/imxrt.c
 GEN      include/version.h
  CC      target/stm32g0.c
target/imxrt.c:325:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
        imxrt_flexspi_lut_insn_s sequence[8] = {0};
                                                ^
                                                {}
1 error generated.
make: *** [imxrt.o] Error 1
make: *** Waiting for unfinished jobs....
target/stm32g0.c:694:50: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
        option_register_s options_req[OPT_REG_COUNT] = {0};
                                                        ^
                                                        {}
1 error generated.
make: *** [stm32g0.o] Error 1
make: *** wait: No child processes.  Stop.
```

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
