### PR TITLE
Fix: qCRC performance uplift

### DIFF
--- a/src/crc32.c
+++ b/src/crc32.c
@@ -136,11 +136,14 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 	*result = crc;
 	return true;
 }
+
+__attribute__((alias("generic_crc32"))) bool bmd_crc32(
+	target_s *const target, uint32_t *const result, const uint32_t base, const size_t len);
 #else
 #include <libopencm3/stm32/crc.h>
 #include "buffer_utils.h"
 
-bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_t base, const size_t len)
+bool stm32_crc32(target_s *const target, uint32_t *const result, const uint32_t base, const size_t len)
 {
 	uint8_t bytes[128U];
 
@@ -185,4 +188,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 	*result = crc;
 	return true;
 }
+
+__attribute__((alias("stm32_crc32"))) bool bmd_crc32(
+	target_s *const target, uint32_t *const result, const uint32_t base, const size_t len);
 #endif

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -113,7 +113,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 	uint8_t bytes[128U];
 #endif
 
-#if ENABLE_DEBUG == 1
+#ifndef DEBUG_INFO_IS_NOOP
 	const uint32_t start_time = platform_time_ms();
 #endif
 	uint32_t last_time = platform_time_ms();
@@ -132,7 +132,9 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 		for (size_t i = 0; i < read_len; i++)
 			crc = crc32_calc(crc, bytes[i]);
 	}
-	DEBUG_WARN("%" PRIu32 " ms\n", platform_time_ms() - start_time);
+#ifndef DEBUG_INFO_IS_NOOP
+	DEBUG_INFO("%s: %" PRIu32 " ms\n", __func__, platform_time_ms() - start_time);
+#endif
 	*result = crc;
 	return true;
 }
@@ -149,6 +151,9 @@ bool stm32_crc32(target_s *const target, uint32_t *const result, const uint32_t 
 
 	CRC_CR |= CRC_CR_RESET;
 
+#ifndef DEBUG_INFO_IS_NOOP
+	const uint32_t start_time = platform_time_ms();
+#endif
 	uint32_t last_time = platform_time_ms();
 	const size_t adjusted_len = len & ~3U;
 	for (size_t offset = 0; offset < adjusted_len; offset += sizeof(bytes)) {
@@ -185,6 +190,9 @@ bool stm32_crc32(target_s *const target, uint32_t *const result, const uint32_t 
 			}
 		}
 	}
+#ifndef DEBUG_INFO_IS_NOOP
+	DEBUG_INFO("%s: %" PRIu32 " ms\n", __func__, platform_time_ms() - start_time);
+#endif
 	*result = crc;
 	return true;
 }

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -133,7 +133,15 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 			crc = crc32_calc(crc, bytes[i]);
 	}
 #ifndef DEBUG_INFO_IS_NOOP
-	DEBUG_INFO("%s: %" PRIu32 " ms\n", __func__, platform_time_ms() - start_time);
+	/* "generic_crc32: 08000110+75272 -> 1353ms, 54 KiB/s" */
+	const uint32_t end_time = platform_time_ms();
+	const uint32_t time_elapsed = end_time - start_time;
+	DEBUG_INFO("%s: %08" PRIx32 "+%" PRIu32 " -> %" PRIu32 "ms", __func__, base, (uint32_t)len, time_elapsed);
+	if (len >= 512U) {
+		const uint32_t speed = len * 1000U / time_elapsed / 1024U;
+		DEBUG_INFO(", %" PRIu32 " KiB/s", speed);
+	}
+	DEBUG_INFO("\n");
 #endif
 	*result = crc;
 	return true;
@@ -191,7 +199,15 @@ bool stm32_crc32(target_s *const target, uint32_t *const result, const uint32_t 
 		}
 	}
 #ifndef DEBUG_INFO_IS_NOOP
-	DEBUG_INFO("%s: %" PRIu32 " ms\n", __func__, platform_time_ms() - start_time);
+	/* "stm32_crc32: 08000110+75272 -> 237ms, 310 KiB/s" */
+	const uint32_t end_time = platform_time_ms();
+	const uint32_t time_elapsed = end_time - start_time;
+	DEBUG_INFO("%s: %08" PRIx32 "+%" PRIu32 " -> %" PRIu32 "ms", __func__, base, (uint32_t)len, time_elapsed);
+	if (len >= 512U) {
+		const uint32_t speed = len * 1000U / time_elapsed / 1024U;
+		DEBUG_INFO(", %" PRIu32 " KiB/s", speed);
+	}
+	DEBUG_INFO("\n");
 #endif
 	*result = crc;
 	return true;

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -155,7 +155,7 @@ __attribute__((alias("generic_crc32"))) bool bmd_crc32(
 
 bool stm32_crc32(target_s *const target, uint32_t *const result, const uint32_t base, const size_t len)
 {
-	uint8_t bytes[128U];
+	uint8_t bytes[1024U]; /* ADIv5 MEM-AP AutoInc range */
 
 	CRC_CR |= CRC_CR_RESET;
 

--- a/src/crc32.c
+++ b/src/crc32.c
@@ -125,7 +125,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 		}
 		const size_t read_len = MIN(sizeof(bytes), len - offset);
 		if (target_mem_read(target, bytes, base + offset, (read_len + 3U) & ~3U)) {
-			DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", (uint32_t)(base + offset));
+			DEBUG_ERROR("%s: error around address 0x%08" PRIx32 "\n", __func__, (uint32_t)(base + offset));
 			return false;
 		}
 
@@ -156,7 +156,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 		}
 		const size_t read_len = MIN(sizeof(bytes), adjusted_len - offset);
 		if (target_mem_read(target, bytes, base + offset, read_len)) {
-			DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", (uint32_t)(base + offset));
+			DEBUG_ERROR("%s: error around address 0x%08" PRIx32 "\n", __func__, (uint32_t)(base + offset));
 			return false;
 		}
 
