### PR TITLE
Feature: Increase SRAM layout detail for STM32H7 chip variants

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -24,8 +24,14 @@
  * the device, providing the XML memory map and Flash memory programming.
  *
  * References:
+ * RM0399 - STM32H745/755 and STM32H747/757 advanced Arm®-based 32-bit MCUs, Rev. 4
+ *   https://www.st.com/resource/en/reference_manual/rm0399-stm32h745755-and-stm32h747757-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
  * RM0433 - STM32H742, STM32H743/753 and STM32H750 Value line advanced Arm®-based 32-bit MCUs, Rev. 8
  *   https://www.st.com/resource/en/reference_manual/dm00314099-stm32h742-stm32h743-753-and-stm32h750-value-line-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf
+ * RM0455 - STM32H7A3/7B3 and STM32H7B0 Value line advanced Arm®-based 32-bit MCUs, Rev. 10
+ *   https://www.st.com/resource/en/reference_manual/rm0455-stm32h7a37b3-and-stm32h7b0-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * RM0468 - STM32H723/733, STM32H725/735 and STM32H730 Value line advanced Arm®-based 32-bit MCUs, Rev. 3
+ *   https://www.st.com/resource/en/reference_manual/rm0468-stm32h723733-stm32h725735-and-stm32h730-value-line-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
  */
 
 /*
@@ -207,14 +213,40 @@ bool stm32h7_probe(target_s *target)
 	target->target_storage = priv_storage;
 
 	/* Build the RAM map */
-	/* Table 7. Memory map and default device memory area attributes RM0433, pg130 */
 	target_add_ram(target, 0x00000000, 0x10000); /* ITCM RAM,   64 KiB */
 	target_add_ram(target, 0x20000000, 0x20000); /* DTCM RAM,  128 KiB */
