### PR TITLE
Feature: gdb_main.c cleanup

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -223,7 +223,6 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 
 		target_halt_resume(cur_target, single_step);
 		SET_RUN_STATE(true);
-		single_step = false;
 		/* fall through */
 	case '?': { /* '?': Request reason for target halt */
 		/*
@@ -438,7 +437,7 @@ static void exec_q_supported(const char *packet, const size_t length)
 	(void)packet;
 	(void)length;
 
-	/* 
+	/*
 	 * This is the first packet sent by GDB, so we can reset the NoAckMode flag here in case
 	 * the previous session was terminated abruptly with NoAckMode enabled
 	 */
@@ -527,9 +526,9 @@ static void exec_q_thread_info(const char *packet, const size_t length)
 		gdb_putpacketz("l");
 }
 
-/* 
+/*
  * GDB will send the packet 'QStartNoAckMode' to enable NoAckMode
- * 
+ *
  * To tell GDB to not use NoAckMode do the following before connnecting to the probe:
  * set remote noack-packet off
  */

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -78,7 +78,12 @@ typedef enum target_halt_reason {
 	TARGET_HALT_ERROR,       /* Failed to read target status */
 	TARGET_HALT_REQUEST,
 	TARGET_HALT_STEPPING,
+	/*
+	 * Used to both indicate that the target hit a breakpoint, and to
+	 * indicate that the target hit a watchpoint but we can't figure out which
+	 */
 	TARGET_HALT_BREAKPOINT,
+	/* Used to indicate the target hit a watchpoint and we know which */
 	TARGET_HALT_WATCHPOINT,
 	TARGET_HALT_FAULT,
 } target_halt_reason_e;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes a clang-tidy lint in `gdb_main_loop()` and adds some documentation to the target_halt_reason enumeration. It does not materially change the firmware (the assignment removed is provably unused) and this PR serves as a predicate to #1657 which presently contains a merge commit for the branch.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
