### PR TITLE
Feature: Fancy DFU on `blackpill-f4`

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -45,10 +45,11 @@ volatile uint32_t magic[2] __attribute__((section(".noinit")));
 
 void platform_init(void)
 {
-	/* Enable GPIO peripherals */
+	/* Enable peripherals */
 	rcc_periph_clock_enable(RCC_GPIOA);
 	rcc_periph_clock_enable(RCC_GPIOC);
 	rcc_periph_clock_enable(RCC_GPIOB);
+	rcc_periph_clock_enable(RCC_CRC);
 
 #ifndef BMP_BOOTLOADER
 	/* Blackpill board has a floating button on PA0. Pull it up and use as active-low. */
@@ -73,26 +74,19 @@ void platform_init(void)
 #endif
 	rcc_clock_setup_pll(&rcc_hse_25mhz_3v3[PLATFORM_CLOCK_FREQ]);
 
-	/* Enable peripherals */
-	rcc_periph_clock_enable(RCC_OTGFS);
-	rcc_periph_clock_enable(RCC_CRC);
-
 	/* Set up DM/DP pins. PA9/PA10 are not routed to USB-C. */
 	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);
 	gpio_set_af(GPIOA, GPIO_AF10, GPIO11 | GPIO12);
-
-	GPIOA_OSPEEDR &= 0x3c00000cU;
-	GPIOA_OSPEEDR |= 0x28000008U;
 
 	/* Set up TDI, TDO, TCK and TMS pins */
 	gpio_mode_setup(TDI_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TDI_PIN);
 	gpio_mode_setup(TDO_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, TDO_PIN);
 	gpio_mode_setup(TCK_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TCK_PIN);
 	gpio_mode_setup(TMS_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, TMS_PIN);
-	gpio_set_output_options(TDI_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TDI_PIN);
-	gpio_set_output_options(TDO_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TDO_PIN);
-	gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TCK_PIN);
-	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TMS_PIN);
+	gpio_set_output_options(TDI_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TDI_PIN);
+	gpio_set_output_options(TDO_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TDO_PIN);
+	gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TCK_PIN);
+	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TMS_PIN);
 
 	/* Set up LED pins */
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_IDLE_RUN | LED_ERROR | LED_BOOTLOADER);
@@ -114,6 +108,9 @@ void platform_init(void)
 	/* https://github.com/libopencm3/libopencm3/pull/1256#issuecomment-779424001 */
 	OTG_FS_GCCFG |= OTG_GCCFG_NOVBUSSENS | OTG_GCCFG_PWRDWN;
 	OTG_FS_GCCFG &= ~(OTG_GCCFG_VBUSBSEN | OTG_GCCFG_VBUSASEN);
+
+	/* By default, do not drive the SWD bus too fast. */
+	platform_max_frequency_set(3000000);
 }
 
 void platform_nrst_set_val(bool assert)

--- a/src/platforms/common/blackpill-f4/usbdfu.c
+++ b/src/platforms/common/blackpill-f4/usbdfu.c
@@ -42,6 +42,7 @@ void dfu_detach(void)
 
 int main(void)
 {
+	/* Enable GPIO peripherals */
 	rcc_periph_clock_enable(RCC_GPIOA);
 
 	/* Blackpill board has a floating button on PA0. Pull it up and use as active-low. */
@@ -62,9 +63,6 @@ int main(void)
 
 	/* Run heartbeat on blue LED */
 	sys_tick_init();
-
-	/* Enable peripherals */
-	rcc_periph_clock_enable(RCC_OTGFS);
 
 	/* Set up USB Pins and alternate function*/
 	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11 | GPIO12);

--- a/src/platforms/common/blackpill-f4/usbdfu.c
+++ b/src/platforms/common/blackpill-f4/usbdfu.c
@@ -97,5 +97,20 @@ static void sys_tick_init(void)
 
 void sys_tick_handler(void)
 {
-	gpio_toggle(LED_PORT, LED_BOOTLOADER | LED_IDLE_RUN);
+	static uint32_t count = 0U;
+	switch (count) {
+	case 0U:
+		/* Reload downcounter */
+		count = 10U;
+		SET_IDLE_STATE(false);
+		break;
+	case 1U:
+		count--;
+		/* Blink like a very slow PWM */
+		SET_IDLE_STATE(true);
+		break;
+	default:
+		count--;
+		break;
+	}
 }

--- a/src/platforms/common/blackpill-f4/usbdfu.c
+++ b/src/platforms/common/blackpill-f4/usbdfu.c
@@ -19,9 +19,10 @@
 
 #include <string.h>
 #include <libopencm3/cm3/systick.h>
+#include <libopencm3/cm3/nvic.h>
+#include <libopencm3/cm3/scb.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
-#include <libopencm3/cm3/scb.h>
 #include <libopencm3/usb/dwc/otg_fs.h>
 
 #include "usbdfu.h"
@@ -30,6 +31,8 @@
 
 uintptr_t app_address = 0x08004000U;
 volatile uint32_t magic[2] __attribute__((section(".noinit")));
