### PR TITLE
Feature: Space-efficient 12-symbol serialno generation

### DIFF
--- a/src/platforms/common/stm32/serialno.c
+++ b/src/platforms/common/stm32/serialno.c
@@ -50,7 +50,9 @@ void read_serial_number(void)
 #elif defined(STM32L0) || defined(STM32F0) || defined(STM32F3)
 	int offset = 5;
 #endif
-	sprintf(serial_no, "%04X%04X%04X", uid[1] + uid[5], uid[0] + uid[4], uid[offset]);
+	utoa_upper(uid[1] + uid[5], serial_no, 16);
+	utoa_upper(uid[0] + uid[4], serial_no + 4, 16);
+	utoa_upper(uid[offset], serial_no + 8, 16);
 #elif DFU_SERIAL_LENGTH == 25
 	const volatile uint32_t *const unique_id_p = (uint32_t *)DESIG_UNIQUE_ID_BASE;
 	uint32_t unique_id = 0;

--- a/src/platforms/common/stm32/serialno.c
+++ b/src/platforms/common/stm32/serialno.c
@@ -2,7 +2,12 @@
  * This file is part of the Black Magic Debug project.
  *
  * Copyright (C) 2015  Black Sphere Technologies Ltd.
+ * Copyright (C) 2017-2021 Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Copyright (C) 2022-2024 1BitSquared <info@1bitsquared.com>
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ * Modified by Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Modified by Rachel Mant <git@dragonmux.network>
+ * Modified by ALTracer <tolstov_den@mail.ru>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
* This can be considered a new feature (because I don't see how it was usable previously)
* There is an existing problem of BMPBootloader with `DFU_SERIAL_LENGTH=13` becoming larger than 16 KiB due to `siprintf` pulled from newlib (not nano).
* The PR solves this problem by replacing the single expensive `sprintf()` call with a few calls of simpler functions and introducing a variant of `utoa()`.

12-symbol serialno consists of three halfwords calculated by pulling 16-bit values from Device Electronic Signature memory. I don't believe `hexify()` can be useful here.

I would not like to choose to mitigate this by downgrading the F4 BMPBootloader to newlib-nano because it would provide a small and inefficient memcpy, which is important for flash writes/upgrade reprogramming speed. And it's not like a bootloader would use *printf anyway.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`) -- and is not applicable
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) -- and is not applicable
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
