### PR TITLE
Msvc fixes

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -744,7 +744,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 		/* Write Flash Memory */
 		const uint32_t count = plen - bin;
 		DEBUG_GDB("Flash Write %08" PRIX32 " %08" PRIX32 "\n", addr, count);
-		if (cur_target && target_flash_write(cur_target, addr, (void *)packet + bin, count))
+		if (cur_target && target_flash_write(cur_target, addr, (uint8_t *)packet + bin, count))
 			gdb_putpacketz("OK");
 		else {
 			target_flash_complete(cur_target);

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -143,7 +143,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 		ERROR_IF_NO_TARGET();
 		const size_t reg_size = target_regs_size(cur_target);
 		if (reg_size) {
-			uint8_t gp_regs[reg_size];
+			uint8_t *gp_regs = alloca(reg_size);
 			target_regs_read(cur_target, gp_regs);
 			gdb_putpacket(hexify(pbuf, gp_regs, reg_size), reg_size * 2U);
 		} else {
@@ -160,7 +160,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 			break;
 		}
 		DEBUG_GDB("m packet: addr = %" PRIx32 ", len = %" PRIx32 "\n", addr, len);
-		uint8_t mem[len];
+		uint8_t *mem = alloca(len);
 		if (target_mem_read(cur_target, mem, addr, len))
 			gdb_putpacketz("E01");
 		else
@@ -171,7 +171,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 		ERROR_IF_NO_TARGET();
 		const size_t reg_size = target_regs_size(cur_target);
 		if (reg_size) {
-			uint8_t gp_regs[reg_size];
+			uint8_t *gp_regs = alloca(reg_size);
 			unhexify(gp_regs, &pbuf[1], reg_size);
 			target_regs_write(cur_target, gp_regs);
 		}
@@ -189,7 +189,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 			break;
 		}
 		DEBUG_GDB("M packet: addr = %" PRIx32 ", len = %" PRIx32 "\n", addr, len);
-		uint8_t mem[len];
+		uint8_t *mem = alloca(len);
 		unhexify(mem, pbuf + hex, len);
 		if (target_mem_write(cur_target, addr, mem, len))
 			gdb_putpacketz("E01");
@@ -268,7 +268,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 			int n;
 			sscanf(pbuf, "P%" SCNx32 "=%n", &reg, &n);
 			// TODO: FIXME, VLAs considered harmful.
-			uint8_t val[strlen(pbuf + n) / 2U];
+			uint8_t *val = alloca(strlen(pbuf + n) / 2U);
 			unhexify(val, pbuf + n, sizeof(val));
 			if (target_reg_write(cur_target, reg, val, sizeof(val)) > 0)
 				gdb_putpacketz("OK");
@@ -403,7 +403,7 @@ static void exec_q_rcmd(const char *packet, const size_t length)
 	else {
 		const char *const response = "Failed\n";
 		const size_t response_length = strlen(response);
-		char pbuf[response_length * 2 + 1];
+		char *pbuf = alloca(response_length * 2 + 1);
 		gdb_putpacket(hexify(pbuf, response, response_length), 2 * response_length);
 	}
 }

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -33,6 +33,11 @@
 // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #define __USE_MINGW_ANSI_STDIO 1
 #endif
+#if defined(_WIN32) || defined(__CYGWIN__)
+#include <malloc.h>
+#else
+#include <alloca.h>
+#endif
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -30,6 +30,12 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+typedef int32_t mode_t;
+#endif /* _MSC_VER */
+
 typedef struct target target_s;
 typedef uint32_t target_addr_t;
 typedef struct target_controller target_controller_s;

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -64,8 +64,9 @@ typedef int32_t socket_t;
 #include "bmp_hosted.h"
 #include "command.h"
 
-static const uint16_t default_port = 2000U;
-static const uint16_t max_port = default_port + 4U;
+#define DEFAULT_PORT 2000U
+static const uint16_t default_port = DEFAULT_PORT;
+static const uint16_t max_port = (DEFAULT_PORT + 4U);
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 const int op_would_block = WSAEWOULDBLOCK;

