### PR TITLE
Fix GCC warnings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,8 +21,14 @@ ifeq (filter, macosx darwin, $(SYS))
 CFLAGS += -Wmaybe-uninitialized -Wstringop-overflow -Wunsafe-loop-optimizations
 endif
 
+ifeq ($(PROBE_HOST),hosted)
+ENABLE_DEBUG = 1
+endif
+
 ifeq ($(ENABLE_DEBUG), 1)
-CFLAGS += -DENABLE_DEBUG
+CFLAGS += -DENABLE_DEBUG=1
+else
+CFLAGS += -DENABLE_DEBUG=0
 endif
 
 SRC =              \

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ CFLAGS += -Wmaybe-uninitialized -Wstringop-overflow -Wunsafe-loop-optimizations
 endif
 
 ifeq ($(PROBE_HOST),hosted)
-ENABLE_DEBUG = 1
+ENABLE_DEBUG := 1
 endif
 
 ifeq ($(ENABLE_DEBUG), 1)
@@ -150,6 +150,8 @@ endif
 
 ifeq ($(ADVERTISE_NOACKMODE), 1)
 CFLAGS += -DADVERTISE_NOACKMODE=1
+else
+CFLAGS += -DADVERTISE_NOACKMODE=0
 endif
 
 OBJ = $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(SRC)))

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -113,7 +113,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 	uint8_t bytes[128U];
 #endif
 
-#if defined(ENABLE_DEBUG)
+#if ENABLE_DEBUG == 1
 	const uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t last_time = platform_time_ms();

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -41,7 +41,7 @@
 #include "rtt.h"
 #endif
 
-#if ADVERTISE_NOACKMODE == 1
+#if defined(ADVERTISE_NOACKMODE) && ADVERTISE_NOACKMODE == 1
 /*
  * This lets GDB know that the probe supports ‘QStartNoAckMode’
  * and prefers to operate in no-acknowledgment mode

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -41,7 +41,7 @@
 #include "rtt.h"
 #endif
 
-#if defined(ADVERTISE_NOACKMODE) && ADVERTISE_NOACKMODE == 1
+#if ADVERTISE_NOACKMODE == 1
 /*
  * This lets GDB know that the probe supports ‘QStartNoAckMode’
  * and prefers to operate in no-acknowledgment mode

--- a/src/include/gdb_if.h
+++ b/src/include/gdb_if.h
@@ -21,7 +21,7 @@
 #ifndef INCLUDE_GDB_IF_H
 #define INCLUDE_GDB_IF_H
 
-#if PC_HOSTED == 0
+#if PC_HOSTED == 0 && !defined(NO_LIBOPENCM3)
 #include <libopencm3/usb/usbd.h>
 void gdb_usb_out_cb(usbd_device *dev, uint8_t ep);
 #endif

--- a/src/include/gdb_main.h
+++ b/src/include/gdb_main.h
@@ -31,6 +31,6 @@ extern target_s *cur_target;
 void gdb_poll_target(void);
 void gdb_main(char *pbuf, size_t pbuf_size, size_t size);
 int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t size, bool in_syscall);
-char *gdb_packet_buffer();
+char *gdb_packet_buffer(void);
 
 #endif /* INCLUDE_GDB_MAIN_H */

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -81,7 +81,12 @@
 #define PRINT_NOOP(...) \
 	do {                \
 	} while (false)
-#if defined(ENABLE_DEBUG)
+
+#ifndef ENABLE_DEBUG
+#define ENABLE_DEBUG 0
+#endif
+
+#if ENABLE_DEBUG == 1
 #define DEBUG_ERROR(...) PLATFORM_PRINTF(__VA_ARGS__)
 #define DEBUG_WARN(...)  PLATFORM_PRINTF(__VA_ARGS__)
 #define DEBUG_INFO(...)  PLATFORM_PRINTF(__VA_ARGS__)

--- a/src/include/rtt_if.h
+++ b/src/include/rtt_if.h
@@ -68,8 +68,8 @@ int rtt_if_exit(void);
 /* target to host: write len bytes from the buffer starting at buf. return number bytes written */
 uint32_t rtt_write(const char *buf, uint32_t len);
 /* host to target: read one character, non-blocking. return character, -1 if no character */
-int32_t rtt_getchar();
+int32_t rtt_getchar(void);
 /* host to target: true if no characters available for reading */
-bool rtt_nodata();
+bool rtt_nodata(void);
 
 #endif /* INCLUDE_RTT_IF_H */

