### PR TITLE
Fix: BMDA SWD no_check routines

### DIFF
--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -681,7 +681,7 @@ static void decode_access(const uint16_t addr, const uint8_t rnw, const uint8_t 
 
 bool adiv5_write_no_check(adiv5_debug_port_s *dp, uint16_t addr, const uint32_t value)
 {
-	decode_access(addr, ADIV5_LOW_WRITE, value);
+	decode_access(addr, ADIV5_LOW_WRITE, 0U, value);
 	DEBUG_PROTO("0x%08" PRIx32 "\n", value);
 	return dp->write_no_check(addr, value);
 }
@@ -689,7 +689,7 @@ bool adiv5_write_no_check(adiv5_debug_port_s *dp, uint16_t addr, const uint32_t 
 uint32_t adiv5_read_no_check(adiv5_debug_port_s *dp, uint16_t addr)
 {
 	uint32_t result = dp->read_no_check(addr);
-	decode_access(addr, ADIV5_LOW_READ, 0U);
+	decode_access(addr, ADIV5_LOW_READ, 0U, 0U);
 	DEBUG_PROTO("0x%08" PRIx32 "\n", result);
 	return result;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes a small bug that crept in when merging #1549 due to the API change in `decode_access()`.

This broke the build due to a missing parameter.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
