### PR TITLE
Workaround for TM4C AP duplication

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -983,6 +983,16 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp)
 				if (target_ap == ap)
 					target_halt_resume(target, false);
 			}
+
+			/*
+			 * Due to the Tiva TM4C1294KCDT repeating the single AP ad-nauseum, this check is needed
+			 * so that we bail rather than repeating the same AP ~256 times.
+			 */
+			if (target->priv_free == cortex_priv_free && cortex_ap(target) == ap &&
+				strstr(target->driver, "Tiva") != NULL) {
+				adiv5_dp_unref(dp);
+				return;
+			}
 		}
 		adiv5_ap_unref(ap);
 	}


### PR DESCRIPTION
## Detailed description
This provides an escape out of the AP initialization process for Tiva processors (like the TM4C1294KCDT) that incorrectly report the same AP multiple times. Developed in discussion with dragonmux when adding support for the aforementioned processor

Note that as this specifically checks for the string `Tiva` in the driver field, this does not prevent an unknown-to-BMP (Tiva or other) processor from spitting out 255 extra APs (or however many the native hardware will do before running out of memory). 

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [X] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do