### PR TITLE
Feature: Support stlink v2 isol variant

### DIFF
--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -39,6 +39,10 @@ ifeq ($(STLINK_FORCE_CLONE), 1)
 CFLAGS += -DSTLINK_FORCE_CLONE=1
 endif
 
+ifeq ($(STLINK_V2_ISOL), 1)
+CFLAGS += -DSTLINK_V2_ISOL=1
+endif
+
 VPATH += platforms/common/stm32
 
 SRC +=          \

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -52,6 +52,19 @@ void platform_init(void)
 #ifdef BLUEPILL
 	led_idle_run = GPIO13;
 	nrst_pin = NRST_PIN_V1;
+#elif defined(STLINK_V2_ISOL)
+	led_idle_run = GPIO9;
+	nrst_pin = NRST_PIN_V2;
+	/* PB12 is SWDIO_IN */
+	gpio_set_mode(GPIOB, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, GPIO12);
+	/* PA4 is used to set SWDCLK floating when set to 1 */
+	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO4);
+	gpio_clear(GPIOA, GPIO4);
+	/* PA1 is used to set SWDIO floating and MUXED to SWDIO_IN when set to 1 */
+	gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO1);
+#elif defined(STLINK_FORCE_CLONE)
+	led_idle_run = GPIO9;
+	nrst_pin = NRST_PIN_CLONE;
 #else
 	switch (rev) {
 	case 0:
@@ -69,7 +82,13 @@ void platform_init(void)
 	}
 #endif
 	/* Setup GPIO ports */
+#ifdef STLINK_V2_ISOL
+	/* In case of ISOL variant, this pin is never set to high impedance */
+	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TMS_PIN);
+#else
+	/* In all other variants, this pin is initialized as high impedance */
 	gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_INPUT_FLOAT, TMS_PIN);
+#endif
 	gpio_set_mode(TCK_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TCK_PIN);
 	gpio_set_mode(TDI_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TDI_PIN);
 


### PR DESCRIPTION
## Detailed description
The [stlink-isol-v2](https://estore.st.com/en/st-link-v2-isol-cpn.html) variant differs from other stlink-v2 variants with how the SWDIO pin is multiplexed. This commit adds support for it. I have tested the commit on my STlink ISOL and it seems to work fine.
## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
N/A