### PR TITLE
Fix: extract method for SWD parity calculation

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -48,7 +48,6 @@
 #include <inttypes.h>
 #include <sys/types.h>
 
-#include "maths_utils.h"
 #include "timing.h"
 #include "platform_support.h"
 #include "align.h"

--- a/src/include/maths_utils.h
+++ b/src/include/maths_utils.h
@@ -37,5 +37,6 @@
 #include <stdint.h>
 
 uint8_t ulog2(uint32_t value);
+uint8_t calculate_odd_parity(uint32_t value);
 
 #endif /* INCLUDE_MATHS_UTILS_H */

--- a/src/maths_utils.c
+++ b/src/maths_utils.c
@@ -74,3 +74,21 @@ uint8_t ulog2(uint32_t value)
 	return (sizeof(uint8_t) * 8U) - result;
 #endif
 }
+
+uint8_t calculate_odd_parity(const uint32_t value)
+{
+#if defined(__GNUC__)
+	/* Ask for the libgcc impl */
+	return __builtin_parity(value);
+#elif defined(_MSC_VER)
+	/* Ask for a CPU insn */
+	return __popcount(value) & 1U;
+#else
+	/* Generic impl */
+	uint8_t result = 0;
+	for (uint32_t bit = 0; bit < 32; ++bit)
+		result ^= (value >> bit) & 1U;
+
+	return result;
+#endif
+}

--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -130,8 +130,8 @@ static bool swdptap_seq_in_parity(uint32_t *ret, size_t clock_cycles)
 	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 
-	size_t parity = __builtin_popcount(result);
-	parity += gpio_get(SWDIO_IN_PORT, SWDIO_IN_PIN) ? 1U : 0U;
+	const bool parity = __builtin_parity(result);
+	const bool bit = gpio_get(SWDIO_IN_PORT, SWDIO_IN_PIN);
 
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
 	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
@@ -140,7 +140,7 @@ static bool swdptap_seq_in_parity(uint32_t *ret, size_t clock_cycles)
 	*ret = result;
 	/* Terminate the read cycle now */
 	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	return parity & 1U;
+	return parity != bit;
 }
 
 static void swdptap_seq_out_clk_delay(uint32_t tms_states, size_t clock_cycles) __attribute__((optimize(3)));
@@ -182,9 +182,9 @@ static void swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles
 
 static void swdptap_seq_out_parity(const uint32_t tms_states, const size_t clock_cycles)
 {
-	int parity = __builtin_popcount(tms_states);
+	const bool parity = __builtin_parity(tms_states);
 	swdptap_seq_out(tms_states, clock_cycles);
-	gpio_set_val(SWDIO_PORT, SWDIO_PIN, parity & 1U);
+	gpio_set_val(SWDIO_PORT, SWDIO_PIN, parity);
 	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 	gpio_set(SWCLK_PORT, SWCLK_PIN);

--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -24,6 +24,7 @@
 #include "platform.h"
 #include "timing.h"
 #include "swd.h"
+#include "maths_utils.h"
 
 #if !defined(SWDIO_IN_PORT)
 #define SWDIO_IN_PORT SWDIO_PORT
@@ -130,7 +131,7 @@ static bool swdptap_seq_in_parity(uint32_t *ret, size_t clock_cycles)
 	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 
-	const bool parity = __builtin_parity(result);
+	const bool parity = calculate_odd_parity(result);
 	const bool bit = gpio_get(SWDIO_IN_PORT, SWDIO_IN_PIN);
 
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
@@ -182,7 +183,7 @@ static void swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles
 
 static void swdptap_seq_out_parity(const uint32_t tms_states, const size_t clock_cycles)
 {
-	const bool parity = __builtin_parity(tms_states);
+	const bool parity = calculate_odd_parity(tms_states);
 	swdptap_seq_out(tms_states, clock_cycles);
 	gpio_set_val(SWDIO_PORT, SWDIO_PIN, parity);
 	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)

--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -34,6 +34,7 @@
 #include "dap.h"
 #include "dap_command.h"
 #include "buffer_utils.h"
+#include "maths_utils.h"
 
 typedef enum dap_swd_turnaround_cycles {
 	DAP_SWD_TURNAROUND_1_CYCLE = 0U,
@@ -127,7 +128,7 @@ static void dap_swd_seq_out_parity(const uint32_t tms_states, const size_t clock
 		DAP_SWD_OUT_SEQUENCE,
 	};
 	write_le4(sequence.data, 0, tms_states);
-	sequence.data[4] = __builtin_parity(tms_states);
+	sequence.data[4] = calculate_odd_parity(tms_states);
 	/* And perform it */
 	if (!perform_dap_swd_sequences(&sequence, 1U))
 		DEBUG_ERROR("dap_swd_seq_out_parity failed\n");
@@ -169,7 +170,7 @@ static bool dap_swd_seq_in_parity(uint32_t *const result, const size_t clock_cyc
 	for (size_t offset = 0; offset < clock_cycles; offset += 8U)
 		data |= sequence.data[offset >> 3U] << offset;
 	*result = data;
-	uint8_t parity = __builtin_parity(data) & 1U;
+	uint8_t parity = calculate_odd_parity(data);
 	parity ^= sequence.data[4] & 1U;
 	return !parity;
 }
@@ -194,7 +195,7 @@ static bool dap_write_reg_no_check(const uint16_t addr, const uint32_t data)
 			33U,
 			DAP_SWD_OUT_SEQUENCE,
 			/* The 4 data bytes are filled in below with write_le4() */
-			{0U, 0U, 0U, 0U, __builtin_parity(data)},
+			{0U, 0U, 0U, 0U, calculate_odd_parity(data)},
 		},
 	};
 	write_le4(sequences[3].data, 0, data);

