### PR TITLE
Fix: Speed up bus turnaround for blackpill-f4 like other platforms

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -115,6 +115,31 @@
 #define SWDIO_PORT TMS_PORT
 #define SWDIO_PIN  TMS_PIN
 
+#define SWDIO_MODE_REG_MULT_PB9 (1U << (9U << 1U))
+#define SWDIO_MODE_REG_MULT_PB8 (1U << (8U << 1U))
+/* Update when adding more alternative pinouts */
+#define SWDIO_MODE_REG_MULT PINOUT_SWITCH(SWDIO_MODE_REG_MULT_PB9, SWDIO_MODE_REG_MULT_PB8)
+#define SWDIO_MODE_REG      GPIO_MODER(TMS_PORT)
+
+#define TMS_SET_MODE()                                                    \
+	gpio_mode_setup(TMS_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TMS_PIN); \
+	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TMS_PIN);
+
+/* Perform SWDIO bus turnaround faster than a gpio_mode_setup() call */
+#define SWDIO_MODE_FLOAT()                       \
+	do {                                         \
+		uint32_t mode_reg = SWDIO_MODE_REG;      \
+		mode_reg &= ~(3U * SWDIO_MODE_REG_MULT); \
+		SWDIO_MODE_REG = mode_reg;               \
+	} while (0)
+
+#define SWDIO_MODE_DRIVE()                      \
+	do {                                        \
+		uint32_t mode_reg = SWDIO_MODE_REG;     \
+		mode_reg |= (1U * SWDIO_MODE_REG_MULT); \
+		SWDIO_MODE_REG = mode_reg;              \
+	} while (0)
+
 #define TRST_PORT PINOUT_SWITCH(GPIOA, GPIOB)
 #define TRST_PIN  PINOUT_SWITCH(GPIO6, GPIO3)
 
@@ -221,10 +246,6 @@
 #define BOOTMAGIC0 UINT32_C(0xb007da7a)
 #define BOOTMAGIC1 UINT32_C(0xbaadfeed)
 
-#define TMS_SET_MODE()     gpio_mode_setup(TMS_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TMS_PIN);
-#define SWDIO_MODE_FLOAT() gpio_mode_setup(SWDIO_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, SWDIO_PIN);
-
-#define SWDIO_MODE_DRIVE() gpio_mode_setup(SWDIO_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, SWDIO_PIN);
 #define UART_PIN_SETUP()                                                                            \
 	do {                                                                                            \
 		gpio_mode_setup(USBUSART_PORT, GPIO_MODE_AF, GPIO_PUPD_NONE, USBUSART_TX_PIN);              \


### PR DESCRIPTION
## Detailed description

* This is not a feature, but may affect external/out-of-tree features (like direction GPIO for bus turnaround).
* The existing problem is a long function call to gpio_mode_setup() in the process of high-performance bitbanging of SWD on `blackpill-f4` family of platforms.
* This PR solves the problem by porting inline code / macros existing in other platforms.

Testing on fix/tap-timing branch with a blackpill-f411ce in max frequency (~8MHz) against a STM32MP157_CM4 shows an increase of performance of loading a 64 KiB binary into RETRAM from 156 to 180 KiB/s. Impact may be less noticeable when using Flash-based targets, or using this BMF with BMDA as proxy.

I'll mention that stlinkv3 also toggles a GPIO wired to direction pin of a bidirectional level translator in the respective macros.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) _and should not affect it_
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) _and should not affect it_
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Enhances #1688 (PR, not an Issue)