### PR TITLE
Feature: declarations cleanup

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -226,7 +226,7 @@ jobs:
   # This workflow tests the experimental Meson build system
   build-linux-meson:
     # Name the job more appropriately so we can tell which windows and which MinGW ABI is in use
-    name: 'build-linux (${{ matrix.os.name }}, ${{ matrix.probe }}'
+    name: 'build-linux (${{ matrix.os.name }}, ${{ matrix.probe }})'
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os.id }}
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -297,7 +297,7 @@ jobs:
       # Build the firmware for all platform variants (currently available)
       - name: Build
         run: |
-          meson setup build --cross-file cross-file/${{ matrix.probe }}.ini
+          meson setup build --cross-file cross-file/${{ matrix.probe }}.ini --werror
           meson compile -C build
 
   size-diff:

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -120,8 +120,8 @@ int target_breakwatch_clear(target_s *target, target_breakwatch_e, target_addr_t
 void target_command_help(target_s *target);
 int target_command(target_s *target, int argc, const char *argv[]);
 
-/* keep target_errno in sync with errno values in gdb/include/gdb/fileio.h */
-typedef enum target_errno {
+/* Defined per GDB's File I/O errno values from gdbsupport/fileio.h */
+typedef enum semihosting_errno {
 	TARGET_SUCCESS = 0,
 	TARGET_EPERM = 1,
 	TARGET_ENOENT = 2,
@@ -145,7 +145,7 @@ typedef enum target_errno {
 	TARGET_ENOSYS = 88,
 	TARGET_ENAMETOOLONG = 91,
 	TARGET_EUNKNOWN = 9999,
-} target_errno_e;
+} semihosting_errno_e;
 
 struct target_controller {
 	void (*destroy_callback)(target_controller_s *, target_s *target);
@@ -153,7 +153,7 @@ struct target_controller {
 
 	void *semihosting_buffer_ptr;
 	size_t semihosting_buffer_len;
-	target_errno_e gdb_errno;
+	semihosting_errno_e gdb_errno;
 	bool interrupted;
 };
 

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -147,12 +147,6 @@ typedef enum target_errno {
 	TARGET_EUNKNOWN = 9999,
 } target_errno_e;
 
-typedef enum target_seek_flag {
-	TARGET_SEEK_SET = 0,
-	TARGET_SEEK_CUR = 1,
-	TARGET_SEEK_END = 2,
-} target_seek_flag_e;
-
 struct target_controller {
 	void (*destroy_callback)(target_controller_s *, target_s *target);
 	void (*printf)(target_controller_s *, const char *fmt, va_list);

--- a/src/main.c
+++ b/src/main.c
@@ -69,13 +69,13 @@ static void bmp_poll_loop(void)
 	gdb_main(pbuf, GDB_PACKET_BUFFER_SIZE, size);
 }
 
+#if PC_HOSTED == 1
 int main(int argc, char **argv)
 {
-#if PC_HOSTED == 1
 	platform_init(argc, argv);
 #else
-	(void)argc;
-	(void)argv;
+int main(void)
+{
 	platform_init();
 #endif
 

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -382,7 +382,7 @@ static size_t debug_serial_debug_write(const char *buf, const size_t len)
  * The result of this function is the number of bytes written.
  */
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-int _write(const int file, const void *const ptr, const size_t len)
+__attribute__((used)) int _write(const int file, const void *const ptr, const size_t len)
 {
 	(void)file;
 #ifdef PLATFORM_HAS_DEBUG
@@ -399,7 +399,7 @@ int _write(const int file, const void *const ptr, const size_t len)
  *
  * The result of this function is always 'true'.
  */
-int isatty(const int file)
+__attribute__((used)) int isatty(const int file)
 {
 	(void)file;
 	return true;
@@ -447,10 +447,10 @@ void debug_monitor_handler(void)
 	__asm__("bx lr");
 }
 #else
-/* This defines stubs for the newlib fake file IO layer for compatibility with GCC 12 `-spec=nosys.spec` */
+/* This defines stubs for the newlib fake file IO layer for compatibility with GCC 12 `-specs=nosys.specs` */
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-int _write(const int file, const void *const buffer, const size_t length)
+__attribute__((used)) int _write(const int file, const void *const buffer, const size_t length)
 {
 	(void)file;
 	(void)buffer;
@@ -458,7 +458,7 @@ int _write(const int file, const void *const buffer, const size_t length)
 }
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-int _read(const int file, void *const buffer, const size_t length)
+__attribute__((used)) int _read(const int file, void *const buffer, const size_t length)
 {
 	(void)file;
 	(void)buffer;
@@ -466,7 +466,7 @@ int _read(const int file, void *const buffer, const size_t length)
 }
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-off_t _lseek(const int file, const off_t offset, const int direction)
+__attribute__((used)) off_t _lseek(const int file, const off_t offset, const int direction)
 {
 	(void)file;
 	(void)offset;
@@ -475,7 +475,7 @@ off_t _lseek(const int file, const off_t offset, const int direction)
 }
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-int _fstat(const int file, stat_s *stats)
+__attribute__((used)) int _fstat(const int file, stat_s *stats)
 {
 	(void)file;
 	memset(stats, 0, sizeof(*stats));
@@ -483,27 +483,27 @@ int _fstat(const int file, stat_s *stats)
 }
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-int _isatty(const int file)
+__attribute__((used)) int _isatty(const int file)
 {
 	(void)file;
 	return true;
 }
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-int _close(const int file)
+__attribute__((used)) int _close(const int file)
 {
 	(void)file;
 	return 0;
 }
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-pid_t _getpid(void)
+__attribute__((used)) pid_t _getpid(void)
 {
 	return 1;
 }
 
 /* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-int _kill(const int pid, const int signal)
+__attribute__((used)) int _kill(const int pid, const int signal)
 {
 	(void)pid;
 	(void)signal;

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -29,7 +29,7 @@ ifneq (,$(findstring linux, $(SYS)))
 else
     HOSTED_BMP_ONLY ?= 1
 endif
-CFLAGS += -DHOSTED_BMP_ONLY=$(HOSTED_BMP_ONLY)
+CFLAGS += -DHOSTED_BMP_ONLY=$(HOSTED_BMP_ONLY) -D_FILE_OFFSET_BITS=64
 
 ifeq ($(ASAN), 1)
     CFLAGS += -fsanitize=address

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -385,7 +385,7 @@ const char *stlink_target_voltage(void)
 	if (adc[0])
 		result = 2.0F * (float)adc[1] * 1.2F / (float)adc[0];
 	static char res[6];
-	const int written = snprintf(res, sizeof(res), "%4.2fV", result);
+	const int written = snprintf(res, sizeof(res), "%4.2fV", (double)result);
 	if (written < 0 || written >= (int)sizeof(res))
 		return "ERROR!";
 	return res;

--- a/src/platforms/hosted/utils.c
+++ b/src/platforms/hosted/utils.c
@@ -21,14 +21,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* This file deduplicates codes used in several pc-hosted platforms
- */
+/* This file defines various utility routines for BMDA */
+
+#include "general.h"
 
 #include <string.h>
 #include <unistd.h>
 #include <sys/time.h>
 
-#include "general.h"
 #include "timing.h"
 #include "bmp_hosted.h"
 
@@ -52,9 +52,6 @@ void platform_delay(uint32_t ms)
 #if defined(_WIN32) && !defined(__MINGW32__)
 	Sleep(ms);
 #else
-#if !defined(usleep)
-	int usleep(unsigned int);
-#endif
 	usleep(ms * 1000U);
 #endif
 }

--- a/src/platforms/launchpad-icdi/platform.h
+++ b/src/platforms/launchpad-icdi/platform.h
@@ -68,7 +68,6 @@ extern uint8_t running_status;
 		gpio_set_output_config(SWDIO_PORT, GPIO_OTYPE_PP, GPIO_DRIVE_2MA, SWDIO_PIN); \
 	}
 
-extern const usbd_driver lm4f_usb_driver;
 #define USB_DRIVER lm4f_usb_driver
 #define USB_IRQ    NVIC_USB0_IRQ
 #define USB_ISR    usb0_isr

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -26,6 +26,7 @@
 #include "aux_serial.h"
 #include "morse.h"
 
+#include <libopencm3/cm3/vector.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/cm3/scb.h>
 #include <libopencm3/cm3/scs.h>
@@ -41,9 +42,6 @@
 
 static void adc_init(void);
 static void setup_vbus_irq(void);
-
-/* This is defined by the linker script */
-extern char vector_table;
 
 #define TPWR_SOFT_START_STEPS 64U
 

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -25,6 +25,7 @@
 #include "usb.h"
 #include "aux_serial.h"
 
+#include <libopencm3/cm3/vector.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/cm3/scb.h>
 #include <libopencm3/cm3/scs.h>
@@ -77,7 +78,6 @@ void platform_init(void)
 	gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, led_idle_run);
 
 	/* Relocate interrupt vector table here */
-	extern uint32_t vector_table;
 	SCB_VTOR = (uintptr_t)&vector_table;
 
 	platform_timing_init();

--- a/src/platforms/stlinkv3/platform.c
+++ b/src/platforms/stlinkv3/platform.c
@@ -28,6 +28,7 @@
 #include "aux_serial.h"
 #include "gdb_if.h"
 
+#include <libopencm3/cm3/vector.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/cm3/scb.h>
 #include <libopencm3/cm3/scs.h>
@@ -229,7 +230,6 @@ void platform_init(void)
 	gpio_set_output_options(LED_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, LED_PIN);
 
 	/* Relocate interrupt vector table here */
-	extern int vector_table;
 	SCB_VTOR = (uintptr_t)&vector_table;
 
 	platform_timing_init();

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -28,6 +28,7 @@
 #include "usb.h"
 #include "aux_serial.h"
 
+#include <libopencm3/cm3/vector.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/cm3/scb.h>
 #include <libopencm3/cm3/scs.h>
@@ -100,7 +101,6 @@ void platform_init(void)
 	AFIO_MAPR = data;
 
 	/* Relocate interrupt vector table here */
-	extern uint32_t vector_table;
 	SCB_VTOR = (uintptr_t)&vector_table;
 
 	platform_timing_init();

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -153,6 +153,4 @@ extern bool debug_bmp;
 extern void set_idle_state(int state);
 #define SET_IDLE_STATE(state) set_idle_state(state)
 
-extern uint8_t detect_rev(void);
-
 #endif /* PLATFORMS_SWLINK_PLATFORM_H */

--- a/src/platforms/swlink/platform_common.c
+++ b/src/platforms/swlink/platform_common.c
@@ -21,10 +21,11 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 
+#include "general.h"
 #include "platform_common.h"
 
 /* Return 0 for the ST-Link on a STM8S Discovery board and 1 for Bluepill */
-uint8_t detect_rev()
+uint8_t detect_rev(void)
 {
 	/* Enable peripherals used by both debugger and DFU. */
 	rcc_periph_clock_enable(RCC_GPIOA);

--- a/src/platforms/swlink/platform_common.h
+++ b/src/platforms/swlink/platform_common.h
@@ -23,7 +23,6 @@
 
 #include <stdint.h>
 
-uint8_t detect_rev();
-void platform_request_boot(void);
+uint8_t detect_rev(void);
 
 #endif /*PLATFORMS_SWLINK_PLATFORM_COMMON_H*/

--- a/src/platforms/swlink/usbdfu.c
+++ b/src/platforms/swlink/usbdfu.c
@@ -25,6 +25,7 @@
 
 #include "usbdfu.h"
 #include "platform.h"
+#include "platform_common.h"
 
 uintptr_t app_address = 0x08002000U;
 uint32_t rev;

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -124,7 +124,7 @@ const char *const semihosting_names[] = {
 #endif
 
 #if PC_HOSTED == 1
-static target_errno_e semihosting_errno(void);
+static semihosting_errno_e semihosting_errno(void);
 #endif
 
 int semihosting_reply(target_controller_s *const tc, char *const pbuf, const int len)
@@ -262,7 +262,7 @@ static int32_t semihosting_remote_write(
  * NB: Must be called immediately after the syscall that might generate a value.
  * No functions or actions may be performed between these two points.
  */
-static target_errno_e semihosting_errno(void)
+static semihosting_errno_e semihosting_errno(void)
 {
 	const int32_t error = errno;
 	switch (error) {
@@ -744,7 +744,7 @@ int32_t semihosting_get_command_line(target_s *const target, const semihosting_s
 	return target_check_error(target) ? -1 : 0;
 }
 
-int32_t semihosting_is_error(const target_errno_e code)
+int32_t semihosting_is_error(const semihosting_errno_e code)
 {
 	/* Convert a FileIO-domain errno into whether it indicates an error has occured or not */
 	const bool is_error = code == TARGET_EPERM || code == TARGET_ENOENT || code == TARGET_EINTR || code == TARGET_EIO ||

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -534,7 +534,7 @@ int32_t semihosting_seek(target_s *const target, const semihosting_s *const requ
 		return result;
 	}
 #endif
-	gdb_putpacket_f("Flseek,%08X,%08lX,%08X", (unsigned)fd, (unsigned long)offset, TARGET_SEEK_SET);
+	gdb_putpacket_f("Flseek,%08X,%08lX,%08X", (unsigned)fd, (unsigned long)offset, SEEK_MODE_SET);
 	return semihosting_get_gdb_response(target->tc) == offset ? 0 : -1;
 }
 

--- a/src/target/semihosting_internal.h
+++ b/src/target/semihosting_internal.h
@@ -73,6 +73,12 @@ typedef enum semihosting_open_flags {
 	OPEN_MODE_TRUNC = 0x400,
 } semihosting_open_flags_e;
 
+typedef enum semihosting_seek_flag {
+	SEEK_MODE_SET = 0,
+	SEEK_MODE_CUR = 1,
+	SEEK_MODE_END = 2,
+} semihosting_seek_flag_e;
+
 typedef enum semihosting_exit_reason {
 	/* Hardware exceptions */
 	EXIT_REASON_BRANCH_THROUGH_ZERO = 0x20000U,


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we aim to tie up some loose ends from the Meson build system's introduction, including the spate of new warnings, and some low-hanging UB that attempting LTO builds finds.

With these changes building normally should now be warnings-free. This also cleans up from the semihosting PRs by moving some straggler enums to the correct files as much as possible and fixing naming around them.

This fixes some more of the classes of warning targeted by the list in #1590

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