--- a/src/platforms/hosted/ftdi_swd.c
+++ b/src/platforms/hosted/ftdi_swd.c
@@ -32,6 +32,7 @@
 #include <ftdi.h>
 #include "ftdi_bmp.h"
 #include "buffer_utils.h"
+#include "maths_utils.h"
 
 typedef enum swdio_status {
 	SWDIO_STATUS_DRIVE,
@@ -237,7 +238,9 @@ static bool ftdi_swd_seq_in_parity_mpsse(uint32_t *const result, const size_t cl
 	uint8_t data_out[5U] = {0};
 	ftdi_jtag_tdi_tdo_seq(data_out, false, NULL, clock_cycles + 1U);
 	const uint32_t data = read_le4(data_out, 0);
-	uint8_t parity = __builtin_parity(data & ((UINT64_C(1) << clock_cycles) - 1U));
+	/* NB: This calculation must be done in 64-bit space due to `1U << 32U` value of 0x00000001'00000000ULL */
+	const uint32_t bitmask = (UINT64_C(1) << clock_cycles) - 1U;
+	uint8_t parity = calculate_odd_parity(data & bitmask);
 	parity ^= data_out[4] & 1U;
 	DEBUG_PROBE("%s %zu clock_cycles: %08" PRIx32 " %s\n", __func__, clock_cycles, data, parity ? "ERR" : "OK");
 	*result = data;
@@ -428,7 +431,7 @@ static void ftdi_swd_seq_out_parity(uint32_t tms_states, size_t clock_cycles)
 {
 	if (clock_cycles > 32U)
 		return;
-	const uint8_t parity = __builtin_parity(tms_states) & 1U;
+	const uint8_t parity = calculate_odd_parity(tms_states);
 	ftdi_swd_turnaround(SWDIO_STATUS_DRIVE);
 	if (do_mpsse)
 		ftdi_swd_seq_out_parity_mpsse(tms_states, parity, clock_cycles);

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -35,6 +35,7 @@
 #include "exception.h"
 #include "cortexm.h"
 #include "buffer_utils.h"
+#include "maths_utils.h"
 
 #include <assert.h>
 #include <unistd.h>

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -42,6 +42,7 @@
 #include "gdb_packet.h"
 #include "semihosting.h"
 #include "platform.h"
+#include "maths_utils.h"
 
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
## Detailed description

This PR is aimed at two problems:
* Problem 1: swdptap of firmware references both popcount and parity builtins to do the same task (of calculating SWD parity), and `__popcountsi2(): 40 bytes` is more expensive. Solution 1: create a shim/dispatcher in maths_utils, name it `swd_odd_parity` and call *that* from swdptap (the gpio-bitbanging one). This leads to cleaner code at that callsite, and less flash space occupied
* Problem 2: *_swd.c `hosted` adapter driver backends also want to calculate parity, and also do that via both popcount and parity builtins. MSVC does not provide these builtins, only the `__popcount` for x86-64 optional instruction. Solution 2: incorporate this _MSC-specific builtin as well into the shim, and tweak all said `hosted` parity calculations to call the shim.

This PR is triggered from the discussion of #1688 two weeks ago.
I decided to name the function `swd_odd_parity()` for where it is going to be used. If future JTAG-PDI code also would want to use it (and attribute alias does not cut it), the reviewer/implementer of that can suggest a better name and I'll mass-rename the touched callsites (with a force-push).
Notice that I drop `maths_utils.h` from `general.h` and include it where needed by this PR. The point on making the shim `static inline` in the header is a valid discussion topic.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
May help fix building BMDA under MSVC with `HOSTED_BMP_ONLY=0` (caveat libusb/hidapi).