### PR TITLE
Feature: RISC-V System Bus support

### DIFF
--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -217,7 +217,7 @@ uint32_t riscv32_pack_data(const void *const src, const uint8_t access_width)
 static void riscv32_abstract_mem_read(
 	riscv_hart_s *const hart, void *const dest, const target_addr_t src, const size_t len)
 {
-	/* Figure out the maxmial width of access to perform, up to the bitness of the target */
+	/* Figure out the maximal width of access to perform, up to the bitness of the target */
 	const uint8_t access_width = riscv_mem_access_width(hart, src, len);
 	const uint8_t access_length = 1U << access_width;
 	/* Build the access command */

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -283,14 +283,29 @@ static void riscv32_sysbus_mem_write(
 void riscv32_mem_read(target_s *const target, void *const dest, const target_addr_t src, const size_t len)
 {
 	/* If we're asked to do a 0-byte read, do nothing */
-	if (!len)
+	if (!len) {
+		DEBUG_PROTO("%s: @ %08" PRIx32 " len %zu\n", __func__, src, len);
 		return;
+	}
 
 	riscv_hart_s *const hart = riscv_hart_struct(target);
 	if (hart->flags & RV_HART_FLAG_MEMORY_SYSBUS)
 		riscv32_sysbus_mem_read(hart, dest, src, len);
 	else
 		riscv32_abstract_mem_read(hart, dest, src, len);
+
+#if ENABLE_DEBUG
+	DEBUG_PROTO("%s: @ %08" PRIx32 " len %zu:", __func__, src, len);
+	const uint8_t *const data = (const uint8_t *)dest;
+	for (size_t offset = 0; offset < len; ++offset) {
+		if (offset == 16U)
+			break;
+		DEBUG_PROTO(" %02x", data[offset]);
+	}
+	if (len > 16U)
+		DEBUG_PROTO(" ...");
+	DEBUG_PROTO("\n");
+#endif
 }
 
 void riscv32_mem_write(target_s *const target, const target_addr_t dest, const void *const src, const size_t len)

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -277,14 +277,11 @@ static void riscv_sysbus_check(riscv_hart_s *const hart)
 		DEBUG_WARN("memory access failed: %u\n", hart->status);
 }
 
-static void riscv32_sysbus_mem_read(
-	riscv_hart_s *const hart, void *const dest, const target_addr_t src, const size_t len)
+static void riscv32_sysbus_mem_native_read(riscv_hart_s *const hart, void *const dest, const target_addr_t src,
+	const size_t len, const uint8_t access_width, const uint8_t access_length)
 {
-	/* Figure out the maxmial width of access to perform, up to the bitness of the target */
-	const uint8_t access_width = riscv_mem_access_width(hart, src, len);
-	const uint8_t access_length = 1U << access_width;
 	/* Build the access command */
-	const uint32_t command = (access_width << RV_SYSBUS_MEM_ACCESS_SHIFT) | RV_SYSBUS_MEM_READ_ON_ADDR |
+	const uint32_t command = ((uint32_t)access_width << RV_SYSBUS_MEM_ACCESS_SHIFT) | RV_SYSBUS_MEM_READ_ON_ADDR |
 		(access_length < len ? RV_SYSBUS_MEM_ADDR_POST_INC | RV_SYSBUS_MEM_READ_ON_DATA : 0U);
 	/*
 	 * Write the command setup to the access control register
@@ -313,6 +310,15 @@ static void riscv32_sysbus_mem_read(
 		riscv32_unpack_data(data + offset, value, access_width);
 	}
 	riscv_sysbus_check(hart);
+}
+
+static void riscv32_sysbus_mem_read(
+	riscv_hart_s *const hart, void *const dest, const target_addr_t src, const size_t len)
+{
+	/* Figure out the maxmial width of access to perform, up to the bitness of the target */
+	const uint8_t access_width = riscv_mem_access_width(hart, src, len);
+	const uint8_t access_length = (uint8_t)(1U << access_width);
+	riscv32_sysbus_mem_native_read(hart, dest, src, len, access_width, access_length);
 }
 
 static void riscv32_sysbus_mem_write(

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -310,6 +310,16 @@ void riscv32_mem_read(target_s *const target, void *const dest, const target_add
 
 void riscv32_mem_write(target_s *const target, const target_addr_t dest, const void *const src, const size_t len)
 {
+	DEBUG_PROTO("%s: @ %" PRIx32 " len %zu:", __func__, dest, len);
+	const uint8_t *const data = (const uint8_t *)src;
+	for (size_t offset = 0; offset < len; ++offset) {
+		if (offset == 16U)
+			break;
+		DEBUG_PROTO(" %02x", data[offset]);
+	}
+	if (len > 16U)
+		DEBUG_PROTO(" ...");
+	DEBUG_PROTO("\n");
 	/* If we're asked to do a 0-byte read, do nothing */
 	if (!len)
 		return;

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -220,8 +220,8 @@ static void riscv32_abstract_mem_read(
 	const uint8_t access_width = riscv_mem_access_width(hart, src, len);
 	const uint8_t access_length = 1U << access_width;
 	/* Build the access command */
-	const uint32_t command = RV_DM_ABST_CMD_ACCESS_MEM | RV_ABST_READ | (access_width << RV_MEM_ACCESS_SHIFT) |
-		(access_length < len ? RV_MEM_ADDR_POST_INC : 0U);
+	const uint32_t command = RV_DM_ABST_CMD_ACCESS_MEM | RV_ABST_READ | (access_width << RV_ABST_MEM_ACCESS_SHIFT) |
+		(access_length < len ? RV_ABST_MEM_ADDR_POST_INC : 0U);
 	/* Write the address to read to arg1 */
 	if (!riscv_dm_write(hart->dbg_module, RV_DM_DATA1, src))
 		return;
@@ -245,8 +245,8 @@ static void riscv32_abstract_mem_write(
 	const uint8_t access_width = riscv_mem_access_width(hart, dest, len);
 	const uint8_t access_length = 1U << access_width;
 	/* Build the access command */
-	const uint32_t command = RV_DM_ABST_CMD_ACCESS_MEM | RV_ABST_WRITE | (access_width << RV_MEM_ACCESS_SHIFT) |
-		(access_length < len ? RV_MEM_ADDR_POST_INC : 0U);
+	const uint32_t command = RV_DM_ABST_CMD_ACCESS_MEM | RV_ABST_WRITE | (access_width << RV_ABST_MEM_ACCESS_SHIFT) |
+		(access_length < len ? RV_ABST_MEM_ADDR_POST_INC : 0U);
 	/* Write the address to write to arg1 */
 	if (!riscv_dm_write(hart->dbg_module, RV_DM_DATA1, dest))
 		return;

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -407,15 +407,12 @@ static void riscv32_sysbus_mem_read(
 		riscv32_sysbus_mem_adjusted_read(hart, data, address, remainder, native_access_width, native_access_length);
 }
 
-static void riscv32_sysbus_mem_write(
-	riscv_hart_s *const hart, const target_addr_t dest, const void *const src, const size_t len)
+static void riscv32_sysbus_mem_native_write(riscv_hart_s *const hart, const target_addr_t dest, const void *const src,
+	const size_t len, const uint8_t access_width, const uint8_t access_length)
 {
-	/* Figure out the maxmial width of access to perform, up to the bitness of the target */
-	const uint8_t access_width = riscv_mem_access_width(hart, dest, len);
-	const uint8_t access_length = 1U << access_width;
 	/* Build the access command */
-	const uint32_t command =
-		(access_width << RV_SYSBUS_MEM_ACCESS_SHIFT) | (access_length < len ? RV_SYSBUS_MEM_ADDR_POST_INC : 0U);
+	const uint32_t command = ((uint32_t)access_width << RV_SYSBUS_MEM_ACCESS_SHIFT) |
+		(access_length < len ? RV_SYSBUS_MEM_ADDR_POST_INC : 0U);
 	/*
 	 * Write the command setup to the access control register
 	 * Then set up the write by writing the address to the address register
@@ -438,6 +435,16 @@ static void riscv32_sysbus_mem_write(
 		}
 	}
 	riscv_sysbus_check(hart);
+}
+
+static void riscv32_sysbus_mem_write(
+	riscv_hart_s *const hart, const target_addr_t dest, const void *const src, const size_t len)
+{
+	/* Figure out the maxmial width of access to perform, up to the bitness of the target */
+	const uint8_t access_width = riscv_mem_access_width(hart, dest, len);
+	const uint8_t access_length = 1U << access_width;
+	/* Check if the access is a natural/native width */
+	riscv32_sysbus_mem_native_write(hart, dest, src, len, access_width, access_length);
 }
 
 void riscv32_mem_read(target_s *const target, void *const dest, const target_addr_t src, const size_t len)

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -262,6 +262,21 @@ static void riscv32_abstract_mem_write(
 	}
 }
 
+static void riscv_sysbus_check(riscv_hart_s *const hart)
+{
+	uint32_t status = 0;
+	/* Read back the system bus status */
+	if (!riscv_dm_read(hart->dbg_module, RV_DM_SYSBUS_CTRLSTATUS, &status))
+		return;
+	/* Store the result and reset the value in the control/status register */
+	hart->status = (status >> 12U) & RISCV_HART_OTHER;
+	if (!riscv_dm_write(hart->dbg_module, RV_DM_SYSBUS_CTRLSTATUS, RISCV_HART_OTHER << 12U))
+		return;
+	/* If something goes wrong, tell the user */
+	if (hart->status != RISCV_HART_NO_ERROR)
+		DEBUG_WARN("memory access failed: %u\n", hart->status);
+}
+
 static void riscv32_sysbus_mem_read(
 	riscv_hart_s *const hart, void *const dest, const target_addr_t src, const size_t len)
 {
@@ -292,29 +307,45 @@ static void riscv32_sysbus_mem_read(
 				return;
 		}
 		uint32_t value = 0;
-		/* Read back and extract the data for this block */
+		/* Read back and unpack the data for this block */
 		if (!riscv_dm_read(hart->dbg_module, RV_DM_SYSBUS_DATA0, &value))
 			return;
 		riscv32_unpack_data(data + offset, value, access_width);
 	}
-	uint32_t status = 0;
-	/* Read back the system bus status */
-	if (!riscv_dm_read(hart->dbg_module, RV_DM_SYSBUS_CTRLSTATUS, &status))
-		return;
-	hart->status = (status >> 12U) & RISCV_HART_OTHER;
-	if (!riscv_dm_write(hart->dbg_module, RV_DM_SYSBUS_CTRLSTATUS, RISCV_HART_OTHER << 12U))
-		return;
-	if (hart->status != RISCV_HART_NO_ERROR)
-		DEBUG_WARN("memory read failed: %u\n", hart->status);
+	riscv_sysbus_check(hart);
 }
 
 static void riscv32_sysbus_mem_write(
 	riscv_hart_s *const hart, const target_addr_t dest, const void *const src, const size_t len)
 {
-	(void)hart;
-	(void)dest;
-	(void)src;
-	(void)len;
+	/* Figure out the maxmial width of access to perform, up to the bitness of the target */
+	const uint8_t access_width = riscv_mem_access_width(hart, dest, len);
+	const uint8_t access_length = 1U << access_width;
+	/* Build the access command */
+	const uint32_t command =
+		(access_width << RV_SYSBUS_MEM_ACCESS_SHIFT) | (access_length < len ? RV_SYSBUS_MEM_ADDR_POST_INC : 0U);
+	/*
+	 * Write the command setup to the access control register
+	 * Then set up the write by writing the address to the address register
+	 */
+	if (!riscv_dm_write(hart->dbg_module, RV_DM_SYSBUS_CTRLSTATUS, command) ||
+		!riscv_dm_write(hart->dbg_module, RV_DM_SYSBUS_ADDR0, dest))
+		return;
+	const uint8_t *const data = (const uint8_t *)src;
+	for (size_t offset = 0; offset < len; offset += access_length) {
+		/* Pack the data for this block and write it */
+		const uint32_t value = riscv32_pack_data(data + offset, access_width);
+		if (!riscv_dm_write(hart->dbg_module, RV_DM_SYSBUS_DATA0, value))
+			return;
+
+		uint32_t status = RV_SYSBUS_STATUS_BUSY;
+		/* Wait for the current write cycle to complete */
+		while (status & RV_SYSBUS_STATUS_BUSY) {
+			if (!riscv_dm_read(hart->dbg_module, RV_DM_SYSBUS_CTRLSTATUS, &status))
+				return;
+		}
+	}
+	riscv_sysbus_check(hart);
 }
 
 void riscv32_mem_read(target_s *const target, void *const dest, const target_addr_t src, const size_t len)

--- a/src/target/riscv64.c
+++ b/src/target/riscv64.c
@@ -121,8 +121,8 @@ static void riscv64_mem_read(target_s *const target, void *const dest, const tar
 	const uint8_t access_width = riscv_mem_access_width(hart, src, len);
 	const uint8_t access_length = 1U << access_width;
 	/* Build the access command */
-	const uint32_t command = RV_DM_ABST_CMD_ACCESS_MEM | RV_ABST_READ | (access_width << RV_MEM_ACCESS_SHIFT) |
-		(access_length < len ? RV_MEM_ADDR_POST_INC : 0U);
+	const uint32_t command = RV_DM_ABST_CMD_ACCESS_MEM | RV_ABST_READ | (access_width << RV_ABST_MEM_ACCESS_SHIFT) |
+		(access_length < len ? RV_ABST_MEM_ADDR_POST_INC : 0U);
 	/* Write the address to read to arg1 */
 	if (!riscv_dm_write(hart->dbg_module, RV_DM_DATA2, src) || !riscv_dm_write(hart->dbg_module, RV_DM_DATA3, 0U))
 		return;

--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -522,7 +522,8 @@ static uint32_t riscv_hart_discover_isa(riscv_hart_s *const hart)
 			return isa_data[0];
 		}
 		/* If that failed, then find out why and instead try the next narrower width */
-		if (hart->status != RISCV_HART_BUS_ERROR && hart->status != RISCV_HART_EXCEPTION)
+		if (hart->status != RISCV_HART_BUS_ERROR && hart->status != RISCV_HART_EXCEPTION &&
+			hart->status != RISCV_HART_NOT_SUPP)
 			return 0;
 		if (hart->access_width == 32U) {
 			hart->access_width = 0U;

--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -634,7 +634,7 @@ bool riscv_csr_write(riscv_hart_s *const hart, const uint16_t reg, const void *c
 uint8_t riscv_mem_access_width(const riscv_hart_s *const hart, const target_addr_t address, const size_t length)
 {
 	/* Grab the Hart's most maxmimally aligned possible write width */
-	uint8_t access_width = riscv_hart_access_width(hart->address_width) >> RV_MEM_ACCESS_SHIFT;
+	uint8_t access_width = riscv_hart_access_width(hart->address_width) >> RV_ABST_MEM_ACCESS_SHIFT;
 	/* Convert the hart access width to a mask - for example, for 32-bit harts, this gives (1U << 2U) - 1U = 3U */
 	uint8_t align_mask = (1U << access_width) - 1U;
 	/* Mask out the bottom bits of both the address and length - anything that determines the alignment */

--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -423,11 +423,15 @@ static void riscv_hart_free(void *const priv)
 
 static bool riscv_dmi_read(riscv_dmi_s *const dmi, const uint32_t address, uint32_t *const value)
 {
-	return dmi->read(dmi, address, value);
+	const bool result = dmi->read(dmi, address, value);
+	if (result)
+		DEBUG_PROTO("%s:  %08" PRIx32 " -> %08" PRIx32 "\n", __func__, address, *value);
+	return result;
 }
 
 static bool riscv_dmi_write(riscv_dmi_s *const dmi, const uint32_t address, const uint32_t value)
 {
+	DEBUG_PROTO("%s: %08" PRIx32 " <- %08" PRIx32 "\n", __func__, address, value);
 	return dmi->write(dmi, address, value);
 }
 

--- a/src/target/riscv_debug.h
+++ b/src/target/riscv_debug.h
@@ -84,6 +84,10 @@ typedef enum riscv_match_size {
 	RV_MATCH_SIZE_128_BIT = 0x00410000U,
 } riscv_match_size_e;
 
+/* These defines specify Hart-specific information such as which memory access style to use */
+#define RV_HART_FLAG_MEMORY_ABSTRACT 0x00U
+#define RV_HART_FLAG_MEMORY_SYSBUS   0x01U
+
 typedef struct riscv_dmi riscv_dmi_s;
 
 /* This structure represents a version-agnostic Debug Module Interface on a RISC-V device */
@@ -122,6 +126,7 @@ typedef struct riscv_hart {
 	uint32_t hartsel;
 	uint8_t access_width;
 	uint8_t address_width;
+	uint8_t flags;
 	riscv_hart_status_e status;
 
 	uint32_t extensions;
@@ -208,5 +213,8 @@ bool riscv_config_trigger(
 uint8_t riscv_mem_access_width(const riscv_hart_s *hart, target_addr_t address, size_t length);
 void riscv32_unpack_data(void *dest, uint32_t data, uint8_t access_width);
 uint32_t riscv32_pack_data(const void *src, uint8_t access_width);
+
+void riscv32_mem_read(target_s *target, void *dest, target_addr_t src, size_t len);
+void riscv32_mem_write(target_s *target, target_addr_t dest, const void *src, size_t len);
 
 #endif /*TARGET_RISCV_DEBUG_H*/

--- a/src/target/riscv_debug.h
+++ b/src/target/riscv_debug.h
@@ -177,6 +177,12 @@ typedef struct riscv_hart {
 #define RV_ABST_MEM_ADDR_POST_INC 0x00080000U
 #define RV_ABST_MEM_ACCESS_SHIFT  20U
 
+#define RV_SYSBUS_MEM_ADDR_POST_INC 0x00010000U
+#define RV_SYSBUS_MEM_READ_ON_ADDR  0x00100000U
+#define RV_SYSBUS_MEM_READ_ON_DATA  0x00008000U
+#define RV_SYSBUS_STATUS_BUSY       0x00200000U
+#define RV_SYSBUS_MEM_ACCESS_SHIFT  17U
+
 /* dpc -> Debug Program Counter */
 #define RV_DPC 0x7b1U
 /* The GPR base defines the starting register space address for the CPU state registers */

--- a/src/target/riscv_debug.h
+++ b/src/target/riscv_debug.h
@@ -167,14 +167,15 @@ typedef struct riscv_hart {
 #define RV_REG_ACCESS_32_BIT  0x00200000U
 #define RV_REG_ACCESS_64_BIT  0x00300000U
 #define RV_REG_ACCESS_128_BIT 0x00400000U
-#define RV_MEM_ADDR_POST_INC  0x00080000U
 
 #define RV_MEM_ACCESS_8_BIT   0x0U
 #define RV_MEM_ACCESS_16_BIT  0x1U
 #define RV_MEM_ACCESS_32_BIT  0x2U
 #define RV_MEM_ACCESS_64_BIT  0x3U
 #define RV_MEM_ACCESS_128_BIT 0x4U
-#define RV_MEM_ACCESS_SHIFT   20U
+
+#define RV_ABST_MEM_ADDR_POST_INC 0x00080000U
+#define RV_ABST_MEM_ACCESS_SHIFT  20U
 
 /* dpc -> Debug Program Counter */
 #define RV_DPC 0x7b1U

--- a/src/target/riscv_debug.h
+++ b/src/target/riscv_debug.h
@@ -85,8 +85,13 @@ typedef enum riscv_match_size {
 } riscv_match_size_e;
 
 /* These defines specify Hart-specific information such as which memory access style to use */
-#define RV_HART_FLAG_MEMORY_ABSTRACT 0x00U
-#define RV_HART_FLAG_MEMORY_SYSBUS   0x01U
+#define RV_HART_FLAG_MEMORY_ABSTRACT    0x00U
+#define RV_HART_FLAG_MEMORY_SYSBUS      0x10U
+#define RV_HART_FLAG_ACCESS_WIDTH_MASK  0x0fU
+#define RV_HART_FLAG_ACCESS_WIDTH_8BIT  0x01U
+#define RV_HART_FLAG_ACCESS_WIDTH_16BIT 0x02U
+#define RV_HART_FLAG_ACCESS_WIDTH_32BIT 0x04U
+#define RV_HART_FLAG_ACCESS_WIDTH_64BIT 0x08U
 
 typedef struct riscv_dmi riscv_dmi_s;
 
@@ -141,12 +146,17 @@ typedef struct riscv_hart {
 
 #define RV_STATUS_VERSION_MASK 0x0000000fU
 
-#define RV_DM_DATA0           0x04U
-#define RV_DM_DATA1           0x05U
-#define RV_DM_DATA2           0x06U
-#define RV_DM_DATA3           0x07U
-#define RV_DM_ABST_CTRLSTATUS 0x16U
-#define RV_DM_ABST_COMMAND    0x17U
+#define RV_DM_DATA0             0x04U
+#define RV_DM_DATA1             0x05U
+#define RV_DM_DATA2             0x06U
+#define RV_DM_DATA3             0x07U
+#define RV_DM_ABST_CTRLSTATUS   0x16U
+#define RV_DM_ABST_COMMAND      0x17U
+#define RV_DM_SYSBUS_CTRLSTATUS 0x38U
+#define RV_DM_SYSBUS_ADDR0      0x39U
+#define RV_DM_SYSBUS_ADDR1      0x3aU
+#define RV_DM_SYSBUS_DATA0      0x3cU
+#define RV_DM_SYSBUS_DATA1      0x3dU
 
 #define RV_DM_ABST_CMD_ACCESS_REG 0x00000000U
 #define RV_DM_ABST_CMD_ACCESS_MEM 0x02000000U

--- a/src/target/riscv_jtag_dtm.c
+++ b/src/target/riscv_jtag_dtm.c
@@ -125,6 +125,12 @@ uint32_t riscv_shift_dtmcs(const riscv_dmi_s *const dmi, const uint32_t control)
 	return status;
 }
 
+static void riscv_dmi_reset(const riscv_dmi_s *const dmi)
+{
+	riscv_shift_dtmcs(dmi, RV_DTMCS_DMI_RESET);
+	jtag_dev_write_ir(dmi->dev_index, IR_DMI);
+}
+
 static bool riscv_shift_dmi(riscv_dmi_s *const dmi, const uint8_t operation, const uint32_t address,
 	const uint32_t data_in, uint32_t *const data_out)
 {
@@ -145,6 +151,8 @@ static bool riscv_shift_dmi(riscv_dmi_s *const dmi, const uint8_t operation, con
 	jtagtap_return_idle(dmi->idle_cycles);
 	/* XXX: Need to deal with when status is 3. */
 	dmi->fault = status;
+	if (status == RV_DMI_FAILURE)
+		riscv_dmi_reset(dmi);
 	return status == RV_DMI_SUCCESS;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we implement support for the RISC-V debug 'System Bus' (sysbus) component, as not all targets have to nor do implement the memory I/O abstract command. This complicates things but is required to support, eg, the ESP32-C3.

To accomplish this, we have to deal with sysbus having made all I/O widths optional to support while also needing to be able to do any arbitrarily sized and aligned read/write. The one benefit is that, depending on implementation, sysbus may be used without halting the Hart, unlike the abstract command interface which requires it halted (read: due to it injecting an instruction stream into the core to run the read/write, though this is strictly an implementation detail).

Unfortunately, this puts the burden of performing the I/O correctly on us, but we've attempted to minimise the logic and complications caused by this and document everything thoroughly. This logic has been tested on an ESP32-C3 and works.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
