### PR TITLE
Fix: semihosting BMDA correctness

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -661,8 +661,10 @@ static void handle_v_packet(char *packet, const size_t plen)
 			}
 			break;
 		}
+		/* Reset the semihosting SYS_CLOCK start point */
+		semihosting_wallclock_epoch = UINT32_MAX;
 #ifdef ENABLE_RTT
-		/* force searching rtt control block */
+		/* Force searching for the RTT control block */
 		rtt_found = false;
 #endif
 		/* Run target program. For us (embedded) this means reset. */

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -277,7 +277,6 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 		break;
 	}
 
-#if PC_HOSTED == 0
 	case 'F': /* Semihosting call finished */
 		if (in_syscall)
 			return semihosting_reply(tc, pbuf, size);
@@ -286,10 +285,6 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 			gdb_putpacketz("");
 		}
 		break;
-#else
-		(void)tc;
-		(void)in_syscall;
-#endif
 
 	case '!': /* Enable Extended GDB Protocol. */
 		/*

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -673,7 +673,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 #endif
 		/* Run target program. For us (embedded) this means reset. */
 		if (cur_target) {
-			target_set_cmdline(cur_target, cmdline);
+			target_set_cmdline(cur_target, cmdline, offset);
 			target_reset(cur_target);
 			gdb_putpacketz("T05");
 		} else if (last_target) {
@@ -681,7 +681,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 
 			/* If we were able to attach to the target again */
 			if (cur_target) {
-				target_set_cmdline(cur_target, cmdline);
+				target_set_cmdline(cur_target, cmdline, offset);
 				target_reset(cur_target);
 				morse(NULL, false);
 				gdb_putpacketz("T05");

--- a/src/hex_utils.c
+++ b/src/hex_utils.c
@@ -65,3 +65,16 @@ char *unhexify(void *const buf, const char *hex, const size_t size)
 		dst[idx] = (unhex_digit(hex[0]) << 4U) | unhex_digit(hex[1]);
 	return buf;
 }
+
+uint64_t hex_string_to_num(const size_t max_digits, const char *const str)
+{
+	uint64_t ret = 0;
+	for (size_t offset = 0; offset < max_digits; ++offset) {
+		const char value = str[offset];
+		if (!is_hex(value))
+			return ret;
+		ret <<= 4U;
+		ret |= unhex_digit(value);
+	}
+	return ret;
+}

--- a/src/include/hex_utils.h
+++ b/src/include/hex_utils.h
@@ -32,4 +32,9 @@ char *unhexify(void *buf, const char *hex, size_t size);
 char hex_digit(uint8_t value);
 uint8_t unhex_digit(char hex);
 
+static inline bool is_hex(const char x)
+{
+	return (x >= '0' && x <= '9') || (x >= 'A' && x <= 'F') || (x >= 'a' && x <= 'f');
+}
+
 #endif /* INCLUDE_HEX_UTILS_H */

--- a/src/include/hex_utils.h
+++ b/src/include/hex_utils.h
@@ -32,6 +32,8 @@ char *unhexify(void *buf, const char *hex, size_t size);
 char hex_digit(uint8_t value);
 uint8_t unhex_digit(char hex);
 
+uint64_t hex_string_to_num(size_t max_digits, const char *str);
+
 static inline bool is_hex(const char x)
 {
 	return (x >= '0' && x <= '9') || (x >= 'A' && x <= 'F') || (x >= 'a' && x <= 'f');

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -157,10 +157,8 @@ struct target_controller {
 	void (*destroy_callback)(target_controller_s *, target_s *target);
 	void (*printf)(target_controller_s *, const char *fmt, va_list);
 
-#if PC_HOSTED == 0
 	void *semihosting_buffer_ptr;
 	size_t semihosting_buffer_len;
-#endif
 	target_errno_e gdb_errno;
 	bool interrupted;
 };

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -147,15 +147,6 @@ typedef enum target_errno {
 	TARGET_EUNKNOWN = 9999,
 } target_errno_e;
 
-typedef enum target_open_flags {
-	TARGET_O_RDONLY = 0x0,
-	TARGET_O_WRONLY = 0x1,
-	TARGET_O_RDWR = 0x2,
-	TARGET_O_APPEND = 0x8,
-	TARGET_O_CREAT = 0x200,
-	TARGET_O_TRUNC = 0x400,
-} target_open_flags_e;
-
 typedef enum target_seek_flag {
 	TARGET_SEEK_SET = 0,
 	TARGET_SEEK_CUR = 1,

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -165,6 +165,10 @@ struct target_controller {
 	void (*destroy_callback)(target_controller_s *, target_s *target);
 	void (*printf)(target_controller_s *, const char *fmt, va_list);
 
+#if PC_HOSTED == 0
+	void *semihosting_buffer_ptr;
+	size_t semihosting_buffer_len;
+#endif
 	target_errno_e gdb_errno;
 	bool interrupted;
 };

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -100,7 +100,7 @@ void target_reset(target_s *target);
 void target_halt_request(target_s *target);
 target_halt_reason_e target_halt_poll(target_s *target, target_addr_t *watch);
 void target_halt_resume(target_s *target, bool step);
-void target_set_cmdline(target_s *target, char *cmdline);
+void target_set_cmdline(target_s *target, const char *cmdline, size_t cmdline_len);
 void target_set_heapinfo(target_s *target, target_addr_t heap_base, target_addr_t heap_limit, target_addr_t stack_base,
 	target_addr_t stack_limit);
 

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -122,6 +122,7 @@ int target_command(target_s *target, int argc, const char *argv[]);
 
 /* keep target_errno in sync with errno values in gdb/include/gdb/fileio.h */
 typedef enum target_errno {
+	TARGET_SUCCESS = 0,
 	TARGET_EPERM = 1,
 	TARGET_ENOENT = 2,
 	TARGET_EINTR = 4,

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -63,6 +63,5 @@ void remote_adiv5_dp_init(adiv5_debug_port_s *dp);
 void remote_add_jtag_dev(uint32_t dev_index, const jtag_dev_s *jtag_dev);
 
 uint64_t remote_decode_response(const char *response, size_t digits);
-uint64_t remote_hex_string_to_num(uint32_t limit, const char *str);
 
 #endif /* PLATFORMS_HOSTED_BMP_REMOTE_H */

--- a/src/platforms/hosted/remote/protocol_v0_jtag.c
+++ b/src/platforms/hosted/remote/protocol_v0_jtag.c
@@ -32,6 +32,7 @@
  */
 
 #include "bmp_remote.h"
+#include "hex_utils.h"
 #include "protocol_v0_defs.h"
 #include "protocol_v0_jtag.h"
 
@@ -103,7 +104,7 @@ void remote_v0_jtag_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t
 			exit(-1);
 		}
 		if (data_out) {
-			const uint64_t packet_data_out = remote_hex_string_to_num(-1, buffer + 1);
+			const uint64_t packet_data_out = hex_string_to_num(-1, buffer + 1);
 			for (size_t idx = 0; idx < bytes; ++idx)
 				data_out[offset + idx] = (uint8_t)(packet_data_out >> (idx * 8U));
 		}
@@ -128,7 +129,7 @@ bool remote_v0_jtag_next(bool tms, bool tdi)
 		exit(-1);
 	}
 
-	return remote_hex_string_to_num(1, buffer + 1);
+	return hex_string_to_num(1, buffer + 1);
 }
 
 void remote_v0_jtag_cycle(const bool tms, const bool tdi, const size_t clock_cycles)

--- a/src/platforms/hosted/remote/protocol_v0_swd.c
+++ b/src/platforms/hosted/remote/protocol_v0_swd.c
@@ -32,6 +32,7 @@
  */
 
 #include "bmp_remote.h"
+#include "hex_utils.h"
 #include "protocol_v0_defs.h"
 #include "protocol_v0_swd.h"
 
@@ -47,7 +48,7 @@ uint32_t remote_v0_swd_seq_in(size_t clock_cycles)
 		DEBUG_ERROR("%s failed, error %s\n", __func__, length ? buffer + 1 : "short response");
 		exit(-1);
 	}
