### PR TITLE
Fix: Missing RISC-V debug guard

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -82,14 +82,22 @@
 #define DEBUG_INFO(...)  PLATFORM_PRINTF(__VA_ARGS__)
 #else
 #define DEBUG_ERROR(...) PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_WARN(...)  PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_INFO(...)  PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_ERROR_IS_NOOP
+#define DEBUG_WARN(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_WARN_IS_NOOP
+#define DEBUG_INFO(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_INFO_IS_NOOP
 #endif
-#define DEBUG_GDB(...)    PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_GDB(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_GDB_IS_NOOP
 #define DEBUG_TARGET(...) PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_PROTO(...)  PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_PROBE(...)  PRINT_NOOP(__VA_ARGS__)
-#define DEBUG_WIRE(...)   PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_TARGET_IS_NOOP
+#define DEBUG_PROTO(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_PROTO_IS_NOOP
+#define DEBUG_PROBE(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_PROBE_IS_NOOP
+#define DEBUG_WIRE(...) PRINT_NOOP(__VA_ARGS__)
+#define DEBUG_WIRE_IS_NOOP
 
 void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #else

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -562,7 +562,9 @@ void riscv32_mem_read(target_s *const target, void *const dest, const target_add
 
 #if ENABLE_DEBUG
 	DEBUG_PROTO("%s: @ %08" PRIx32 " len %zu:", __func__, src, len);
+#ifndef DEBUG_PROTO_IS_NOOP
 	const uint8_t *const data = (const uint8_t *)dest;
+#endif
 	for (size_t offset = 0; offset < len; ++offset) {
 		if (offset == 16U)
 			break;
@@ -578,7 +580,9 @@ void riscv32_mem_write(target_s *const target, const target_addr_t dest, const v
 {
 #if ENABLE_DEBUG
 	DEBUG_PROTO("%s: @ %" PRIx32 " len %zu:", __func__, dest, len);
+#ifndef DEBUG_PROTO_IS_NOOP
 	const uint8_t *const data = (const uint8_t *)src;
+#endif
 	for (size_t offset = 0; offset < len; ++offset) {
 		if (offset == 16U)
 			break;

--- a/src/target/riscv32.c
+++ b/src/target/riscv32.c
@@ -576,6 +576,7 @@ void riscv32_mem_read(target_s *const target, void *const dest, const target_add
 
 void riscv32_mem_write(target_s *const target, const target_addr_t dest, const void *const src, const size_t len)
 {
+#if ENABLE_DEBUG
 	DEBUG_PROTO("%s: @ %" PRIx32 " len %zu:", __func__, dest, len);
 	const uint8_t *const data = (const uint8_t *)src;
 	for (size_t offset = 0; offset < len; ++offset) {
@@ -586,6 +587,7 @@ void riscv32_mem_write(target_s *const target, const target_addr_t dest, const v
 	if (len > 16U)
 		DEBUG_PROTO(" ...");
 	DEBUG_PROTO("\n");
+#endif
 	/* If we're asked to do a 0-byte read, do nothing */
 	if (!len)
 		return;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses an oversight of #1683 resulting in a build error when `ENABLE_DEBUG` is not true.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
