### PR TITLE
Fix: Momentary bandgap reference read glitch

### DIFF
--- a/src/platforms/common/stm32/timing_stm32.c
+++ b/src/platforms/common/stm32/timing_stm32.c
@@ -35,6 +35,7 @@ uint32_t target_clk_divider = 0;
 static size_t morse_tick = 0;
 #if defined(PLATFORM_HAS_POWER_SWITCH) && defined(STM32F1)
 static uint8_t monitor_ticks = 0;
+static uint8_t monitor_error_count = 0;
 
 /* Derived from calculating (1.2V / 3.0V) * 4096 */
 #define ADC_VREFINT_MAX 1638U
@@ -119,7 +120,12 @@ void sys_tick_handler(void)
 
 			/* Now compare the reference against the known good range */
 			if (ref > ADC_VREFINT_MAX || ref < ADC_VREFINT_MIN) {
-				/* Something's wrong, so turn tpwr off and set the morse blink pattern */
+				monitor_error_count++;
+			} else if (monitor_error_count)
+				monitor_error_count--;
+
+			/* Something's wrong, and it is not a glitch, so turn tpwr off and set the morse blink pattern */
+			if (monitor_error_count > 3) {
 				platform_target_set_power(false);
 				morse("TPWR ERROR", true);
 			}


### PR DESCRIPTION
## Detailed description

Added an error counter to address an occasional glitch, where a threshold violation is detected during normal operation.

Now we need to count 3 threshold violations to trigger the protection mechanism.

<!-- Filling this template is mandatory -->


<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do


