### PR TITLE
common/swdptap: make SWD timing more consistent

### DIFF
--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -101,6 +101,11 @@ static uint32_t swdptap_seq_in_clk_delay(const size_t clock_cycles)
 	uint32_t value = 0;
 	if (!clock_cycles)
 		return 0;
+	/*
+	 * Count down instead of up, because with an up-count, some ARM-GCC
+	 * versions use an explicit CMP, missing the optimization of converting
+	 * to a faster down-count that uses SUBS followed by BCS/BCC.
+	 */
 	for (size_t cycle = clock_cycles; cycle--;) {
 		for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
 			continue;
@@ -127,6 +132,11 @@ static uint32_t swdptap_seq_in_no_delay(const size_t clock_cycles)
 	if (!clock_cycles)
 		return 0;
 	uint32_t value = 0;
+	/*
+	 * Count down instead of up, because with an up-count, some ARM-GCC
+	 * versions use an explicit CMP, missing the optimization of converting
+	 * to a faster down-count that uses SUBS followed by BCS/BCC.
+	 */
 	for (size_t cycle = clock_cycles; cycle--;) {
 		/* Reordering barrier */
 		__asm__("" ::: "memory");
@@ -183,6 +193,11 @@ static void swdptap_seq_out_clk_delay(const uint32_t tms_states, const size_t cl
 	bool bit = value & 1U;
 	if (!clock_cycles)
 		return;
+	/*
+	 * Count down instead of up, because with an up-count, some ARM-GCC
+	 * versions use an explicit CMP, missing the optimization of converting
+	 * to a faster down-count that uses SUBS followed by BCS/BCC.
+	 */
 	for (size_t cycle = clock_cycles; cycle--;) {
 		/* Reordering barrier */
 		__asm__("" ::: "memory");
@@ -209,6 +224,11 @@ static void swdptap_seq_out_no_delay(const uint32_t tms_states, const size_t clo
 	bool bit = value & 1U;
 	if (!clock_cycles)
 		return;
+	/*
+	 * Count down instead of up, because with an up-count, some ARM-GCC
+	 * versions use an explicit CMP, missing the optimization of converting
+	 * to a faster down-count that uses SUBS followed by BCS/BCC.
+	 */
 	for (size_t cycle = clock_cycles; cycle--;) {
 		/* Reordering barrier */
 		__asm__("" ::: "memory");

--- a/src/platforms/common/swdptap.c
+++ b/src/platforms/common/swdptap.c
@@ -104,7 +104,7 @@ static uint32_t swdptap_seq_in_clk_delay(const size_t clock_cycles)
 	for (size_t cycle = clock_cycles; cycle--;) {
 		for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
 			continue;
-		bool bit = gpio_get(SWDIO_IN_PORT, SWDIO_IN_PIN);
+		const bool bit = gpio_get(SWDIO_IN_PORT, SWDIO_IN_PIN);
 		gpio_set(SWCLK_PORT, SWCLK_PIN);
 		for (volatile uint32_t counter = target_clk_divider; counter > 0; --counter)
 			continue;
@@ -180,7 +180,7 @@ static void swdptap_seq_out_clk_delay(uint32_t tms_states, size_t clock_cycles) 
 static void swdptap_seq_out_clk_delay(const uint32_t tms_states, const size_t clock_cycles)
 {
 	uint32_t value = tms_states;
-	bool bit = value & 1;
+	bool bit = value & 1U;
 	if (!clock_cycles)
 		return;
 	for (size_t cycle = clock_cycles; cycle--;) {
@@ -194,7 +194,7 @@ static void swdptap_seq_out_clk_delay(const uint32_t tms_states, const size_t cl
 			continue;
 		__asm__("nop" ::: "memory");
 		value >>= 1U;
-		bit = value & 1;
+		bit = value & 1U;
 		/* Reordering barrier */
 		__asm__("" ::: "memory");
 		gpio_clear(SWCLK_PORT, SWCLK_PIN);
@@ -206,7 +206,7 @@ static void swdptap_seq_out_no_delay(uint32_t tms_states, size_t clock_cycles) _
 static void swdptap_seq_out_no_delay(const uint32_t tms_states, const size_t clock_cycles)
 {
 	uint32_t value = tms_states;
-	bool bit = value & 1;
+	bool bit = value & 1U;
 	if (!clock_cycles)
 		return;
 	for (size_t cycle = clock_cycles; cycle--;) {
@@ -217,7 +217,7 @@ static void swdptap_seq_out_no_delay(const uint32_t tms_states, const size_t clo
 		gpio_set(SWCLK_PORT, SWCLK_PIN);
 		__asm__("nop" ::: "memory");
 		value >>= 1U;
-		bit = value & 1;
+		bit = value & 1U;
 		/* Reordering barrier */
 		__asm__("" ::: "memory");
 	}


### PR DESCRIPTION
Make SWD timing more consistent: output changes (including floating) take place after the falling edge, and reads take place before the rising edge.

This includes moving a gpio_get to occur after the clock-low delay, which would help reduce incorrect reads from lower-bandwidth target connections.

Eliminate redundant GPIO operations, typically ones that set the clock low, by making the bit string input/output primitives always end by outputting a falling clock edge.

## Detailed description

This makes the bit banging code more consistent and easier to analyze. It also removes some redundant clearing of the clock, typically because most existing big banging functions ended on a falling clock edge, and also began with an explicit clearing of the clock. This is no longer necessary, if we adopt a convention that the "resting" phase of the clock is low.

It also moves a misplaced `gpio_get` from before a clock-low delay to after it, so it comes right before the rising clock edge. This can help avoid incorrect reads from lower-bandwidth target connections. It might be helpful for @stansotn or someone else with such target connections to test it out.

I'll mark it ready for review after testing on BMDA, though I suspect that BMDA might slow things down too enough to make the differences harder to see on the logic analyzer.

Note that adopting an inlined busy-loop function as in #1688 might be needed to gain more significant clock consistency.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

N/A
