### PR TITLE
Fix: Missing Cortex-A/R memory IO diagnostics

### DIFF
--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -1000,6 +1000,19 @@ static void cortexar_mem_read(target_s *const target, void *const dest, const ta
 		cortexr_mem_read_slow(target, (uint8_t *)dest, src, len);
 	/* Deal with any data faults that occured */
 	cortexr_mem_handle_fault(target, __func__, fault_status, fault_addr);
+
+	DEBUG_PROTO("%s: Reading %zu bytes @0x%" PRIx32 ":", __func__, len, src);
+#ifndef DEBUG_PROTO_IS_NOOP
+	const uint8_t *const data = (const uint8_t *)dest;
+#endif
+	for (size_t offset = 0; offset < len; ++offset) {
+		if (offset == 16U)
+			break;
+		DEBUG_PROTO(" %02x", data[offset]);
+	}
+	if (len > 16U)
+		DEBUG_PROTO(" ...");
+	DEBUG_PROTO("\n");
 }
 
 /* Fast path for cortexar_mem_write(). Assumes the address to read data from is already loaded in r0. */

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -1061,7 +1061,19 @@ static void cortexar_mem_write(
 	target_s *const target, const target_addr_t dest, const void *const src, const size_t len)
 {
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
-	DEBUG_TARGET("%s: Writing %zu bytes @0x%" PRIx32 "\n", __func__, len, dest);
+	DEBUG_PROTO("%s: Writing %zu bytes @0x%" PRIx32 ":", __func__, len, dest);
+#ifndef DEBUG_PROTO_IS_NOOP
+	const uint8_t *const data = (const uint8_t *)src;
+#endif
+	for (size_t offset = 0; offset < len; ++offset) {
+		if (offset == 16U)
+			break;
+		DEBUG_PROTO(" %02x", data[offset]);
+	}
+	if (len > 16U)
+		DEBUG_PROTO(" ...");
+	DEBUG_PROTO("\n");
+
 	/* Cache DFSR and DFAR in case we wind up triggering a data fault */
 	const uint32_t fault_status = cortexar_coproc_read(target, CORTEXAR_DFSR);
 	const uint32_t fault_addr = cortexar_coproc_read(target, CORTEXAR_DFAR);

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -556,11 +556,14 @@ static uint32_t cortexar_coproc_read(target_s *const target, const uint8_t copro
 	cortexar_run_insn(target,
 		ARM_MRC_INSN |
 			ENCODE_CP_ACCESS(coproc & 0xfU, (op >> 8U) & 0x7U, 0U, (op >> 4U) & 0xfU, op & 0xfU, (op >> 12U) & 0x7U));
-	return cortexar_core_reg_read(target, 0U);
+	const uint32_t result = cortexar_core_reg_read(target, 0U);
+	DEBUG_PROTO("%s: coproc %u (%04x): %08" PRIx32 "\n", __func__, coproc, op, result);
+	return result;
 }
 
 static void cortexar_coproc_write(target_s *const target, const uint8_t coproc, const uint16_t op, const uint32_t value)
 {
+	DEBUG_PROTO("%s: coproc %u (%04x): %08" PRIx32 "\n", __func__, coproc, op, value);
 	/*
 	 * Perform a write of a coprocessor - which one (between 0 and 15) is given by the coproc parameter
 	 * and which register of the coprocessor to write and the operands required is given by op.


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes/improves the diagnostics in the Cortex-A/R memory IO routines so we get comparable debugging information to the Cortex-M memory IO routines to aid with debugging target support.

This wound up being a problem we needed solved when writing the Renesas RZ/A1LU support which is an upcoming PR.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
