### PR TITLE
Fix: platforms/common/stm32: fix for adc_start_conversion_direct not being defined for STM32F4

### DIFF
--- a/src/platforms/common/stm32/timing_stm32.c
+++ b/src/platforms/common/stm32/timing_stm32.c
@@ -33,7 +33,7 @@ static volatile uint32_t time_ms = 0;
 uint32_t target_clk_divider = 0;
 
 static size_t morse_tick = 0;
-#ifdef PLATFORM_HAS_POWER_SWITCH
+#if defined(PLATFORM_HAS_POWER_SWITCH) && defined(STM32F1)
 static uint8_t monitor_ticks = 0;
 
 /* Derived from calculating (1.2V / 3.0V) * 4096 */
@@ -90,7 +90,7 @@ void sys_tick_handler(void)
 	} else
 		++morse_tick;
 
-#ifdef PLATFORM_HAS_POWER_SWITCH
+#if defined(PLATFORM_HAS_POWER_SWITCH) && defined(STM32F1)
 	/* First check if target power is presently enabled */
 	if (platform_target_get_power()) {
 		/*


### PR DESCRIPTION

<!-- Filling this template is mandatory -->

## Detailed description
The function `adc_start_conversion_direct()` is only defined for STM32F1, and not for STM32F4.

This caused a compilation issue for STM32F4 based boards.

This pull request fixes this issue, as described in #1644, by adding a check if the platform is based on an STM32F1.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Fixes #1644

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
