### PR TITLE
Fix: RISC-V missing quirks

### DIFF
--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -676,7 +676,12 @@ static void riscv_hart_discover_triggers(riscv_hart_s *const hart)
 		riscv_csr_write(hart, RV_TRIG_SELECT | RV_CSR_FORCE_32_BIT, &trigger);
 		/* Try reading the trigger info */
 		uint32_t info = 0;
-		if (!riscv_csr_read(hart, RV_TRIG_INFO | RV_CSR_FORCE_32_BIT, &info)) {
+		/*
+		 * If the read succeeds but info is still 0, assume we're talking to something like a WCH device
+		 * which'll do this despite not actually implementing the tinfo register. Handle it the same as
+		 * the read explicitly failing.
+		 */
+		if (!riscv_csr_read(hart, RV_TRIG_INFO | RV_CSR_FORCE_32_BIT, &info) || !info) {
 			/*
 			 * If that fails, it's probably because the tinfo register isn't implemented, so read
 			 * the tdata1 register instead and extract the type from the MSb and build the info bitset from that


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

When #1380 was merged and the source branch deleted, it closed a follow-up PR which adds handling for a quirk of how WCH RISC-V devices work in regards their trigger slot information registers. This PR re-introduces that fix along with a short explainer on why it's needed and what it's doing.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
