### PR TITLE
Feature: platforms/blackpill-f4: only setup LED_BOOTLOADER once

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -114,7 +114,11 @@ void platform_init(void)
 	gpio_set_output_options(TRST_PORT, GPIO_OTYPE_OD, GPIO_OSPEED_2MHZ, TRST_PIN);
 
 	/* Set up LED pins */
-	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_IDLE_RUN | LED_ERROR | LED_BOOTLOADER);
+	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_IDLE_RUN | LED_ERROR);
+	/* Set up LED_BOOTLOADER if it hasn't been set up yet in the bootloader section above */
+#ifdef BMP_BOOTLOADER
+	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_BOOTLOADER);
+#endif
 	gpio_mode_setup(LED_PORT_UART, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_UART);
 
 #ifdef PLATFORM_HAS_POWER_SWITCH


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This pull request slightly updates the code for the blackpill-f4 platforms:
- it adds an `#ifdef` around the line of the code where the `LED_BOOTLOADER` pin is set up using `gpio_mode_setup()` for the second time in the same file, in case `BMP_BOOTLOADER` is not defined. This change is made as it is redundant to setup the `LED_BOOTLOADER` pin twice.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
