### PR TITLE
Fix: CMSIS-DAP packet size handling

### DIFF
--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -88,6 +88,7 @@ typedef struct bmda_probe {
 	uint8_t interface_num;
 	uint8_t in_ep;
 	uint8_t out_ep;
+	uint16_t max_packet_length;
 #endif
 } bmda_probe_s;
 

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -406,6 +406,11 @@ static void check_cmsis_interface_type(libusb_device *const device, bmda_probe_s
 			if (strstr(interface_string, "CMSIS") == NULL)
 				continue;
 
+			/* Scan through the endpoints finding the one with the narrowest max transfer length */
+			info->max_packet_length = UINT16_MAX;
+			for (uint8_t index = 0; index < descriptor->bNumEndpoints; ++index)
+				info->max_packet_length = MIN(descriptor->endpoint[index].wMaxPacketSize, info->max_packet_length);
+
 			/* Check if it's a CMSIS-DAP v2 interface */
 			if (descriptor->bInterfaceClass == 0xffU && descriptor->bNumEndpoints == 2U) {
 				info->interface_num = descriptor->bInterfaceNumber;
@@ -417,6 +422,8 @@ static void check_cmsis_interface_type(libusb_device *const device, bmda_probe_s
 					else
 						info->out_ep = ep;
 				}
+				/* If we've found a CMSIS-DAP v2 interface, look no further - we want to prefer these to v1. */
+				break;
 			}
 		}
 	}

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -259,6 +259,8 @@ static bool dap_init_bulk(void)
 		DEBUG_ERROR("libusb_claim_interface() failed\n");
 		return false;
 	}
+	/* Base the packet size on the one retrieved from the device descriptors */
+	packet_size = bmda_probe_info.max_packet_length;
 	in_ep = bmda_probe_info.in_ep;
 	out_ep = bmda_probe_info.out_ep;
 	return true;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -104,8 +104,13 @@ static libusb_device_handle *usb_handle = NULL;
 static uint8_t in_ep;
 static uint8_t out_ep;
 static hid_device *handle = NULL;
-static uint8_t buffer[1024U];
-static size_t report_size = 64U + 1U; // TODO: read actual report size
+/* Provide enough space for up to a HS USB HID payload + the HID report ID byte */
+static uint8_t buffer[1025U];
+/*
+ * Start by defaulting this to the typical size of `DAP_PACKET_SIZE` for FS USB. This value is pulled from here:
+ * https://www.keil.com/pack/doc/CMSIS/DAP/html/group__DAP__Config__Debug__gr.html#gaa28bb1da2661291634c4a8fb3e227404
+ */
+static size_t report_size = 64U;
 bool dap_has_swd_sequence = false;
 
 dap_version_s dap_adaptor_version(dap_info_e version_kind);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes the way the CMSIS-DAP code handles adaptor packet sizing and the differences between HID and Bulk endpoint (v1 and v2) based firmware.

Tested working against ORBTrace and picoprobe (which is based directly on the ARM reference implementation).

This finally solves the mystery too of how the packet size and buffer interact with one another and the HIDAPI code, documenting this properly.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
