### PR TITLE
Fix: BMDA Windows serial timeouts

### DIFF
--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -230,6 +230,9 @@ bool serial_open(const bmda_cli_options_s *const cl_opts, const char *const seri
 		handle_dev_error(port_handle, "setting communication timeouts for device");
 		return false;
 	}
+
+	/* Having adjusted the line state, discard anything sat in the receive buffer */
+	PurgeComm(port_handle, PURGE_RXCLEAR);
 	return true;
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Following blackmagic-debug/bmpflash#12 which as part of the speed-ups fixes the timeouts configuration for the remote protocol on Windows, as BMDA has the same exact issue, this PR ports those same fixes over.

Tested on the same laptop and VM to validate we've not obviously broken anything.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
