### PR TITLE
misc: add nix-direnv integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use nix --arg pkgs 'import <nixpkgs> { }'

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ src/artifacts/
 src/ftd2xx.dll
 
 scripts/swolisten
+
+.direnv/


### PR DESCRIPTION
## Detailed description

Quality of life improvement for [nix-direnv](https://github.com/nix-community/nix-direnv) users:
When such a users cd's into the blackmagic repo dir, direnv let's them know that a development environment is available. The user can opt-in to using it, which immediately imports the devshell that is described in the `shell.nix` already present in the repo. In contrast to just running `nix-shell` from the repo root, the direnv integration defaults to using the currently installed nixpkgs checkout, instead of picking the pinpointed version from the repo. Given the generic nature of the `shell.nix`, this is likely not less robust than the pinpointed version from `shell.nix`, and it saves a lot of time upon first execution, as no completely unrelated nixpkgs checkout has to be fetched.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