--- a/src/platforms/common/aux_serial.h
+++ b/src/platforms/common/aux_serial.h
@@ -69,7 +69,7 @@ void aux_serial_send(size_t len);
 void aux_serial_update_receive_buffer_fullness(void);
 bool aux_serial_receive_buffer_empty(void);
 void aux_serial_drain_receive_buffer(void);
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 void aux_serial_stage_debug_buffer(void);
 #endif
 void aux_serial_stage_receive_buffer(void);

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -77,7 +77,7 @@ static void debug_serial_receive_callback(usbd_device *dev, uint8_t ep);
 static bool debug_serial_send_complete = true;
 #endif
 
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 /*
  * This call initialises "SemiHosting", only we then do our own SVC interrupt things to
  * route all output through to the debug USB serial interface if debug_bmp is true.
@@ -214,7 +214,7 @@ void usb_serial_set_config(usbd_device *dev, uint16_t value)
 	usb_serial_set_state(dev, GDB_IF_NO, CDCACM_GDB_ENDPOINT + 1U);
 	usb_serial_set_state(dev, UART_IF_NO, CDCACM_UART_ENDPOINT + 1U);
 
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 	initialise_monitor_handles();
 #endif
 }
@@ -249,7 +249,7 @@ uint32_t debug_serial_fifo_send(const char *const fifo, const uint32_t fifo_begi
 	return fifo_begin;
 }
 
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 static bool debug_serial_fifo_buffer_empty(void)
 {
 	return debug_serial_debug_write_index == debug_serial_debug_read_index;
@@ -270,17 +270,17 @@ static void debug_serial_send_data(void)
 	 * If fifo empty, nothing further to do. */
 	if (usb_get_config() != 1 ||
 		(aux_serial_receive_buffer_empty()
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 			&& debug_serial_fifo_buffer_empty()
 #endif
 				)) {
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 		debug_serial_debug_read_index = debug_serial_debug_write_index;
 #endif
 		aux_serial_drain_receive_buffer();
 		debug_serial_send_complete = true;
 	} else {
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 		debug_serial_debug_read_index = debug_serial_fifo_send(
 			debug_serial_debug_buffer, debug_serial_debug_read_index, debug_serial_debug_write_index);
 #endif

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -40,7 +40,7 @@
  *
  */
 
-#ifndef ENABLE_DEBUG
+#if ENABLE_DEBUG != 1
 #include <sys/stat.h>
 #include <string.h>
 
@@ -77,7 +77,7 @@ static void debug_serial_receive_callback(usbd_device *dev, uint8_t ep);
 static bool debug_serial_send_complete = true;
 #endif
 
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 /*
  * This call initialises "SemiHosting", only we then do our own SVC interrupt things to
  * route all output through to the debug USB serial interface if debug_bmp is true.
@@ -214,7 +214,7 @@ void usb_serial_set_config(usbd_device *dev, uint16_t value)
 	usb_serial_set_state(dev, GDB_IF_NO, CDCACM_GDB_ENDPOINT + 1U);
 	usb_serial_set_state(dev, UART_IF_NO, CDCACM_UART_ENDPOINT + 1U);
 
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 	initialise_monitor_handles();
 #endif
 }
@@ -249,7 +249,7 @@ uint32_t debug_serial_fifo_send(const char *const fifo, const uint32_t fifo_begi
 	return fifo_begin;
 }
 
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 static bool debug_serial_fifo_buffer_empty(void)
 {
 	return debug_serial_debug_write_index == debug_serial_debug_read_index;
@@ -270,17 +270,17 @@ static void debug_serial_send_data(void)
 	 * If fifo empty, nothing further to do. */
 	if (usb_get_config() != 1 ||
 		(aux_serial_receive_buffer_empty()
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 			&& debug_serial_fifo_buffer_empty()
 #endif
 				)) {
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 		debug_serial_debug_read_index = debug_serial_debug_write_index;
 #endif
 		aux_serial_drain_receive_buffer();
 		debug_serial_send_complete = true;
 	} else {
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 		debug_serial_debug_read_index = debug_serial_fifo_send(
 			debug_serial_debug_buffer, debug_serial_debug_read_index, debug_serial_debug_write_index);
 #endif
@@ -339,7 +339,7 @@ static void debug_serial_receive_callback(usbd_device *dev, uint8_t ep)
 #endif
 }
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 #ifdef PLATFORM_HAS_DEBUG
 static void debug_serial_append_char(const char c)
 {

--- a/src/platforms/f072/platform.h
+++ b/src/platforms/f072/platform.h
@@ -133,7 +133,7 @@
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR          tim3_isr
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 extern bool debug_bmp;
 #define DEBUG printf
 #else

--- a/src/platforms/f3/platform.h
+++ b/src/platforms/f3/platform.h
@@ -126,7 +126,7 @@
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR          tim3_isr
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 extern bool debug_bmp;
 #define DEBUG printf
 #else

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -2,7 +2,7 @@ ifeq ($(origin CC),default)
     CC := gcc
 endif
 SYS := $(shell $(CC) -dumpmachine)
-CFLAGS += -DENABLE_DEBUG -DPLATFORM_HAS_DEBUG
+CFLAGS += -DPLATFORM_HAS_DEBUG
 CFLAGS +=-I ./target
 
 ENABLE_CORTEXAR := 1

--- a/src/platforms/hosted/dap_jtag.c
+++ b/src/platforms/hosted/dap_jtag.c
@@ -108,7 +108,7 @@ static void dap_jtag_tdi_seq(const bool final_tms, const uint8_t *const data_in,
 
 static bool dap_jtag_next(const bool tms, const bool tdi)
 {
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	const uint8_t tms_byte = tms ? 1 : 0;
 #endif
 	const uint8_t tdi_byte = tdi ? 1 : 0;

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -30,7 +30,7 @@
 #define PLATFORM_HAS_TRACESWO
 #define PLATFORM_HAS_POWER_SWITCH
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 #define PLATFORM_HAS_DEBUG
 extern bool debug_bmp;
 #endif

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -31,7 +31,7 @@
 #include <libopencm3/stm32/memorymap.h>
 #include <libopencm3/usb/usbd.h>
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 #define PLATFORM_HAS_DEBUG
 extern bool debug_bmp;
 #endif

--- a/src/platforms/stlinkv3/platform.h
+++ b/src/platforms/stlinkv3/platform.h
@@ -32,7 +32,7 @@
 #include <libopencm3/stm32/f1/memorymap.h>
 #include <libopencm3/usb/usbd.h>
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 #define PLATFORM_HAS_DEBUG
 extern bool debug_bmp;
 #endif

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -28,7 +28,7 @@
 #include "timing.h"
 #include "timing_stm32.h"
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 #define PLATFORM_HAS_DEBUG
 extern bool debug_bmp;
 #endif

--- a/src/remote.c
+++ b/src/remote.c
@@ -317,7 +317,7 @@ static void remote_packet_process_general(char *packet, const size_t packet_len)
 #endif
 		break;
 	case REMOTE_START:
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 		debug_bmp = true;
 #endif
 		remote_respond_string(REMOTE_RESP_OK, PLATFORM_IDENT "" FIRMWARE_VERSION);

--- a/src/remote.c
+++ b/src/remote.c
@@ -317,7 +317,7 @@ static void remote_packet_process_general(char *packet, const size_t packet_len)
 #endif
 		break;
 	case REMOTE_START:
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 		debug_bmp = true;
 #endif
 		remote_respond_string(REMOTE_RESP_OK, PLATFORM_IDENT "" FIRMWARE_VERSION);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -126,7 +126,7 @@ typedef enum arm_arch {
 	aa_end
 } arm_arch_e;
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 #define ARM_COMPONENT_STR(...) __VA_ARGS__
 #else
 #define ARM_COMPONENT_STR(...)
@@ -177,7 +177,7 @@ static const struct {
 	uint16_t arch_id;
 	arm_arch_e arch;
 	cid_class_e cidc;
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	const char *type;
 	const char *full;
 #endif
@@ -272,7 +272,7 @@ static const struct {
 	{0xfff, 0x00, 0, aa_end, cidc_unknown, ARM_COMPONENT_STR("end", "end")},
 };
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 static const char *adiv5_arm_ap_type_string(const uint8_t ap_type, const uint8_t ap_class)
 {
 	/*
@@ -543,7 +543,7 @@ static void adiv5_component_probe(
 		return;
 	}
 
-#if defined(ENABLE_DEBUG)
+#if ENABLE_DEBUG == 1
 	char *indent = alloca(recursion + 1U);
 
 	for (size_t i = 0; i < recursion; i++)
@@ -608,7 +608,7 @@ static void adiv5_component_probe(
 			}
 		}
 
-#if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
+#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
 		/* Check SYSMEM bit */
 		const uint32_t memtype = adiv5_mem_read32(ap, addr | ADIV5_ROM_MEMTYPE) & ADIV5_ROM_MEMTYPE_SYSMEM;
 
@@ -747,7 +747,7 @@ adiv5_access_port_s *adiv5_new_ap(adiv5_debug_port_s *dp, uint8_t apsel)
 
 	memcpy(ap, &tmpap, sizeof(*ap));
 
-#if defined(ENABLE_DEBUG)
+#if ENABLE_DEBUG == 1
 	/* Grab the config register to get a complete set */
 	uint32_t cfg = adiv5_ap_read(ap, ADIV5_AP_CFG);
 	DEBUG_INFO("AP %3u: IDR=%08" PRIx32 " CFG=%08" PRIx32 " BASE=%08" PRIx32 " CSW=%08" PRIx32, apsel, ap->idr, cfg,

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -476,7 +476,7 @@ static uint32_t cortexm_initial_halt(adiv5_access_port_s *ap)
  */
 static bool cortexm_prepare(adiv5_access_port_s *ap)
 {
-#if (defined(PC_HOSTED) && PC_HOSTED == 1) || (ENABLE_DEBUG == 1)
+#if (defined(PC_HOSTED) && PC_HOSTED == 1) || ENABLE_DEBUG == 1
 	uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t dhcsr = cortexm_initial_halt(ap);
@@ -608,7 +608,7 @@ static void adiv5_component_probe(
 			}
 		}
 
-#if (ENABLE_DEBUG == 1) && defined(PLATFORM_HAS_DEBUG)
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 		/* Check SYSMEM bit */
 		const uint32_t memtype = adiv5_mem_read32(ap, addr | ADIV5_ROM_MEMTYPE) & ADIV5_ROM_MEMTYPE_SYSMEM;
 

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -476,7 +476,7 @@ static uint32_t cortexm_initial_halt(adiv5_access_port_s *ap)
  */
 static bool cortexm_prepare(adiv5_access_port_s *ap)
 {
-#if (defined(PC_HOSTED) && PC_HOSTED == 1) || ENABLE_DEBUG == 1
+#if PC_HOSTED == 1 || ENABLE_DEBUG == 1
 	uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t dhcsr = cortexm_initial_halt(ap);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -476,7 +476,7 @@ static uint32_t cortexm_initial_halt(adiv5_access_port_s *ap)
  */
 static bool cortexm_prepare(adiv5_access_port_s *ap)
 {
-#if PC_HOSTED == 1 || ENABLE_DEBUG == 1
+#if (defined(PC_HOSTED) && PC_HOSTED == 1) || (ENABLE_DEBUG == 1)
 	uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t dhcsr = cortexm_initial_halt(ap);

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* 
+/*
  * This file implements the SWD specific functions of the
  * ARM Debug Interface v5 Architecture Specification, ARM doc IHI0031A.
  */
@@ -67,7 +67,7 @@ static void swd_line_reset_sequence(const bool idle_cycles)
 }
 
 /* Switch out of dormant state into SWD */
-static void dormant_to_swd_sequence()
+static void dormant_to_swd_sequence(void)
 {
 	/*
 	 * ARM Debug Interface Architecture Specification, ADIv5.0 to ADIv5.2. ARM IHI 0031C
@@ -102,7 +102,7 @@ static void dormant_to_swd_sequence()
 }
 
 /* Deprecated JTAG-to-SWD select sequence */
-static void jtag_to_swd_sequence()
+static void jtag_to_swd_sequence(void)
 {
 	/*
 	 * ARM Debug Interface Architecture Specification, ADIv5.0 to ADIv5.2. ARM IHI 0031C

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -964,7 +964,7 @@ static void cortexr_mem_handle_fault(
 	const cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
 	/* If we suffered a fault of some kind, grab the reason and restore DFSR/DFAR */
 	if (priv->core_status & CORTEXAR_STATUS_DATA_FAULT) {
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 		const uint32_t fault_status = cortexar_coproc_read(target, CORTEXAR_DFSR);
 		const uint32_t fault_addr = cortexar_coproc_read(target, CORTEXAR_DFAR);
 #else

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -117,7 +117,7 @@ typedef struct cortexm_priv {
 	uint32_t demcr;
 } cortexm_priv_s;
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 const char *const semihosting_names[] = {
 	"",
 	"SYS_OPEN",
@@ -1470,7 +1470,7 @@ static int cortexm_hostio_request(target_s *target)
 		target_mem_read(target, params, arm_regs[1], sizeof(params));
 	int32_t ret = 0;
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	const char *syscall_descr = NULL;
 	if (syscall < ARRAY_LENGTH(semihosting_names))
 		syscall_descr = semihosting_names[syscall];

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -656,7 +656,7 @@ static bool efm32_flash_write(target_flash_s *f, target_addr_t dest, const void 
 	/* Run flashloader */
 	const bool ret = cortexm_run_stub(t, SRAM_BASE, dest, STUB_BUFFER_BASE, len, priv_storage->device->msc_addr) == 0;
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	/* Check the MSC_IF */
 	uint32_t msc = priv_storage->device->msc_addr;
 	uint32_t msc_if = target_mem_read32(t, EFM32_MSC_IF(msc));

--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -218,7 +218,7 @@ bool imxrt_probe(target_s *const target)
 	snprintf(priv->name, IMXRT_NAME_MAX_LENGTH, "i.MXRT%u", priv->chip_id);
 	target->driver = priv->name;
 
-#if defined(ENABLE_DEBUG) && (PC_HOSTED == 1 || defined(ESP_LOGD))
+#if (ENABLE_DEBUG == 1) && (PC_HOSTED == 1 || defined(ESP_LOGD))
 	const uint8_t boot_mode = (target_mem_read32(target, IMXRT_SRC_BOOT_MODE2) >> 24U) & 3U;
 #endif
 	DEBUG_TARGET("i.MXRT boot mode is %x\n", boot_mode);
@@ -521,7 +521,7 @@ static void imxrt_spi_wait_complete(target_s *const target)
 	target_mem_write32(target, IMXRT_FLEXSPI1_INT(priv), IMXRT_FLEXSPI1_INT_PRG_CMD_DONE);
 	/* Check if any errors occured */
 	if (target_mem_read32(target, IMXRT_FLEXSPI1_INT(priv)) & IMXRT_FLEXSPI1_INT_CMD_ERR) {
-#if defined(ENABLE_DEBUG) && PC_HOSTED == 1
+#if (ENABLE_DEBUG == 1) && PC_HOSTED == 1
 		/* Read out the status code and display it */
 		const uint32_t status = target_mem_read32(target, IMXRT_FLEXSPI1_STAT1(priv));
 		DEBUG_TARGET("Error executing sequence, offset %u, error code %u\n", (uint8_t)(status >> 16U) & 0xfU,

--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -218,7 +218,7 @@ bool imxrt_probe(target_s *const target)
 	snprintf(priv->name, IMXRT_NAME_MAX_LENGTH, "i.MXRT%u", priv->chip_id);
 	target->driver = priv->name;
 
-#if (ENABLE_DEBUG == 1) && (PC_HOSTED == 1 || defined(ESP_LOGD))
+#if ENABLE_DEBUG == 1 && (PC_HOSTED == 1 || defined(ESP_LOGD))
 	const uint8_t boot_mode = (target_mem_read32(target, IMXRT_SRC_BOOT_MODE2) >> 24U) & 3U;
 #endif
 	DEBUG_TARGET("i.MXRT boot mode is %x\n", boot_mode);
@@ -521,7 +521,7 @@ static void imxrt_spi_wait_complete(target_s *const target)
 	target_mem_write32(target, IMXRT_FLEXSPI1_INT(priv), IMXRT_FLEXSPI1_INT_PRG_CMD_DONE);
 	/* Check if any errors occured */
 	if (target_mem_read32(target, IMXRT_FLEXSPI1_INT(priv)) & IMXRT_FLEXSPI1_INT_CMD_ERR) {
-#if (ENABLE_DEBUG == 1) && PC_HOSTED == 1
+#if ENABLE_DEBUG == 1 && PC_HOSTED == 1
 		/* Read out the status code and display it */
 		const uint32_t status = target_mem_read32(target, IMXRT_FLEXSPI1_STAT1(priv));
 		DEBUG_TARGET("Error executing sequence, offset %u, error code %u\n", (uint8_t)(status >> 16U) & 0xfU,

--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -29,12 +29,12 @@ const jtag_dev_descr_s dev_descr[] = {
 	{
 		.idcode = 0x0ba00477U,
 		.idmask = 0x0fff0fffU,
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 		.descr = "ADIv5 JTAG-DP port.",
 #endif
 		.handler = adiv5_jtag_dp_handler,
 	},
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	{
 		.idcode = 0x00000477U,
 		.idmask = 0x00000fffU,
@@ -339,7 +339,7 @@ const jtag_dev_descr_s dev_descr[] = {
 	{
 		.idcode = 0x00000093U,
 		.idmask = 0x00000fffU,
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 		.descr = "Xilinx.",
 #endif
 		.ir_quirks =
@@ -352,13 +352,13 @@ const jtag_dev_descr_s dev_descr[] = {
 	{
 		.idcode = 0x0000563dU,
 		.idmask = 0x0fffffffU,
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 		.descr = "RISC-V debug v0.13.",
 #endif
 		.handler = riscv_jtag_dtm_handler,
 	},
 #endif
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	{
 		.idcode = 0x000007a3U,
 		.idmask = 0x00000fffU,
@@ -394,7 +394,7 @@ const jtag_dev_descr_s dev_descr[] = {
 	{
 		.idcode = 0U,
 		.idmask = 0U,
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 		.descr = "Unknown",
 #endif
 	},

--- a/src/target/jtag_devs.h
+++ b/src/target/jtag_devs.h
@@ -31,7 +31,7 @@ typedef struct jtag_ir_quirks {
 typedef struct jtag_dev_descr {
 	uint32_t idcode;
 	uint32_t idmask;
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	const char *descr;
 #endif
 	void (*handler)(uint8_t jd_index);

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -191,7 +191,7 @@ static bool jtag_read_idcodes(void)
 
 static void jtag_display_idcodes(void)
 {
-#if ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	for (size_t device = 0; device < jtag_dev_count; ++device) {
 		const char *description = "Unknown";
 		for (size_t idx = 0; dev_descr[idx].idcode; ++idx) {

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -41,7 +41,7 @@ typedef struct __attribute__((aligned(4))) iap_frame {
 	iap_result_s result;
 } iap_frame_s;
 
-#if defined(ENABLE_DEBUG)
+#if ENABLE_DEBUG == 1
 static const char *const iap_error[] = {
 	"CMD_SUCCESS",
 	"Invalid command",
@@ -261,7 +261,7 @@ iap_status_e lpc_iap_call(lpc_flash_s *const flash, iap_result_s *const result, 
 		*result = results;
 
 /* This guard block deals with the fact iap_error is only defined when ENABLE_DEBUG is */
-#if defined(ENABLE_DEBUG)
+#if ENABLE_DEBUG == 1
 	if (results.return_code < ARRAY_LENGTH(iap_error))
 		DEBUG_INFO("%s: result %s, ", __func__, iap_error[results.return_code]);
 	else

--- a/src/target/rp.c
+++ b/src/target/rp.c
@@ -223,7 +223,7 @@ bool rp_probe(target_s *target)
 		return false;
 	}
 
-#if defined(ENABLE_DEBUG)
+#if ENABLE_DEBUG == 1
 	if ((boot_magic >> BOOTROM_VERSION_SHIFT) == 1)
 		DEBUG_WARN("Old Bootrom Version 1!\n");
 #endif

--- a/src/target/sfdp.c
+++ b/src/target/sfdp.c
@@ -43,7 +43,7 @@
 
 static inline void sfdp_debug_print(const uint32_t address, const void *const buffer, const uint32_t length)
 {
-#if ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	DEBUG_INFO("%" PRIu32 " byte SFDP read at 0x%" PRIx32 ":\n", length, address);
 	const uint8_t *const data = buffer;
 	for (size_t i = 0; i < length; i += 8U) {

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -465,7 +465,7 @@ static bool stm32h7_crc_bank(target_s *target, uint32_t addr)
 	target_mem_write32(target, reg_base + FLASH_CRCCR, crc_ctrl);
 	target_mem_write32(target, reg_base + FLASH_CRCCR, crc_ctrl | FLASH_CRCCR_START_CRC);
 	uint32_t status = FLASH_SR_CRC_BUSY;
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG == 1
 	const uint8_t bank = reg_base == FPEC1_BASE ? 1 : 2;
 #endif
 	while (status & FLASH_SR_CRC_BUSY) {


### PR DESCRIPTION
## Detailed description

I build with GCC's `-Werror`, so I needed to fix a few warnings.

* Assert that constants are `#define`d, before checking their value
* Fixes for function declarations not being prototypes (missing `void` argument)
* Added a missing `NO_LIBOPENCM3` check, when aiming to disable compilation of the library

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
