### PR TITLE
native/platform: fix DFU detach

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -414,7 +414,7 @@ const char *platform_target_voltage(void)
 void platform_request_boot(void)
 {
 	/* Disconnect USB cable */
-	gpio_set_mode(USB_PU_PORT, GPIO_MODE_INPUT, 0, USB_PU_PIN);
+	gpio_set_mode(USB_PU_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, USB_PU_PIN);
 
 	/* Drive boot request pin */
 	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO12);


### PR DESCRIPTION
DFU detach wasn't lowering the USB pullup. This meant that BMP was rebooting into DFU bootloader mode, but the host wasn't re-enumerating it, because it hadn't detected a detach.

In `platform_request_boot`, The `gpio_set_mode` config was for analog instead of floating input. PA8 isn't defined as an analog pin on this chip, so it's arguably undefined behavior.

Also confirmed that using `scb_reset_system` instead of `scb_reset_core` to do the DFU reboot would correctly detach and enter the bootloader, if the boot button was held down.

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
