### PR TITLE
Fix: memleak/handling FTDI adapters

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -549,6 +549,7 @@ int find_debuggers(bmda_cli_options_s *cl_opts, bmda_probe_s *info)
 		// Don't know the cable type, ask user to specify with "-c"
 		DEBUG_WARN("Multiple FTDI adapters match Vendor and Product ID.\n");
 		DEBUG_WARN("Please specify adapter type on command line using \"-c\" option.\n");
+		probe_info_list_free(probe_list);
 		return -1; //false
 	}
 	/* If the selected probe is CMSIS-DAP, check for v2 interfaces */

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -412,7 +412,7 @@ bool ftdi_lookup_adapter_from_vid_pid(bmda_cli_options_s *const cl_opts, const p
 bool ftdi_lookup_cable_by_product(bmda_cli_options_s *cl_opts, const char *product)
 {
 	if (cl_opts->opt_cable)
-		return false;
+		return true;
 
 	for (const cable_desc_s *cable = &cable_desc[0]; cable->vendor; ++cable) {
 		if (cable->description && strstr(product, cable->description) != 0) {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

This PR fixes a memory leak in `bmp_libusb` and a bug in `ftdi_bmp`. 

The former was a missing `probe_info_list_free` inside a failure case for FTDI lookups. The  latter being a case where the `ftdi_lookup_cable_by_product` would erroneously return `false` if the cable was specified on the command line with `-c` resulting in an incorrect lookup failure.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
