### PR TITLE
command: Convert format-string in rtt

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -534,8 +534,8 @@ static bool cmd_rtt(target_s *t, int argc, const char **argv)
 		}
 		if (rtt_flag_ram)
 			gdb_outf("ram: 0x%08" PRIx32 " 0x%08" PRIx32, rtt_ram_start, rtt_ram_end);
-		gdb_outf(
-			"\nmax poll ms: %u min poll ms: %u max errs: %u\n", rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
+		gdb_outf("\nmax poll ms: %" PRIu32 " min poll ms: %" PRIu32 " max errs: %" PRIu32 "\n", rtt_max_poll_ms,
+			rtt_min_poll_ms, rtt_max_poll_errs);
 	} else if (argc >= 2 && strncmp(argv[1], "channel", command_len) == 0) {
 		/* mon rtt channel switches to auto rtt channel selection
 		   mon rtt channel number... selects channels given */
@@ -554,9 +554,9 @@ static bool cmd_rtt(target_s *t, int argc, const char **argv)
 	} else if (argc == 2 && strncmp(argv[1], "ident", command_len) == 0)
 		rtt_ident[0] = '\0';
 	else if (argc == 2 && strncmp(argv[1], "poll", command_len) == 0)
-		gdb_outf("%u %u %u\n", rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
+		gdb_outf("%" PRIu32 " %" PRIu32 " %" PRIu32 "\n", rtt_max_poll_ms, rtt_min_poll_ms, rtt_max_poll_errs);
 	else if (argc == 2 && strncmp(argv[1], "cblock", command_len) == 0) {
-		gdb_outf("cbaddr: 0x%x\n", rtt_cbaddr);
+		gdb_outf("cbaddr: 0x%08" PRIx32 "\n", rtt_cbaddr);
 		gdb_out("ch ena i/o buffer@      size   head   tail flag\n");
 		for (uint32_t i = 0; i < rtt_num_up_chan + rtt_num_down_chan; ++i) {
 			gdb_outf("%2" PRIu32 "   %c %s 0x%08" PRIx32 " %6" PRIu32 " %6" PRIu32 " %6" PRIu32 " %4" PRIu32 "\n", i,


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

## Detailed description
This PR brings the format strings in cmd_rtt up to date, removing  gcc -Wformat errors, but keeping existing functionality.
See #1676

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [ ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [ ] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
