### PR TITLE
misc: consolidate alignment macros into single header out of adiv5

### DIFF
--- a/src/include/align.h
+++ b/src/include/align.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Written by Rafael Silva <perigoso@riseup.net>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef INCLUDE_ALIGN_H
+#define INCLUDE_ALIGN_H
+
+typedef enum align {
+	ALIGN_BYTE = 0,     /* 8 bit alignment */
+	ALIGN_HALFWORD = 1, /* 16 bit alignment */
+	ALIGN_WORD = 2,     /* 32 bit alignment */
+	ALIGN_DWORD = 3     /* 64 bit alignment */
+} align_e;
+
+#define ALIGN_OF(x)     (((x)&3U) == 0 ? ALIGN_WORD : (((x)&1U) == 0 ? ALIGN_HALFWORD : ALIGN_BYTE))
+#define MIN_ALIGN(x, y) MIN(ALIGN_OF(x), ALIGN_OF(y))
+
+#define ALIGN(x, n) (((x) + (n)-1) & ~((n)-1))
+
+#endif /* INCLUDE_ALIGN_H */

--- a/src/include/align.h
+++ b/src/include/align.h
@@ -34,13 +34,13 @@
 #define INCLUDE_ALIGN_H
 
 typedef enum align {
-	ALIGN_BYTE = 0,     /* 8 bit alignment */
-	ALIGN_HALFWORD = 1, /* 16 bit alignment */
-	ALIGN_WORD = 2,     /* 32 bit alignment */
-	ALIGN_DWORD = 3     /* 64 bit alignment */
+	ALIGN_8BIT = 0U,
+	ALIGN_16BIT = 1U,
+	ALIGN_32BIT = 2U,
+	ALIGN_64BIT = 3U,
 } align_e;
 
-#define ALIGN_OF(x)     (((x)&3U) == 0 ? ALIGN_WORD : (((x)&1U) == 0 ? ALIGN_HALFWORD : ALIGN_BYTE))
+#define ALIGN_OF(x)     (((x)&3U) == 0 ? ALIGN_32BIT : (((x)&1U) == 0 ? ALIGN_16BIT : ALIGN_8BIT))
 #define MIN_ALIGN(x, y) MIN(ALIGN_OF(x), ALIGN_OF(y))
 
 #define ALIGN(x, n) (((x) + (n)-1) & ~((n)-1))

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -45,6 +45,7 @@
 #include "maths_utils.h"
 #include "timing.h"
 #include "platform_support.h"
+#include "align.h"
 
 #ifndef ARRAY_LENGTH
 #define ARRAY_LENGTH(arr) (sizeof(arr) / sizeof((arr)[0]))
@@ -104,7 +105,6 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #define DEBUG_WIRE(...)   debug_wire(__VA_ARGS__)
 #endif
 
-#define ALIGN(x, n) (((x) + (n)-1) & ~((n)-1))
 #undef MIN
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #undef MAX

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -486,13 +486,11 @@ bool dap_run_cmd(const void *const request_data, const size_t request_length, vo
 	return (size_t)result >= response_length;
 }
 
