### PR TITLE
mm32: typo in comment

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -367,7 +367,7 @@ bool at32fxx_probe(target_s *target)
 /*
  * On STM32, 16-bit writes use bits 0:15 for even halfwords; bits 16:31 for odd halfwords.
  * On MM32 cortex-m0, 16-bit writes always use bits 0:15.
- * Set both halfwords to the same value, works on both STM32 and NN32.
+ * Set both halfwords to the same value, works on both STM32 and MM32.
  */
 void mm32l0_mem_write_sized(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len, align_e align)
 {


### PR DESCRIPTION
Small typo in comment.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
