### PR TITLE
Fix: libusb overflow with JLink

### DIFF
--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -295,9 +295,16 @@ static bool jlink_get_version(void)
 	if (version_length > sizeof(jlink.fw_version))
 		return false;
 
-	/* Read vesion string directly into jlink.version */
+	/* Read version string directly into jlink.version */
 	bmda_usb_transfer(bmda_probe_info.usb_link, NULL, 0, jlink.fw_version, version_length, JLINK_USB_TIMEOUT);
-	jlink.fw_version[version_length - 1U] = '\0'; /* Ensure null termination */
+	/* Ensure null termination */
+	char *const null_termination = jlink.fw_version + version_length - 1U;
+	*null_termination = '\0';
+
+	/* Replace NULL separating version and copyright string, if it exists */
+	char *const null_separator = strchr(jlink.fw_version, '\0');
+	if (null_separator != NULL && null_separator != null_termination)
+		*null_separator = '\n';
 
 	DEBUG_INFO("Firmware version: %s\n", jlink.fw_version);
 

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -317,6 +317,22 @@ static bool jlink_get_version(void)
 	return true;
 }
 
+static bool jlink_get_extended_capabilities(void)
+{
+	uint8_t buffer[32U];
+	if (!jlink_simple_query(JLINK_CMD_INFO_GET_PROBE_EXTENDED_CAPABILITIES, buffer, sizeof(buffer)))
+		return false;
+
+	uint32_t ext_caps[4];
+	for (size_t i = 0; i < 4; i++)
+		ext_caps[i] = read_le4(buffer, i * 4U);
+
+	DEBUG_INFO("Extended capabilities: 0x%08" PRIx32, ext_caps[0]);
+	DEBUG_INFO(" 0x%08" PRIx32 " 0x%08" PRIx32 " 0x%08" PRIx32 "\n", ext_caps[1], ext_caps[2], ext_caps[3]);
+
+	return true;
+}
+
 static bool jlink_get_capabilities(void)
 {
 	uint8_t buffer[4U];
@@ -324,8 +340,10 @@ static bool jlink_get_capabilities(void)
 		return false;
 
 	jlink.capabilities = read_le4(buffer, 0);
-	DEBUG_INFO("Capabilities: 0x%08" PRIx32 "\n", jlink.capabilities);
+	if (jlink.capabilities & JLINK_CAPABILITY_EXTENDED_CAPABILITIES)
+		return jlink_get_extended_capabilities();
 
+	DEBUG_INFO("Capabilities: 0x%08" PRIx32 "\n", jlink.capabilities);
 	return true;
 }
 


### PR DESCRIPTION
## Detailed description

* Trying to use BMDA with JLink adapters may raise a LIBUSB_ERROR_OVERFLOW under specific conditions.
* This pull request solves this problem by properly anticipating full-length responses in USB read calls.

RM08001 states that the IO TRANSACTION (JTAG3) command should return TDO (or SWDIO) data according to requested nBytes length, like JTAG2, and one more byte for OK status from adapter (or nonzero error). Requesting that in two libusb calls may not work on [my] setup and render BMDA inoperable with this adapter type.

Reading some libusb docs I figured that we should optimistically request a read for length of entire possible packet, then check whether we got handed that 1 byte less (apparently some firmwares give it in a separate bulk packet), and only then do a second read for it. The 1028-byte stack buffer of hosted (4+2*512 for header, tms & tdi) allows for receiving (512+1), but a dedicated smaller buffer could also suffice.

~~I consider this an intermittent bug because I cannot reproduce it after rebooting the machine. Detected against a STLinkReflashed adapter after a week of uptime on an Intel Pentium N6000 host, that is with Jasper Lake PCH USB3 HCI.~~
Once you let **J-Link Commander software** interact with their adapter firmware, it changes the responses' framing. I suppose anything else using `libjlinkarm.so`  also will, like RTTViewer and GDBServer. I reproduced the bug on two different machines running Linux, and on three different adapters (V8 from 2015 and Reflash from 2017). V5 from 2008 are not affected and always split the status byte. I could NOT reproduce the bug on Windows 10, and it required swapping drivers between proprietary and WinUSB a lot. Still, 
I believe fixing BMDA for developers toggling between JLink gdbserver and BMDA on Linux machines (this is possible in Eclipse CDT and derived IDEs) is useful, and might even reduce the number of libusb calls. I tried V7.88k, V6.98, V6.34, V5.12h.

Below that change I also tacked two other commits. One avoids discarding the copyright string returned by adapter in firmware version behind a nul byte (which is treated like a terminator by printf), another queries any extended capabilities of adapters, when supported. These are not strictly required to fix the problem I faced.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) -- not applicable
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None reported yet.