-	const uint32_t result = remote_hex_string_to_num(-1, buffer + 1);
+	const uint32_t result = hex_string_to_num(-1, buffer + 1);
 	DEBUG_PROBE("%s %zu clock_cycles: %08" PRIx32 "\n", __func__, clock_cycles, result);
 	return result;
 }
@@ -65,7 +66,7 @@ bool remote_v0_swd_seq_in_parity(uint32_t *result, size_t clock_cycles)
 		exit(-1);
 	}
 
-	*result = remote_hex_string_to_num(-1, buffer + 1);
+	*result = hex_string_to_num(-1, buffer + 1);
 	DEBUG_PROBE("%s %zu clock_cycles: %08" PRIx32 " %s\n", __func__, clock_cycles, *result,
 		buffer[0] != REMOTE_RESP_OK ? "ERR" : "OK");
 	return buffer[0] != REMOTE_RESP_OK;

--- a/src/remote.c
+++ b/src/remote.c
@@ -40,7 +40,6 @@
 
 #define HTON(x)    (((x) <= '9') ? (x) - '0' : ((TOUPPER(x)) - 'A' + 10))
 #define TOUPPER(x) ((((x) >= 'a') && ((x) <= 'z')) ? ((x) - ('a' - 'A')) : (x))
-#define ISHEX(x)   ((((x) >= '0') && ((x) <= '9')) || (((x) >= 'A') && ((x) <= 'F')) || (((x) >= 'a') && ((x) <= 'f')))
 
 /* Return numeric version of string, until illegal hex digit, or max */
 uint64_t remote_hex_string_to_num(const uint32_t max, const char *const str)
@@ -48,7 +47,7 @@ uint64_t remote_hex_string_to_num(const uint32_t max, const char *const str)
 	uint64_t ret = 0;
 	for (size_t i = 0; i < max; ++i) {
 		const char value = str[i];
-		if (!ISHEX(value))
+		if (!is_hex(value))
 			return ret;
 		ret = (ret << 4U) | HTON(value);
 	}

