### PR TITLE
Feature: Working logs on `blackpill-f4` via DebugMon

### DIFF
--- a/src/platforms/common/blackpill-f4/Makefile.inc
+++ b/src/platforms/common/blackpill-f4/Makefile.inc
@@ -10,16 +10,16 @@ CFLAGS +=                           \
 	-mfloat-abi=hard                \
 	-mfpu=fpv4-sp-d16               \
 	-DSTM32F4                       \
+	-DDFU_SERIAL_LENGTH=13          \
 	-I../libopencm3/include         \
 	-Iplatforms/common/stm32        \
 	-Iplatforms/common/blackpill-f4
 
-LDFLAGS_BOOT =              \
+LDFLAGS_BOOT :=              \
 	-lopencm3_stm32f4       \
 	-Wl,-T,$(LINKER_SCRIPT) \
 	-nostartfiles           \
 	-lc                     \
-	-lnosys                 \
 	-Wl,-Map=mapfile        \
 	-mthumb                 \
 	-mcpu=cortex-m4         \
@@ -32,10 +32,8 @@ ifeq ($(BMP_BOOTLOADER), 1)
 $(info  Load address 0x08004000 for BMPBootloader)
 LDFLAGS = $(LDFLAGS_BOOT) -Wl,-Ttext=0x8004000
 CFLAGS += -DAPP_START=0x08004000 -DBMP_BOOTLOADER
-CFLAGS += -DDFU_SERIAL_LENGTH=9
 else
-LDFLAGS += $(LDFLAGS_BOOT)
-CFLAGS += -DDFU_SERIAL_LENGTH=13
+LDFLAGS = $(LDFLAGS_BOOT)
 endif
 
 ifdef ALTERNATIVE_PINOUT
@@ -44,6 +42,12 @@ endif
 
 ifdef SHIELD
 CFLAGS += -DSHIELD=$(SHIELD)
+endif
+
+ifeq ($(ENABLE_DEBUG), 1)
+LDFLAGS += --specs=rdimon.specs
+else
+LDFLAGS += --specs=nosys.specs
 endif
 
 VPATH +=                          \
@@ -63,7 +67,7 @@ all:	blackmagic.bin
 else
 all:	blackmagic.bin  blackmagic_dfu.bin blackmagic_dfu.hex
 blackmagic_dfu: usbdfu.o dfucore.o dfu_f4.o serialno.o
-	$(CC) $^ -o $@ $(LDFLAGS_BOOT)
+	$(CC) $^ -o $@ $(LDFLAGS_BOOT) --specs=nosys.specs
 
 blackmagic_dfu.bin:    blackmagic_dfu
 	$(OBJCOPY) -O binary $^ $@

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -29,6 +29,7 @@
 
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/cm3/scb.h>
+#include <libopencm3/cm3/scs.h>
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/exti.h>
 #include <libopencm3/stm32/usart.h>
@@ -103,6 +104,10 @@ void platform_init(void)
 #endif
 
 	platform_timing_init();
+#if ENABLE_DEBUG == 1
+	/* Allow vectoring to DebugMon exception handler upon semihosting breakpoints */
+	SCS_DEMCR |= SCS_DEMCR_VC_MON_EN;
+#endif
 	blackmagic_usb_init();
 	aux_serial_init();
 

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -29,6 +29,11 @@
 
 #define PLATFORM_HAS_TRACESWO
 
+#if ENABLE_DEBUG == 1
+#define PLATFORM_HAS_DEBUG
+extern bool debug_bmp;
+#endif
+
 /*
  * If the SHIELD macro is passed to make, other macros are defined.
  * Build the code using `make PROBE_HOST=blackpill-f4x1cx SHIELD=1` to define the SHIELD macro.


### PR DESCRIPTION
## Detailed description

* This is a new feature common to other platforms but missing from this one.
* There is an existing problem of no log traces available on `blackpill-f4` family of platforms.
* The PR solves the problem by adding required pieces and fixing linker flags.

How to reproduce the issue: build with `PROBE_HOST=blackpill-f411ce ENABLE_DEBUG=1`, optionally also with `BMP_BOOTLOADER=1`, upgrade/flash to the board, open gdb, ask for `monitor debug_bmp enable` (aka "mon debug en") -- `Target does not support this command.` Even though the binary is 40 KiB bigger.

I've been carrying the patches to use logging on my platform of choice since probably June 2023, which is when I started using the project, and I'm tired of unstashing them on top of every feature branch I'm testing just to see some important `DEBUG_INFO()`s. Both `stlink` and `swlink` work without such changes (but they can't fit both logs and default targets, which is a separate problem solved by an edited Makefile dirtying the working copy).

After another round through reading up on semihosting and debugging down through how it actually works, I now understand how this optional BMP feature was implemented on `native` all the way back in 2016 in PR151 https://github.com/blackmagic-debug/blackmagic/commit/966f360515e387fb79223a75986aa7b79878268a

Note two things: 1) I do not intend to downgrade to newlib-nano in BMPbootloader or in BMF, because it provides a faster memcpy and actual working mallopt+malloc_trim. 2) That means that the bootloader with 12-symbol serialno will no longer fit under 16 KiB, but I have a proposal in a separate PR to deal with it. Platform MaskROM generates a 12-symbol serial number when enumerating on USB, and I would like to enforce feature parity with it.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
