### PR TITLE
Fix: -Wformat in gdbserver (gdb_main, command, gdb_hostio)

### DIFF
--- a/src/gdb_hostio.c
+++ b/src/gdb_hostio.c
@@ -90,7 +90,7 @@ static int hostio_get_response(target_controller_s *const tc)
 /* Interface to host system calls */
 int hostio_open(target_controller_s *tc, target_addr_t path, size_t path_len, target_open_flags_e flags, mode_t mode)
 {
-	gdb_putpacket_f("Fopen,%08X/%X,%08X,%08X", path, path_len, flags, mode);
+	gdb_putpacket_f("Fopen,%08" PRIX32 "/%08" PRIX32 ",%08X,%08" PRIX32, path, (uint32_t)path_len, flags, mode);
 	return hostio_get_response(tc);
 }
 
@@ -102,49 +102,50 @@ int hostio_close(target_controller_s *tc, int fd)
 
 int hostio_read(target_controller_s *tc, int fd, target_addr_t buf, unsigned int count)
 {
-	gdb_putpacket_f("Fread,%08X,%08X,%08X", fd, buf, count);
+	gdb_putpacket_f("Fread,%08X,%08" PRIX32 ",%08X", fd, buf, count);
 	return hostio_get_response(tc);
 }
 
 int hostio_write(target_controller_s *tc, int fd, target_addr_t buf, unsigned int count)
 {
-	gdb_putpacket_f("Fwrite,%08X,%08X,%08X", fd, buf, count);
+	gdb_putpacket_f("Fwrite,%08X,%08" PRIX32 ",%08X", fd, buf, count);
 	return hostio_get_response(tc);
 }
 
 long hostio_lseek(target_controller_s *tc, int fd, long offset, target_seek_flag_e flag)
 {
-	gdb_putpacket_f("Flseek,%08X,%08X,%08X", fd, offset, flag);
+	gdb_putpacket_f("Flseek,%08X,%08lX,%08X", fd, offset, flag);
 	return hostio_get_response(tc);
 }
 
 int hostio_rename(target_controller_s *tc, target_addr_t oldpath, size_t old_len, target_addr_t newpath, size_t new_len)
 {
-	gdb_putpacket_f("Frename,%08X/%X,%08X/%X", oldpath, old_len, newpath, new_len);
+	gdb_putpacket_f("Frename,%08" PRIX32 "/%08" PRIX32 ",%08" PRIX32 "/%08" PRIX32, oldpath, (uint32_t)old_len, newpath,
+		(uint32_t)new_len);
 	return hostio_get_response(tc);
 }
 
 int hostio_unlink(target_controller_s *tc, target_addr_t path, size_t path_len)
 {
-	gdb_putpacket_f("Funlink,%08X/%X", path, path_len);
+	gdb_putpacket_f("Funlink,%08" PRIX32 "/%08" PRIX32, path, (uint32_t)path_len);
 	return hostio_get_response(tc);
 }
 
 int hostio_stat(target_controller_s *tc, target_addr_t path, size_t path_len, target_addr_t buf)
 {
-	gdb_putpacket_f("Fstat,%08X/%X,%08X", path, path_len, buf);
+	gdb_putpacket_f("Fstat,%08" PRIX32 "/%08" PRIX32 ",%08" PRIX32, path, (uint32_t)path_len, buf);
 	return hostio_get_response(tc);
 }
 
 int hostio_fstat(target_controller_s *tc, int fd, target_addr_t buf)
 {
-	gdb_putpacket_f("Ffstat,%X,%08X", fd, buf);
+	gdb_putpacket_f("Ffstat,%X,%08" PRIX32, fd, buf);
 	return hostio_get_response(tc);
 }
 
 int hostio_gettimeofday(target_controller_s *tc, target_addr_t tv, target_addr_t tz)
 {
-	gdb_putpacket_f("Fgettimeofday,%08X,%08X", tv, tz);
+	gdb_putpacket_f("Fgettimeofday,%08" PRIX32 ",%08" PRIX32, tv, tz);
 	return hostio_get_response(tc);
 }
 
@@ -156,6 +157,6 @@ int hostio_isatty(target_controller_s *tc, int fd)
 
 int hostio_system(target_controller_s *tc, target_addr_t cmd, size_t cmd_len)
 {
-	gdb_putpacket_f("Fsystem,%08X/%X", cmd, cmd_len);
+	gdb_putpacket_f("Fsystem,%08" PRIX32 "/%08" PRIX32, cmd, (uint32_t)cmd_len);
 	return hostio_get_response(tc);
 }

