### PR TITLE
fix SWD turnaround issues

### DIFF
--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -68,17 +68,18 @@ static void swdptap_turnaround(const swdio_status_t dir)
 
 	if (dir == SWDIO_STATUS_FLOAT) {
 		SWDIO_MODE_FLOAT();
-	} else {
+	} else
 		gpio_clear(SWCLK_PORT, SWCLK_PIN);
-		for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
-			continue;
-	}
+
+	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
+		continue;
 
 	gpio_set(SWCLK_PORT, SWCLK_PIN);
 	for (volatile uint32_t counter = target_clk_divider + 1; counter > 0; --counter)
 		continue;
 
 	if (dir == SWDIO_STATUS_DRIVE) {
+		gpio_clear(SWCLK_PORT, SWCLK_PIN);
 		SWDIO_MODE_DRIVE();
 	}
 }

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -142,6 +142,7 @@ uint32_t adiv5_swd_read_no_check(const uint16_t addr)
 	const uint8_t res = swd_proc.seq_in(3U);
 	uint32_t data = 0;
 	swd_proc.seq_in_parity(&data, 32U);
+	swd_proc.seq_out(0, 8U);
 	return res == SWDP_ACK_OK ? data : 0;
 }
 
@@ -427,19 +428,20 @@ uint32_t firmware_swdp_low_access(adiv5_debug_port_s *dp, const uint8_t RnW, con
 			DEBUG_ERROR("SWD access resulted in parity error\n");
 			raise_exception(EXCEPTION_ERROR, "SWD parity error");
 		}
-	} else {
+	} else
 		swd_proc.seq_out_parity(value, 32U);
-		/* ARM Debug Interface Architecture Specification ADIv5.0 to ADIv5.2
-		 * tells to clock the data through SW-DP to either :
-		 * - immediate start a new transaction
-		 * - continue to drive idle cycles
-		 * - or clock at least 8 idle cycles
-		 *
-		 * Implement last option to favour correctness over
-		 *   slight speed decrease
-		 */
-		swd_proc.seq_out(0, 8U);
-	}
+
+	/* ARM Debug Interface Architecture Specification ADIv5.0 to ADIv5.2
+	 * tells to clock the data through SW-DP to either :
+	 * - immediate start a new transaction
+	 * - continue to drive idle cycles
+	 * - or clock at least 8 idle cycles
+	 *
+	 * Implement last option to favour correctness over
+	 *   slight speed decrease
+	 */
+	swd_proc.seq_out(0, 8U);
+
 	return response;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

There were multiple problems with SWD turnaround. In the write-to-read direction, a short clock pulse could be produced (#1706). When terminating a read transaction, the clock wasn't driven low. If a subsequent clock float was requested, as for a detach, the clock would float low, then be driven high when re-enabled, causing an extra rising clock edge.

Additionally, idle cycles weren't being inserted as required after a read transaction.

There's a small chance of a regression with targets that pull the SWD clock high.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1706.

## Details

These are debug logs from BMDA.

Log excerpt from unpatched, attaching after detaching. Note the non-response error after re-enabling the clock.

```
!SI20#
       K2000497C
remote_v0_swd_seq_in_parity 32 clock_cycles: 2000497c OK
Read RDBUFF: 0x2000497c
!GE0#
       K0
gdb_putpacket: OK
gdb_getpacket: vAttach;1
!GE1#
       K0
remote_v0_swd_seq_out 8 clock_cycles: 0000008d
!So088d#
       K0
!Si03#
       K7
remote_v0_swd_seq_in 3 clock_cycles: 00000007
!SI20#
       PFFFFFFFF
remote_v0_swd_seq_in_parity 32 clock_cycles: ffffffff ERR
Read STATUS: 0x00000000
DP Error 0x00000000
ap_mem_write_sized @ e000edf0 len 4, align 4: 03 00 5f a0
Write AP 0 CSW: 0xa3000052
remote_v0_swd_seq_out 8 clock_cycles: 000000b1
!So08b1#
       K0
!Si03#
       K7
remote_v0_swd_seq_in 3 clock_cycles: 00000007
SWD access resulted in no response
!SI20#
       PFFFFFFFF
remote_v0_swd_seq_in_parity 32 clock_cycles: ffffffff ERR
Recovering and re-trying access
```

Full log from unpatched code:
[unpatched.txt](https://github.com/blackmagic-debug/blackmagic/files/13815259/unpatched.txt)


Log excerpt from patched, with only the `swdptap_turnaround` fix. Note the lack of non-response error after re-enabling the clock.

```
!SI20#
       K1
remote_v0_swd_seq_in_parity 32 clock_cycles: 00000001 OK
Read RDBUFF: 0x00000001
!GE0#
       K0
gdb_putpacket: OK
gdb_getpacket: vAttach;1
!GE1#
       K0
remote_v0_swd_seq_out 8 clock_cycles: 0000008d
!So088d#
       K0
!Si03#
       K1
remote_v0_swd_seq_in 3 clock_cycles: 00000001
!SI20#
       KF0000040
remote_v0_swd_seq_in_parity 32 clock_cycles: f0000040 OK
Read STATUS: 0xf0000040
DP Error 0x00000000
```

Full log from patch with only `swdptap_turnaround` fix:
[ta-no-8idle.txt](https://github.com/blackmagic-debug/blackmagic/files/13815260/ta-no-8idle.txt)

Full log with both commits:
[ta-with-8idle.txt](https://github.com/blackmagic-debug/blackmagic/files/13815262/ta-with-8idle.txt)
