### PR TITLE
feature: memwatch: read memory while running

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,6 +32,7 @@ else
 CFLAGS += -DENABLE_DEBUG=0
 endif
 
+
 SRC =              \
 	adiv5.c        \
 	adiv5_jtag.c   \
@@ -146,6 +147,16 @@ CFLAGS += -DPC_HOSTED=1
 else
 CFLAGS += -DPC_HOSTED=0
 include platforms/common/Makefile.inc
+endif
+
+ifdef ENABLE_MEMWATCH
+CFLAGS += -DENABLE_MEMWATCH=$(ENABLE_MEMWATCH)
+SRC += memwatch.c
+ifndef PC_HOSTED
+ifeq ($(ENABLE_MEMWATCH), 1)
+SRC += ftoa.c
+endif
+endif
 endif
 
 ifeq ($(ENABLE_RTT), 1)

--- a/src/ftoa.c
+++ b/src/ftoa.c
@@ -1,0 +1,450 @@
+#include "ftoa.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Convert IEEE single precison numbers into decimal ASCII strings, while
+   satisfying the following two properties:
+   1) Calling strtof or '(float) strtod' on the result must produce the
+   original float, independent of the rounding mode used by strtof/strtod.
+   2) Minimize the number of produced decimal digits. E.g. the float 0.7f
+   should convert to "0.7", not "0.69999999".
+
+   To solve this we use a dedicated single precision version of
+   Florian Loitsch's Grisu2 algorithm. See
+   http://florian.loitsch.com/publications/dtoa-pldi2010.pdf?attredirects=0
+
+   The code below is derived from Loitsch's C code, which
+   implements the same algorithm for IEEE double precision. See
+   http://florian.loitsch.com/publications/bench.tar.gz?attredirects=0
+
+   Adapted for 32-bit float by Peter Barfuss(bofh453)
+   Subnormal numbers by Koen De Vleeschauwer
+*/
+
+#define DIY_SIGNIFICAND_SIZE 64
+#define SP_SIGNIFICAND_MASK  0x7fffff
+#define SP_HIDDEN_BIT        0x800000 /* 2^23 */
+
+#define OUTCHAR(ch)          \
+	{                        \
+		if (len < size)      \
+			str[len++] = ch; \
+	}
+
+typedef union _f32 {
+	float f;
+	unsigned int i;
+} _f32;
+
+#if defined(__x86_64__) || defined(__amd64__)
+static uint64_t multiply(uint64_t x, uint32_t y)
+{
+	uint64_t y0 = ((uint64_t)y << 32), ac, tmp;
+	__asm__ __volatile__("mulq %3" : "=a"(tmp), "=d"(ac) : "%0"(x), "rm"(y0));
+	// tmp += 0x80000000; /* Round.  */
+	return ac + (tmp >> 63);
+}
+#else
+static uint64_t multiply(uint64_t x, uint32_t y)
+{
+	uint64_t xlo = (x & 0xffffffff);
+	uint64_t xhi = (x >> 32);
+	return ((xhi * y) + ((xlo * y) >> 31));
+}
+#endif
+
+static int k_comp(int n)
+{
+	/* k = n * log(2); rational approximation using continuous fractions */
+	int32_t k = (int32_t)n * 97879 / 325147;
+	return n < 0 ? k - 1 : k;
+}
+
+/* Cached powers of ten from 10**-37..10**45.
+   Scaled so the leftmost bit is 1. */
+
+/* Significands.  */
+static uint64_t powers_ten[84] = {
+	0x881cea14545c7575,
+	0xaa242499697392d3,
+	0xd4ad2dbfc3d07788,
+	0x84ec3c97da624ab5,
+	0xa6274bbdd0fadd62,
+	0xcfb11ead453994ba,
+	0x81ceb32c4b43fcf5,
+	0xa2425ff75e14fc32,
+	0xcad2f7f5359a3b3e,
+	0xfd87b5f28300ca0e,
+	0x9e74d1b791e07e48,
+	0xc612062576589ddb,
+	0xf79687aed3eec551,
+	0x9abe14cd44753b53,
+	0xc16d9a0095928a27,
+	0xf1c90080baf72cb1,
+	0x971da05074da7bef,
+	0xbce5086492111aeb,
+	0xec1e4a7db69561a5,
+	0x9392ee8e921d5d07,
+	0xb877aa3236a4b449,
+	0xe69594bec44de15b,
+	0x901d7cf73ab0acd9,
+	0xb424dc35095cd80f,
+	0xe12e13424bb40e13,
+	0x8cbccc096f5088cc,
+	0xafebff0bcb24aaff,
+	0xdbe6fecebdedd5bf,
+	0x89705f4136b4a597,
+	0xabcc77118461cefd,
+	0xd6bf94d5e57a42bc,
+	0x8637bd05af6c69b6,
+	0xa7c5ac471b478423,
+	0xd1b71758e219652c,
+	0x83126e978d4fdf3b,
+	0xa3d70a3d70a3d70a,
+	0xcccccccccccccccd,
+	0x8000000000000000,
+	0xa000000000000000,
+	0xc800000000000000,
+	0xfa00000000000000,
+	0x9c40000000000000,
+	0xc350000000000000,
+	0xf424000000000000,
+	0x9896800000000000,
+	0xbebc200000000000,
+	0xee6b280000000000,
+	0x9502f90000000000,
+	0xba43b74000000000,
+	0xe8d4a51000000000,
+	0x9184e72a00000000,
+	0xb5e620f480000000,
+	0xe35fa931a0000000,
+	0x8e1bc9bf04000000,
+	0xb1a2bc2ec5000000,
+	0xde0b6b3a76400000,
+	0x8ac7230489e80000,
+	0xad78ebc5ac620000,
+	0xd8d726b7177a8000,
+	0x878678326eac9000,
+	0xa968163f0a57b400,
+	0xd3c21bcecceda100,
+	0x84595161401484a0,
+	0xa56fa5b99019a5c8,
+	0xcecb8f27f4200f3a,
+	0x813f3978f8940984,
+	0xa18f07d736b90be5,
+	0xc9f2c9cd04674edf,
+	0xfc6f7c4045812296,
+	0x9dc5ada82b70b59e,
+	0xc5371912364ce305,
+	0xf684df56c3e01bc7,
+	0x9a130b963a6c115c,
+	0xc097ce7bc90715b3,
+	0xf0bdc21abb48db20,
+	0x96769950b50d88f4,
+	0xbc143fa4e250eb31,
+	0xeb194f8e1ae525fd,
+	0x92efd1b8d0cf37be,
+	0xb7abc627050305ae,
+	0xe596b7b0c643c719,
+	0x8f7e32ce7bea5c70,
+	0xb35dbf821ae4f38c,
+	0xe0352f62a19e306f,
+};
+
+/* Exponents.
+
+Using an inline function to remember the sign saves 84 byte flash.
+Original table looked like this:
+
+static int16_t powers_ten_e[84] = {
+    -127, -124, -121, -117, -114, -111, -107, -104, -101, -98, -94, -91,
+    -88,  -84,  -81,  -78,  -74,  -71,  -68,  -64,  -61,  -58, -54, -51,
+    -48,  -44,  -41,  -38,  -34,  -31,  -28,  -24,  -21,  -18, -14, -11,
+    -8,   -4,   -1,   2,    5,    9,    12,   15,   19,   22,  25,  29,
+    32,   35,   39,   42,   45,   49,   52,   55,   59,   62,  65,  69,
+    72,   75,   79,   82,   85,   89,   92,   95,   98,   102, 105, 108,
+    112,  115,  118,  122,  125,  128,  132,  135,  138,  142, 145, 148,
+};
+*/
+
+static uint8_t powers_ten_e[84] = {
+	127,
+	124,
+	121,
+	117,
+	114,
+	111,
+	107,
+	104,
+	101,
+	98,
+	94,
+	91,
+	88,
+	84,
+	81,
+	78,
+	74,
+	71,
+	68,
+	64,
+	61,
+	58,
+	54,
+	51,
+	48,
+	44,
+	41,
+	38,
+	34,
+	31,
+	28,
+	24,
+	21,
+	18,
+	14,
+	11,
+	8,
+	4,
+	1,
+	2,
+	5,
+	9,
+	12,
+	15,
+	19,
+	22,
+	25,
+	29,
+	32,
+	35,
+	39,
+	42,
+	45,
+	49,
+	52,
+	55,
+	59,
+	62,
+	65,
+	69,
+	72,
+	75,
+	79,
+	82,
+	85,
+	89,
+	92,
+	95,
+	98,
+	102,
+	105,
+	108,
+	112,
+	115,
+	118,
+	122,
+	125,
+	128,
+	132,
+	135,
+	138,
+	142,
+	145,
+	148,
+};
+
+static inline int32_t power_ten_e(uint32_t i)
+{
+	return i < 39 ? -powers_ten_e[i] : powers_ten_e[i];
+}
+
+/*
+ * compute decimal integer m, exp such that:
+ *  f = m*10^exp
+ *  m is as short as possible without losing exactness
+ */
+uint32_t ftoa(char *str, size_t size, float f, int32_t precision)
+{
+	uint32_t w_lower, w_upper;
+	uint64_t D_upper, D_lower, delta, c_mk, one, p2;
+	_f32 f2;
+	int ve = 0, mk = 0;
+	unsigned int len = 0;
+	unsigned char p1;
+	char *msg = NULL;
+	uint8_t digits[16] = {0};
+	const int32_t sizeof_digits = sizeof(digits) / sizeof(digits[0]);
+
+	if (str == NULL)
+		return 0;
+
+	if (precision > 8)
+		precision = 8;
+
+	/* handle negative numbers */
+	if (f < 0) {
+		f = -f;
+		OUTCHAR('-');
+	}
+
+	/* handle nan, infinity, and zero. */
+	f2.f = f;
+	uint32_t w = f2.i & 0x7fffffffU;
+	if (w == 0U) /* zero */ {
+		OUTCHAR('0');
+		if (precision > 0) {
+			OUTCHAR('.');
+			for (int i = 0; i < precision; i++)
+				OUTCHAR('0');
+		}
+		if (len < size)
+			str[len] = 0;
+		return len;
+	} else if (w < 0x800000U) { /* subnormal number */
+		ve = -126 - 1;
+		f2.i = (f2.i & SP_SIGNIFICAND_MASK);
+		/* normalize */
+		if (f2.i != 0U) /* safe */
+			while (!(f2.i & (SP_HIDDEN_BIT >> 1U))) {
+				f2.i <<= 1;
+				ve--;
+			}
+	} else if (w >= 0x7f800000U) { /* not a number, infinity */
+		msg = w > 0x7f800000U ? "nan" : "inf";
+	} else { /* normal number */
+		ve = (f2.i >> 23) - 127 - 1;
+		f2.i = ((f2.i & SP_SIGNIFICAND_MASK) | SP_HIDDEN_BIT);
+	}
+
+	if (msg) {
+		char ch;
+		while (1) {
+			ch = *msg++;
+			if (ch == 0)
+				break;
+			OUTCHAR(ch);
+		}
+		if (len < size)
+			str[len] = 0;
+		return len;
+	}
+
+	w_upper = (f2.i << 2) + 2;
+	w_lower = (f2.i << 2) - 1;
+	if (f2.i != SP_HIDDEN_BIT) {
+		w_lower--;
+	}
+	w_upper <<= (DIY_SIGNIFICAND_SIZE - 58);
+	w_lower <<= (DIY_SIGNIFICAND_SIZE - 58);
+
+	mk = k_comp(ve - 1);
+	int32_t idx = 37 - mk;
+	if ((idx < 0) || (idx >= (int32_t)(sizeof(powers_ten) / sizeof(powers_ten[0])))) {
+		/* index out of range, table too small? */
+		OUTCHAR('?');
+		if (len < size)
+			str[len] = 0;
+		return len;
+	}
+	ve = ve + power_ten_e(idx) - DIY_SIGNIFICAND_SIZE + 7;
+	one = ((uint64_t)1 << -ve) - 1;
+
+	c_mk = powers_ten[idx];
+	D_upper = multiply(c_mk, w_upper);
+	D_lower = multiply(c_mk, w_lower);
+
+	D_upper--;
+	D_lower++;
+
+	delta = (D_upper - D_lower);
+	p1 = D_upper >> -ve;
+	p2 = D_upper & one;
+
+	uint32_t digit1 = p1 / 10;
+	if (digit1)
+		mk++;
+
+	/* decide when to print in decimal or scientific notation  */
+	bool f_format = (mk < 6) && (mk > -5);
+	bool e_format = !f_format;
+	int32_t pos = 1;
+
+	/* leading zeroes */
+	if (f_format && (mk < 0))
+		pos = -mk + 1;
+
+	/* first one or two digits */
+	if (digit1)
+		digits[pos++] = digit1;
+	digits[pos++] = p1 % 10;
+
+	/* following digits */
+	do {
+		p2 *= 10;
+		digits[pos++] = (p2 >> -ve);
+		p2 &= one;
+		delta *= 10;
+	} while (p2 > delta);
+
+	/* position of the decimal point */
+	uint32_t decimal_point = 1;
+	if (f_format && (mk > 0))
+		decimal_point = mk + 1;
+
+	/* rounding */
+	if ((precision >= 0) && (decimal_point + precision + 1 < sizeof_digits)) {
+		digits[decimal_point + precision + 1] += 5;
+		for (int i = decimal_point + precision + 1; i > 0; --i)
+			if (digits[i] >= 10) {
+				digits[i] = digits[i] - 10;
+				digits[i - 1]++;
+				if (e_format && (i == 1)) {
+					/* rounding added a '1' in front of the number */
+					decimal_point = 0;
+					mk++;
+				}
+			}
+	}
+
+	/* print */
+	uint32_t first_digit = 0;
+	uint32_t last_digit = sizeof_digits - 1;
+	if (digits[0] != 0)
+		first_digit = 0;
+	else
+		first_digit = 1;
+	if (precision >= 0)
+		last_digit = decimal_point + precision;
+	else {
+		/* find last non-zero digit */
+		for (last_digit = pos; last_digit >= first_digit; last_digit--)
+			if (digits[last_digit] != 0)
+				break;
+		if (f_format && (last_digit < decimal_point))
+			last_digit = decimal_point;
+	}
+	if (last_digit >= sizeof_digits)
+		last_digit = sizeof_digits - 1;
+	/* print digits */
+	for (uint32_t i = first_digit; i <= last_digit; i++) {
+		OUTCHAR('0' + digits[i]);
+		if ((i == decimal_point) && (i != last_digit))
+			OUTCHAR('.');
+	}
+
+	/* print exponent */
+	if (e_format) {
+		OUTCHAR('e');
+		OUTCHAR(mk >= 0 ? '+' : '-');
+		if (mk < 0)
+			mk = -mk;
+		OUTCHAR('0' + (mk / 10));
+		OUTCHAR('0' + (mk % 10));
+	}
+
+	if (len < size)
+		str[len] = 0;
+
+	return len;
+}

