### PR TITLE
Feature: Add LED feedback for USB enumeration

### DIFF
--- a/src/platforms/common/stm32/timing_stm32.c
+++ b/src/platforms/common/stm32/timing_stm32.c
@@ -21,6 +21,7 @@
 #include "general.h"
 #include "platform.h"
 #include "morse.h"
+#include "usb.h"
 
 #include <libopencm3/cm3/systick.h>
 #include <libopencm3/cm3/nvic.h>
@@ -43,6 +44,18 @@ static uint8_t monitor_ticks = 0;
  */
 #define ADC_VREFINT_MIN 1404U
 #endif
+
+static void usb_config_morse_msg_update(void)
+{
+	if (usb_config_is_updated()) {
+		if (usb_config == 0)
+			morse("NO USB HOST.", true);
+		else
+			morse(NULL, false);
+
+		usb_config_clear_updated();
+	}
+}
 
 void platform_timing_init(void)
 {
@@ -71,6 +84,7 @@ void sys_tick_handler(void)
 	if (morse_tick >= MORSECNT) {
 		if (running_status)
 			gpio_toggle(LED_PORT, LED_IDLE_RUN);
+		usb_config_morse_msg_update();
 		SET_ERROR_STATE(morse_update());
 		morse_tick = 0;
 	} else

--- a/src/platforms/common/usb.c
+++ b/src/platforms/common/usb.c
@@ -40,6 +40,15 @@ static uint8_t usbd_control_buffer[512];
  * to fit your EP0 transactions.
  */
 
+static bool usb_config_updated = true;
+
+static void usb_config_set_updated(usbd_device *const dev, const uint16_t value)
+{
+	(void)dev;
+	(void)value;
+	usb_config_updated = true;
+}
+
 void blackmagic_usb_init(void)
 {
 	read_serial_number();
@@ -51,6 +60,7 @@ void blackmagic_usb_init(void)
 	microsoft_os_register_descriptor_sets(usbdev, microsoft_os_descriptor_sets, DESCRIPTOR_SETS);
 	usbd_register_set_config_callback(usbdev, usb_serial_set_config);
 	usbd_register_set_config_callback(usbdev, dfu_set_config);
+	usbd_register_set_config_callback(usbdev, usb_config_set_updated);
 
 	nvic_set_priority(USB_IRQ, IRQ_PRI_USB);
 	nvic_enable_irq(USB_IRQ);
@@ -64,4 +74,14 @@ uint16_t usb_get_config(void)
 void USB_ISR(void)
 {
 	usbd_poll(usbdev);
+}
+
+bool usb_config_is_updated(void)
+{
+	return usb_config_updated;
+}
+
+void usb_config_clear_updated(void)
+{
+	usb_config_updated = false;
 }

--- a/src/platforms/common/usb.h
+++ b/src/platforms/common/usb.h
@@ -58,4 +58,10 @@ void blackmagic_usb_init(void);
 /* Returns current usb configuration, or 0 if not configured. */
 uint16_t usb_get_config(void);
 
+/* Returns true if usb config has been updated. */
+bool usb_config_is_updated(void);
+
+/* Clears usb config updated flag. */
+void usb_config_clear_updated(void);
+
 #endif /* PLATFORMS_COMMON_USB_H */


### PR DESCRIPTION
## Detailed description

* Addresses #1566 (WIP).
* Monitors USB configuration state in `usb_config_morse_msg_update()` within the systick handler.
* Outputs a message using the morse subsystem (error LED) if USB is not configured.
* No patches to libopencm3 required.

Tested in the following scenarios:
1. USB host data lines disabled and then enabled
- Plug in to host USB hub with data lines disabled
  ```bash
  $ echo 1 | sudo tee /sys/bus/usb/devices/3-1.4/port/disable
   ```
  -  Result- error LED outputs morse message
- Enable data lines
  ```bash
  $ echo 0 | sudo tee /sys/bus/usb/devices/3-1.4/port/disable
  ```
  - Result- error LED turns off
2. Unbind and rebind host driver
- Plug in to USB hub with data lines enabled
  - Result- error LED is off
- Unbind host driver
  ```bash
  $ echo '3-1.4' | sudo tee /sys/bus/usb/drivers/usb/unbind
  ```
  -  Result- error LED outputs morse message
- Rebind host driver
  ```bash
  $ echo '3-1.4' | sudo tee /sys/bus/usb/drivers/usb/bind
  ```
  - Result- error LED turns off

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
