### PR TITLE
Feature: platforms/blackpill-f4: add SHIELD macro

### DIFF
--- a/src/platforms/common/blackpill-f4/Makefile.inc
+++ b/src/platforms/common/blackpill-f4/Makefile.inc
@@ -42,6 +42,10 @@ ifdef ALTERNATIVE_PINOUT
 CFLAGS += -DALTERNATIVE_PINOUT=$(ALTERNATIVE_PINOUT)
 endif
 
+ifdef SHIELD
+CFLAGS += -DSHIELD=$(SHIELD)
+endif
+
 VPATH +=                          \
 	platforms/common/stm32        \
 	platforms/common/blackpill-f4

--- a/src/platforms/common/blackpill-f4/README.md
+++ b/src/platforms/common/blackpill-f4/README.md
@@ -46,6 +46,14 @@ make clean
 make PROBE_HOST=blackpill-f4x1cx ALTERNATIVE_PINOUT=1
 ```
 
+or, if you are using a PCB (printed circuit board) as a shield for your Black Pill F4, run:
+
+```sh
+cd blackmagic
+make clean
+make PROBE_HOST=blackpill-f4x1cx SHIELD=1
+```
+
 ## Firmware upgrade with dfu-util
 
 - Install [dfu-util](https://dfu-util.sourceforge.net).

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -29,6 +29,25 @@
 
 #define PLATFORM_HAS_TRACESWO
 
+/*
+ * If the SHIELD macro is passed to make, other macros are defined.
+ * Build the code using `make PROBE_HOST=blackpill-f4x1cx SHIELD=1` to define the SHIELD macro.
+ */
+#ifdef SHIELD
+/* Error handling for the SHIELD macro. If SHIELD has a value > 1, or < 1, an error is thrown. */
+#if SHIELD < 1 || SHIELD > 1
+#error "Invalid value for SHIELD. Value is smaller than 1, or larger than 1. If SHIELD is defined, the value must be 1"
+#endif
+/* If SHIELD is defined, the platform is able to power the vRef pin using the PWR_BR pin and the PLATFORM_HAS_POWER_SWITCH is defined. */
+#ifndef PLATFORM_HAS_POWER_SWITCH
+#define PLATFORM_HAS_POWER_SWITCH
+#endif /* PLATFORM_HAS_POWER_SWITCH */
+/* If SHIELD is defined and ALTERNATIVE_PINOUT is not defined, the ALTERNATIVE_PINOUT 1 is selected. */
+#ifndef ALTERNATIVE_PINOUT
+#define ALTERNATIVE_PINOUT 1
+#endif /* ALTERNATIVE_PINOUT */
+#endif /* SHIELD */
+
 /* Error handling for ALTERNATIVE_PINOUT
  * If ALTERNATIVE_PINOUT has a value >= 4 (undefined), or <= 0, an error is thrown.
  */

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -48,7 +48,8 @@
 #endif /* ALTERNATIVE_PINOUT */
 #endif /* SHIELD */
 
-/* Error handling for ALTERNATIVE_PINOUT
+/*
+ * Error handling for ALTERNATIVE_PINOUT
  * If ALTERNATIVE_PINOUT has a value >= 4 (undefined), or <= 0, an error is thrown.
  */
 #ifdef ALTERNATIVE_PINOUT
@@ -57,7 +58,8 @@
 #endif
 #endif /* ALTERNATIVE_PINOUT */
 
-/* Pinout switcher helper function for alternative pinouts.
+/*
+ * Pinout switcher helper function for alternative pinouts.
  * If ALTERNATIVE_PINOUT is passed to make, an alternative pinout is selected.
  * If ALTERNATIVE_PINOUT == 1, it outputs the argument opt1,
  * if ALTERNATIVE_PINOUT == 2, it outputs the argument opt2,
@@ -169,7 +171,8 @@
 /* For STM32F4 DMA trigger source must be specified. Channel 4 is selected, in line with the USART selected in the DMA table. */
 #define USBUSART_DMA_TRG DMA_SxCR_CHSEL_4
 
-/* To use USART1 as USBUSART, DMA2 is selected from https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf, page 170, table 28.
+/*
+ * To use USART1 as USBUSART, DMA2 is selected from https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf, page 170, table 28.
  * This table defines USART1_TX as stream 7, channel 4, and USART1_RX as stream 5, channel 4.
  */
 #define USBUSART1                USART1
@@ -190,7 +193,8 @@
 #define USBUSART1_DMA_RX_IRQ     NVIC_DMA2_STREAM5_IRQ
 #define USBUSART1_DMA_RX_ISRx(x) dma2_stream5_isr(x)
 
-/* To use USART2 as USBUSART, DMA1 is selected from https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf, page 170, table 27.
+/*
+ * To use USART2 as USBUSART, DMA1 is selected from https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf, page 170, table 27.
  * This table defines USART2_TX as stream 6, channel 4, and USART2_RX as stream 5, channel 4.
  */
 #define USBUSART2                USART2


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

This pull request implements a new `SHIELD` macro for the blackpill-f4 platforms.

The SHIELD macro is used to compile the blackpill-f4 code for the use case when a printed circuit expansion board (also known as shield) is used with one of the blackpill-f4 boards.

If the SHIELD macro is passed to make, other macros are defined. If SHIELD is defined, the platform is able to power the vRef pin using the PWR_BR pin. Therefore the PLATFORM_HAS_POWER_SWITCH is defined. If SHIELD is defined and ALTERNATIVE_PINOUT is not defined, the ALTERNATIVE_PINOUT 1 is selected.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
