### PR TITLE
Fix: honor capability bits of legacy J-Link V5 probes

### DIFF
--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -332,6 +332,10 @@ static inline bool jlink_interface_available(const uint8_t interface)
 
 static uint8_t jlink_selected_interface(void)
 {
+	/* V5.4 does only JTAG and hangs on 0xc7 commands */
+	if (!(jlink.capabilities & JLINK_CAPABILITY_INTERFACES))
+		return JLINK_INTERFACE_JTAG;
+
 	uint8_t buffer[4U];
 	if (!jlink_simple_request_8(JLINK_CMD_INTERFACE_GET, JLINK_INTERFACE_GET_CURRENT, buffer, sizeof(buffer)))
 		return UINT8_MAX; /* Invalid interface, max value is 31 */
@@ -364,11 +368,20 @@ bool jlink_select_interface(const uint8_t interface)
 static bool jlink_get_interfaces(void)
 {
 	uint8_t buffer[4U];
-	if (!jlink_simple_request_8(JLINK_CMD_INTERFACE_GET, JLINK_INTERFACE_GET_AVAILABLE, buffer, sizeof(buffer)))
-		return false;
+	/*
+	 * HW V5.40 IAR-KS 2006 hangs on 0xc7 commands (0xff and 0xfe),
+	 * and is known to not implement SWD or anything else besides JTAG.
+	 * Check the dedicated capability bit
+	 */
+	if (!(jlink.capabilities & JLINK_CAPABILITY_INTERFACES))
+		jlink.available_interfaces = JLINK_INTERFACE_AVAILABLE(JLINK_INTERFACE_JTAG);
+	else {
+		if (!jlink_simple_request_8(JLINK_CMD_INTERFACE_GET, JLINK_INTERFACE_GET_AVAILABLE, buffer, sizeof(buffer)))
+			return false;
 
-	/* Available_interfaces is a 32bit bitfield/mask */
-	jlink.available_interfaces = read_le4(buffer, 0);
+		/* Available_interfaces is a 32bit bitfield/mask */
+		jlink.available_interfaces = read_le4(buffer, 0);
+	}
 
 	/* Print the available interfaces, marking the selected one, and unsuported ones */
 	const uint8_t selected_interface = jlink_selected_interface();


### PR DESCRIPTION
## Detailed description

Add support for older J-Link V5 adapters to BMDA. 
OEM considers these "legacy" https://wiki.segger.com/J-Link_BASE_V5_or_lower , in fact everything pre-V11.
IMO these are still okay for raw sequences and "accelerated bit-banging" of conventional good old JTAG, fixed-direction bus transceivers included.

* This does not look like a new feature.
* Current Blackmagic Hosted App crashes V5 hardware (2008 firmware) adapters (but works with JLink V8 hw 2014 fw)
* This pull request adds a few checks regarding "multiple interfaces" capability bits to keep BMDA+JLink V5 always in JTAG mode.

I tested this on V5.4 and V5.3 yellow "Kickstart" adapters from 2006 and now they at least work. Also tested on V8 (same AT91SAM7S64, more bus transceivers for bidirectional SWD), no regressions, both SWD & JTAG are accessible and working.
Code loosely follows similar checks from openocd+libjaylink, published UM08001 and aims to be a follow-up to #1548. 
The firmware in question does not support 0xc7 "EMU_CMD_SELECT_IF" commands at all. I can remove irrelevant parts of in-code comments on request.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) -- not applicable
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
I would open an issue about this back in August, but instead I provide a suggested fix here.