### PR TITLE
Fix: Clang fall-through warnings

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -195,7 +195,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 	}
 	case 's': /* 's [addr]': Single step [start at addr] */
 		single_step = true;
-		/* fall through */
+		BMD_FALLTHROUGH
 	case 'c': /* 'c [addr]': Continue [at addr] */
 	case 'C': /* 'C sig[;addr]': Continue with signal [at addr] */
 		if (!cur_target) {
@@ -205,7 +205,7 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 
 		target_halt_resume(cur_target, single_step);
 		SET_RUN_STATE(true);
-		/* fall through */
+		BMD_FALLTHROUGH
 	case '?': { /* '?': Request reason for target halt */
 		/*
 		 * This packet isn't documented as being mandatory,
@@ -714,7 +714,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 		switch (packet[6]) {
 		case 's': /* 's': Single step */
 			single_step = true;
-			/* fall through */
+			BMD_FALLTHROUGH
 		case 'c': /* 'c': Continue */
 		case 'C': /* 'C sig': Continue with signal */
 			if (!cur_target) {

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -21,6 +21,10 @@
 #ifndef INCLUDE_GENERAL_H
 #define INCLUDE_GENERAL_H
 
+#if !defined(__cplusplus) && __STDC__ != 1
+#error "Black Magic Debug must be built in a standards compliant C mode"
+#endif
+
 #ifndef _GNU_SOURCE
 // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #define _GNU_SOURCE

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -62,15 +62,6 @@
 
 #if PC_HOSTED == 0
 /*
- * XXX: This entire system needs replacing with something better thought out
- *
- * When built as firmware, if the target supports debugging, DEBUG_ERROR, DEBUG_WARN and
- * DEBUG_INFO get defined to a macro that turns them into printf() calls. The rest of the
- * levels turn into no-ops.
- *
- * When built as BMDA, the debug macros all turn into various kinds of console-printing
- * function, w/ gating for diagnostics other than warnings and info.
- *
  * XXX: This is not really the proper place for all this as this is too intrusive into
  * the rest of the code base. The correct way to do this would be to define a debug
  * logging layer and allow BMDA to override the default logging subsystem via

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -121,6 +121,25 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #undef MAX
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 
+/* Define this macro helper if the compiler doesn't for us */
+#ifndef __has_c_attribute
+#define __has_c_attribute(x) 0
+#endif
+
+/* If we're in C23 mode or newer, we can use the proper fallthrough attribute */
+#if __STDC_VERSION__ >= 202311L && __has_c_attribute(fallthrough)
+#define BMD_FALLTHROUGH [[fallthrough]];
+/* If we're on Clang, we can use the old style attribute on Clang 10 and newer */
+#elif defined(__clang__) && __clang_major__ >= 10
+#define BMD_FALLTHROUGH __attribute__((fallthrough));
+/* If we're on GCC then we have to be on at least GCC 7 for the attribute */
+#elif defined(__GNUC__) && __GNUC__ >= 7
+#define BMD_FALLTHROUGH __attribute__((fallthrough));
+/* If none of the above is true, make the annotation a no-op */
+#else
+#define BMD_FALLTHROUGH
+#endif
+
 #if defined(_MSC_VER) && !defined(__clang__)
 #define BMD_UNUSED
 #else

--- a/src/target/renesas_ra.c
+++ b/src/target/renesas_ra.c
@@ -702,6 +702,7 @@ static bool renesas_rv40_pe_mode(target_s *const target, const pe_mode_e pe_mode
 	case PNR_SERIES_RA6E2:
 	case PNR_SERIES_RA6T2:
 		has_fmeprot = true;
+		BMD_FALLTHROUGH
 	default:
 		break;
 	}

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -541,8 +541,8 @@ bool stm32f1_probe(target_s *target)
 	case 0x422U: /* STM32F30x */
 	case 0x446U: /* STM32F303xD/E and STM32F398xE */
 		target_add_ram(target, 0x10000000, 0x4000);
-		/* fall through */
 
+		BMD_FALLTHROUGH
 	case 0x432U: /* STM32F37x */
 	case 0x439U: /* STM32F302C8 */
 		target->driver = "STM32F3";

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -604,7 +604,7 @@ static bool optcr_mask(target_s *const t, uint32_t *const val)
 		break;
 	case ID_STM32F72X:
 		val[2] &= ~0x800000ffU;
-		/* Fall through*/
+		BMD_FALLTHROUGH
 	case ID_STM32F74X:
 		val[0] &= ~0x3f000000U;
 		break;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses the Clang warnings about switch-case fall-through caused by it not understanding the magic comment `/* fall through */`. To do this we've introduced a new macro and definition logic to use the compiler attribute for the job.

Tested on GCC 12, ARM GCC 12 and Clang 18. CI build items should be added in the future but as CI needs an overhaul post-Meson-PR we'll do that in a separate PR.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