--- a/src/ftoa.h
+++ b/src/ftoa.h
@@ -1,0 +1,21 @@
+#ifndef FTOA_H
+#define FTOA_H
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ The ftoa() function converts a floating point number f into a character string.
+ s is the address of a buffer. At most size bytes will be written.
+ f is a 32-bit single precision IEEE754 floating point number.
+ precision is the the number of digits to appear after the decimal point.
+ If precision is negative, all digits are printed, and sscanf() of the printed
+ output produces the orginal float. Upon successful return, returns the number
+ of characters printed (minus terminating 0).
+ */
+uint32_t ftoa(char *s, size_t size, float f, int32_t precision);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/include/memwatch.h
+++ b/src/include/memwatch.h
@@ -1,0 +1,32 @@
+#ifndef MEMWATCH_H
+#define MEMWATCH_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <target.h>
+
+#define MEMWATCH_NUM 8
+/* string length has to be long enough to store an address 0x20000000 */
+#define MEMWATCH_STRLEN 12
+
+typedef enum memwatch_format {
+	MEMWATCH_FMT_SIGNED,
+	MEMWATCH_FMT_UNSIGNED,
+	MEMWATCH_FMT_FLOAT,
+	MEMWATCH_FMT_HEX
+} memwatch_format_e;
+
+typedef struct {
+	uint32_t addr;
+	uint32_t value;
+	char name[MEMWATCH_STRLEN];
+	memwatch_format_e format;
+	int32_t precision;
+} memwatch_s;
+
+extern memwatch_s memwatch_table[MEMWATCH_NUM];
+extern uint32_t memwatch_cnt;
+extern bool memwatch_timestamp;
+extern void poll_memwatch(target_s *cur_target);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
 #include "gdb_packet.h"
 #include "morse.h"
 #include "command.h"
