### PR TITLE
Fix: Cortex-A halt handling of OSLock becoming set between resumption and the next halt

### DIFF
--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -907,9 +907,16 @@ static target_halt_reason_e cortexa_halt_poll(target_s *t, target_addr_t *watch)
 	cortexa_oslock_unlock(t);
 
 	DEBUG_INFO("%s: DBGDSCR = 0x%08" PRIx32 "\n", __func__, dbgdscr);
-	/* Reenable DBGITR */
-	dbgdscr |= CORTEXAR_DBG_DSCR_ITR_ENABLE;
+	cortexa_decode_bitfields(CORTEXAR_DBG_DSCR, dbgdscr);
+
+	/* Enable halting debug mode */
+	dbgdscr |= CORTEXAR_DBG_DSCR_HALT_DBG_ENABLE | CORTEXAR_DBG_DSCR_ITR_ENABLE;
+	dbgdscr &= ~DBGDSCR_EXTDCCMODE_MASK;
 	cortex_dbg_write32(t, CORTEXAR_DBG_DSCR, dbgdscr);
+
+	dbgdscr = cortex_dbg_read32(t, CORTEXAR_DBG_DSCR);
+	DEBUG_INFO("%s: DBGDSCR = 0x%08" PRIx32 "\n", __func__, dbgdscr);
+	cortexa_decode_bitfields(CORTEXAR_DBG_DSCR, dbgdscr);
 
 	/* Find out why we halted */
 	target_halt_reason_e reason = TARGET_HALT_BREAKPOINT;

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -610,20 +610,6 @@ bool cortexa_probe(adiv5_access_port_s *ap, target_addr_t base_address)
 	 */
 	cortexa_oslock_unlock(target);
 
-	uint32_t dbgdscr = cortex_dbg_read32(target, CORTEXAR_DBG_DSCR);
-	DEBUG_INFO("%s: DBGDSCR = 0x%08" PRIx32 " (1)\n", __func__, dbgdscr);
-	cortexa_decode_bitfields(CORTEXAR_DBG_DSCR, dbgdscr);
-
-	/* Enable halting debug mode */
-	dbgdscr |= CORTEXAR_DBG_DSCR_HALT_DBG_ENABLE | CORTEXAR_DBG_DSCR_ITR_ENABLE;
-	cortex_dbg_write32(target, CORTEXAR_DBG_DSCR, dbgdscr);
-	dbgdscr &= ~DBGDSCR_EXTDCCMODE_MASK;
-	cortex_dbg_write32(target, CORTEXAR_DBG_DSCR, dbgdscr);
-
-	dbgdscr = cortex_dbg_read32(target, CORTEXAR_DBG_DSCR);
-	DEBUG_INFO("%s: DBGDSCR = 0x%08" PRIx32 " (2)\n", __func__, dbgdscr);
-	cortexa_decode_bitfields(CORTEXAR_DBG_DSCR, dbgdscr);
-
 	/* Try to halt the target core */
 	target_halt_request(target);
 	platform_timeout_s timeout;

--- a/src/target/cortexa.c
+++ b/src/target/cortexa.c
@@ -963,7 +963,7 @@ void cortexa_halt_resume(target_s *t, bool step)
 	if (step)
 		dbgdscr |= DBGDSCR_INTDIS;
 	else
-		dbgdscr &= ~DBGDSCR_INTDIS;
+		dbgdscr &= ~(DBGDSCR_INTDIS | CORTEXAR_DBG_DSCR_HALT_DBG_ENABLE);
 	dbgdscr &= ~CORTEXAR_DBG_DSCR_ITR_ENABLE;
 	cortex_dbg_write32(t, CORTEXAR_DBG_DSCR, dbgdscr);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In #1628 handling for the Cortex-A/R register for "OSLock" was introduced into `cortexa_probe()`, but this handling doesn't quite go far enough as it's possible for software running on the core to re-set this bit between the core being resumed and its next halt.

This PR address that by moving that logic into cortexa_halt_poll() so it gets applied every halt so we reduce the chances of getting stuck unable to set ITRen and so unable to launch instructions on the core that enable us to do debugging.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