+
+static void sys_tick_init(void);
 
 void dfu_detach(void)
 {
@@ -53,8 +56,11 @@ int main(void)
 
 	/* Assert blue LED as indicator we are in the bootloader */
 	rcc_periph_clock_enable(RCC_GPIOC);
-	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_BOOTLOADER);
-	gpio_set(LED_PORT, LED_BOOTLOADER);
+	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_BOOTLOADER | LED_IDLE_RUN);
+	gpio_clear(LED_PORT, LED_BOOTLOADER | LED_IDLE_RUN);
+
+	/* Run heartbeat on blue LED */
+	sys_tick_init();
 
 	/* Enable peripherals */
 	rcc_periph_clock_enable(RCC_OTGFS);
@@ -75,4 +81,21 @@ int main(void)
 
 void dfu_event(void)
 {
+}
+
+static void sys_tick_init(void)
+{
+	/* Use SysTick at 10Hz to toggle-blink the blue LED at 5 Hz */
+	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
+	systick_set_reload(rcc_ahb_frequency / 8U / 10U);
+	/* SYSTICK_IRQ with low priority */
+	nvic_set_priority(NVIC_SYSTICK_IRQ, 14U << 4U);
+	systick_interrupt_enable();
+	/* Start the heartbeat timer */
+	systick_counter_enable();
+}
+
+void sys_tick_handler(void)
+{
+	gpio_toggle(LED_PORT, LED_BOOTLOADER | LED_IDLE_RUN);
 }

--- a/src/platforms/common/stm32/dfu_f4.c
+++ b/src/platforms/common/stm32/dfu_f4.c
@@ -75,6 +75,9 @@ void dfu_flash_program_buffer(const uint32_t baseaddr, const void *const buf, co
 	const uint32_t *const buffer = (const uint32_t *)buf;
 	for (size_t i = 0; i < len; i += 4U)
 		flash_program_word(baseaddr + i, buffer[i >> 2U]);
+
+	/* Call the platform specific dfu event callback. */
+	dfu_event();
 }
 
 uint32_t dfu_poll_timeout(uint8_t cmd, uint32_t addr, uint16_t blocknum)

--- a/src/platforms/common/stm32/dfu_f4.c
+++ b/src/platforms/common/stm32/dfu_f4.c
@@ -41,7 +41,29 @@ static uint32_t sector_addr[] = {
 	0,
 };
 
-static uint16_t sector_erase_time[] = {500, 500, 500, 500, 1100, 2600, 2600, 2600, 2600, 2600, 2600, 2600, 2600};
+/* Sector erase times in milliseconds, max, for x32 parallelism at 2.7-3.6v */
+typedef enum erase_times_f4 {
+	ERASE_TIME_16KB = 500,
+	ERASE_TIME_64KB = 1100,
+	ERASE_TIME_128KB = 2600,
+} erase_times_f4_e;
+
+static erase_times_f4_e sector_erase_time[] = {
+	ERASE_TIME_16KB,
+	ERASE_TIME_16KB,
+	ERASE_TIME_16KB,
+	ERASE_TIME_16KB,
+	ERASE_TIME_64KB,
+	ERASE_TIME_128KB,
+	ERASE_TIME_128KB,
+	ERASE_TIME_128KB,
+	ERASE_TIME_128KB,
+	ERASE_TIME_128KB,
+	ERASE_TIME_128KB,
+	ERASE_TIME_128KB,
+	ERASE_TIME_128KB,
+};
+
 static uint8_t sector_num = 0xff;
 
 static_assert(ARRAY_LENGTH(sector_erase_time) == ARRAY_LENGTH(sector_addr) - 1U,


### PR DESCRIPTION
## Detailed description

* This looks like a feature to end users but is just a collection of tweaks and ported code.
* The existing problem is an inefficient DFU configuration for `blackpill-f4` family of platforms (and probably other STM32F4 boards).
* This PR solves the problem by tightening DFU F4 delays, introducing an LED show/blinky in BMPBootloader (usbdfu), and provisioning it all to fit under 16 KiB for optimal reachable performance.

The first couple commits belong to the serialno PR this PR is based on (or blocks on). I fail to see what mechanism checks that the usbdfu binary fits under the allocated space (8 1-KiB sectors for F1, first 16 KiB sector for F4, etc.), but I noticed that flipping the DFU_SERIAL_LENGTH from 9 to 13 pulled sprintf and bloated the dfu binary past first sector. See that PR for details.

The `dfu_f4.c` changes are required and beneficial for BMPBootloader to work how I tested it to, but can be split into its separate PR if needed. I could submit similar delay tunings for `dfu_f1.c` I am using on F103CB boards.

The last commit is a general platform cleanup, but it can be amended or rebased away depending on situation.

Measurements for reference:
ST MaskROM DFU ~ 7.75 KiB/s (fine for flashing BMPBootloader)
BMPBootloader on `main` ~12 KiB/s (excessive delays)
BMPBootloader on this PR branch ~ 43 KiB/s (up to 54 KiB/s if fitting under 0x08020000 and tuning delays further)
4x reduced upload time (down to ~3 seconds) is worth it for developers reflashing their boards often.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Closes #1516, or so I suppose (after a possible removal of `LED_BOOTLOADER` for good)