+#include "memwatch.h"
 #ifdef ENABLE_RTT
 #include "rtt.h"
 #endif
@@ -58,6 +59,10 @@ static void bmp_poll_loop(void)
 #ifdef ENABLE_RTT
 		if (rtt_enabled)
 			poll_rtt(cur_target);
+#endif
+#ifdef ENABLE_MEMWATCH
+		if (memwatch_cnt != 0)
+			poll_memwatch(cur_target);
 #endif
 	}
 

--- a/src/memwatch.c
+++ b/src/memwatch.c
@@ -1,0 +1,85 @@
+#include "general.h"
+#include "gdb_packet.h"
+#include "memwatch.h"
+#ifdef ENABLE_RTT
+#include "rtt_if.h"
+#endif
+#if PC_HOSTED == 1
+#include <unistd.h>
+#else
+#include "usb_serial.h"
+#include "ftoa.h"
+#endif
+
+memwatch_s memwatch_table[MEMWATCH_NUM];
+uint32_t memwatch_cnt = 0;
+bool memwatch_timestamp = false;
+
+#ifndef ENABLE_RTT
+static uint32_t rtt_write(const char *buf, uint32_t len)
+{
+#if PC_HOSTED == 1
+	return write(1, buf, len);
+#else
+	uint32_t start_ms = platform_time_ms();
+	while (usbd_ep_write_packet(usbdev, CDCACM_UART_ENDPOINT, buf, len) <= 0) {
+		if (platform_time_ms() - start_ms >= 25)
+			return 0; /* drop silently */
+	}
+	return len;
+#endif
+}
+#endif
+
+void poll_memwatch(target_s *cur_target)
+{
+	union val32_u {
+		uint32_t i;
+		volatile float f;
+	} val;
+
+	char buf[64];
+	char timestamp[64];
+	uint32_t len;
+	if (!cur_target || (memwatch_cnt == 0))
+		return;
+
+	for (uint32_t i = 0; i < memwatch_cnt; i++) {
+		if (!target_mem32_read(cur_target, &val.i, memwatch_table[i].addr, sizeof(val.i)) &&
+			(val.i != memwatch_table[i].value)) {
+			if (memwatch_timestamp)
+				snprintf(timestamp, sizeof(timestamp), "%" PRIu32 " ", platform_time_ms());
+			else
+				timestamp[0] = '\0';
+			switch (memwatch_table[i].format) {
+			case MEMWATCH_FMT_SIGNED:
+				len = snprintf(buf, sizeof(buf), "%s%s %" PRId32 "\r\n", timestamp, memwatch_table[i].name, val.i);
+				break;
+			case MEMWATCH_FMT_UNSIGNED:
+				len = snprintf(buf, sizeof(buf), "%s%s %" PRIu32 "\r\n", timestamp, memwatch_table[i].name, val.i);
+				break;
+			case MEMWATCH_FMT_FLOAT:
+#if ENABLE_MEMWATCH == 1
+#if PC_HOSTED == 1
+				len = snprintf(buf, sizeof(buf), "%s%s %.*g\r\n", timestamp, memwatch_table[i].name,
+					memwatch_table[i].precision, val.f);
+#else
+				char fbuf[32];
+				ftoa(fbuf, sizeof(fbuf), val.f, memwatch_table[i].precision);
+				fbuf[sizeof(fbuf) - 1] = '\0';
+				len = snprintf(buf, sizeof(buf), "%s%s %s\r\n", timestamp, memwatch_table[i].name, fbuf);
+#endif
+				break;
+#endif
+			case MEMWATCH_FMT_HEX:
+			default:
+				len = snprintf(buf, sizeof(buf), "%s%s 0x%" PRIx32 "\r\n", timestamp, memwatch_table[i].name, val.i);
+				break;
+			}
+			buf[sizeof(buf) - 1] = '\0';
+			rtt_write(buf, len);
+			memwatch_table[i].value = val.i;
+		}
+	}
+	return;
+}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

