### PR TITLE
Fix: Remote protocol target communications initialisation

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -187,7 +187,9 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 {
 	switch (packet[1]) {
 	case REMOTE_INIT: /* JS = initialise ============================= */
+		remote_dp.dp_low_write = NULL;
 		remote_dp.dp_read = fw_adiv5_jtagdp_read;
+		remote_dp.error = adiv5_jtagdp_error;
 		remote_dp.low_access = fw_adiv5_jtagdp_low_access;
 		remote_dp.abort = adiv5_jtagdp_abort;
 		jtagtap_init();

--- a/src/remote.c
+++ b/src/remote.c
@@ -123,6 +123,15 @@ static void remote_respond_string(const char response_code, const char *const st
 	gdb_if_putchar(REMOTE_EOM, 1);
 }
 
+/*
+ * This faked ADIv5 DP structure holds the currently used low-level implementation functions (SWD vs JTAG)
+ * and basic DP state for remote protocol requests made. This is shared between remote_packet_process_swd()
+ * and remote_packet_process_jtag() for use by remote_packet_process_adiv5() so its faked AP can do the right
+ * thing.
+ *
+ * REMOTE_INIT for SWD and JTAG rewrite the dp_low_write, dp_read, error, low_access and abort function
+ * pointers to reconfigure this structure appropriately.
+ */
 static adiv5_debug_port_s remote_dp = {
 	.ap_read = firmware_ap_read,
 	.ap_write = firmware_ap_write,

--- a/src/remote.c
+++ b/src/remote.c
@@ -135,7 +135,9 @@ static void remote_packet_process_swd(const char *const packet, const size_t pac
 	switch (packet[1]) {
 	case REMOTE_INIT: /* SS = initialise =============================== */
 		if (packet_len == 2) {
+			remote_dp.dp_low_write = firmware_dp_low_write;
 			remote_dp.dp_read = firmware_swdp_read;
+			remote_dp.error = firmware_swdp_error;
 			remote_dp.low_access = firmware_swdp_low_access;
 			remote_dp.abort = firmware_swdp_abort;
 			swdptap_init();

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -387,6 +387,7 @@ uint32_t fw_adiv5_jtagdp_low_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_
 uint32_t firmware_swdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 
+bool firmware_dp_low_write(uint16_t addr, uint32_t data);
 uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 
 void firmware_swdp_abort(adiv5_debug_port_s *dp, uint32_t abort);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -389,6 +389,7 @@ uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr);
 
 bool firmware_dp_low_write(uint16_t addr, uint32_t data);
 uint32_t firmware_swdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
+uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
 
 void firmware_swdp_abort(adiv5_debug_port_s *dp, uint32_t abort);
 void adiv5_jtagdp_abort(adiv5_debug_port_s *dp, uint32_t abort);

--- a/src/target/adiv5_jtag.c
+++ b/src/target/adiv5_jtag.c
@@ -37,8 +37,6 @@
 #define IR_DPACC 0xaU
 #define IR_APACC 0xbU
 
-static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, bool protocol_recovery);
-
 void adiv5_jtag_dp_handler(const uint8_t dev_index)
 {
 	adiv5_debug_port_s *dp = calloc(1, sizeof(*dp));
@@ -89,7 +87,7 @@ uint32_t fw_adiv5_jtagdp_read(adiv5_debug_port_s *dp, uint16_t addr)
 	return fw_adiv5_jtagdp_low_access(dp, ADIV5_LOW_READ, ADIV5_DP_RDBUFF, 0);
 }
 
-static uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
+uint32_t adiv5_jtagdp_error(adiv5_debug_port_s *dp, const bool protocol_recovery)
 {
 	(void)protocol_recovery;
 	const uint32_t status = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT) & ADIV5_DP_CTRLSTAT_ERRMASK;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR seeks to address a crash-inducing bug reported by ALTracer on Discord. Under certain conditions during failed communications with a target over the remote protocol, `dp->error()` is called and the remote protocol layer in the firmware was improperly initialising the faked DP structure it uses, resulting in an attempted call through a NULL function pointer.

This patch addresses this problem for both JTAG and SWD over remote protocol + documents that structure a bit to help prevent future problems.

Tested by ALTracer against the STM32MP157 with which this bug was found and triggered.

This bug has existed in the firmware since about 3 years ago and does affect v1.7, v1.8 and v1.9 - we may wish to backport it at least to v1.9 because of this.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
