### PR TITLE
Fix: Added pinout documentation to the stlink platform

### DIFF
--- a/src/platforms/stlink/README.md
+++ b/src/platforms/stlink/README.md
@@ -18,6 +18,22 @@ then they often don't provide a UART interface. In this case, build the firmware
 
 Note: on some clones, SWIM is strongly pulled up by a 680 Ohm resistor.
 
+## External connections
+
+| Function  | Normal Pin | Alt Pin |
+| --------- | ---------- | ------- |
+| SWCLK/TCK |  PA5       |    -    |
+| TDO       |  PA6       |    -    |
+| TDI       |  PA7       |    -    |
+| SWDIO/TMS |  PB14      |    -    |
+| SWO       |  PA10      |    -    |
+| nRST      |  PB0       | PB6     |
+
+The alternative pinout uses the same pins as the normal unless noted otherwise for a function.
+This second pinout is used on some clone boards - if you are using a clone, check the schematic.
+
+NB: SWDIO/TMS is on P**B**14, not P**A**14.
+
 ## Upload BMP Firmware
 
 * Keep the original ST Bootloader.


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR adds the pinout documentation figured out in #1632 to the README.md for the ST-Link platform.

While we aren't very satisfied by this representation of the pinout, it starts to address the documentation issue of the stlink and swlink platforms a touch.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