@@ -169,7 +169,7 @@ bool generic_crc32(target_s *const target, uint32_t *const result, const uint32_
 	const size_t remainder = len - adjusted_len;
 	if (remainder) {
 		if (target_mem_read(target, bytes, base + adjusted_len, remainder)) {
-			DEBUG_ERROR("generic_crc32 error around address 0x%08" PRIx32 "\n", (uint32_t)(base + adjusted_len));
+			DEBUG_ERROR("%s: error around address 0x%08" PRIx32 "\n", __func__, (uint32_t)(base + adjusted_len));
 			return false;
 		}
 		for (size_t offset = 0; offset < remainder; ++offset) {

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -488,7 +488,7 @@ static void exec_q_crc(const char *packet, const size_t length)
 			return;
 		}
 		uint32_t crc;
-		if (!generic_crc32(cur_target, &crc, addr, addr_length))
+		if (!bmd_crc32(cur_target, &crc, addr, addr_length))
 			gdb_putpacketz("E03");
 		else
 			gdb_putpacket_f("C%" PRIx32, crc);

--- a/src/include/crc32.h
+++ b/src/include/crc32.h
@@ -24,6 +24,6 @@
 #include <stdint.h>
 #include <target.h>
 
-bool generic_crc32(target_s *target, uint32_t *crc, uint32_t base, size_t len);
+bool bmd_crc32(target_s *target, uint32_t *crc, uint32_t base, size_t len);
 
 #endif /* INCLUDE_CRC32_H */


### PR DESCRIPTION
## Detailed description

* On the scale between "fix" and "feature" this is closer to "fix".
* The existing problem is suboptimal performance of `(gdb) compare-sections` because of extra ADIv5 MEM-AP setup overhead.
* This PR solves that by increasing the stack buffer inside `generic_crc32()` from 128 to 1024 bytes.

There is an intentionally separate commit which adds DEBUG_INFO logs displaying "KiB/s" metric to BMDA, and copies that (ms and KiB/s) to the implementation for STM32 CRC IP enabled platforms. I avoid this calculation for small sections/regions (abundant in some firmware projects) for integer precision and overhead reasons.

On my quest to increasing runtime performance such that BMP-compatibles are more usable (Quality of Life for developers) against targets with Big Flash and with RTT, following (and testing) the SWD improvements, I decided to use some sort of benchmark internal to BMD (to not have to wire up and look at an LA or MSO). Uploads to reprogrammable flash bottleneck in said flash erase/write times, BMDA communication bottlenecks in either USB FS link, libusb or host syscalls, and there's no dedicated iperf3/speedtest between BMDA and BMPremote (using [un]hexify). But the GDB RSP `qCRC` packet it uses to check for section mismatch is pretty much ideal because a) the packets sent over RSP are pretty small, for just addresses and checksum values; b) STM32 CRC handles most of the calculations; c) the only remaining part is ADIv5 SWD (or JTAG) acceleration driver and gpio-bitbanging driver.

Dragonmux highlighted that ADIv5 MEM-AP has a feature of Target Address Register autoincrement (for up to 10 bit, so 1024-byte long and aligned regions) configured in CSW and checked in driver methods. I tried increasing said buffer to 4096 bytes first, on `blackpill-f411ce` as the development kit with bigger SRAM and CPU speed, and also increasing BMPremote v3 packet lengths from 1024 to 4096 bytes as well. This did not display additional runtime benefit, rather, it may not fly on smaller adapters.

The change 128->1024 is tested by me on both `blackpill-f411ce` and `swlink` adapters with ENABLE_DEBUG=1, and these logs indicate approximately +15% `(gdb) compare-sections` speed boost both on `no_delay` and `1 delay` TAP frequency settings (compared to BMF built without the stack buffer change). 

```
SWD no_delay: len = 163252: 160 KiB/s,        996 ms
SWD  1 delay: len = 163252: 105 KiB/s,        1505 ms
SWD  2 delay: len = 163252: 64 KiB/s, 2489 ms
before (128). After (1024):
SWD no_delay: len = 163252: 183 KiB/s,        867 ms
SWD  1 delay: len = 163252: 115 KiB/s,        1380 ms
SWD  2 delay: len = 163252: 72 KiB/s, 2210 ms
```

I reason it may be useful, and somewhat not expensive, because there are a few more places in BMF with stack buffers of similar size (memory-map.xml generator and samx5x nvm page code come to mind), which are not run simultaneously with this. Pinning the buffer to `static` storage duration in .bss, even if it guarantees allocation at link-time, is worse, because it is not used during >90% of the BMF runtime/lifetime. Repurposing the gdb packet buffer is another idea, but it may be more difficult in execution (or same for target flash buffers). I cannot in good conscience make it a dynamic buffer while BMF relies on newlib's `-lnosys` provided optimistic `_sbrk` -- it does not allow catching failed mallocs or stack/heap overflows.

Value of 128 looks somewhat arbitrary to me -- I couldn't find arguments supporting it in git history commit messages, or GH issues and PRs. It was introduced a long time ago in PR #108 and then copied in https://github.com/blackmagic-debug/blackmagic/commit/72790893aea9887e78d5b57b95ae2e791dc57f62 in 2016. Value of 4096 (0x1000) was introduced in PR #922 in https://github.com/blackmagic-debug/blackmagic/commit/e58b7d623b4c8b4ec9317fa1bfdd27f6189f012c for BMDA along with other changes catering to H7 target usecase.

PR should not have significant impact on Flash size.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
