### PR TITLE
meson: add build target feedback to summary

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -300,3 +300,12 @@ Dependencies:
 	libusb: @2@
 '''.format(libftdi.found(), hidapi.found(), libusb.found()))
 endif
+
+summary(
+	{
+		'Building Firmware': is_firmware_build,
+		'Building BMDA': is_variable('bmda'),
+	},
+	bool_yn: true,
+	section: 'Black Magic Debug',
+)


### PR DESCRIPTION
Add wether firmware and BMDA are being built to the summary output

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

This just adds a couple entries to meson configuration summary output, telling the user if it's configured to build firmware, and if it's configured to build BMDA, given that the following situations are possible:
 - building firmware and BMDA
 - building  firmware but not BMDA
 - building BMDA but not firmware
Some feedback as to which one we are in felt needed.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] ~~It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))~~
* [ ] ~~It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))~~
* [x] I've tested it to the best of my ability
* [c] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
