### PR TITLE
mm32: support for mm32spin05

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -435,6 +435,11 @@ bool mm32l0xx_probe(target_s *target)
 		flash_kbyte = 128;
 		ram_kbyte = 8;
 		break;
+	case 0xcc4460b1:
+		name = "MM32SPIN05";
+		flash_kbyte = 32;
+		ram_kbyte = 4;
+		break;
 	case 0xcc56a097U:
 		name = "MM32SPIN27";
 		flash_kbyte = 128;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR provides support for a new target: MindMotion MM32SPIN05 and updates documentation how to add new MindMotion MM32 processors.
```
(gdb) tar ext /dev/ttyBmpGdb
Remote debugging using /dev/ttyBmpGdb
(gdb) mon swd
Available Targets:
No. Att Driver
 1      MM32SPIN05 M0
```
### HOWTO: Add new MM32 Cortex-M0

To add support for a new MM32 Cortex-M0 processor, first check the product id at address 0x40013400.
E.g. for MM32SPIN05:
```
(gdb) mon swd
Target voltage: 
Available Targets:
No. Att Driver
*** 1   Unknown ARM Cortex-M Designer 0x43b Part ID 0x471 M0
(gdb) at 1
Attaching to Remote target
warning: No executable has been specified and target does not support
determining executable automatically.  Try using the "file" command.
warning: while parsing target memory map (at line 1): Required element <memory> is missing
0xfffffffe in ?? ()
(gdb) set mem inaccessible-by-default off
(gdb) x 0x40013400
0x40013400:	0xcc4460b1
```
then add a new case to the switch statement in file src/target/stm32f1.c, function mm32l0xx_probe() :
```
case 0xcc4460b1:
        name = "MM32SPIN05";
        flash_kbyte = 32;
        ram_kbyte = 4;
        break;
```
where flash_kbyte is the amount of flash at 0x08000000, and ram_kbyte is the amount of ram at 0x20000000.

### HOWTO: Add new MM32 Cortex-M3

To add support for a new MM32 Cortex-M3 processor, first check the product id at address 0x40007080.
E.g. for MM32F3273:
```
(gdb) mon swd
(gdb) at 1
(gdb) set mem inaccessible-by-default off
(gdb) x 0x40007080
0x40007080:	0xcc9aa0e7
```
then add a new case to the switch statement in file src/target/stm32f1.c, function mm32f3xx_probe() :
```
case 0xcc9aa0e7U:
        name = "MM32F3270";
        flash_kbyte = 512;
        ram1_kbyte = 128;
        break;
```
where flash_kbyte is the amount of flash at 0x08000000, and ram1_kbyte is the amount of ram at 0x20000000.
If the processor also has ram at 0x30000000 (e.g. STAR-MC1), set ram2_kbyte to the amount of ram at 0x30000000.

If different models exist that have the same id but different amounts of flash or ram, choose the model with the largest amount of flash or ram.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
