### PR TITLE
send initial usb cdc notification from the correct endpoint

### DIFF
--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -211,8 +211,8 @@ void usb_serial_set_config(usbd_device *dev, uint16_t value)
 	/* Notify the host that DCD is asserted.
 	 * Allows the use of /dev/tty* devices on *BSD/MacOS
 	 */
-	usb_serial_set_state(dev, GDB_IF_NO, CDCACM_GDB_ENDPOINT);
-	usb_serial_set_state(dev, UART_IF_NO, CDCACM_UART_ENDPOINT);
+	usb_serial_set_state(dev, GDB_IF_NO, CDCACM_GDB_ENDPOINT + 1U);
+	usb_serial_set_state(dev, UART_IF_NO, CDCACM_UART_ENDPOINT + 1U);
 
 #if defined(ENABLE_DEBUG) && defined(PLATFORM_HAS_DEBUG)
 	initialise_monitor_handles();


### PR DESCRIPTION
Hi,

I was looking into usb-cdc-acm implementations to understand the required descriptors/endpoints when I found something that's probably a bug:

It looks like usb cdc acm notifications are sent from the data endpoint in `usb_serial_set_config()`
instead of the notifications endpoint. The function `usb_serial_set_state()` is called twice more in this file, but with notification endpoints as argument.

https://github.com/blackmagic-debug/blackmagic/blob/main/src/platforms/common/usb_serial.c#L106
https://github.com/blackmagic-debug/blackmagic/blob/main/src/platforms/common/usb_serial.c#L144

`make PROBE_HOST=native` fails for me for both pre & post fix, due to firmware size overruns, but I've tested an stlink / blue pill build which works.

I was expecting the wrongly sent data to come out of ttyACM[01] without the fix, but that doesn't seem to be the case.
I guess Linux only sends serial data that arrives after you open the device and I probably wasn't fast enough to win this race.

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (`make PROBE_HOST=native`)
* [*] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

 * I used HOSTED_BMP_ONLY=1 to avoid installing dependencies, but the change is in the firmware anyway

## Closing issues