-#define ALIGNOF(x) (((x)&3) == 0 ? ALIGN_WORD : (((x)&1) == 0 ? ALIGN_HALFWORD : ALIGN_BYTE))
-
 static void dap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
 {
 	if (len == 0)
 		return;
-	align_e align = MIN(ALIGNOF(src), ALIGNOF(len));
+	const align_e align = MIN_ALIGN(src, len);
 	DEBUG_WIRE("dap_mem_read @ %" PRIx32 " len %zu, align %d\n", src, len, align);
 	/* If the read can be done in a single transaction, use the dap_read_single() fast-path */
 	if ((1U << align) == len) {

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -270,7 +270,7 @@ bool dap_read_block(
 		return false;
 	}
 
-	if (align > ALIGN_HALFWORD)
+	if (align > ALIGN_16BIT)
 		memcpy(dest, data, len);
 	else {
 		for (size_t i = 0; i < blocks; ++i) {
@@ -287,7 +287,7 @@ bool dap_write_block(
 	const size_t blocks = len >> MAX(align, 2U);
 	uint32_t data[256];
 
-	if (align > ALIGN_HALFWORD)
+	if (align > ALIGN_16BIT)
 		memcpy(data, src, len);
 	else {
 		for (size_t i = 0; i < blocks; ++i) {
@@ -336,14 +336,14 @@ static void mem_access_setup(const adiv5_access_port_s *const target_ap,
 {
 	uint32_t csw = target_ap->csw | ADIV5_AP_CSW_ADDRINC_SINGLE;
 	switch (align) {
-	case ALIGN_BYTE:
+	case ALIGN_8BIT:
 		csw |= ADIV5_AP_CSW_SIZE_BYTE;
 		break;
-	case ALIGN_HALFWORD:
+	case ALIGN_16BIT:
 		csw |= ADIV5_AP_CSW_SIZE_HALFWORD;
 		break;
-	case ALIGN_DWORD:
-	case ALIGN_WORD:
+	case ALIGN_64BIT:
+	case ALIGN_32BIT:
 		csw |= ADIV5_AP_CSW_SIZE_WORD;
 		break;
 	}

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -741,14 +741,14 @@ static void stlink_mem_write(
 		/* Now generate an appropriate access packet */
 		stlink_mem_command_s command;
 		switch (align) {
-		case ALIGN_BYTE:
+		case ALIGN_8BIT:
 			command = stlink_memory_access(STLINK_DEBUG_WRITEMEM_8BIT, addr, amount, ap->apsel);
 			break;
-		case ALIGN_HALFWORD:
+		case ALIGN_16BIT:
 			command = stlink_memory_access(STLINK_DEBUG_APIV2_WRITEMEM_16BIT, addr, amount, ap->apsel);
 			break;
-		case ALIGN_WORD:
-		case ALIGN_DWORD:
+		case ALIGN_32BIT:
+		case ALIGN_64BIT:
 			command = stlink_memory_access(STLINK_DEBUG_WRITEMEM_32BIT, addr, amount, ap->apsel);
 			break;
 		}

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -995,14 +995,14 @@ void ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align)
 	uint32_t csw = ap->csw | ADIV5_AP_CSW_ADDRINC_SINGLE;
 
 	switch (align) {
-	case ALIGN_BYTE:
+	case ALIGN_8BIT:
 		csw |= ADIV5_AP_CSW_SIZE_BYTE;
 		break;
-	case ALIGN_HALFWORD:
+	case ALIGN_16BIT:
 		csw |= ADIV5_AP_CSW_SIZE_HALFWORD;
 		break;
-	case ALIGN_DWORD:
-	case ALIGN_WORD:
+	case ALIGN_64BIT:
+	case ALIGN_32BIT:
 		csw |= ADIV5_AP_CSW_SIZE_WORD;
 		break;
 	}
@@ -1014,7 +1014,7 @@ void ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align)
 void *adiv5_unpack_data(void *const dest, const uint32_t src, const uint32_t data, const align_e align)
 {
 	switch (align) {
-	case ALIGN_BYTE: {
+	case ALIGN_8BIT: {
 		/*
 		 * Mask off the bottom 2 bits of the address to figure out which byte of data to use
 		 * then multiply that by 8 and shift the data down by the result to pick one of the 4 possible bytes
@@ -1024,7 +1024,7 @@ void *adiv5_unpack_data(void *const dest, const uint32_t src, const uint32_t dat
 		memcpy(dest, &value, sizeof(value));
 		break;
 	}
-	case ALIGN_HALFWORD: {
+	case ALIGN_16BIT: {
 		/*
 		 * Mask off the 2nd bit of the address to figure out which 16 bits of data to use
 		 * then multiply that by 8 and shift the data down by the result to pick one of the 2 possible 16-bit blocks
@@ -1034,8 +1034,8 @@ void *adiv5_unpack_data(void *const dest, const uint32_t src, const uint32_t dat
 		memcpy(dest, &value, sizeof(value));
 		break;
 	}
-	case ALIGN_DWORD:
-	case ALIGN_WORD:
+	case ALIGN_64BIT:
+	case ALIGN_32BIT:
 		/*
 		 * When using 32- or 64-bit alignment, we don't have to do anything special, just memcpy() the data to the
 		 * destination buffer (this avoids issues with unaligned writes and UB casts)
@@ -1050,7 +1050,7 @@ void *adiv5_unpack_data(void *const dest, const uint32_t src, const uint32_t dat
 const void *adiv5_pack_data(const uint32_t dest, const void *const src, uint32_t *const data, const align_e align)
 {
 	switch (align) {
-	case ALIGN_BYTE: {
+	case ALIGN_8BIT: {
 		uint8_t value;
 		/* Copy the data to pack in from the source buffer */
 		memcpy(&value, src, sizeof(value));
@@ -1058,7 +1058,7 @@ const void *adiv5_pack_data(const uint32_t dest, const void *const src, uint32_t
 		*data = (uint32_t)value << (8U * (dest & 3U));
 		break;
 	}
-	case ALIGN_HALFWORD: {
+	case ALIGN_16BIT: {
 		uint16_t value;
 		/* Copy the data to pack in from the source buffer (avoids unaligned read issues) */
 		memcpy(&value, src, sizeof(value));

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -989,8 +989,6 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp)
 	adiv5_dp_unref(dp);
 }
 
-#define ALIGNOF(x) (((x)&3U) == 0 ? ALIGN_WORD : (((x)&1U) == 0 ? ALIGN_HALFWORD : ALIGN_BYTE))
-
 /* Program the CSW and TAR for sequential access at a given width */
 void ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align)
 {
@@ -1079,10 +1077,10 @@ const void *adiv5_pack_data(const uint32_t dest, const void *const src, uint32_t
 	return (const uint8_t *)src + (1 << align);
 }
 
-void advi5_mem_read_bytes(adiv5_access_port_s *ap, void *dest, uint32_t src, size_t len)
+void advi5_mem_read_bytes(adiv5_access_port_s *const ap, void *dest, uint32_t src, size_t len)
 {
 	uint32_t osrc = src;
-	const align_e align = MIN(ALIGNOF(src), ALIGNOF(len));
+	const align_e align = MIN_ALIGN(src, len);
 
 	if (len == 0)
 		return;
@@ -1144,8 +1142,8 @@ uint32_t firmware_ap_read(adiv5_access_port_s *ap, uint16_t addr)
 	return ret;
 }
 
-void adiv5_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len)
+void adiv5_mem_write(adiv5_access_port_s *const ap, const uint32_t dest, const void *const src, const size_t len)
 {
-	align_e align = MIN(ALIGNOF(dest), ALIGNOF(len));
+	const align_e align = MIN_ALIGN(dest, len);
 	adiv5_mem_write_sized(ap, dest, src, len, align);
 }

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -219,13 +219,6 @@
 #define SWDP_ACK_FAULT       0x04U
 #define SWDP_ACK_NO_RESPONSE 0x07U
 
-typedef enum align {
-	ALIGN_BYTE = 0,
-	ALIGN_HALFWORD = 1,
-	ALIGN_WORD = 2,
-	ALIGN_DWORD = 3
-} align_e;
-
 typedef struct adiv5_access_port adiv5_access_port_s;
 typedef struct adiv5_debug_port adiv5_debug_port_s;
 

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -43,7 +43,7 @@
 #include "adiv5.h"
 
 #define SRAM_BASE        0x20000000U
-#define STUB_BUFFER_BASE ALIGN(SRAM_BASE + sizeof(efm32_flash_write_stub), 4)
+#define STUB_BUFFER_BASE ALIGN(SRAM_BASE + sizeof(efm32_flash_write_stub), 4U)
 
 static bool efm32_flash_erase(target_flash_s *f, target_addr_t addr, size_t len);
 static bool efm32_flash_write(target_flash_s *f, target_addr_t dest, const void *src, size_t len);

--- a/src/target/lmi.c
+++ b/src/target/lmi.c
@@ -31,7 +31,7 @@
 #include "cortexm.h"
 
 #define SRAM_BASE        0x20000000U
-#define STUB_BUFFER_BASE ALIGN(SRAM_BASE + sizeof(lmi_flash_write_stub), 4)
+#define STUB_BUFFER_BASE ALIGN(SRAM_BASE + sizeof(lmi_flash_write_stub), 4U)
 
 #define BLOCK_SIZE 0x400U
 

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -325,7 +325,7 @@ static bool lpc_flash_write(target_flash_s *tf, target_addr_t dest, const void *
 		DEBUG_ERROR("Prepare failed\n");
 		return false;
 	}
-	const uint32_t bufaddr = ALIGN(f->iap_ram + sizeof(iap_frame_s), 4);
+	const uint32_t bufaddr = ALIGN(f->iap_ram + sizeof(iap_frame_s), 4U);
 	target_mem_write(f->f.t, bufaddr, src, len);
 	/* Only LPC80x has reserved pages!*/
 	if (!f->reserved_pages || dest + len <= tf->length - len) {

--- a/src/target/stm32_common.h
+++ b/src/target/stm32_common.h
@@ -28,11 +28,11 @@
 static inline const char *stm32_psize_to_string(const align_e psize)
 {
 	switch (psize) {
-	case ALIGN_DWORD:
+	case ALIGN_64BIT:
 		return "x64";
-	case ALIGN_WORD:
+	case ALIGN_32BIT:
 		return "x32";
-	case ALIGN_HALFWORD:
+	case ALIGN_16BIT:
 		return "x16";
 	default:
 		return "x8";
@@ -42,13 +42,13 @@ static inline const char *stm32_psize_to_string(const align_e psize)
 static inline bool stm32_psize_from_string(target_s *t, const char *const str, align_e *psize)
 {
 	if (strcasecmp(str, "x8") == 0)
-		*psize = ALIGN_BYTE;
+		*psize = ALIGN_8BIT;
 	else if (strcasecmp(str, "x16") == 0)
-		*psize = ALIGN_HALFWORD;
+		*psize = ALIGN_16BIT;
 	else if (strcasecmp(str, "x32") == 0)
-		*psize = ALIGN_WORD;
+		*psize = ALIGN_32BIT;
 	else if (strcasecmp(str, "x64") == 0)
-		*psize = ALIGN_DWORD;
+		*psize = ALIGN_64BIT;
 	else {
 		tc_printf(t, "usage: monitor psize (x8|x16|x32|x32)\n");
 		return false;

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -379,7 +379,7 @@ void mm32l0_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *
 		uint32_t tmp = 0;
 		/* Pack data into correct data lane */
 		switch (align) {
-		case ALIGN_BYTE: {
+		case ALIGN_8BIT: {
 			uint8_t value;
 			memcpy(&value, src, sizeof(value));
 			/* copy byte to be written to all four bytes of the uint32_t */
@@ -388,7 +388,7 @@ void mm32l0_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *
 			tmp = tmp | tmp << 16U;
 			break;
 		}
-		case ALIGN_HALFWORD: {
+		case ALIGN_16BIT: {
 			uint16_t value;
 			memcpy(&value, src, sizeof(value));
 			/* copy halfword to be written to both halfwords of the uint32_t */
@@ -396,8 +396,8 @@ void mm32l0_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *
 			tmp = tmp | tmp << 16U;
 			break;
 		}
-		case ALIGN_DWORD:
-		case ALIGN_WORD:
+		case ALIGN_64BIT:
+		case ALIGN_32BIT:
 			memcpy(&tmp, src, sizeof(tmp));
 			break;
 		}
@@ -700,7 +700,7 @@ static bool stm32f1_flash_write(target_flash_s *flash, target_addr_t dest, const
 		stm32f1_flash_clear_eop(target, FLASH_BANK1_OFFSET);
 
 		target_mem_write32(target, FLASH_CR, FLASH_CR_PG);
-		cortexm_mem_write_sized(target, dest, src, offset, ALIGN_HALFWORD);
+		cortexm_mem_write_sized(target, dest, src, offset, ALIGN_16BIT);
 
 		/* Wait for completion or an error */
 		if (!stm32f1_flash_busy_wait(target, FLASH_BANK1_OFFSET, NULL))
@@ -714,7 +714,7 @@ static bool stm32f1_flash_write(target_flash_s *flash, target_addr_t dest, const
 		stm32f1_flash_clear_eop(target, FLASH_BANK2_OFFSET);
 
 		target_mem_write32(target, FLASH_CR + FLASH_BANK2_OFFSET, FLASH_CR_PG);
-		cortexm_mem_write_sized(target, dest + offset, data + offset, remainder, ALIGN_HALFWORD);
+		cortexm_mem_write_sized(target, dest + offset, data + offset, remainder, ALIGN_16BIT);
 
 		/* Wait for completion or an error */
 		if (!stm32f1_flash_busy_wait(target, FLASH_BANK2_OFFSET, NULL))

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -162,7 +162,7 @@ static void stm32f4_add_flash(target_s *const t, const uint32_t addr, const size
 	f->erased = 0xffU;
 	sf->base_sector = base_sector;
 	sf->bank_split = split;
-	sf->psize = ALIGN_WORD;
+	sf->psize = ALIGN_32BIT;
 	target_add_flash(t, f);
 }
 
@@ -484,7 +484,7 @@ static bool stm32f4_flash_erase(target_flash_s *f, target_addr_t addr, size_t le
 	stm32f4_flash_s *sf = (stm32f4_flash_s *)f;
 	stm32f4_flash_unlock(t);
 
-	align_e psize = ALIGN_WORD;
+	align_e psize = ALIGN_32BIT;
 	/*
 	 * XXX: What is this and why does it exist?
 	 * A dry-run walk-through says it'll pull out the psize for the Flash region added first by stm32f4_attach()
@@ -761,7 +761,7 @@ static bool stm32f4_cmd_option(target_s *t, int argc, const char **argv)
 static bool stm32f4_cmd_psize(target_s *t, int argc, const char **argv)
 {
 	if (argc == 1) {
-		align_e psize = ALIGN_WORD;
+		align_e psize = ALIGN_32BIT;
 		/*
 		 * XXX: What is this and why does it exist?
 		 * A dry-run walk-through says it'll pull out the psize for the Flash region added first by stm32f4_attach()

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -182,7 +182,7 @@ static void stm32h7_add_flash(target_s *target, uint32_t addr, size_t length, si
 		flash->regbase = FPEC1_BASE;
 	else
 		flash->regbase = FPEC2_BASE;
-	flash->psize = ALIGN_DWORD;
+	flash->psize = ALIGN_64BIT;
 	target_add_flash(target, target_flash);
 }
 
@@ -400,7 +400,7 @@ static bool stm32h7_check_bank(target_s *const target, const uint32_t reg_base)
 /* Both banks are erased in parallel.*/
 static bool stm32h7_mass_erase(target_s *target)
 {
-	align_e psize = ALIGN_DWORD;
+	align_e psize = ALIGN_64BIT;
 	/*
 	 * XXX: What is this and why does it exist?
 	 * A dry-run walk-through says it'll pull out the psize for the first Flash region added by stm32h7_probe()
@@ -499,7 +499,7 @@ static bool stm32h7_crc(target_s *target, int argc, const char **argv)
 static bool stm32h7_cmd_psize(target_s *target, int argc, const char **argv)
 {
 	if (argc == 1) {
-		align_e psize = ALIGN_DWORD;
+		align_e psize = ALIGN_64BIT;
 		/*
 		 * XXX: What is this and why does it exist?
 		 * A dry-run walk-through says it'll pull out the psize for the first Flash region added by stm32h7_probe()


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This is a cleanup of alignment type and helper macros. the align type was moved out of the adiv5 specific files to a general header, along with it's related macros, some of which were being defined in multiple places, an additional macro was added for the common pattern of getting the minimum alignment for two given addresses.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
