### PR TITLE
Fix: Declare smaller timeouts in F1 DFU to speed up probe upgrades

### DIFF
--- a/src/platforms/common/stm32/dfu_f1.c
+++ b/src/platforms/common/stm32/dfu_f1.c
@@ -56,10 +56,24 @@ void dfu_flash_program_buffer(const uint32_t baseaddr, const void *const buf, co
 
 uint32_t dfu_poll_timeout(uint8_t cmd, uint32_t addr, uint16_t blocknum)
 {
-	(void)cmd;
 	(void)addr;
 	(void)blocknum;
-	return 100;
+
+	/*
+	 * Page (1KiB) erase times:
+	 * STM32F103CB: 20 ms (min), 40 ms (max);
+	 *  GD32F103CB: 50 ms (typ), 400 ms (max);
+	 */
+	if (cmd == CMD_ERASE)
+		return 20U;
+
+	/*
+	 * Programming times:
+	 * STM32F103CB: 40 us (min), 52.5 us (typ), 70 us (max) -- for 16-bit half-word
+	 *  GD32F103CB: 37.5 us (typ), 105 us (max) -- for 32-bit word
+	 * 52.5 us * 512 half-words, or 105 us * 256 words, gives 26.88 ms estimate (typ)
+	 */
+	return 27U;
 }
 
 void dfu_protect(bool enable)


### PR DESCRIPTION
## Detailed description

* Not a new feature.
* The existing problem is slow (suboptimal) DFU upgrade times of F103CB-based BMP-compatibles.
* This PR solves this problem by decreasing timeouts returned from BMPBootloader.

This commit from July 2023 resulted from a deeper look into `dfu-util` operation (and partially `bmputil`) and BMPBootloader DFU internals (usbdfu, dfucore, dfu_f1). Armed with some DFU operation specs and MCU datasheets for STM32F103CB and GD32F103xx, I added a bit of instrumentation (blinky on dfu_event) to `swlink` and tried to reduce the timings.

The logic is similar to `dfu_f4.c` in that there should be two different timeouts for page erase (1 KiB on F1) and buffer program (1024 because of `wTransferSize` over EP0) calculated from *typical* or *minimum* characteristic times (but not *maximum*). Making the host wait less then come knocking with 1ms polls is safe; and faster than making it wait "for sure long enough". Why that is so -- may need additional argumentation.

Tested on WeAct Studio BluePillPlus boards containing STM32F103CB and GD32F103CB with no regressions (the payload is then manually verified over SWD to match by qCRC) and with a measurable speedup, helpful for both developers often upgrading to daily builds, and for end-users waiting up on the yearly release upgrade.

Example time for a full 120 KiB upload (128 capacity - 8 for bootloader) on current `main`: 100ms * 120 page erases + 100ms * 120 buffers = 24 seconds, not accounting for synchronous transfer of payload data over USB FS Control EP0.
Example time for a full 120 KiB upload with this patch: 20ms * 120 page erases + 27ms * 120 buffers = 5.64 seconds plus USB exchange. This is, too, a preliminary 4x-5x improvement.
`bmputil` should benefit from this, too, and it measures upgrade times with a different algorithm than I do with `/usr/bin/time -v dfu-util -d 1d50:6017 -s 0x08002000:leave -D src/blackmagic.elf`.
Detailed speed tests may be conducted on request. Doing these measurements on a MaskROM USB DFU-capable `blackpill-f411ce` to replace the bootloader is easier, but F1 parts need either a USB-UART + stm32flash (and BOOT0 button/jumper manipulation) or a proper SWD adapter.
Commit message optionally subject to editing.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`) -- and is not applicable
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