# memwatch - read memory while target running

This PR introduces a new monitor command, *memwatch*.
The memwatch command reads target memory while the target is running.
Inspecting memory without halting the target is useful when debugging hard real time systems.

The arguments to "mon memwatch" are names, formats (/d, /u, /f, /x, /t), and memory addresses. Up to 8 memory addresses may be monitored at the same time. The "mon memwatch" command can be applied to Arm Cortex-M targets only.

## Example

Assume target firmware contains a variable called "counter". In gdb:

```
(gdb) p &counter
$1 = (<data variable, no debug info> *) 0x20000224 <counter>
(gdb) mon memwatch counter /d 0x20000224
0x20000224
(gdb) r
```
When the variable changes, output is written to the usb serial:

```
counter 0
counter 1
counter 2
counter 3
counter 4
```
To switch off, enter "mon memwatch" without arguments.

```
(gdb) mon memwatch
```

## Compiling

To compile bmp with memwatch support, add ENABLE_MEMWATCH=1 to the command line. E.g.:
```
git clone https://github.com/blackmagic-debug/blackmagic
cd blackmagic
wget https://github.com/blackmagic-debug/blackmagic/pull/1655.patch
patch -p 1 -i 1655.patch
make PROBE_HOST=blackpill-f411ce ENABLE_MEMWATCH=1
```
Pre-built [binaries](https://github.com/koendv/blackmagic-firmware/releases/tag/memwatch).

## Arguments

The command arguments in detail:

```
mon memwatch [/t] [[NAME] [/d|/u|/f|/x] ADDRESS]...
```

Up to 8 addresses of watchpoints may be specified.

```
mon memwatch x1 /d 0x20000224 x2 0x20000228 x3 0x2000022c x4 0x20000230 x5 0x20000234 x6 0x20000238 x7 0x2000023c x8 0x20000240
```

NAME begins with a letter a-z A-Z. NAME is printed on every line of output. If NAME has been omitted, the address is printed instead:

```
(gdb) mon memwatch /d 0x20000224
```
prints
```
0x20000224 0
0x20000224 1
0x20000224 2
0x20000224 3
0x20000224 4
```

Format is one of

- /d signed 32-bit integer
- /u unsigned 32-bit integer
- /f 32-bit float
- /x hex 32-bit integer
- /t timestamp in ms

If format is not given, default is hex, or the last used format.

```
(gdb) mon memwatch counter 0x20000224
```
prints
```
counter 0x0
counter 0x1
counter 0x2
counter 0x3
counter 0x4
```

Address is a hexadecimal number. The address is the minimum necessary to define a watchpoint.

```
(gdb) mon memwatch 0x20000224
```
prints
```
0x20000224 0x0
0x20000224 0x1
0x20000224 0x2
0x20000224 0x3
0x20000224 0x4
```
The '/f' format prints IEEE754 32-bit single-precision "float":
```
(gdb) mon memwatch counter /d 0x20000224 root /f 0x20000248
```
prints
```
counter 0
root 0
counter 1
root 1
counter 2
root 1.41421
counter 3
root 1.73205
counter 4
root 2                                          
```

On the Black Magic Probe firmware probes /f defaults to printing all significant digits, without any rounding.
On the pc-based Black Magic Debug App /f defaults to printing to 6 decimal places "%.6g".
Optionally, /f may be followed by a digit, indicating the number of decimal places.
Example: /f4 prints floating point numbers to four decimal places.

The '/t' format prints a timestamp in milliseconds:
```
(gdb) mon memwatch /t counter /d 0x20000224
```
prints
```
20601 counter 0
20613 counter 1
21613 counter 2
22613 counter 3
23613 counter 4
```

With both target and bmp running on a stm32f411, memory is polled 1000 times per second.
## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

fixes #1532