### PR TITLE
Fix: Target power soft-start for older native hardware

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -152,10 +152,10 @@ void platform_init(void)
 	rcc_periph_clock_enable(RCC_USB);
 	rcc_periph_clock_enable(RCC_GPIOA);
 	rcc_periph_clock_enable(RCC_GPIOB);
-	if (hwversion >= 6) {
+	if (hwversion >= 6)
 		rcc_periph_clock_enable(RCC_GPIOC);
+	if (hwversion >= 1)
 		rcc_periph_clock_enable(RCC_TIM1);
-	}
 	rcc_periph_clock_enable(RCC_AFIO);
 	rcc_periph_clock_enable(RCC_CRC);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Due to a small accident with Git, the initial commit for this patch is already on `main` as b83657e1, so in this PR we fix a small mistake with the platform initialisation that saw the timer used by soft-start failing to be powered up on hardware older than the BMP v2.3 hardware. 

This enables tpwr soft-start for hw1 and up.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
