### PR TITLE
Fix: target printf style format cleanup

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -443,7 +443,7 @@ static bool cmd_halt_timeout(target_s *t, int argc, const char **argv)
 	(void)t;
 	if (argc > 1)
 		cortexm_wait_timeout = strtoul(argv[1], NULL, 0);
-	gdb_outf("Cortex-M timeout to wait for device halts: %d\n", cortexm_wait_timeout);
+	gdb_outf("Cortex-M timeout to wait for device halts: %u\n", cortexm_wait_timeout);
 	return true;
 }
 

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -798,7 +798,7 @@ static target_s *cortexar_probe(
 			priv->base.dcache_line_length = CORTEX_CTR_DCACHE_LINE(cache_type);
 
 		DEBUG_TARGET("%s: ICache line length = %u, DCache line length = %u\n", __func__,
-			priv->base.icache_line_length << 2U, priv->base.dcache_line_length << 2U);
+			priv->base.icache_line_length * 4U, priv->base.dcache_line_length * 4U);
 	} else
 		target_check_error(target);
 

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -791,7 +791,7 @@ static bool stm32l4_cmd_erase_bank1(target_s *const t, const int argc, const cha
 {
 	(void)argc;
 	(void)argv;
-	gdb_outf("Erasing bank %u: ", 1);
+	gdb_outf("Erasing bank %u: ", 1U);
 	const bool result = stm32l4_cmd_erase(t, FLASH_CR_MER1);
 	gdb_out("done\n");
 	return result;
@@ -801,7 +801,7 @@ static bool stm32l4_cmd_erase_bank2(target_s *const t, const int argc, const cha
 {
 	(void)argc;
 	(void)argv;
-	gdb_outf("Erasing bank %u: ", 2);
+	gdb_outf("Erasing bank %u: ", 2U);
 	const bool result = stm32l4_cmd_erase(t, FLASH_CR_MER2);
 	gdb_out("done\n");
 	return result;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses some of the new warnings being produced under Meson which uncovered some additional printf-style format string mistakes that were being made.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
