### PR TITLE
common: remove rdimon when debug is enabled

### DIFF
--- a/src/platforms/common/stm32/meson.build
+++ b/src/platforms/common/stm32/meson.build
@@ -67,7 +67,7 @@ platform_stm32_link_args = [
 	'-lc',
 	'-nostartfiles',
 	'--specs=nano.specs',
-	get_option('debug_output') ? '--specs=rdimon.specs' : '--specs=nosys.specs',
+	'--specs=nosys.specs',
 	'-Wl,-gc-sections',
 ]
 

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -73,14 +73,6 @@ static bool debug_serial_send_complete = true;
 #endif
 
 #if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
-/*
- * This call initialises "SemiHosting", only we then do our own SVC interrupt things to
- * route all output through to the debug USB serial interface if debug_bmp is true.
- *
- * https://github.com/mirror/newlib-cygwin/blob/master/newlib/libc/sys/arm/syscalls.c#L115
- */
-void initialise_monitor_handles(void);
-
 static char debug_serial_debug_buffer[AUX_UART_BUFFER_SIZE];
 static uint16_t debug_serial_debug_write_index;
 static uint16_t debug_serial_debug_read_index;
@@ -225,10 +217,6 @@ void usb_serial_set_config(usbd_device *dev, uint16_t value)
 	 */
 	usb_serial_set_state(dev, GDB_IF_NO, CDCACM_GDB_NOTIF_ENDPOINT);
 	usb_serial_set_state(dev, UART_IF_NO, CDCACM_UART_NOTIF_ENDPOINT);
-
-#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
-	initialise_monitor_handles();
-#endif
 }
 
 void debug_serial_send_stdout(const uint8_t *const data, const size_t len)


### PR DESCRIPTION
Save about 1.2KiB (depending on GCC version) by redirecting `_write` directly in `libnosys`, instead of pulling in `librdimon`.

## Detailed description

* Improves firmware footprint on native BMP when debug output is enabled
* There doesn't appear to be a current need to use `librdimon` semihosting capabilities
* `libnosys` I/O functions such as `_write` can be retargeted directly without using semihosting
* Initializing `librdimon` semihosting brings in a lot of unused code

I haven't tested on other probe platforms, so I might have unintentionally broken something.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

N/A
