### PR TITLE
Fix: Avoid a hang in scanning Cortex-A of STM32MP15x

### DIFF
--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -508,6 +508,8 @@ bool cortexa_probe(adiv5_access_port_s *ap, target_addr_t base_address)
 	target->halt_poll = cortexa_halt_poll;
 	target->halt_resume = cortexa_halt_resume;
 
+#if 0 /* Trying to halt STM32MP15x Cortex-A cores during probe locks up BMDA/BMF! */
+
 	/* Try to halt the target core */
 	target_halt_request(target);
 	platform_timeout_s timeout;
@@ -518,6 +520,7 @@ bool cortexa_probe(adiv5_access_port_s *ap, target_addr_t base_address)
 	/* If we did not succeed, we must abort at this point. */
 	if (reason == TARGET_HALT_FAULT || reason == TARGET_HALT_ERROR)
 		return false;
+#endif
 
 	cortex_read_cpuid(target);
 	/* The format of the debug identification register is described in DDI0406C §C11.11.15 pg2217 */

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -837,6 +837,11 @@ static target_halt_reason_e cortexa_halt_poll(target_s *t, target_addr_t *watch)
 void cortexa_halt_resume(target_s *t, bool step)
 {
 	cortexa_priv_s *priv = t->priv;
+
+	uint32_t dbgdscr = cortex_dbg_read32(t, CORTEXAR_DBG_DSCR);
+	if (!(dbgdscr & CORTEXAR_DBG_DSCR_HALTED)) /* Not halted */
+		return;
+
 	/* Set breakpoint comparator for single stepping if needed */
 	if (step) {
 		uint32_t addr = priv->reg_cache.r[15];
@@ -856,7 +861,7 @@ void cortexa_halt_resume(target_s *t, bool step)
 	cortexar_run_insn(t, MCR | ICIALLU); /* invalidate cache */
 
 	/* Disable DBGITR.  Not sure why, but RRQ is ignored otherwise. */
-	uint32_t dbgdscr = cortex_dbg_read32(t, CORTEXAR_DBG_DSCR);
+	dbgdscr = cortex_dbg_read32(t, CORTEXAR_DBG_DSCR);
 	if (step)
 		dbgdscr |= DBGDSCR_INTDIS;
 	else

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -927,11 +927,6 @@ static target_halt_reason_e cortexa_halt_poll(target_s *t, target_addr_t *watch)
 void cortexa_halt_resume(target_s *t, bool step)
 {
 	cortexa_priv_s *priv = t->priv;
-
-	uint32_t dbgdscr = cortex_dbg_read32(t, CORTEXAR_DBG_DSCR);
-	if (!(dbgdscr & CORTEXAR_DBG_DSCR_HALTED)) /* Not halted */
-		return;
-
 	/* Set breakpoint comparator for single stepping if needed */
 	if (step) {
 		uint32_t addr = priv->reg_cache.r[15];
@@ -951,7 +946,7 @@ void cortexa_halt_resume(target_s *t, bool step)
 	cortexar_run_insn(t, MCR | ICIALLU); /* invalidate cache */
 
 	/* Disable DBGITR.  Not sure why, but RRQ is ignored otherwise. */
-	dbgdscr = cortex_dbg_read32(t, CORTEXAR_DBG_DSCR);
+	uint32_t dbgdscr = cortex_dbg_read32(t, CORTEXAR_DBG_DSCR);
 	if (step)
 		dbgdscr |= DBGDSCR_INTDIS;
 	else

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -98,11 +98,11 @@ typedef struct cortexa_priv {
 #define CORTEXAR_DBG_LAR   0xfb0U /* Lock Access */
 #define CORTEXAR_DBG_LSR   0xfb4U /* Lock Status */
 
-#define DBGOSLSR_OSLM0 (1U << 0U)
-#define DBGOSLSR_OSLK  (1U << 1U)
-#define DBGOSLSR_NTT   (1U << 2U)
-#define DBGOSLSR_OSLM1 (1U << 3U)
-#define DBGOSLSR_OSLM  (DBGOSLSR_OSLM0 | DBGOSLSR_OSLM1)
+#define CORTEXAR_DBG_OSLSR_OSLM0 (1U << 0U)
+#define CORTEXAR_DBG_OSLSR_OSLK  (1U << 1U)
+#define CORTEXAR_DBG_OSLSR_NTT   (1U << 2U)
+#define CORTEXAR_DBG_OSLSR_OSLM1 (1U << 3U)
+#define CORTEXAR_DBG_OSLSR_OSLM  (CORTEXAR_DBG_OSLSR_OSLM0 | CORTEXAR_DBG_OSLSR_OSLM1)
 
 #define CORTEXAR_DBG_IDR_BREAKPOINT_MASK  0xfU
 #define CORTEXAR_DBG_IDR_BREAKPOINT_SHIFT 24U
@@ -588,14 +588,15 @@ bool cortexa_probe(adiv5_access_port_s *ap, target_addr_t base_address)
 	uint32_t dbg_osreg = cortex_dbg_read32(target, CORTEXAR_DBG_OSLSR);
 	DEBUG_INFO("%s: DBGOSLSR = 0x%08" PRIx32 "\n", __func__, dbg_osreg);
 	/* Is OS Lock implemented? */
-	if ((dbg_osreg & DBGOSLSR_OSLM) == DBGOSLSR_OSLM0 || (dbg_osreg & DBGOSLSR_OSLM) == DBGOSLSR_OSLM1) {
+	if ((dbg_osreg & CORTEXAR_DBG_OSLSR_OSLM) == CORTEXAR_DBG_OSLSR_OSLM0 ||
+		(dbg_osreg & CORTEXAR_DBG_OSLSR_OSLM) == CORTEXAR_DBG_OSLSR_OSLM1) {
 		/* Is OS Lock set? */
-		if (dbg_osreg & DBGOSLSR_OSLK) {
+		if (dbg_osreg & CORTEXAR_DBG_OSLSR_OSLK) {
 			DEBUG_WARN("%s: OSLock set! Trying to unlock\n", __func__);
 			cortex_dbg_write32(target, CORTEXAR_DBG_OSLAR, 0U);
 			dbg_osreg = cortex_dbg_read32(target, CORTEXAR_DBG_OSLSR);
 
-			if ((dbg_osreg & DBGOSLSR_OSLK) != 0) {
+			if ((dbg_osreg & CORTEXAR_DBG_OSLSR_OSLK) != 0) {
 				DEBUG_ERROR("%s: OSLock sticky, core not powered?\n", __func__);
 			}
 		}

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -91,8 +91,12 @@ typedef struct cortexa_priv {
 #define CORTEXAR_DBG_WCR   0x1c0U
 #define CORTEXAR_CTR       0xd04U
 
+#define CORTEXAR_DBG_DSCCR 0x028U
+#define CORTEXAR_DBG_DSMCR 0x02cU
 #define CORTEXAR_DBG_OSLAR 0x300U
 #define CORTEXAR_DBG_OSLSR 0x304U
+#define CORTEXAR_DBG_LAR   0xfb0U /* Lock Access */
+#define CORTEXAR_DBG_LSR   0xfb4U /* Lock Status */
 
 #define DBGOSLSR_OSLM0 (1U << 0U)
 #define DBGOSLSR_OSLK  (1U << 1U)
@@ -628,6 +632,15 @@ bool cortexa_attach(target_s *target)
 
 	/* Clear any pending fault condition */
 	target_check_error(target);
+
+#if 0
+	/* Reset 0xc5acce55 lock access to deter software */
+	cortex_dbg_write32(target, CORTEXAR_DBG_LAR, 0U);
+	/* Cache write-through */
+	cortex_dbg_write32(target, CORTEXAR_DBG_DSCCR, 0U);
+	/* Disable TLB lookup and refill/eviction */
+	cortex_dbg_write32(target, CORTEXAR_DBG_DSMCR, 0U);
+#endif
 
 	uint32_t dbg_osreg = cortex_dbg_read32(target, CORTEXAR_DBG_OSLSR);
 	DEBUG_INFO("%s: DBGOSLSR = 0x%08X\n", __func__, dbg_osreg);


### PR DESCRIPTION
## Detailed description
BMD at current `main` busy-loops (hangs, effective DoS) if user attempts to scan a STM32MP15x device with any of supported adapters, requiring BMDA restart or probe reboot. This behaviour was enabled recently by Cortex-A related PRs. Previously BMD did not attempt to attach, halt, or otherwise touch CA7 during scan/probe.

* This is more a fix than a feature, but introduces registers not touched previously.
* The pull request solves an existing problem of BMD hang upon trying to even scan STM32MP15x SoC.
* To solve this, the pull request implements checking and clearing OSLock in ARMv7-A Debug registers.

It took three consecutive days of log analysis from different adapters and gdbserver software with help and suggestions from Dragonmux to come up with some working fix.
Our working hypothesis is that even in Engineering Boot, the primary bootloader (BootROM) enables OSLock, which per Arch.ref.man. prohibits external debugger access to some registers. OpenOCD clears it, so when working through a kind of adapter both servers speak, I could observe BMDA working fine with this target *after* running OOCD once and *before* power-cycling DUT (there is no good SRST/Reset button solution without dropping Vdd+Vddcore, see errata).

I tried coding a few different things across cortexa.c and most of them ended up here. Namely, the OSLock check, the HALT_DBG_ENABLE + ITR_ENABLE typo fix, the unused LAR/DSCCR/DSMCR clears, macro definitons for these, and last but not least, my helper routine for printing human-readable names for set bits of a register to save developers from the hassle of ~~using a decoder ring~~ keeping A.R.M. and calculator open for understanding some hex dumps.

Note that because the problem happens in cortexa_probe, earlier than cortexa_attach, I had to move HDBGen+ITRen writes up there. This is less clean because the user is not guaranteed to attach (so BMD then runs detach cleanup), but I submit just the bug fix for now.

This patchset as it stands was successfully tested in operation by me against STM32MP157D-DK1 with its onboard STLink/V2-1 SWD-only, but also against custom hardware connected to {STLink/V2 standalone; JLink V8; CMSIS-DAP v1/v2 free-dap on rp2040; finally a BMP(-compatible) blackpill-f411ce}. On all debuggers the hang is not seen anymore, in GDB attach and run/continue works, proper general register values are shown. On BMP there's no hang anymore in *_scan which required pressing the probe's reset button.

I understand this patchset may be not as clean and subject to renames and nitpicks, but a) I needed to fix in VCS a known good working solution; b) this problem blocks my PR1546, in which CM4 target support code would not be reachable anymore. I may agree to rebase away all changes except OSLock which is the core change, and/or reformat the DSCR-touching stuff. 

Users of Cortex-A targets are welcome to test this patchset on their setups in case I introduce a regression for them by fixing the regression I face.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Not quite fixes but helps #1546.