### PR TITLE
Fix: BMDA remote protocol writes

### DIFF
--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -237,7 +237,6 @@ bool platform_buffer_write(const void *const data, const size_t length)
 			DEBUG_ERROR("Serial write failed %lu, written %zu\n", GetLastError(), offset);
 			return false;
 		}
-		offset += written;
 	}
 	return true;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes a bug in platform_buffer_write() for Windows which would make wrongly it skip chunks of the buffer to write, corrupting the message to send.

This should probably be backported to v1.10 and v1.9.

This bug was introduced in v1.9.0-rc0.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
