### PR TITLE
Fix building `hosted` under FreeBSD

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -46,12 +46,6 @@
 #include "traceswo.h"
 #endif
 
-#if defined(_WIN32)
-#include <malloc.h>
-#else
-#include <alloca.h>
-#endif
-
 static bool cmd_version(target_s *t, int argc, const char **argv);
 static bool cmd_help(target_s *t, int argc, const char **argv);
 

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -55,11 +55,6 @@
 #define GDB_QSUPPORTED_NOACKMODE
 #endif
 
-#if defined(_WIN32)
-#include <malloc.h>
-#else
-#include <alloca.h>
-#endif
 #include <stdlib.h>
 
 typedef enum gdb_signal {

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -35,7 +35,8 @@
 #endif
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <malloc.h>
-#else
+/* `alloca()` on FreeBSD is visible from <stdlib.h>, and <alloca.h> does not exist */
+#elif !defined(__FreeBSD__)
 #include <alloca.h>
 #endif
 #include <stdint.h>

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -44,6 +44,10 @@ HIDAPILIB = hidapi
 ifneq (,$(findstring linux,$(SYS)))
     SRC += serial_unix.c
     HIDAPILIB = hidapi-hidraw
+else ifneq (,$(findstring freebsd,$(SYS)))
+    # On FreeBSD, only the hidapi on libusb-1.0 variant exists
+    SRC += serial_unix.c
+    HIDAPILIB = hidapi
 else ifneq (,$(findstring mingw,$(SYS)))
     FLAVOUR = $(shell which $(CC))
     ifneq (,$(findstring ucrt64,$(FLAVOUR)))

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -45,11 +45,6 @@
 
 #include <string.h>
 #include <assert.h>
-#if defined(_WIN32) || defined(__CYGWIN__)
-#include <malloc.h>
-#else
-#include <alloca.h>
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
## Detailed description

* Not a feature.
* The problem is BMDA fails to build from source (FTBFS) on FreeBSD because of no `<alloca.h>` and missing hidapi-hidraw.
* PR solves this by purging all (3) of alloca.h references in light of #1661 and guarding the remaining inclusion by OS-specific macro. And adding a proper/available hidapi library name.

Tested on NomadBSD 13.2-RELEASE and a bunch of cheap adapters I have. `HOSTED_BMP_ONLY=0`. CMSIS-DAP (Picoprobe, free-dap) are detected, opened in v2/bulk mode and result in successful scan of an empty chain (nothing wired up). BMP-compatibles work only after indicating a `--device /dev/ttyU0` and under root privileges (there is no `/dev/serial/by-id`); including scanning SWD and attaching to a Cortex-M target. JLink and STLink/v2 result in a crash in `libusb.so.3.0.0` due to write into zero page on first bulk write transaction. `ASAN=1` also works btw. FTDI MPSSE not tested. Noting that `devel/openocd-0.11.0` works on the same machine with the same JLink/STLink without crashing, and `devel/gdb` looks like built with multiarch support.

Building: `sudo pkg install libftdi1 hidapi` and then `gmake -C src/ PROBE_HOST=hosted HOSTED_BMP_ONLY=0 CC=gcc12 -j6` because Makefiles of this project are incompatible with default `bmake` to which `make` aliases.
This PR does not cover building BMF and libopencm3 under *BSD. I could not install https://www.freshports.org/devel/gcc-arm-embedded/ due to symlink collisions, but python 3.9 is present (for GENHDR) and there may not be other problems to that.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
@DanielO may try using BMDA on his FreeBSD machine now, in addition to the Orbuculum suite (see https://github.com/orbcode/orbuculum/pull/134)