### PR TITLE
Fix: timer setup Flash usage

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -225,7 +225,7 @@ void platform_init(void)
 		 */
 		timer_set_mode(TIM1, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
 		/* Use PWM mode 1 so that the signal generated is low till it exceeds the set value */
-		timer_set_oc_mode(TIM1, TIM_OC3, TIM_OCM_PWM1);
+		timer_set_oc3_mode(TIM1, TIM_OCM_PWM1);
 		/* Mark the output active-low due to how this drives the target pin */
 		timer_set_oc_polarity_low(TIM1, TIM_OC3N);
 		timer_enable_oc_output(TIM1, TIM_OC3N);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

ALTracer was kind enough to point out on Discord that the timer setup code for BMP introduced in #1615 also wound up introducing ~400 bytes of extra Flash usage for a single function - `timer_set_oc_mode()` - so this PR, in combination with some changes to libopencm3, addresses this.

This results in a 332 byte saving.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
