### PR TITLE
Fix: allow gdbserver to idle more

### DIFF
--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -55,7 +55,10 @@ void gdb_set_noackmode(bool enable)
 	if (!enable && noackmode)
 		gdb_if_putchar(GDB_PACKET_ACK, 1U);
 
-	DEBUG_GDB("%s NoAckMode\n", enable ? "Enabling" : "Disabling");
+	/* Log only changes */
+	if (noackmode != enable)
+		DEBUG_GDB("%s NoAckMode\n", enable ? "Enabling" : "Disabling");
+
 	noackmode = enable;
 }
 

--- a/src/platforms/common/stm32/gdb_if.c
+++ b/src/platforms/common/stm32/gdb_if.c
@@ -88,7 +88,8 @@ static void gdb_if_update_buf(void)
 	count_out = usbd_ep_read_packet(usbdev, CDCACM_GDB_ENDPOINT, buffer_out, CDCACM_PACKET_SIZE);
 	out_ptr = 0;
 #else
-	__asm__ volatile("cpsid i; isb");
+	cm_disable_interrupts();
+	__asm__ volatile("isb");
 	if (count_new) {
 		memcpy(buffer_out, double_buffer_out, count_new);
 		count_out = count_new;
@@ -96,7 +97,10 @@ static void gdb_if_update_buf(void)
 		out_ptr = 0;
 		usbd_ep_nak_set(usbdev, CDCACM_GDB_ENDPOINT, 0);
 	}
-	__asm__ volatile("cpsie i; isb");
+	cm_enable_interrupts();
+	__asm__ volatile("isb");
+	if (!count_new)
+		__WFI();
 #endif
 	if (!count_out)
 		__WFI();


### PR DESCRIPTION
## Detailed description

* This is not a new feature.
* The problem existing on stm32f4/dwc2 platforms is full busy-polling between gdb interactions, whereas the stm32f1 platforms sleep (WFI). Also under DEBUG_GDB any BMP will spam "Enabling NoAckMode" to ttyBmpTarg.
* This PR solves the problems by updating the gdb interface to also WFI when no data is received (in stm32f4/f7 specific part); and by gating the logging statement to only log on actual state changes.

First problem discovered by running orbtop over swlink against blackpill-f4; second problem discovered earlier in the process of fixing semihosting.

Also update the `cpsid i; isb` to more idiomatic style and to use libopencm3 API (there's no __ISB(), like there is CMSIS).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
There seem to be no issues highlighting this, and I rarely report issues myself.