### PR TITLE
target/flashstub: fix variable initialization in stm32f1_flash_write_…

### DIFF
--- a/src/target/flashstub/lmi.c
+++ b/src/target/flashstub/lmi.c
@@ -34,7 +34,7 @@
 void __attribute__((naked))
 stm32f1_flash_write_stub(const uint32_t *const dest, const uint32_t *const src, const uint32_t size)
 {
-	for (uint32_t i; i < (size / 4U); ++i) {
+	for (uint32_t i = 0; i < (size / 4U); ++i) {
 		LMI_FLASH_FMA = (uintptr_t)(dest + i);
 		LMI_FLASH_FMD = src[i];
 		LMI_FLASH_FMC = LMI_FLASH_FMC_WRKEY | LMI_FLASH_FMC_WRITE;


### PR DESCRIPTION
## Detailed description

This PR ensures that the loop counter is initialized to 0 in `stm32f1_flash_write_stub` function.

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (`make PROBE_HOST=native`)
* [ ] It builds as BMDA (`make PROBE_HOST=hosted`)
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

None.
