### PR TITLE
Fixes for CMSIS_DAP

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -475,7 +475,7 @@ static ssize_t dap_run_cmd_raw(const uint8_t *const request_data, const size_t r
 	const size_t result = (size_t)response;
 
 	DEBUG_WIRE("response: ");
-	for (size_t i = 0; i < result; i++)
+	for (size_t i = 0; i < response_length + 1; i++)
 		DEBUG_WIRE("%02x ", data[i]);
 	DEBUG_WIRE("\n");
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -325,6 +325,13 @@ dap_version_s dap_adaptor_version(const dap_info_e version_kind)
 	if (!end)
 		return version;
 	version.minor = minor;
+
+	if (minor > 9 ) {
+        /* Version 1.1.0 is encoded as 1.10 on MCU-Link firmware V2.250 */
+		version.minor = minor / 10;
+		version.revision = minor % 10;
+		return version;
+	}
 	/* Check if it's worth trying to convert anything more */
 	if ((size_t)(end - version_str) >= version_length || end[0] != '.')
 		return version;

--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -67,7 +67,7 @@ bool dap_swd_init(adiv5_debug_port_s *target_dp)
 	/* Mark that we're going into SWD mode and configure the CMSIS-DAP adaptor accordingly */
 	dap_disconnect();
 	dap_mode = DAP_CAP_SWD;
-	dap_swd_configure(DAP_SWD_TURNAROUND_1_CYCLE, DAP_SWD_FAULT_ALWAYS_DATA_PHASE);
+	dap_swd_configure(DAP_SWD_TURNAROUND_1_CYCLE, DAP_SWD_FAULT_NO_DATA_PHASE);
 	dap_connect();
 	dap_reset_link(target_dp);
 

--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -248,7 +248,7 @@ static uint32_t dap_swd_clear_error(adiv5_debug_port_s *const target_dp, const b
 		 * into the expected state.
 		 */
 		dap_line_reset();
-		if (target_dp->version >= 2)
+		if (dap_has_swd_sequence && target_dp->version >= 2)
 			dap_write_reg_no_check(ADIV5_DP_TARGETSEL, target_dp->targetsel);
 		dap_read_reg(target_dp, ADIV5_DP_DPIDR);
 		/* Exception here is unexpected, so do not catch */


### PR DESCRIPTION
main with MCU-Link V3.108 with a DPV2 target prints tons of error message. MCU-Link V2.250 does not find aDPV2 target

-  Fix decoding of the MCU-Link V2.250 version string
- Provide code for waking up from dormant state for CMSIS-DAP < V1.2
- Do not use dap_write_reg_no_check if adapter does provides swd_sequence
- Configure for DAP_SWD_FAULT_NO_DATA_PHASE
-  Handle turnaround with dap_swd_seq_in and dap_swd_seq_out_parity for >= V1.2 devices
- Use raw sequences in multidrop_scan when transaction will fail for most tries or transaction does not send acknowledge by design


## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
