### PR TITLE
Fix revision-reporting command for STM32MP15x

### DIFF
--- a/src/target/stm32mp15.c
+++ b/src/target/stm32mp15.c
@@ -56,6 +56,9 @@
 #define DBGMCU_CTRL_DBGSTOP  (1U << 1U)
 #define DBGMCU_CTRL_DBGSTBY  (1U << 2U)
 
+#define STM32MP15_DBGMCU_IDCODE_DEV_MASK  0x00000fffU
+#define STM32MP15_DBGMCU_IDCODE_REV_SHIFT 16U
+
 /* Taken from DP_TARGETID.TPARTNO = 0x5000 in §66.8.3 of RM0436 rev 6, pg3669 */
 /* Taken from DBGMCU_IDC.DEV_ID = 0x500 in §66.10.9 of RM0436 rev 6, pg3825 */
 #define ID_STM32MP15x 0x500U
@@ -200,8 +203,8 @@ static bool stm32mp15_cmd_rev(target_s *const target, const int argc, const char
 	(void)argv;
 	/* DBGMCU identity code register */
 	const uint32_t dbgmcu_idcode = target_mem_read32(target, DBGMCU_IDCODE);
-	const uint16_t rev_id = (dbgmcu_idcode >> 16U) & 0xffffU;
-	const uint16_t dev_id = (dbgmcu_idcode & 0xfffU) << 4U;
+	const uint16_t rev_id = dbgmcu_idcode >> STM32MP15_DBGMCU_IDCODE_REV_SHIFT;
+	const uint16_t dev_id = dbgmcu_idcode & STM32MP15_DBGMCU_IDCODE_DEV_MASK;
 
 	/* Print device */
 	switch (dev_id) {


### PR DESCRIPTION
## Detailed description

* The problem existing approx. since 9a5e3e7b is `monitor revision` failing to report silicon revision of STM32MP15x device.
* This PR solves the immediate minor problem by adjusting the bitshifts in `stm32mp15_cmd_rev()` of DBGMCU_IDCODE to match the DEV_ID value.

Tested on a live device over both DP transports. IDC is 0x20016500.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Appending an issue here, in case I manage to fix both.

There is a related issue of MP15x having an erroneous 0x450 ID in JTAG mode matching H74x 0x450 (0x4500) ID in JTAG mode. This manifests as "STM32MP15 M7" detected by BMD instead of "STM32H7 M7" when scanning e.g. a Nucleo-H743ZI2 over 4-wire JTAG (its onboard ST-LINK/V3E is SWD-only). Fixing that involves editing similar IDCODE values in stm32h7.c to match stm32h5.c target driver style, and implementing some actual readout of DBGMCU->IDC for more robust detection, like in `stm32mp15_ident()`. IDC is 0x20016450.
For now I only update `stm32h7_cmd_rev()` to match the two aforementioned drivers of High Performance chips. Because of the way the matching works, I also had to touch a bunch more lines. I'm not sure where does part_id come from depending on the transport used. If this change belongs to a separate PR potentially fully solving the detection problem of H7 (in a way compatible with MP15x due to probing order and multi-AP configuration), then I could rebase/move it out for that.