### PR TITLE
platforms/stlink: add support for forcing ST-Link v2 clone detection

### DIFF
--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -35,6 +35,10 @@ ifeq ($(BLUEPILL), 1)
 CFLAGS += -DBLUEPILL=1
 endif
 
+ifeq ($(STLINK_FORCE_CLONE), 1)
+CFLAGS += -DSTLINK_FORCE_CLONE=1
+endif
+
 VPATH += platforms/common/stm32
 
 SRC +=          \

--- a/src/platforms/stlink/README.md
+++ b/src/platforms/stlink/README.md
@@ -18,6 +18,14 @@ then they often don't provide a UART interface. In this case, build the firmware
 
 Note: on some clones, SWIM is strongly pulled up by a 680 Ohm resistor.
 
+Some of the clones are not detected correctly by the firmware
+(`version` output will say e.g. `Hardware Version 1` instead of
+`Hardware Version 257`) because of differences in internal
+connections. In this case you can build the firmware with
+`STLINK_FORCE_CLONE=1` to force the firmware to use the clone pinmap
+(nRST on PB6).
+
+
 ## External connections
 
 | Function  | Normal Pin | Alt Pin |

--- a/src/platforms/stlink/stlink_common.c
+++ b/src/platforms/stlink/stlink_common.c
@@ -88,6 +88,11 @@ uint32_t detect_rev(void)
 		RCC_CFGR |= (RCC_CFGR_MCO_HSE << 24U);
 		gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO8);
 	}
+
+	/* Override detection to use clone pinmap (i.e. PB6 as nRST). */
+#if defined(STLINK_FORCE_CLONE)
+	revision = 0x101;
+#endif
 	/* Clean up after ourself on boards that aren't identified as ST-Link v2.1's */
 	if ((revision & 0xff) < 2U) {
 		gpio_clear(GPIOA, GPIO12);


### PR DESCRIPTION
One of the ST-Link v2 clones I have (labelled "MINI ST-Link v2", "A" on one side of the PCB and "QYF-0685" on the other) gets detected as hardware version 1 rather than as a v2 clone (hardware version 257). It has PC13 pulled low via a 4.7kΩ resistor and PB11 connected to PB10 rather than pulled up. PA15 seems to be unconnected.

It's hard to tell how other clones are wired and if PB10 is connected to something else on them. The safest choice is to provide a compile-time option to force "detection" of a clone (so we use PB6 for nRST).

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
  * nop, neither does `main` (flash size overflow, known issue)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
