### PR TITLE
memwatch - read memory while running

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -56,6 +56,7 @@ SRC =              \
 	kinetis.c      \
 	main.c         \
 	maths_utils.c  \
+	memwatch.c     \
 	morse.c        \
 	msp432e4.c     \
 	msp432p4.c     \

--- a/src/include/memwatch.h
+++ b/src/include/memwatch.h
@@ -1,0 +1,29 @@
+#ifndef MEMWATCH_H
+#define MEMWATCH_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <target.h>
+
+#define MEMWATCH_NUM 8
+/* string length has to be long enough to store an address 0x20000000 */
+#define MEMWATCH_STRLEN 12
+
+typedef enum memwatch_format {
+	MEMWATCH_FMT_SIGNED,
+	MEMWATCH_FMT_UNSIGNED,
+	MEMWATCH_FMT_HEX
+} memwatch_format_e;
+
+typedef struct {
+	uint32_t addr;
+	uint32_t value;
+	char name[MEMWATCH_STRLEN];
+	memwatch_format_e format;
+} memwatch_s;
+
+extern memwatch_s memwatch_table[MEMWATCH_NUM];
+extern uint32_t memwatch_cnt;
+extern void poll_memwatch(target_s *cur_target);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
 #include "gdb_packet.h"
 #include "morse.h"
 #include "command.h"
+#include "memwatch.h"
 #ifdef ENABLE_RTT
 #include "rtt.h"
 #endif
@@ -59,6 +60,8 @@ static void bmp_poll_loop(void)
 		if (rtt_enabled)
 			poll_rtt(cur_target);
 #endif
+		if (memwatch_cnt != 0)
+			poll_memwatch(cur_target);
 	}
 
 	SET_IDLE_STATE(true);

--- a/src/memwatch.c
+++ b/src/memwatch.c
@@ -1,0 +1,46 @@
+#include "general.h"
+#include "gdb_packet.h"
+#include "memwatch.h"
+#if PC_HOSTED == 1
+#include <unistd.h>
+#else
+#include "usb_serial.h"
+#endif
+
+memwatch_s memwatch_table[MEMWATCH_NUM];
+uint32_t memwatch_cnt = 0;
+
+void poll_memwatch(target_s *cur_target)
+{
+	uint32_t val;
+	char buf[64];
+	uint32_t len;
+	if (!cur_target || (memwatch_cnt == 0))
+		return;
+
+	for (uint32_t i = 0; i < memwatch_cnt; i++) {
+		if (!target_mem_read(cur_target, &val, memwatch_table[i].addr, sizeof(val)) &&
+			(val != memwatch_table[i].value)) {
+			switch (memwatch_table[i].format) {
+			case MEMWATCH_FMT_SIGNED:
+				len = snprintf(buf, sizeof(buf), "%s: %" PRId32 "\r\n", memwatch_table[i].name, val);
+				break;
+			case MEMWATCH_FMT_UNSIGNED:
+				len = snprintf(buf, sizeof(buf), "%s: %" PRIu32 "\r\n", memwatch_table[i].name, val);
+				break;
+			case MEMWATCH_FMT_HEX:
+			default:
+				len = snprintf(buf, sizeof(buf), "%s: 0x%" PRIx32 "\r\n", memwatch_table[i].name, val);
+				break;
+			}
+#if PC_HOSTED == 1
+			int l = write(1, buf, len);
+			(void)l;
+#else
+			debug_serial_fifo_send(buf, 0, len);
+#endif
+			memwatch_table[i].value = val;
+		}
+	}
+	return;
+}


### PR DESCRIPTION
This PR introduces a new monitor command, *memwatch*.
The memwatch command polls variables in target memory.

The argument to "mon memwatch" are names, formats (/d, /u, /x), and memory addresses. You can watch up to 8 memory addresses at the same time.

In gdb:

```
(gdb) p &counter
$1 = (<data variable, no debug info> *) 0x20000224 <counter>
(gdb) mon memwatch counter /d 0x20000224
0x20000224
(gdb) r
```
When the variable changes, output is written to the usb serial:

```
counter: 0
counter: 1
counter: 2
counter: 3
counter: 4
```
To switch off, enter "mon watchpoint" without arguments.

In detail:

```
mon memwatch  [[NAME] [/d|/u|/x] ADDRESS]...
```

Up to 8 addresses of watchpoints may be specified.

Where NAME begins with a letter. If NAME is omitted, the address is used as name:

```
(gdb) mon memwatch /d 0x20000224
```
gives:
```
0x20000224: 0
0x20000224: 1
0x20000224: 2
0x20000224: 3
0x20000224: 4
```

Format is one of

- /d signed 32-bit integer
- /u unsigned 32-bit integer
- /x hex 32-bit integer

If format is not given, default is hex, or the last used format.

```
(gdb) mon memwatch counter 0x20000224
```
gives:
```
counter: 0x0
counter: 0x1
counter: 0x2
counter: 0x3
counter: 0x4
```

Address is a hexadecimal number. The address is necessary to define a watchpoint.

```
(gdb) mon memwatch 0x20000224
```
gives
```
0x20000224: 0x0
0x20000224: 0x1
0x20000224: 0x2
0x20000224: 0x3
0x20000224: 0x4
```

With both target and bmp running on a stm32f411, memory is polled 1000 times per second.
## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
