### PR TITLE
Fix: platforms/blackpill-f4: invert state of SET_IDLE_STATE

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -230,9 +230,13 @@
 	{                             \
 		running_status = (state); \
 	}
-#define SET_IDLE_STATE(state)                        \
-	{                                                \
-		gpio_set_val(LED_PORT, LED_IDLE_RUN, state); \
+/*
+ * The state of LED_IDLE_RUN is inverted, as the led used for
+ * LED_IDLE_RUN (PC13) needs to be pulled low to turn the led on.
+ */
+#define SET_IDLE_STATE(state)                         \
+	{                                                 \
+		gpio_set_val(LED_PORT, LED_IDLE_RUN, !state); \
 	}
 #define SET_ERROR_STATE(state)                    \
 	{                                             \


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

This pull request fixes the issue that LED_IDLE_RUN is not working on the blackpill-f4 platforms when it is assigned to PC13, the onboard LED. The issue is caused by the need to set PC13 to low to turn the LED on, rather than to set PC13 to high to turn the LED on.
The root cause of this is the schematic of how the LED is connected to PC13:
3.3v -> R 1k -> Blue LED -> PC13 ([reference](https://stm32-base.org/assets/pdf/boards/original-schematic-STM32F411CEU6_WeAct_Black_Pill_V2.0.pdf)).

This pull request fixes the issue described, by inverting the state used by for SET_IDLE_STATE. This results in setting PC13 to low when the state is true, and PC13 to high when the state is false. This is exactly the behavior needed to turn the LED on when the state is true.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
This issue is a partial fix to #1516

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
