### PR TITLE
Fix: Tiva-C AP leak

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -994,6 +994,7 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp)
 			 */
 			if (target->priv_free == cortex_priv_free && cortex_ap(target) == ap &&
 				strstr(target->driver, "Tiva") != NULL) {
+				adiv5_ap_unref(ap);
 				adiv5_dp_unref(dp);
 				return;
 			}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a memory leak of the AP structure for Tiva-C targets due to a missing unref in the part-specific bailout path in `adiv5_dp_init` used to avoid re-scanning the same AP multiple times due to a hardware bug.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
