### PR TITLE
Fix: RISC-V vs ENABLE_DEBUG=1

### DIFF
--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -348,13 +348,17 @@ const jtag_dev_descr_s dev_descr[] = {
 				.ir_value = 1U,
 			},
 	},
-#ifdef ENABLE_DEBUG
+#ifdef ENABLE_RISCV
 	{
 		.idcode = 0x0000563dU,
 		.idmask = 0x0fffffffU,
+#ifdef ENABLE_DEBUG
 		.descr = "RISC-V debug v0.13.",
+#endif
 		.handler = riscv_jtag_dtm_handler,
 	},
+#endif
+#ifdef ENABLE_DEBUG
 	{
 		.idcode = 0x000007a3U,
 		.idmask = 0x00000fffU,

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -182,6 +182,7 @@ bool gd32f1_probe(target_s *target)
 	return true;
 }
 
+#ifdef ENABLE_RISCV
 /* Identify RISC-V GD32VF1 chips */
 bool gd32vf1_probe(target_s *const target)
 {
@@ -210,6 +211,7 @@ bool gd32vf1_probe(target_s *const target)
 
 	return true;
 }
+#endif
 
 static bool at32f40_detect(target_s *target, const uint16_t part_id)
 {


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes a bug pointed out to us by ALTracer on Discord where passing ENABLE_DEBUG=1 for the firwmare without also passing ENABLE_RISCV=1 would result in a broken build due to missing preprocessor logic in jtag_devs.c

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