--- a/src/rtt.c
+++ b/src/rtt.c
@@ -89,9 +89,9 @@ static uint32_t fast_search(target_s *const cur_target, const uint32_t ram_start
 	static const uint64_t r = 0x73b07d01;
 	static const uint32_t stride = 128;
 	uint64_t t = 0;
-	uint8_t srch_buf[m + stride];
+	uint8_t *srch_buf = alloca(m + stride);
 
-	memset(srch_buf, 0, sizeof(srch_buf));
+	memset(srch_buf, 0, m + stride);
 
 	for (uint32_t addr = ram_start; addr < ram_end; addr += stride) {
 		uint32_t buf_siz = MIN(stride, ram_end - addr);

--- a/src/rtt.c
+++ b/src/rtt.c
@@ -275,7 +275,7 @@ uint32_t rtt_aligned_mem_read(target_s *t, void *dest, target_addr_t src, size_t
 		return target_mem_read(t, dest, src, len);
 
 	const uint32_t retval = target_mem_read(t, dest, src0, len0);
-	memmove(dest, dest + offset, len);
+	memmove(dest, (uint8_t *)dest + offset, len);
 	return retval;
 }
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -544,7 +544,7 @@ static void adiv5_component_probe(
 	}
 
 #if defined(ENABLE_DEBUG)
-	char indent[recursion + 1U];
+	char *indent = alloca(recursion + 1U);
 
 	for (size_t i = 0; i < recursion; i++)
 		indent[i] = ' ';

--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -279,7 +279,7 @@ static bool ch32f1_wait_flash_ready(target_s *t, uint32_t addr)
 }
 
 /* Fast flash for ch32. Load 128 bytes chunk and then write them */
-static int ch32f1_upload(target_s *t, uint32_t dest, const void *src, uint32_t offset)
+static int ch32f1_upload(target_s *t, uint32_t dest, const uint8_t *src, uint32_t offset)
 {
 	volatile uint32_t sr, magic;
 	const uint32_t *ss = (const uint32_t *)(src + offset);
@@ -319,7 +319,7 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 	size_t length = len;
 #ifdef CH32_VERIFY
 	target_addr_t org_dest = dest;
-	const void *org_src = src;
+	const uint8_t *org_src = (const uint8_t *)src;
 #endif
 	DEBUG_INFO("CH32: flash write 0x%" PRIx32 " ,size=%" PRIu32 "\n", dest, (uint32_t)len);
 
@@ -337,7 +337,7 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 			return false;
 
 		for (size_t i = 0; i < 8U; i++) {
-			if (ch32f1_upload(t, dest, src, i * 16U)) {
+			if (ch32f1_upload(t, dest, (const uint8_t *)src, i * 16U)) {
 				DEBUG_ERROR("Cannot upload to buffer\n");
 				return false;
 			}
@@ -359,7 +359,7 @@ static bool ch32f1_flash_write(target_flash_s *f, target_addr_t dest, const void
 		else
 			length = 0;
 		dest += 128U;
-		src += 128U;
+		src = (const uint8_t *)src + 128U;
 
 		sr = target_mem_read32(t, FLASH_SR); // 13
 		ch32f1_flash_lock(t);

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -473,7 +473,7 @@ static bool kinetis_flash_cmd_write(target_flash_s *f, target_addr_t dest, const
 		else
 			len = 0;
 		dest += kf->write_len;
-		src += kf->write_len;
+		src = (const uint8_t *)src + kf->write_len;
 	}
 
 	return true;

--- a/src/target/msp432p4.c
+++ b/src/target/msp432p4.c
@@ -285,7 +285,7 @@ static bool msp432_flash_write(target_flash_s *f, target_addr_t dest, const void
 	DEBUG_WARN("Flash protect: 0x%08" PRIX32 "\n", target_mem_read32(t, mf->flash_protect_register));
 
 	/* Prepare input data */
-	uint32_t regs[t->regs_size / sizeof(uint32_t)]; // Use of VLA
+	uint32_t *regs = alloca(t->regs_size / sizeof(uint32_t)); // Use of VLA
 	target_regs_read(t, regs);
 	regs[0] = SRAM_WRITE_BUFFER; // Address of buffer to be flashed in R0
 	regs[1] = dest;              // Flash address to be write to in R1

--- a/src/target/renesas.c
+++ b/src/target/renesas.c
@@ -596,7 +596,7 @@ static bool renesas_rv40_flash_write(target_flash_s *const f, target_addr_t dest
 			target_mem_write16(t, RV40_CMD, *(uint16_t *)src);
 
 			/* 2 bytes of data */
-			src += 2U;
+			src = (const uint8_t *)src + 2U;
 		}
 
 		/* Issue write end command */

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -313,7 +313,7 @@ void target_regs_read(target_s *t, void *data)
 		t->regs_read(t, data);
 	else {
 		for (size_t x = 0, i = 0; x < t->regs_size;)
-			x += target_reg_read(t, i++, data + x, t->regs_size - x);
+			x += target_reg_read(t, i++, (uint8_t *)data + x, t->regs_size - x);
 	}
 }
 
@@ -323,7 +323,7 @@ void target_regs_write(target_s *t, const void *data)
 		t->regs_write(t, data);
 	else {
 		for (size_t x = 0, i = 0; x < t->regs_size;)
-			x += target_reg_write(t, i++, data + x, t->regs_size - x);
+			x += target_reg_write(t, i++, (const uint8_t *)data + x, t->regs_size - x);
 	}
 }
 

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -213,7 +213,7 @@ static bool flash_buffered_flush(target_flash_s *flash)
 	return result;
 }
 
-static bool flash_buffered_write(target_flash_s *flash, target_addr_t dest, const void *src, size_t len)
+static bool flash_buffered_write(target_flash_s *flash, target_addr_t dest, const uint8_t *src, size_t len)
 {
 	bool result = true; /* Catch false returns with &= */
 	while (len) {
@@ -292,7 +292,7 @@ bool target_flash_write(target_s *target, target_addr_t dest, const void *src, s
 		}
 
 		dest = local_end_addr;
-		src += local_length;
+		src = (const uint8_t *)src + local_length;
 		len -= local_length;
 	}
 	return result;

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -65,7 +65,7 @@ struct target_flash {
 	flash_erase_func erase;      /* Erase a range of flash */
 	flash_write_func write;      /* Write to flash */
 	flash_done_func done;        /* Finish flash operations */
-	void *buf;                   /* Buffer for flash operations */
+	uint8_t *buf;                /* Buffer for flash operations */
 	target_addr_t buf_addr_base; /* Address of block this buffer is for */
 	target_addr_t buf_addr_low;  /* Address of lowest byte written */
 	target_addr_t buf_addr_high; /* Address of highest byte written */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This includes several fixes that help to build under MSVC. In particular, this helps me to build blackmagic as a module under Rust, which effectively uses Cargo to drive MSVC.

There are two broad classes of fixes:

1. Pointer math on `void *` was replaced with pointer math on `uint8_t *` where necessary. This is because MSVC refuses to compile this type of code, ahd it's UB anyway. It was assumed that `void *` math is the same as `uint8_t *` math.
2. VLAs are totally unsupported. While there is a desire to remove them entirely from BMP, they were replaced with `alloca()` instead.

There are additional fixes for missing features on MSVC, however this includes most of the fixes in my local branch.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