--- a/src/gdb_hostio.c
+++ b/src/gdb_hostio.c
@@ -28,20 +28,20 @@ int hostio_reply(target_controller_s *const tc, char *const pbuf, const int len)
 {
 	(void)len;
 
-	/* 
+	/*
 	 * File-I/O Remote Protocol Extension
 	 * See https://sourceware.org/gdb/onlinedocs/gdb/Protocol-Basics.html#Protocol-Basics
-	 * 
+	 *
 	 * This handles the F Reply Packet, sent by GDB after handling the File-I/O Request Packet.
-	 * 
+	 *
 	 * The F reply packet consists of the following:
-	 * 
+	 *
 	 * - retcode, the return code of the system call as hexadecimal value.
 	 * - errno, the errno set by the call, in protocol-specific representation.
 	 * 		Can be omitted if the call was successful.
 	 * - Ctrl-C flag, sent only if user requested a break.
 	 * 		In this case, errno must be sent as well, even if the call was successful.
-	 * 		The Ctrl-C flag itself consists of the character ‘C’: 
+	 * 		The Ctrl-C flag itself consists of the character ‘C’:
 	 */
 
 	const bool retcode_is_negative = pbuf[1U] == '-';
@@ -52,7 +52,7 @@ int hostio_reply(target_controller_s *const tc, char *const pbuf, const int len)
 	const int items = sscanf(pbuf + (retcode_is_negative ? 2U : 1U), "%x,%x,%c", &retcode, &errno_, &ctrl_c_flag);
 
 	if (items < 1) {
-		/* 
+		/*
 		 * Something went wrong with the sscanf or the packet format, avoid UB
 		 * FIXME: how do we properly handle this?
 		 */

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -496,7 +496,7 @@ static void exec_q_crc(const char *packet, const size_t length)
 		if (!generic_crc32(cur_target, &crc, addr, addr_length))
 			gdb_putpacketz("E03");
 		else
-			gdb_putpacket_f("C%lx", crc);
+			gdb_putpacket_f("C%" PRIx32, crc);
 	}
 }
 
@@ -846,7 +846,7 @@ void gdb_poll_target(void)
 		gdb_putpacket_f("T%02X", GDB_SIGINT);
 		break;
 	case TARGET_HALT_WATCHPOINT:
-		gdb_putpacket_f("T%02Xwatch:%08X;", GDB_SIGTRAP, watch);
+		gdb_putpacket_f("T%02Xwatch:%08" PRIX32 ";", GDB_SIGTRAP, watch);
 		break;
 	case TARGET_HALT_FAULT:
 		gdb_putpacket_f("T%02X", GDB_SIGSEGV);

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -39,7 +39,7 @@ size_t gdb_getpacket(char *packet, size_t size);
 void gdb_putpacket(const char *packet, size_t size);
 void gdb_putpacket2(const char *packet1, size_t size1, const char *packet2, size_t size2);
 #define gdb_putpacketz(packet) gdb_putpacket((packet), strlen(packet))
-void gdb_putpacket_f(const char *packet, ...);
+void gdb_putpacket_f(const char *packet, ...) __attribute__((format(printf, 1, 2)));
 void gdb_put_notification(const char *packet, size_t size);
 #define gdb_put_notificationz(packet) gdb_put_notification((packet), strlen(packet))
 

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -45,6 +45,6 @@ void gdb_put_notification(const char *packet, size_t size);
 
 void gdb_out(const char *buf);
 void gdb_voutf(const char *fmt, va_list);
-void gdb_outf(const char *fmt, ...);
+void gdb_outf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 
 #endif /* INCLUDE_GDB_PACKET_H */


### PR DESCRIPTION
## Detailed description

* This is not a functional feature; rather, an attempt to reduce unexpected behaviour, especially in BMF.
* The problem is many printf-like calls in BMD core code are not checked by compiler for their correctness.
* This pull request solves this problem by marking the printf-like functions with format attributes. Where applicable, this PR also tries to fix appearing warnings.

I deal here only with `gdb_voutf()` and `gdb_putpacket_f()`, as their direct usage (with dubious specificators, specifically) is less numerous. Let someone else deal with all the `tc_printf()`.

I am build-testing the changes for `native` on Linux amd64, and for `swlink` which is armv7-m. Runtime testing pending -- there is no code coverage tooling, so I have to reason about which aspects need testing, like GDB remote monitor commands for rtt options and semihosting heapinfo.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Partially fixes #1675. See that for a more detailed description.