### PR TITLE
Fix LPC40xx crash with hosted

### DIFF
--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -165,6 +165,7 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_XPSR_EXCEPTION_MASK 0x0000001fU
 
 #define CORTEXM_TOPT_INHIBIT_NRST (1U << 2U)
+#define CORTEXM_TOPT_FLAVOUR_V7MF (1U << 1U)
 
 bool cortexm_attach(target_s *t);
 void cortexm_detach(target_s *t);

--- a/src/target/lpc40xx.c
+++ b/src/target/lpc40xx.c
@@ -22,6 +22,7 @@
 #include "target.h"
 #include "target_internal.h"
 #include "cortex.h"
+#include "cortexm.h"
 #include "lpc_common.h"
 #include "adiv5.h"
 
@@ -82,7 +83,8 @@ static void lpc40xx_add_flash(target_s *target, uint32_t addr, size_t len, size_
 
 bool lpc40xx_probe(target_s *target)
 {
-	if ((target->cpuid & CORTEX_CPUID_PARTNO_MASK) != CORTEX_M4)
+	if ((target->cpuid & CORTEX_CPUID_PARTNO_MASK) != CORTEX_M4 ||
+		(target->target_options & CORTEXM_TOPT_FLAVOUR_V7MF) != 0)
 		return false;
 
 	/*


### PR DESCRIPTION
## Detailed description

Scanning an unknown ARM Cortex M4F (TM4C1294KCDT) microcontroller crashes BMDA while running lpc40xx_probe, as that did not check to make sure that the (potential) core being probed was only a M4 (not a M4F). From discussing this with dragonmux, this adds in a check for that at the beginning of the probe routine.

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do
