### PR TITLE
Fix: proper IR  quirk handling for Xilinx FPGAs

### DIFF
--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -332,7 +332,7 @@ const jtag_dev_descr_s dev_descr[] = {
 		.descr = "Xilinx 12-bit IR.",
 		.ir_quirks =
 			{
-				.ir_length = 6U,
+				.ir_length = 12U,
 				.ir_value = 1U,
 			},
 	},

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -301,7 +301,7 @@ const jtag_dev_descr_s dev_descr[] = {
 		.ir_quirks =
 			{
 				.ir_length = 6U,
-				.ir_value = 1U,
+				.ir_value = 0x11U,
 			},
 	},
 	{

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -104,8 +104,6 @@ const jtag_dev_descr_s dev_descr[] = {
 		.idmask = 0xffffffffU,
 		.descr = "NXP: LPC17xx family.",
 	},
-#endif
-#ifdef ENABLE_DEBUG
 	{
 		.idcode = 0x1396d093U,
 		.idmask = 0xffffffffU,

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -113,7 +113,7 @@ const jtag_dev_descr_s dev_descr[] = {
 		.ir_quirks =
 			{
 				.ir_length = 18U,
-				.ir_value = 0b010001010001010001U,
+				.ir_value = 0x11451U,
 			},
 	},
 	{

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -105,6 +105,238 @@ const jtag_dev_descr_s dev_descr[] = {
 		.descr = "NXP: LPC17xx family.",
 	},
 #endif
+#ifdef ENABLE_DEBUG
+	{
+		.idcode = 0x1396d093U,
+		.idmask = 0xffffffffU,
+		.descr = "Xilinx XCVU440.",
+		.ir_quirks =
+			{
+				.ir_length = 18U,
+				.ir_value = 0b010001010001010001U,
+			},
+	},
+	{
+		.idcode = 0x0484a093U,
+		.idmask = 0x0fffffffU,
+		.descr = "Xilinx, 6-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04af2093U,
+		.idmask = 0x0fffffffU,
+		.descr = "Xilinx 12-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 12U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x036d9093U,
+		.idmask = 0x0fffffffU,
+		.descr = "Xilinx 22-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 22U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x036db093U,
+		.idmask = 0x0fffffffU,
+		.descr = "Xilinx 38-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 38U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x0396d093U,
+		.idmask = 0x0fffdfffU,
+		.descr = "Xilinx 18-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 18U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x03931093U,
+		.idmask = 0x0fffdfffU,
+		.descr = "Xilinx 18-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 18U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04b79093U,
+		.idmask = 0x0fffbfffU,
+		.descr = "Xilinx 18-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 18U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04ac0033U,
+		.idmask = 0x0fff9fffU,
+		.descr = "Xilinx 6-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x0380d093U,
+		.idmask = 0x0feddfffU,
+		.descr = "Xilinx 12-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 12U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04600093U,
+		.idmask = 0x0fe53fffU,
+		.descr = "Xilinx 12-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 12U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04b21093U,
+		.idmask = 0x0ffa1fffU,
+		.descr = "Xilinx 12-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 12U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04b01093U,
+		.idmask = 0x0ffa1fffU,
+		.descr = "Xilinx 18-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 18U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04b01093U,
+		.idmask = 0x0ff81fffU,
+		.descr = "Xilinx 18-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 18U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04b01093U,
+		.idmask = 0x0ff09fffU,
+		.descr = "Xilinx 24-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 24U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04d00093U,
+		.idmask = 0x0ffc0fffU,
+		.descr = "Xilinx 21-bit OR 14-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 21U, // Not ideal but *shrug*
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x03681093U,
+		.idmask = 0x0ff81fffU,
+		.descr = "Xilinx 24-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04c00093U,
+		.idmask = 0x0fe88fffU,
+		.descr = "Xilinx 28-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 28U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x03800093U,
+		.idmask = 0x0fe80fffU,
+		.descr = "Xilinx 6-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x03600093U,
+		.idmask = 0x0fe00fffU,
+		.descr = "Xilinx 6-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04c00093U,
+		.idmask = 0x0fe00fffU,
+		.descr = "Xilinx 6-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04a00093U,
+		.idmask = 0x0fe00fffU,
+		.descr = "Xilinx 6-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x04600093U,
+		.idmask = 0x0fe00fffU,
+		.descr = "Xilinx 12-bit IR.",
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 1U,
+			},
+	},
+#endif
 	{
 		.idcode = 0x00000093U,
 		.idmask = 0x00000fffU,

--- a/src/target/jtag_devs.h
+++ b/src/target/jtag_devs.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 typedef struct jtag_ir_quirks {
-	uint16_t ir_value;
+	uint32_t ir_value;
 	uint8_t ir_length;
 } jtag_ir_quirks_s;
 

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -27,7 +27,7 @@
 #include "jtagtap.h"
 
 #define JTAG_MAX_DEVS   32U
-#define JTAG_MAX_IR_LEN 16U
+#define JTAG_MAX_IR_LEN 38U
 
 typedef struct jtag_dev {
 	uint32_t jd_idcode;

--- a/src/target/jtag_scan.h
+++ b/src/target/jtag_scan.h
@@ -27,7 +27,7 @@
 #include "jtagtap.h"
 
 #define JTAG_MAX_DEVS   32U
-#define JTAG_MAX_IR_LEN 38U
+#define JTAG_MAX_IR_LEN 32U /* NOTE: This is not long enough for all Xilinx devices */
 
 typedef struct jtag_dev {
 	uint32_t jd_idcode;


### PR DESCRIPTION


## Detailed description

This fixes potentials issues that one may run into when they have a scan-chain with an Xilinx FPGA on it, as not all Xilinx FPGAs have the 6-bit IR. The documentation such as UG570[^1] states that the IR is 6-bits as a general rule of thumb, however one must consult  the device specific BSDL[^2] files in order to divine the correct IR length for any given device.

Upon consultation of the BSDL models provided by Xilinx, it is made apparent that the following IR lengths are present: 6, 12, 14, 18, 21, 22, 28, and 38. While the vast majority of the devices are in-fact 6-bit wide IR devices, the chance of encountering a device with one of the other IR lengths is reasonably high.

Rather than individually listing each device ID and it's IR length, effort has been made to reduce the device ID space into the greatest common denominators, which then uses the IR quirks machinery to ensure that the IR length is set correctly.

This should enable  more robust handling of scan-chains with Xilinx FPGAs present on them.


## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do



[^1]: https://docs.xilinx.com/v/u/en-US/ug570-ultrascale-configuration
[^2]: https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/device-models.html
