### PR TITLE
Fix: Semihosting in BMP

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -117,6 +117,42 @@ typedef struct cortexm_priv {
 	uint32_t demcr;
 } cortexm_priv_s;
 
+#ifdef ENABLE_DEBUG
+const char *const semihosting_names[] = {
+	"",
+	"SYS_OPEN",
+	"SYS_CLOSE",
+	"SYS_WRITEC",
+	"SYS_WRITE0",
+	"SYS_WRITE",
+	"SYS_READ",
+	"SYS_READC",
+	"SYS_ISERROR",
+	"SYS_ISTTY",
+	"SYS_SEEK",
+	"0x0b",
+	"SYS_FLEN",
+	"SYS_TMPNAM",
+	"SYS_REMOVE",
+	"SYS_RENAME",
+	"SYS_CLOCK",
+	"SYS_TIME",
+	"SYS_SYSTEM",
+	"SYS_ERRNO",
+	"0x14",
+	"SYS_GET_CMDLINE",
+	"SYS_HEAPINFO",
+	"0x17",
+	[SEMIHOSTING_SYS_EXIT] = "SYS_EXIT",
+	/* 7 reserved */
+	[SEMIHOSTING_SYS_EXIT_EXTENDED] = "SYS_EXIT_EXTENDED",
+	/* 15 reserved */
+	[SEMIHOSTING_SYS_ELAPSED] = "SYS_ELAPSED",
+	[SEMIHOSTING_SYS_TICKFREQ] = "SYS_TICKFREQ",
+	"",
+};
+#endif
+
 /* Register number tables */
 static const uint32_t regnum_cortex_m[CORTEXM_GENERAL_REG_COUNT] = {
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, /* standard r0-r15 */
@@ -1434,8 +1470,16 @@ static int cortexm_hostio_request(target_s *target)
 		target_mem_read(target, params, arm_regs[1], sizeof(params));
 	int32_t ret = 0;
 
-	DEBUG_INFO("syscall 0" PRIx32 "%" PRIx32 " (%" PRIx32 " %" PRIx32 " %" PRIx32 " %" PRIx32 ")\n", syscall, params[0],
-		params[1], params[2], params[3]);
+#ifdef ENABLE_DEBUG
+	const char *syscall_descr = NULL;
+	if (syscall < ARRAY_LENGTH(semihosting_names))
+		syscall_descr = semihosting_names[syscall];
+	if (syscall_descr == NULL)
+		syscall_descr = "";
+
+	DEBUG_INFO("syscall %12s (%" PRIx32 " %" PRIx32 " %" PRIx32 " %" PRIx32 ")\n", syscall_descr, params[0], params[1],
+		params[2], params[3]);
+#endif
 	switch (syscall) {
 #if PC_HOSTED == 1
 


### PR DESCRIPTION
## Detailed description

* The problem is BMP's implementation of semihosting via GDB File-I/O (not BMDA) has been broken since #1284. Some attempt was made in #1432 to make it at least not crash the adapter.
* The PR solves the problem by introducing a second loop to service GDB packets before/other than F-reply.

I based the WIP tree on PR1432 single commit v1.9.0-435-g906f8878 backported to just past PR1284 merge, v1.9.0-55-g5cf0dd27. I had to enable DEBUG_GDB, DEBUG_GDB_WIRE and drop a bunch of drivers to fit into `swlink`, because my adapter of choice (blackpill-f411ce) did not exist until approximately v1.9.0-700 in usable form. The logs from BMP internals were **critical** for understanding how RSP packets go missing.

Current patch adds a `while(true)` loop at stack depth of 9 functions to allow for parsing the 1-4 packets GDB has to emit before finishing the semihosting File-I/O syscall and returning its result code. AFAIK this has to be avoided in out-of-tree projects like Farpatch which will reboot due to watchdog timeouts from not going through the superloop often enough. But this variant seems to work, and you all can decide how to improve it, because it provides some starting/reference point.

The less related change replaces the `syscall 0lx1 (800289c 0 3 20000054)` prints 
with more readable `syscall     SYS_OPEN (800289c 0 3 20000054)`. Since v1.10.0 release I don't care about flash space much; it can be dropped in case of backporting, but it shouldn't affect release firmware because it's in DEBUG_INFO (and I could gate it on ENABLE_DEBUG for 332 bytes).

Tested on `swlink` attached to Nucleo-G071RB target running SemihostingTest.ino over SWD (with its onboard JLinkReflash idling), using GDB-8/10/12 (NuttX, ST, GNU-RM).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) *and should not affect it*
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1678.