-	target_add_ram(target, 0x24000000, 0x80000); /* AXI RAM,   512 KiB */
-	target_add_ram(target, 0x30000000, 0x20000); /* AHB SRAM1, 128 KiB */
-	target_add_ram(target, 0x30020000, 0x20000); /* AHB SRAM2, 128 KiB */
-	target_add_ram(target, 0x30040000, 0x08000); /* AHB SRAM3,  32 KiB */
-	target_add_ram(target, 0x38000000, 0x10000); /* AHB SRAM4,  64 KiB */
+	switch (target->part_id) {
+	case ID_STM32H72x: {
+		/* Table 6. Memory map and default device memory area attributes RM0468, pg133 */
+		target_add_ram(target, 0x24000000, 0x20000); /* AXI RAM,  128 KiB */
+		target_add_ram(target, 0x24020000, 0x30000); /* AXI RAM,  192 KiB (TCM_AXI_SHARED) */
+		target_add_ram(target, 0x30000000, 0x4000);  /* AHB SRAM1, 16 KiB */
+		target_add_ram(target, 0x30004000, 0x4000);  /* AHB SRAM2, 16 KiB */
+		target_add_ram(target, 0x38000000, 0x4000);  /* AHB SRAM4, 16 KiB */
+		break;
+	}
+	case ID_STM32H74x: {
+		/* Table 7. Memory map and default device memory area attributes RM0433, pg130 */
+		target_add_ram(target, 0x24000000, 0x80000); /* AXI RAM,   512 KiB */
+		target_add_ram(target, 0x30000000, 0x20000); /* AHB SRAM1, 128 KiB */
+		target_add_ram(target, 0x30020000, 0x20000); /* AHB SRAM2, 128 KiB */
+		target_add_ram(target, 0x30040000, 0x08000); /* AHB SRAM3,  32 KiB */
+		target_add_ram(target, 0x38000000, 0x10000); /* AHB SRAM4,  64 KiB */
+		break;
+	}
+	case ID_STM32H7Bx: {
+		/* Table 6. Memory map and default device memory area attributes RM0455, pg131 */
+		target_add_ram(target, 0x24000000, 0x40000); /* AXI RAM1, 256 KiB */
+		target_add_ram(target, 0x24040000, 0x60000); /* AXI RAM2, 384 KiB */
+		target_add_ram(target, 0x240a0000, 0x60000); /* AXI RAM3, 384 KiB */
+		target_add_ram(target, 0x30000000, 0x10000); /* AHB SRAM1, 64 KiB */
+		target_add_ram(target, 0x30010000, 0x10000); /* AHB SRAM2, 64 KiB */
+		target_add_ram(target, 0x38000000, 0x08000); /* SRD SRAM,  32 KiB */
+		break;
+	}
+	default:
+		break;
+	}
 
 	/* Build the Flash map */
 	switch (target->part_id) {

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -208,18 +208,18 @@ bool stm32h7_probe(target_s *target)
 
 	/* Build the RAM map */
 	/* Table 7. Memory map and default device memory area attributes RM0433, pg130 */
-	target_add_ram(target, 0x00000000, 0x10000); /* ITCM RAM,   64kiB */
-	target_add_ram(target, 0x20000000, 0x20000); /* DTCM RAM,  128kiB */
-	target_add_ram(target, 0x24000000, 0x80000); /* AXI RAM,   512kiB */
-	target_add_ram(target, 0x30000000, 0x20000); /* AHB SRAM1, 128kiB */
-	target_add_ram(target, 0x30020000, 0x20000); /* AHB SRAM2, 128kiB */
-	target_add_ram(target, 0x30040000, 0x08000); /* AHB SRAM3,  32kiB */
-	target_add_ram(target, 0x38000000, 0x10000); /* AHB SRAM4,  64kiB */
+	target_add_ram(target, 0x00000000, 0x10000); /* ITCM RAM,   64 KiB */
+	target_add_ram(target, 0x20000000, 0x20000); /* DTCM RAM,  128 KiB */
+	target_add_ram(target, 0x24000000, 0x80000); /* AXI RAM,   512 KiB */
+	target_add_ram(target, 0x30000000, 0x20000); /* AHB SRAM1, 128 KiB */
+	target_add_ram(target, 0x30020000, 0x20000); /* AHB SRAM2, 128 KiB */
+	target_add_ram(target, 0x30040000, 0x08000); /* AHB SRAM3,  32 KiB */
+	target_add_ram(target, 0x38000000, 0x10000); /* AHB SRAM4,  64 KiB */
 
 	/* Build the Flash map */
 	switch (target->part_id) {
 	case ID_STM32H74x: {
-		/* Read the Flash size from the device (expressed in kiB) and multiply it by 1024 */
+		/* Read the Flash size from the device (expressed in KiB) and multiply it by 1024 */
 		const uint32_t flash_size = target_mem_read32(target, STM32H7_FLASH_SIZE) << 10U;
 		/* STM32H750nB */
 		if (flash_size == FLASH_SECTOR_SIZE)

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -218,35 +218,34 @@ bool stm32h7_probe(target_s *target)
 	switch (target->part_id) {
 	case ID_STM32H72x: {
 		/* Table 6. Memory map and default device memory area attributes RM0468, pg133 */
-		target_add_ram(target, 0x24000000, 0x20000); /* AXI RAM,  128 KiB */
-		target_add_ram(target, 0x24020000, 0x30000); /* AXI RAM,  192 KiB (TCM_AXI_SHARED) */
-		target_add_ram(target, 0x30000000, 0x4000);  /* AHB SRAM1, 16 KiB */
-		target_add_ram(target, 0x30004000, 0x4000);  /* AHB SRAM2, 16 KiB */
-		target_add_ram(target, 0x38000000, 0x4000);  /* AHB SRAM4, 16 KiB */
+		target_add_ram(target, 0x24000000, 0x20000); /* AXI RAM,    128 KiB */
+		target_add_ram(target, 0x24020000, 0x30000); /* AXI RAM,    192 KiB (TCM_AXI_SHARED) */
+		target_add_ram(target, 0x30000000, 0x8000);  /* AHB SRAM1+2, 32 KiB [16+16] contiguous */
+		target_add_ram(target, 0x38000000, 0x4000);  /* AHB SRAM4,   16 KiB, D3 domain */
 		break;
 	}
 	case ID_STM32H74x: {
 		/* Table 7. Memory map and default device memory area attributes RM0433, pg130 */
-		target_add_ram(target, 0x24000000, 0x80000); /* AXI RAM,   512 KiB */
-		target_add_ram(target, 0x30000000, 0x20000); /* AHB SRAM1, 128 KiB */
-		target_add_ram(target, 0x30020000, 0x20000); /* AHB SRAM2, 128 KiB */
-		target_add_ram(target, 0x30040000, 0x08000); /* AHB SRAM3,  32 KiB */
-		target_add_ram(target, 0x38000000, 0x10000); /* AHB SRAM4,  64 KiB */
+		target_add_ram(target, 0x24000000, 0x80000); /* AXI RAM,       512 KiB */
+		target_add_ram(target, 0x30000000, 0x48000); /* AHB SRAM1+2+3, 288 KiB [128+128+32] contiguous */
+		target_add_ram(target, 0x38000000, 0x10000); /* AHB SRAM4,      64 KiB, D3 domain */
 		break;
 	}
 	case ID_STM32H7Bx: {
 		/* Table 6. Memory map and default device memory area attributes RM0455, pg131 */
-		target_add_ram(target, 0x24000000, 0x40000); /* AXI RAM1, 256 KiB */
-		target_add_ram(target, 0x24040000, 0x60000); /* AXI RAM2, 384 KiB */
-		target_add_ram(target, 0x240a0000, 0x60000); /* AXI RAM3, 384 KiB */
-		target_add_ram(target, 0x30000000, 0x10000); /* AHB SRAM1, 64 KiB */
-		target_add_ram(target, 0x30010000, 0x10000); /* AHB SRAM2, 64 KiB */
-		target_add_ram(target, 0x38000000, 0x08000); /* SRD SRAM,  32 KiB */
+		target_add_ram(target, 0x24000000, 0x100000); /* AXI RAM1+2+3, 1024 KiB [256+384+384] contiguous, */
+		target_add_ram(target, 0x30000000, 0x10000);  /* AHB SRAM1+2,   128 KiB [64+64] contiguous, */
+		target_add_ram(target, 0x38000000, 0x8000);   /* SRD SRAM4,      32 KiB, Smart run domain */
 		break;
 	}
 	default:
 		break;
 	}
+
+	/*
+	 * Note on SRD from AN5293, 3. System architecture differences between STM32F7 and STM32H7 Series
+	 * > The D3 domain evolved into a domain called SRD domain (or smart-run domain).
+	 */
 
 	/* Build the Flash map */
 	switch (target->part_id) {


### PR DESCRIPTION
## Detailed description

* This sounds like a feature (target flavour support).
* The existing problem is STM32H7 driver declaring the memory map of H74x for all chips detected, even if there are ID codes for H72x and H7Bx.
* This PR solves the problem by adding different parts of the memory maps, dispatched on part ID.

Flash cost is around +170 bytes. I am not sure whether contiguous regions composed of different SRAM banks should be added as such (increasing detail, but also BMP flash footprint and memory impact for memory-map.xml) or as single long regions. I tried keeping the common regions (ITCM and DTCM) unified, but a portion of DTCM can be aliased on some flavours (see RM).

I could only test on Nucleo-H743ZI2 and WeAct Studios MiniH723 boards. H72 has smaller regions and total amount of SRAM than H74. I don't have a H7B0 family chip to test on. STM32H745I-DISCO (dual-core?) is accessible but problematic (JTAG doesn't work).
Hence I add the Ref.man. descriptions and links from which the infromation is lifted.

There is a related bug of STM32H743 being detected over JTAG as "STM32MP15x M7" because of IDcode errata of the latter. I may tackle it here (to reduce churn) or in a new PR. SWD works as expected, but BMD may want actual DBGMCU->IDC read outs added to this target (and CM7/CM4 core checks).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

I could've posted an issue about these two things, but I also seem to be able to write a fix, and code contributions are best discussed/reviewed in a PR, not an Issue.