### PR TITLE
Fix: Remote protocol UBSAN error

### DIFF
--- a/src/platforms/hosted/remote/protocol_v0_jtag.c
+++ b/src/platforms/hosted/remote/protocol_v0_jtag.c
@@ -85,7 +85,7 @@ void remote_v0_jtag_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t
 		const size_t bytes = (chunk_length + 7U) >> 3U;
 		if (data_in) {
 			for (size_t idx = 0; idx < bytes; ++idx)
-				packet_data_in |= data_in[offset + idx] << (idx * 8U);
+				packet_data_in |= (uint32_t)data_in[offset + idx] << (idx * 8U);
 		}
 		/*
 		 * Build the remote protocol message to send, and send it.

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -373,7 +373,7 @@ static uint32_t adiv5_ap_read_id(adiv5_access_port_s *ap, uint32_t addr)
 	uint8_t data[16];
 	adiv5_mem_read(ap, data, addr, sizeof(data));
 	for (size_t i = 0; i < 4U; ++i)
-		res |= (data[4U * i] << (i * 8U));
+		res |= (uint32_t)data[4U * i] << (i * 8U);
 	return res;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR comes after a UBSAN issue was found by ALTracer on Discord which involves a missing widening cast needed to legalise the packet data in shifting in the BMP remote protocol v0 JTAG implementation.

This is because C defines left shifting by more than a type's width to be undefined behaviour so we have to pre-widen the data to resolve this.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
