### PR TITLE
target/stm32f1: fix split-bank erase

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -573,7 +573,7 @@ static bool stm32f1_flash_unlock(target_s *target, uint32_t bank_offset)
 {
 	target_mem_write32(target, FLASH_KEYR + bank_offset, KEY1);
 	target_mem_write32(target, FLASH_KEYR + bank_offset, KEY2);
-	uint32_t ctrl = target_mem_read32(target, FLASH_CR);
+	uint32_t ctrl = target_mem_read32(target, FLASH_CR + bank_offset);
 	if (ctrl & FLASH_CR_LOCK)
 		DEBUG_ERROR("unlock failed, cr: 0x%08" PRIx32 "\n", ctrl);
 	return !(ctrl & FLASH_CR_LOCK);


### PR DESCRIPTION
Add a missing `bank_offset` when checking for bank unlock completion.

## Detailed description

Discovered while testing #1709 on a GD32F303CGT6 target. It probably affects all split-bank STM32F1 parts or compatibles, as long as they have split flash banks.

The check for flash bank unlock completion failed for bank 2, because it was checking the register for bank 1. This probably went unnoticed for quite a while, because bank 2 is likely used for application data storage instead of code.

Only tested against GD32F303CGT6, which has split flash banks. Testing could only occur in conjunction with #1709, with which it merged cleanly. I don't have access to any other affected targets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

N/A