--- a/src/remote.h
+++ b/src/remote.h
@@ -360,7 +360,6 @@
 			REMOTE_UINT24, REMOTE_EOM, 0                                                                  \
 	}
 
-uint64_t remote_hex_string_to_num(uint32_t limit, const char *str);
 void remote_packet_process(unsigned int i, char *packet);
 
 #endif /* REMOTE_H */

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -60,7 +60,7 @@ const command_s cortexm_cmd_list[] = {
 };
 
 /* target options recognised by the Cortex-M target */
-#define TOPT_FLAVOUR_V6M (1U << 0U) /* if not set, target is assumed to be v7m */
+#define CORTEXM_TOPT_FLAVOUR_V6M (1U << 1U) /* if not set, target is assumed to be v7m */
 
 static const char *cortexm_regs_description(target_s *target);
 static void cortexm_regs_read(target_s *target, void *data);
@@ -1216,7 +1216,7 @@ static uint32_t cortexm_dwt_func(target_s *target, target_breakwatch_e type)
 {
 	uint32_t x = 0;
 
-	if ((target->target_options & TOPT_FLAVOUR_V6M) == 0)
+	if ((target->target_options & CORTEXM_TOPT_FLAVOUR_V6M) == 0)
 		x = CORTEXM_DWT_FUNC_DATAVSIZE_WORD;
 
 	switch (type) {

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -47,15 +47,9 @@
 #include <assert.h>
 
 static bool cortexm_vector_catch(target_s *target, int argc, const char **argv);
-#if PC_HOSTED == 0
-static bool cortexm_redirect_stdout(target_s *target, int argc, const char **argv);
-#endif
 
 const command_s cortexm_cmd_list[] = {
 	{"vector_catch", cortexm_vector_catch, "Catch exception vectors"},
-#if PC_HOSTED == 0
-	{"redirect_stdout", cortexm_redirect_stdout, "Redirect semihosting stdout to USB UART"},
-#endif
 	{NULL, NULL, NULL},
 };
 
@@ -1359,17 +1353,6 @@ static bool cortexm_vector_catch(target_s *target, int argc, const char **argv)
 	tc_printf(target, "\n");
 	return true;
 }
-
-#if PC_HOSTED == 0
-static bool cortexm_redirect_stdout(target_s *target, int argc, const char **argv)
-{
-	if (argc == 1)
-		gdb_outf("Semihosting stdout redirection: %s\n", target->stdout_redirected ? "enabled" : "disabled");
-	else
-		target->stdout_redirected = !strncmp(argv[1], "enable", strlen(argv[1]));
-	return true;
-}
-#endif
 
 static bool cortexm_hostio_request(target_s *const target)
 {

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -164,7 +164,7 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_XPSR_THUMB          (1U << 24U)
 #define CORTEXM_XPSR_EXCEPTION_MASK 0x0000001fU
 
-#define CORTEXM_TOPT_FLAVOUR_V7MF (1U << 1U)
+#define CORTEXM_TOPT_FLAVOUR_V7MF (1U << 2U)
 
 bool cortexm_attach(target_s *target);
 void cortexm_detach(target_s *target);

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -163,7 +163,7 @@ static int semihosting_remote_read(target_controller_s *tc, int fd, target_addr_
 }
 
 /* Interface to host system calls */
-static int tc_write(target_s *target, int fd, target_addr_t buf, uint32_t count)
+static int semihosting_remote_write(target_s *target, int fd, target_addr_t buf, uint32_t count)
 {
 	if (target->stdout_redirected && (fd == STDOUT_FILENO || fd == STDERR_FILENO)) {
 		while (count) {
@@ -331,7 +331,7 @@ int32_t semihosting_write(target_s *const target, const semihosting_s *const req
 	const int32_t result = write(fd, buf, buf_len);
 	free(buf);
 #else
-	const int32_t result = tc_write(target, fd, buf_taddr, buf_len);
+	const int32_t result = semihosting_remote_write(target, fd, buf_taddr, buf_len);
 #endif
 	if (result >= 0)
 		return buf_len - result;
@@ -350,7 +350,7 @@ int32_t semihosting_writec(target_s *const target, const semihosting_s *const re
 	fputc(ch, stderr);
 	return 0;
 #else
-	return tc_write(target, STDERR_FILENO, ch_taddr, 1);
+	return semihosting_remote_write(target, STDERR_FILENO, ch_taddr, 1);
 #endif
 }
 
@@ -374,7 +374,7 @@ int32_t semihosting_write0(target_s *const target, const semihosting_s *const re
 	}
 	const int32_t len = str_end_taddr - str_begin_taddr;
 	if (len >= 0) {
-		const int32_t result = tc_write(target, STDERR_FILENO, str_begin_taddr, len);
+		const int32_t result = semihosting_remote_write(target, STDERR_FILENO, str_begin_taddr, len);
 		if (result != len)
 			return -1;
 	}

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -479,37 +479,13 @@ int32_t semihosting_write(target_s *const target, const semihosting_s *const req
 int32_t semihosting_writec(target_s *const target, const semihosting_s *const request)
 {
 	const target_addr_t ch_taddr = request->r1;
-#if PC_HOSTED == 1
-	if (ch_taddr == TARGET_NULL)
-		return -1;
-	const uint8_t ch = target_mem_read8(target, ch_taddr);
-	if (target_check_error(target))
-		return -1;
-	fputc(ch, stderr);
-	target->tc->gdb_errno = semihosting_errno();
-	return 0;
-#else
 	(void)semihosting_remote_write(target, STDOUT_FILENO, ch_taddr, 1);
 	return 0;
-#endif
 }
 
 int32_t semihosting_write0(target_s *const target, const semihosting_s *const request)
 {
 	const target_addr_t str_begin_taddr = request->r1;
-#if PC_HOSTED == 1
-	if (str_begin_taddr == TARGET_NULL)
-		return -1;
-	for (target_addr_t char_taddr = str_begin_taddr; !target_check_error(target); ++char_taddr) {
-		const uint8_t chr = target_mem_read8(target, char_taddr);
-		if (chr == 0U)
-			break;
-		if (fputc(chr, stderr) == EOF) {
-			target->tc->gdb_errno = semihosting_errno();
-			break;
-		}
-	}
-#else
 	target_addr_t str_end_taddr;
 	for (str_end_taddr = str_begin_taddr; target_mem_read8(target, str_end_taddr) != 0; ++str_end_taddr) {
 		if (target_check_error(target))
@@ -521,7 +497,6 @@ int32_t semihosting_write0(target_s *const target, const semihosting_s *const re
 		if (result != len)
 			return -1;
 	}
-#endif
 	return 0;
 }
 

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -393,8 +393,9 @@ int32_t semihosting_open(target_s *const target, const semihosting_s *const requ
 		O_WRONLY | O_CREAT | O_APPEND, /* a, ab */
 		O_RDWR | O_CREAT | O_APPEND,   /* a+, a+b */
 	};
-	const int32_t native_open_mode =
-		native_open_mode_flags[request->params[1] >> 1U] | ((request->params[1] & 1U) ? O_BINARY : 0U);
+	int32_t native_open_mode = native_open_mode_flags[request->params[1] >> 1U];
+	if (request->params[1] & 1U)
+		native_open_mode |= O_BINARY;
 
 	const int32_t result = open(file_name, native_open_mode | O_NOCTTY, 0644);
 	target->tc->gdb_errno = semihosting_errno();

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -265,6 +265,10 @@ int32_t semihosting_open(target_s *const target, const semihosting_s *const requ
 int32_t semihosting_close(target_s *const target, const semihosting_s *const request)
 {
 	const int32_t fd = request->params[0] - 1;
+	/* If the file descriptor requested is one of the special ones from ":tt" operations, do nothing */
+	if (fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO)
+		return 0;
+		/* Otherwise close the descriptor returned by semihosting_open() */
 #if PC_HOSTED == 1
 	(void)target;
 	return close(fd);

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -277,11 +277,15 @@ int32_t semihosting_close(target_s *const target, const semihosting_s *const req
 int32_t semihosting_read(target_s *const target, const semihosting_s *const request)
 {
 	const target_addr_t buf_taddr = request->params[1];
+#if PC_HOSTED == 1
 	if (buf_taddr == TARGET_NULL)
 		return -1;
+#endif
 	const uint32_t buf_len = request->params[2];
+#if PC_HOSTED == 1
 	if (buf_len == 0)
 		return 0;
+#endif
 	const int32_t fd = request->params[0] - 1;
 
 #if PC_HOSTED == 1
@@ -305,11 +309,15 @@ int32_t semihosting_write(target_s *const target, const semihosting_s *const req
 {
 	const int32_t fd = request->params[0] - 1;
 	const target_addr_t buf_taddr = request->params[1];
+#if PC_HOSTED == 1
 	if (buf_taddr == TARGET_NULL)
 		return -1;
+#endif
 	const uint32_t buf_len = request->params[2];
+#if PC_HOSTED == 1
 	if (buf_len == 0)
 		return 0;
+#endif
 
 #if PC_HOSTED == 1
 	uint8_t *const buf = malloc(buf_len);
@@ -333,9 +341,9 @@ int32_t semihosting_write(target_s *const target, const semihosting_s *const req
 int32_t semihosting_writec(target_s *const target, const semihosting_s *const request)
 {
 	const target_addr_t ch_taddr = request->r1;
+#if PC_HOSTED == 1
 	if (ch_taddr == TARGET_NULL)
 		return -1;
-#if PC_HOSTED == 1
 	const uint8_t ch = target_mem_read8(target, ch_taddr);
 	if (target_check_error(target))
 		return -1;
@@ -349,9 +357,9 @@ int32_t semihosting_writec(target_s *const target, const semihosting_s *const re
 int32_t semihosting_write0(target_s *const target, const semihosting_s *const request)
 {
 	const target_addr_t str_begin_taddr = request->r1;
+#if PC_HOSTED == 1
 	if (str_begin_taddr == TARGET_NULL)
 		return -1;
-#if PC_HOSTED == 1
 	for (target_addr_t char_taddr = str_begin_taddr; !target_check_error(target); ++char_taddr) {
 		const uint8_t chr = target_mem_read8(target, char_taddr);
 		if (chr == 0U)

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -182,28 +182,6 @@ static int tc_write(target_s *target, int fd, target_addr_t buf, uint32_t count)
 	gdb_putpacket_f("Fwrite,%08X,%08" PRIX32 ",%08" PRIX32, (unsigned)fd, buf, count);
 	return semihosting_get_gdb_response(target->tc);
 }
-
-/* probe memory access functions */
-static void probe_mem_read(
-	target_s *target __attribute__((unused)), void *probe_dest, target_addr_t target_src, size_t len)
-{
-	uint8_t *dst = (uint8_t *)probe_dest;
-	uint8_t *src = (uint8_t *)target_src;
-
-	DEBUG_INFO("probe_mem_read\n");
-
-	memcpy(dst, src, len);
-}
-
-static void probe_mem_write(
-	target_s *target __attribute__((unused)), target_addr_t target_dest, const void *probe_src, size_t len)
-{
-	uint8_t *dst = (uint8_t *)target_dest;
-	uint8_t *src = (uint8_t *)probe_src;
-
-	DEBUG_INFO("probe_mem_write\n");
-	memcpy(dst, src, len);
-}
 #endif
 
 #if PC_HOSTED == 1

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -340,12 +340,12 @@ int32_t semihosting_open(target_s *const target, const semihosting_s *const requ
 	 * See DUI0471C, Table 8-3
 	 */
 	static const uint16_t open_mode_flags[] = {
-		TARGET_O_RDONLY,                                    /* r, rb */
-		TARGET_O_RDWR,                                      /* r+, r+b */
-		TARGET_O_WRONLY | TARGET_O_CREAT | TARGET_O_TRUNC,  /* w, wb */
-		TARGET_O_RDWR | TARGET_O_CREAT | TARGET_O_TRUNC,    /* w+, w+b */
-		TARGET_O_WRONLY | TARGET_O_CREAT | TARGET_O_APPEND, /* a, ab */
-		TARGET_O_RDWR | TARGET_O_CREAT | TARGET_O_APPEND,   /* a+, a+b */
+		OPEN_MODE_RDONLY,                                      /* r, rb */
+		OPEN_MODE_RDWR,                                        /* r+, r+b */
+		OPEN_MODE_WRONLY | OPEN_MODE_CREAT | OPEN_MODE_TRUNC,  /* w, wb */
+		OPEN_MODE_RDWR | OPEN_MODE_CREAT | OPEN_MODE_TRUNC,    /* w+, w+b */
+		OPEN_MODE_WRONLY | OPEN_MODE_CREAT | OPEN_MODE_APPEND, /* a, ab */
+		OPEN_MODE_RDWR | OPEN_MODE_CREAT | OPEN_MODE_APPEND,   /* a+, a+b */
 	};
 	const uint32_t open_mode = open_mode_flags[request->params[1] >> 1U];
 
@@ -356,9 +356,9 @@ int32_t semihosting_open(target_s *const target, const semihosting_s *const requ
 		/* Handle requests for console I/O */
 		if (!strncmp(file_name, ":tt", 4U)) {
 			int32_t result = -1;
-			if (open_mode == TARGET_O_RDONLY)
+			if (open_mode == OPEN_MODE_RDONLY)
 				result = STDIN_FILENO;
-			else if (open_mode & TARGET_O_TRUNC)
+			else if (open_mode & OPEN_MODE_TRUNC)
 				result = STDOUT_FILENO;
 			else
 				result = STDERR_FILENO;
@@ -371,7 +371,7 @@ int32_t semihosting_open(target_s *const target, const semihosting_s *const requ
 		/* Handle a request for the features "file" */
 		if (!strncmp(file_name, ":semihosting-features", 22U)) {
 			/* Only let the firmware "open" the file if they ask for it in read-only mode */
-			if (open_mode == TARGET_O_RDONLY) {
+			if (open_mode == OPEN_MODE_RDONLY) {
 				semihosting_features_offset = 0U;
 				return INT32_MAX;
 			}

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -710,11 +710,6 @@ int32_t semihosting_time(target_s *const target)
 
 int32_t semihosting_readc(target_s *const target)
 {
-#if PC_HOSTED == 1
-	const int32_t ch = getchar();
-	target->tc->gdb_errno = semihosting_errno();
-	return ch;
-#else
 	/* Define space for a character */
 	uint8_t ch = '?';
 
@@ -730,7 +725,6 @@ int32_t semihosting_readc(target_s *const target)
 		return -1;
 	/* Extract the character read from the buffer */
 	return ch;
-#endif
 }
 
 int32_t semihosting_exit(target_s *const target, const semihosting_exit_reason_e reason, const uint32_t status_code)

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -156,7 +156,7 @@ int semihosting_reply(target_controller_s *const tc, char *const pbuf, const int
 	}
 
 	/* If the call was successful the errno may be omitted */
-	tc->gdb_errno = items >= 2 ? gdb_errno : 0;
+	tc->gdb_errno = items >= 2 ? gdb_errno : TARGET_SUCCESS;
 
 	/* If break is requested */
 	tc->interrupted = items == 3 && ctrl_c_flag == 'C';

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -20,6 +20,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
+ * This file implements support for the ARM-defined semihosting interface for
+ * target to debugger service syscalls
+ *
+ * References:
+ * DUI0471 - ARM Compiler Software DEvelopment Guide Version 5.06 (semihosting v1)
+ *   https://developer.arm.com/documentation/dui0471/m/what-is-semihosting-
+ * ARM Architecture ABI: Semihosting v2
+ *   https://developer.arm.com/documentation/100863/latest/ ->
+ *   https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst
+ */
+
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -167,9 +167,10 @@ static int32_t semihosting_get_gdb_response(target_controller_s *const tc)
 }
 
 /* Interface to host system calls */
-static int semihosting_remote_read(target_controller_s *tc, int fd, target_addr_t buf, unsigned int count)
+static int32_t semihosting_remote_read(
+	target_controller_s *const tc, const int32_t fd, const target_addr_t buf, const uint32_t count)
 {
-	gdb_putpacket_f("Fread,%08X,%08" PRIX32 ",%08X", fd, buf, count);
+	gdb_putpacket_f("Fread,%08X,%08" PRIX32 ",%08" PRIX32, (unsigned)fd, buf, count);
 	return semihosting_get_gdb_response(tc);
 }
 

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -156,7 +156,7 @@ static int32_t semihosting_get_gdb_response(target_controller_s *const tc)
 }
 
 /* Interface to host system calls */
-static int hostio_read(target_controller_s *tc, int fd, target_addr_t buf, unsigned int count)
+static int semihosting_remote_read(target_controller_s *tc, int fd, target_addr_t buf, unsigned int count)
 {
 	gdb_putpacket_f("Fread,%08X,%08" PRIX32 ",%08X", fd, buf, count);
 	return semihosting_get_gdb_response(tc);
@@ -298,7 +298,7 @@ int32_t semihosting_read(target_s *const target, const semihosting_s *const requ
 	if (target_check_error(target))
 		return -1;
 #else
-	const int32_t result = hostio_read(target->tc, fd, buf_taddr, buf_len);
+	const int32_t result = semihosting_remote_read(target->tc, fd, buf_taddr, buf_len);
 #endif
 	if (result >= 0)
 		return buf_len - result;
@@ -581,7 +581,7 @@ int32_t semihosting_readc(target_s *const target)
 	target->tc->semihosting_buffer_ptr = &ch;
 	target->tc->semihosting_buffer_len = 1U;
 	/* Call GDB and ask for a character using read(STDIN_FILENO) */
-	const int32_t result = hostio_read(target->tc, STDIN_FILENO, target->ram->start, 1U);
+	const int32_t result = semihosting_remote_read(target->tc, STDIN_FILENO, target->ram->start, 1U);
 	target->target_options &= ~TOPT_IN_SEMIHOSTING_SYSCALL;
 	/* Check if the GDB remote read() */
 	if (result != 1)

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -231,19 +231,21 @@ int32_t semihosting_open(target_s *const target, const semihosting_s *const requ
 	};
 	const uint32_t open_mode = open_mode_flags[request->params[1] >> 1U];
 
-	char filename[4];
-	target_mem_read(target, filename, file_name_taddr, sizeof(filename));
+	if (file_name_length <= 4U) {
+		char file_name[4U];
+		target_mem_read(target, file_name, file_name_taddr, file_name_length + 1U);
 
-	/* Handle requests for console I/O */
-	if (!strncmp(filename, ":tt", 4U)) {
-		int32_t result = -1;
-		if (open_mode == TARGET_O_RDONLY)
-			result = STDIN_FILENO;
-		else if (open_mode & TARGET_O_TRUNC)
-			result = STDOUT_FILENO;
-		else
-			result = STDERR_FILENO;
-		return result + 1;
+		/* Handle requests for console I/O */
+		if (!strncmp(file_name, ":tt", 4U)) {
+			int32_t result = -1;
+			if (open_mode == TARGET_O_RDONLY)
+				result = STDIN_FILENO;
+			else if (open_mode & TARGET_O_TRUNC)
+				result = STDOUT_FILENO;
+			else
+				result = STDERR_FILENO;
+			return result + 1;
+		}
 	}
 
 #if PC_HOSTED == 1

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -397,7 +397,8 @@ int32_t semihosting_writec(target_s *const target, const semihosting_s *const re
 	fputc(ch, stderr);
 	return 0;
 #else
-	return semihosting_remote_write(target, STDERR_FILENO, ch_taddr, 1);
+	(void)semihosting_remote_write(target, STDOUT_FILENO, ch_taddr, 1);
+	return 0;
 #endif
 }
 
@@ -421,7 +422,7 @@ int32_t semihosting_write0(target_s *const target, const semihosting_s *const re
 	}
 	const int32_t len = str_end_taddr - str_begin_taddr;
 	if (len >= 0) {
-		const int32_t result = semihosting_remote_write(target, STDERR_FILENO, str_begin_taddr, len);
+		const int32_t result = semihosting_remote_write(target, STDOUT_FILENO, str_begin_taddr, len);
 		if (result != len)
 			return -1;
 	}

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -681,12 +681,9 @@ int32_t semihosting_get_command_line(target_s *const target, const semihosting_s
 	/* Figure out how long the command line string is */
 	const size_t command_line_length = strlen(target->cmdline) + 1U;
 	/* Check that we won't exceed the target buffer with the write */
-	if (command_line_length > buffer_length) {
-		target->tc->gdb_errno = TARGET_EINVAL;
-		return -1;
-	}
-	/* Try to write the data to the target along with the actual length value */
-	if (target_mem_write(target, buffer_taddr, target->cmdline, command_line_length))
+	if (command_line_length > buffer_length ||
+		/* Try to write the data to the target along with the actual length value */
+		target_mem_write(target, buffer_taddr, target->cmdline, command_line_length))
 		return -1;
 	target_mem_write32(target, request->r1 + 4U, command_line_length);
 	return target_check_error(target) ? -1 : 0;
@@ -729,10 +726,8 @@ int32_t semihosting_temp_name(target_s *const target, const semihosting_s *const
 	/* Now extract and check that we have enough space to write the result back to */
 	const target_addr_t buffer_taddr = request->params[0];
 	const size_t buffer_length = request->params[2];
-	if (buffer_length < sizeof(file_name)) {
-		target->tc->gdb_errno = TARGET_EINVAL;
+	if (buffer_length < sizeof(file_name))
 		return -1;
-	}
 	/* If we have enough space, attempt the write back */
 	return target_mem_write(target, buffer_taddr, file_name, SEMIHOSTING_TEMPNAME_LENGTH) ? -1 : 0;
 }

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -117,7 +117,6 @@ const char *const semihosting_names[] = {
 };
 #endif
 
-#if PC_HOSTED == 0
 int semihosting_reply(target_controller_s *const tc, char *const pbuf, const int len)
 {
 	(void)len;
@@ -206,7 +205,6 @@ static int32_t semihosting_remote_write(
 	gdb_putpacket_f("Fwrite,%08X,%08" PRIX32 ",%08" PRIX32, (unsigned)fd, buf, count);
 	return semihosting_get_gdb_response(target->tc);
 }
-#endif
 
 #if PC_HOSTED == 1
 /*

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -578,19 +578,9 @@ int32_t semihosting_remove(target_s *const target, const semihosting_s *const re
 
 int32_t semihosting_system(target_s *const target, const semihosting_s *const request)
 {
-#if PC_HOSTED == 1
-	const char *cmd = semihosting_read_string(target, request->params[0], request->params[1]);
-	if (cmd == NULL)
-		return -1;
-	const int32_t result = system(cmd);
-	target->tc->gdb_errno = semihosting_errno();
-	free((void *)cmd);
-	return result;
-#else
 	/* NB: Before use first enable system calls with the following gdb command: 'set remote system-call-allowed 1' */
 	gdb_putpacket_f("Fsystem,%08" PRIX32 "/%08" PRIX32, request->params[0], request->params[1] + 1U);
 	return semihosting_get_gdb_response(target->tc);
-#endif
 }
 
 int32_t semihosting_file_length(target_s *const target, const semihosting_s *const request)

--- a/src/target/semihosting.h
+++ b/src/target/semihosting.h
@@ -25,6 +25,8 @@
 
 #include "general.h"
 
+extern uint32_t semihosting_wallclock_epoch;
+
 int32_t semihosting_request(target_s *target, uint32_t syscall, uint32_t r1);
 int semihosting_reply(target_controller_s *tc, char *packet, int len);
 

--- a/src/target/semihosting_internal.h
+++ b/src/target/semihosting_internal.h
@@ -64,6 +64,15 @@ typedef struct semihosting_time {
 	uint32_t seconds;
 } semihosting_time_s;
 
+typedef enum semihosting_open_flags {
+	OPEN_MODE_RDONLY = 0x0,
+	OPEN_MODE_WRONLY = 0x1,
+	OPEN_MODE_RDWR = 0x2,
+	OPEN_MODE_APPEND = 0x8,
+	OPEN_MODE_CREAT = 0x200,
+	OPEN_MODE_TRUNC = 0x400,
+} semihosting_open_flags_e;
+
 typedef enum semihosting_exit_reason {
 	/* Hardware exceptions */
 	EXIT_REASON_BRANCH_THROUGH_ZERO = 0x20000U,

--- a/src/target/semihosting_internal.h
+++ b/src/target/semihosting_internal.h
@@ -23,16 +23,6 @@
 
 #include "general.h"
 
-/*
- * If the target wants to read the special filename ":semihosting-features"
- * to know what semihosting features are supported, it's easiest to create
- * that file on the host in the directory where gdb runs,
- * or, if using pc-hosted, where blackmagic_hosted runs.
- *
- * $ echo -e 'SHFB\x03' > ":semihosting-features"
- * $ chmod 0444 ":semihosting-features"
- */
-
 /* ARM Semihosting syscall numbers, from "Semihosting for AArch32 and AArch64 Version 3.0" */
 
 #define SEMIHOSTING_SYS_CLOCK         0x10U

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -21,6 +21,7 @@
 #include "general.h"
 #include "target_internal.h"
 #include "gdb_packet.h"
+#include "command.h"
 
 #include <stdarg.h>
 #include <unistd.h>
@@ -37,10 +38,12 @@ target_s *target_list = NULL;
 
 static bool target_cmd_mass_erase(target_s *target, int argc, const char **argv);
 static bool target_cmd_range_erase(target_s *target, int argc, const char **argv);
+static bool target_cmd_redirect_output(target_s *target, int argc, const char **argv);
 
 const command_s target_cmd_list[] = {
 	{"erase_mass", target_cmd_mass_erase, "Erase whole device Flash"},
 	{"erase_range", target_cmd_range_erase, "Erase a range of memory on a device"},
+	{"redirect_stdout", target_cmd_redirect_output, "Redirect semihosting output to aux USB serial"},
 	{NULL, NULL, NULL},
 };
 
@@ -487,6 +490,15 @@ static bool target_cmd_range_erase(target_s *const t, const int argc, const char
 	const uint32_t length = strtoul(argv[2], NULL, 0);
 
 	return target_flash_erase(t, addr, length);
+}
+
+static bool target_cmd_redirect_output(target_s *target, int argc, const char **argv)
+{
+	if (argc == 1) {
+		gdb_outf("Semihosting stdout redirection: %s\n", target->stdout_redirected ? "enabled" : "disabled");
+		return true;
+	}
+	return parse_enable_or_disable(argv[1], &target->stdout_redirected);
 }
 
 /* Accessor functions */

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -279,7 +279,6 @@ bool target_attached(target_s *target)
 /* Memory access functions */
 int target_mem_read(target_s *const target, void *const dest, const target_addr_t src, const size_t len)
 {
-#if PC_HOSTED == 0
 	/* If we're processing a semihosting syscall and it needs IO redirected, handle that instead */
 	if (target->target_options & TOPT_IN_SEMIHOSTING_SYSCALL) {
 		/* Make sure we can't go over the bounds of the buffer */
@@ -288,7 +287,6 @@ int target_mem_read(target_s *const target, void *const dest, const target_addr_
 		memcpy(dest, target->tc->semihosting_buffer_ptr, amount);
 		return false;
 	}
-#endif
 	/* Otherwise if the target defines a memory read function, call that instead and check for errors */
 	if (target->mem_read)
 		target->mem_read(target, dest, src, len);
@@ -297,7 +295,6 @@ int target_mem_read(target_s *const target, void *const dest, const target_addr_
 
 int target_mem_write(target_s *const target, const target_addr_t dest, const void *const src, const size_t len)
 {
-#if PC_HOSTED == 0
 	/* If we're processing a semihosting syscall and it needs IO redirected, handle that instead */
 	if (target->target_options & TOPT_IN_SEMIHOSTING_SYSCALL) {
 		/* Make sure we can't go over the bounds of the buffer */
@@ -306,7 +303,6 @@ int target_mem_write(target_s *const target, const target_addr_t dest, const voi
 		memcpy(target->tc->semihosting_buffer_ptr, src, amount);
 		return false;
 	}
-#endif
 	/* Otherwise if the target defines a memory write function, call that instead and check for errors */
 	if (target->mem_write)
 		target->mem_write(target, dest, src, len);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -27,7 +27,8 @@
 #include "platform_support.h"
 #include "target_probe.h"
 
-#define TOPT_INHIBIT_NRST (1U << 0U)
+#define TOPT_INHIBIT_NRST           (1U << 0U)
+#define TOPT_IN_SEMIHOSTING_SYSCALL (1U << 31U)
 
 extern target_s *target_list;
 

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -161,9 +161,7 @@ struct target {
 	char cmdline[MAX_CMDLINE];
 	target_addr_t heapinfo[4];
 	target_command_s *commands;
-#if PC_HOSTED == 0
 	bool stdout_redirected;
-#endif
 
 	target_s *next;
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses the correctness of the semihosting implementation in BMDA and represents the last in the series.

We do this in two major steps - fixing the mechanism by which I/O with the probe is done for SYS_FLEN, SYS_TIME, and SYS_READC which solves issues with how GDB sees these transfers; and then fixing how and when BMDA inserts its own libc syscalls in to speed things up.

This also provides support for BMDA to do stdio redirection just like the firmware, so the user gets the expected behaviour by default (semihosting output and interaction in GDB), while then being able to punt that onto the controlling TTY for BMDA.

As best as we can tell, with this PR we now have a conforming semihosting implementation that works the same in both firmware and as BMDA and which meets the [specifications set forth by ARM](https://github.com/ARM-software/abi-aa/blob/main/semihosting/semihosting.rst).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
