### PR TITLE
Fix `monitor erase*` usage messages (UX)

### DIFF
--- a/src/target/target.c
+++ b/src/target/target.c
@@ -437,7 +437,7 @@ static bool target_cmd_mass_erase(target_s *const t, const int argc, const char 
 	(void)argc;
 	(void)argv;
 	if (!t || !t->mass_erase) {
-		gdb_out("Mass erase not implemented for target_s");
+		gdb_out("Mass erase not implemented for target\n");
 		return true;
 	}
 	gdb_out("Erasing device Flash: ");
@@ -449,9 +449,9 @@ static bool target_cmd_mass_erase(target_s *const t, const int argc, const char 
 static bool target_cmd_range_erase(target_s *const t, const int argc, const char **const argv)
 {
 	if (argc < 3) {
-		gdb_out("usage: monitor erase_range <address> <count>");
-		gdb_out("\t<address> is an address in the first page to erase");
-		gdb_out("\t<count> is the number bytes after that to erase, rounded to the next higher whole page");
+		gdb_out("usage: monitor erase_range <address> <count>\n");
+		gdb_out("\t<address> is an address in the first page to erase\n");
+		gdb_out("\t<count> is the number bytes after that to erase, rounded to the next higher whole page\n");
 		return true;
 	}
 	const uint32_t addr = strtoul(argv[1], NULL, 0);


### PR DESCRIPTION
## Detailed description

* Some remote monitor messages of BMD are formatted improperly.
* This pull request fixes this UX problem by cosmetically editing some message strings.

This is how it was rendered:
```
(gdb) mon erase_range
usage: monitor erase_range <address> <count>        <address> is an address in the first page to erase        <count> is the number bytes after that to erase, rounded to the next higher whole page(gdb)
```
This is how it should look:
```
(gdb) mon erase_range
usage: monitor erase_range <address> <count>
        <address> is an address in the first page to erase
        <count> is the number bytes after that to erase, rounded to the next higher whole page
(gdb)
```

And the `Mass erase not implemented for target_s(gdb)` error I got while using STM32MP157 Cortex-A7. For Cortex-M4 it somehow assigned `stm32f1_mass_erase()`, but that should be dealt in a different PR.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
