### PR TITLE
Feature: Soft start for target power on BMP

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -37,12 +37,15 @@
 #include <libopencm3/stm32/adc.h>
 #include <libopencm3/stm32/spi.h>
 #include <libopencm3/stm32/flash.h>
+#include <libopencm3/stm32/timer.h>
 
 static void adc_init(void);
 static void setup_vbus_irq(void);
 
 /* This is defined by the linker script */
 extern char vector_table;
+
+#define TPWR_SOFT_START_STEPS 64U
 
 /*
  * Starting with hardware version 4 we are storing the hardware version in the
@@ -149,8 +152,10 @@ void platform_init(void)
 	rcc_periph_clock_enable(RCC_USB);
 	rcc_periph_clock_enable(RCC_GPIOA);
 	rcc_periph_clock_enable(RCC_GPIOB);
-	if (hwversion >= 6)
+	if (hwversion >= 6) {
 		rcc_periph_clock_enable(RCC_GPIOC);
+		rcc_periph_clock_enable(RCC_TIM1);
+	}
 	rcc_periph_clock_enable(RCC_AFIO);
 	rcc_periph_clock_enable(RCC_CRC);
 
@@ -206,6 +211,36 @@ void platform_init(void)
 	} else if (hwversion > 1) {
 		gpio_set(PWR_BR_PORT, PWR_BR_PIN);
 		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_OPENDRAIN, PWR_BR_PIN);
+	}
+
+	/* Configure Timer 1 Channel 3N to allow tpwr to be soft start on hw6 */
+	if (hwversion >= 6) {
+		/* The pin mapping is a secondary mapping for the pin. We need to enable that. */
+		gpio_primary_remap(AFIO_MAPR_SWJ_CFG_FULL_SWJ, AFIO_MAPR_TIM1_REMAP_PARTIAL_REMAP);
+		/*
+		 * Configure Timer 1 to run the the power control pin PWM and switch the timer on
+		 * NB: We don't configure the pin mode here but rather we configure it to the alt-mode and back in
+		 * platform_target_set_power() below due to GD32 errata involving PB2 (AUX serial LED).
+		 * See §3.7.6 of the GD32F103 Compatability Summary for details.
+		 */
+		timer_set_mode(TIM1, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
+		/* Use PWM mode 1 so that the signal generated is low till it exceeds the set value */
+		timer_set_oc_mode(TIM1, TIM_OC3, TIM_OCM_PWM1);
+		/* Mark the output active-low due to how this drives the target pin */
+		timer_set_oc_polarity_low(TIM1, TIM_OC3N);
+		timer_enable_oc_output(TIM1, TIM_OC3N);
+		timer_set_oc_value(TIM1, TIM_OC3, 0);
+		/* Make sure dead-time is switched off as this interferes with the correct waveform generation */
+		timer_set_deadtime(TIM1, 0);
+		/*
+		 * Configure for 64 steps which also makes this output a 562.5kHz PWM signal
+		 * given the lack of prescaling and being a peripheral on APB1 (36MHz)
+		 */
+		timer_set_period(TIM1, TPWR_SOFT_START_STEPS - 1U);
+		timer_enable_break_main_output(TIM1);
+		timer_continuous_mode(TIM1);
+		timer_update_on_overflow(TIM1);
+		timer_enable_counter(TIM1);
 	}
 
 	if (hwversion >= 5) {
@@ -272,12 +307,42 @@ bool platform_target_get_power(void)
 	return false;
 }
 
+static inline void platform_wait_pwm_cycle()
+{
+	while (!timer_get_flag(TIM1, TIM_SR_UIF))
+		continue;
+	timer_clear_flag(TIM1, TIM_SR_UIF);
+}
+
 bool platform_target_set_power(const bool power)
 {
 	if (platform_hwversion() <= 0)
 		return false;
-
+	/* If we're on hw6 or newer, and are turning the power on */
+	if (platform_hwversion() >= 6 && power) {
+		/* Configure the pin to be driven by the timer */
+		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, PWR_BR_PIN);
+		timer_clear_flag(TIM1, TIM_SR_UIF);
+		/* Wait for one PWM cycle to have taken place */
+		platform_wait_pwm_cycle();
+		/* Soft start power on the target */
+		for (size_t step = 1U; step < TPWR_SOFT_START_STEPS; ++step) {
+			/* Set the new PWM value */
+			timer_set_oc_value(TIM1, TIM_OC3, step);
+			/* Wait for one PWM cycle to have taken place */
+			platform_wait_pwm_cycle();
+		}
+	}
+	/* Set the pin state */
 	gpio_set_val(PWR_BR_PORT, PWR_BR_PIN, !power);
+	/*
+	 * If we're turning power on and running hw6+, now configure the pin back over to GPIO and
+	 * reset state timer for the next request
+	 */
+	if (platform_hwversion() >= 6 && power) {
+		gpio_set_mode(PWR_BR_PORT, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_OPENDRAIN, PWR_BR_PIN);
+		timer_set_oc_value(TIM1, TIM_OC3, 0U);
+	}
 	return true;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address an issue with target power bring-up that has come about on BMP v2.3b hardware. During bring-up with targets that have a heavy capacitive load, the power supply on BMP winds up dropping below the brown-out threshold and on recovering, shoots way up to 4.5V before coming back down into regulation.

This results in dangerous conditions for the processor that could lead to damage, and for the target to which we're attached. To fix this, this PR implements power-on soft start using PWM to gradually bring the target's power rail up and charge the capacitors without causing problems on our own power supply. This is accomplished with a high frequency (1.125MHz) pulse train and 32 steps from "off" to fully "on".

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1567
