### PR TITLE
Fix: Cortex-A support

### DIFF
--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -508,10 +508,6 @@ bool cortexa_probe(adiv5_access_port_s *ap, target_addr_t base_address)
 	target->halt_poll = cortexa_halt_poll;
 	target->halt_resume = cortexa_halt_resume;
 
-	/* Set up APB CSW, we won't touch this again */
-	uint32_t csw = ap->csw | ADIV5_AP_CSW_SIZE_WORD;
-	adiv5_ap_write(ap, ADIV5_AP_CSW, csw);
-
 	cortex_read_cpuid(target);
 	/* The format of the debug identification register is described in DDI0406C §C11.11.15 pg2217 */
 	const uint32_t debug_id = cortex_dbg_read32(target, CORTEXAR_DBG_IDR);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we set out to complete the replacement of the `apb_read()` and `apb_write()` functions in the Cortex-A code using the newer `cortex_dbg_read32()` and `cortex_dbg_write32()` functions as the former functions make gross assumptions about the state and configuration of the AP that no longer hold.

This had resulted in scan-then-crash issues on targets and would have caused issues on any part that has both a Cortex-M and Cortex-A core on the same Access Port as the Cortex-M code would have caused the same state inconsistency problem.

This also reduces the Flash footprint for the Cortex-A support by ~200 bytes.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
