### PR TITLE
Fix xtensa formatting

### DIFF
--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -964,16 +964,15 @@ static void cortexr_mem_handle_fault(
 	const cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
 	/* If we suffered a fault of some kind, grab the reason and restore DFSR/DFAR */
 	if (priv->core_status & CORTEXAR_STATUS_DATA_FAULT) {
-#if ENABLE_DEBUG == 1
+#ifndef DEBUG_WARN_IS_NOOP
 		const uint32_t fault_status = cortexar_coproc_read(target, CORTEXAR_DFSR);
 		const uint32_t fault_addr = cortexar_coproc_read(target, CORTEXAR_DFAR);
+		DEBUG_WARN("%s: Failed at 0x%08" PRIx32 " (%08" PRIx32 ")\n", func, fault_addr, fault_status);
 #else
 		(void)func;
 #endif
 		cortexar_coproc_write(target, CORTEXAR_DFAR, orig_fault_addr);
 		cortexar_coproc_write(target, CORTEXAR_DFSR, orig_fault_status);
-
-		DEBUG_WARN("%s: Failed at 0x%08" PRIx32 " (%08" PRIx32 ")\n", func, fault_addr, fault_status);
 	}
 }
 

--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -331,7 +331,7 @@ static bool imxrt_ident_device(target_s *const target)
 		priv->flexspi_base = IMXRT117x_FLEXSPI1_BASE;
 		break;
 	default:
-		DEBUG_TARGET("Unknown ROM fingerprint at %08x = %08x\n", rom_location, fingerprint);
+		DEBUG_TARGET("Unknown ROM fingerprint at %08" PRIx32 " = %08" PRIx32 "\n", rom_location, fingerprint);
 		break;
 	}
 

--- a/src/target/msp432e4.c
+++ b/src/target/msp432e4.c
@@ -224,7 +224,8 @@ bool msp432e4_probe(target_s *const target)
 		(devid1 & MSP432E4_SYS_CTRL_DID1_FAMILY_MASK) != MSP432E4_SYS_CTRL_DID1_MSP432E4)
 		return false;
 
-	DEBUG_TARGET("%s: Device version %x:%x, part ID %x, pin count %u, temperature grade %x, package type %x\n",
+	DEBUG_TARGET("%s: Device version %" PRIx32 ":%" PRIx32 ", part ID %" PRIx32 ", pin count %" PRIu32
+				 ", temperature grade %" PRIx32 ", package type %" PRIx32 "\n",
 		__func__, (devid0 >> MSP432E4_SYS_CTRL_DID0_VERSION_MAJ_SHIFT) & MSP432E4_SYS_CTRL_DID0_VERSION_MAJ_MASK,
 		devid0 & MSP432E4_SYS_CTRL_DID0_VERSION_MIN_MASK,
 		(devid1 >> MSP432E4_SYS_CTRL_DID1_PART_NUM_SHIFT) & MSP432E4_SYS_CTRL_DID1_PART_NUM_MASK,


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Debug print statements were added that cause build breakage on ESP32 Xtensa targets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
