### PR TITLE
samd: fix device id register masks

### DIFF
--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -135,9 +135,9 @@ const command_s samd_cmd_list[] = {
 #define SAMD_DID_DEVSEL_POS    0U
 #define SAMD_DID_REVISION_MASK 0x0fU
 #define SAMD_DID_REVISION_POS  8U
-#define SAMD_DID_SERIES_MASK   0x1fU
+#define SAMD_DID_SERIES_MASK   0x3fU
 #define SAMD_DID_SERIES_POS    16U
-#define SAMD_DID_FAMILY_MASK   0x3fU
+#define SAMD_DID_FAMILY_MASK   0x1fU
 #define SAMD_DID_FAMILY_POS    23U
 
 /* Peripheral ID */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In the Device Identification Register (DID) of samd mcu's, the "series" field is 6 bit, and the "family" field is 5 bit.
This PR sets the correct masks for these fields. 

See also #571, #1162 and #1659.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
