### PR TITLE
Add MSVC compatibility for BMDA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,5 @@ repos:
   - id: check-accidental-assignment
     args: [--strict, --skip-keywords, DO_PRAGMA, --] # strict, check in all parentheses found, skip check in DO_PRAGMA macro
     # FIXME: Known assignment in find_debuggers, needs large refactoring, ignore file temporarily so we get a working check for the rest of the code base
+    # FIXME: getopt_long.c relies on C89 semantics
     exclude: '^src/platforms/hosted/bmp_serial.c'

--- a/deps/hidapi.wrap
+++ b/deps/hidapi.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://github.com/libusb/hidapi
+revision = HEAD
+clone-recursive = false
+
+[provide]
+hidapi_raw = hidapi_dep
+hidapi = hidapi_dep

--- a/meson.build
+++ b/meson.build
@@ -90,6 +90,7 @@ endif
 # Project wide flags
 extended_warnings = [
 	'-Warith-conversion',
+	'-w24244', # 'conversion' conversion from 'type1' to 'type2', possible loss of data (integer version)
 	'-Wbad-function-cast',
 	# '-Wcast-align=strict',
 	'-Wcast-function-type',
@@ -98,13 +99,18 @@ extended_warnings = [
 	'-Wdangling-else',
 	'-Wdouble-promotion',
 	'-Wduplicated-branches',
+	'-w24754', # Conversion rules for arithmetic operations in a comparison mean that one branch cannot be executed.
 	'-Wfloat-conversion',
 	# '-Wformat-overflow=2',
 	# '-Wformat-signedness',
 	'-Wformat-truncation',
 	'-Wformat=2',
+	'-w24774', # ‘<function>’ : format string expected in argument <position> is not a string literal
+	'-w24777', #‘<function>’ : format string ‘<format-string>’ requires an argument of type ‘<type>’, but variadic argument <position> has type ‘<type>’ 
 	'-Wimplicit-fallthrough',
 	'-Wmaybe-uninitialized',
+	'-w24701', # Potentially uninitialized local variable 'name' used
+	'-w24703', # Potentially uninitialized local pointer variable 'name' used
 	'-Wmissing-attributes',
 	'-Wmissing-braces',
 	'-Wno-char-subscripts',
@@ -112,20 +118,25 @@ extended_warnings = [
 	# '-Wpacked',
 	'-Wredundant-decls',
 	'-Wreturn-type',
+	'-w24013', # 'function' undefined; assuming extern returning int
 	'-Wsequence-point',
 	'-Wshadow=local',
+	'-w24456', # declaration of 'identifier' hides previous local declaration
+	'-w24457', # declaration of 'identifier' hides function parameter
 	# '-Wsign-conversion',
 	# '-Wstack-protector',
 	'-Wstrict-aliasing',
 	'-Wstrict-overflow=3',
 	'-Wstring-compare',
 	'-Wstringop-overflow',
-	'-Wunknown-pragmas',
+	'-Wunknown-pragmas', # MSVC's C4081 and it's a level 1 warning
 	'-Wunsafe-loop-optimizations',
 	'-Wunsuffixed-float-constant',
 	'-Wunused-const-variable=2',
+	'-w24189', # 'identifier' : local variable is initialized but not referenced
 	'-Wunused-local-typedefs',
 	'-Wunused',
+	'-w24101', # 'identifier' : unreferenced local variable
 	'-Wvla-parameter',
 	'-Wvla',
 ]

--- a/src/command.c
+++ b/src/command.c
@@ -34,15 +34,18 @@
 #include "target_internal.h"
 #include "morse.h"
 #include "version.h"
-#include "serialno.h"
 #include "jtagtap.h"
+
+#if PC_HOSTED == 0
 #include "jtag_scan.h"
+#endif
 
 #ifdef ENABLE_RTT
 #include "rtt.h"
 #endif
 
 #ifdef PLATFORM_HAS_TRACESWO
+#include "serialno.h"
 #include "traceswo.h"
 #endif
 

--- a/src/command.c
+++ b/src/command.c
@@ -76,6 +76,10 @@ static bool cmd_debug_bmp(target_s *t, int argc, const char **argv);
 static bool cmd_shutdown_bmda(target_s *t, int argc, const char **argv);
 #endif
 
+#ifdef _MSC_VER
+#define strtok_r strtok_s
+#endif
+
 const command_s cmd_list[] = {
 	{"version", cmd_version, "Display firmware version info"},
 	{"help", cmd_help, "Display help for monitor commands"},

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -34,17 +34,25 @@
 #define GDB_PACKET_NOTIFICATION_START '%'
 #define GDB_PACKET_ESCAPE_XOR         (0x20U)
 
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
+#define GDB_FORMAT_ATTR __attribute__((format(__MINGW_PRINTF_FORMAT, 1, 2)))
+#elif defined(__GNUC__) || defined(__clang__)
+#define GDB_FORMAT_ATTR __attribute__((format(printf, 1, 2)))
+#else
+#define GDB_FORMAT_ATTR
+#endif
+
 void gdb_set_noackmode(bool enable);
 size_t gdb_getpacket(char *packet, size_t size);
 void gdb_putpacket(const char *packet, size_t size);
 void gdb_putpacket2(const char *packet1, size_t size1, const char *packet2, size_t size2);
 #define gdb_putpacketz(packet) gdb_putpacket((packet), strlen(packet))
-void gdb_putpacket_f(const char *packet, ...) __attribute__((format(printf, 1, 2)));
+void gdb_putpacket_f(const char *packet, ...) GDB_FORMAT_ATTR;
 void gdb_put_notification(const char *packet, size_t size);
 #define gdb_put_notificationz(packet) gdb_put_notification((packet), strlen(packet))
 
 void gdb_out(const char *buf);
 void gdb_voutf(const char *fmt, va_list);
-void gdb_outf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void gdb_outf(const char *fmt, ...) GDB_FORMAT_ATTR;
 
 #endif /* INCLUDE_GDB_PACKET_H */

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -140,6 +140,21 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #define strcasecmp  _stricmp
 #define strncasecmp _strnicmp
 
-#endif
+// FIXME: BMDA still uses this function in gdb_packet.c
+// It's defined here as an export from utils.c would pollute the ABI of libbmd
+static inline int vasprintf(char **strp, const char *const fmt, va_list ap)
+{
+	const int actual_size = vsnprintf(NULL, 0, fmt, ap);
+	if (actual_size < 0)
+		return -1;
+
+	*strp = malloc(actual_size + 1);
+	if (!*strp)
+		return -1;
+
+	return vsnprintf(*strp, actual_size + 1, fmt, ap);
+}
+
+#endif /* _MSC_VER */
 
 #endif /* INCLUDE_GENERAL_H */

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -39,6 +39,7 @@
 #elif !defined(__FreeBSD__)
 #include <alloca.h>
 #endif
+// IWYU pragma: begin_keep
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -51,6 +52,7 @@
 #include "timing.h"
 #include "platform_support.h"
 #include "align.h"
+// IWYU pragma: end_keep
 
 #ifndef ARRAY_LENGTH
 #define ARRAY_LENGTH(arr) (sizeof(arr) / sizeof((arr)[0]))
@@ -127,5 +129,17 @@ void debug_serial_send_stdout(const uint8_t *data, size_t len);
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #undef MAX
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#define BMD_UNUSED
+#else
+#define BMD_UNUSED __attribute__((unused))
+#endif
+
+#ifdef _MSC_VER
+#define strcasecmp  _stricmp
+#define strncasecmp _strnicmp
+
+#endif
 
 #endif /* INCLUDE_GENERAL_H */

--- a/src/main.c
+++ b/src/main.c
@@ -34,7 +34,7 @@
 #endif
 
 /* This has to be aligned so the remote protocol can re-use it without causing Problems */
-static char pbuf[GDB_PACKET_BUFFER_SIZE + 1U] __attribute__((aligned(8)));
+static char BMD_ALIGN_DEF(8) pbuf[GDB_PACKET_BUFFER_SIZE + 1U];
 
 char *gdb_packet_buffer()
 {

--- a/src/maths_utils.c
+++ b/src/maths_utils.c
@@ -82,7 +82,7 @@ uint8_t calculate_odd_parity(const uint32_t value)
 	return __builtin_parity(value);
 #elif defined(_MSC_VER)
 	/* Ask for a CPU insn */
-	return __popcount(value) & 1U;
+	return __popcnt(value) & 1U;
 #else
 	/* Generic impl */
 	uint8_t result = 0;

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -35,8 +35,10 @@
 #include "remote/protocol_v3.h"
 
 #include <assert.h>
-#include <sys/time.h>
 #include <errno.h>
+#ifndef _MSC_VER
+#include <sys/time.h>
+#endif
 
 #include "adiv5.h"
 

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -20,22 +20,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "general.h"
-#include "gdb_if.h"
 #include "version.h"
 #include "remote.h"
 #include "target.h"
 #include "bmp_remote.h"
-#include "cli.h"
 #include "hex_utils.h"
-#include "exception.h"
 
 #include "remote/protocol_v0.h"
 #include "remote/protocol_v1.h"
 #include "remote/protocol_v2.h"
 #include "remote/protocol_v3.h"
 
-#include <assert.h>
-#include <errno.h>
 #ifndef _MSC_VER
 #include <sys/time.h>
 #endif

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -22,17 +22,13 @@
  * binary file from the command line.
  */
 
+#include "general.h"
+
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <getopt.h>
-#include "version.h"
-#include "general.h"
-#include "target_internal.h"
-#include "cortexm.h"
-#include "command.h"
-#include "cli.h"
-#include "bmp_hosted.h"
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #include <io.h>
@@ -46,6 +42,13 @@
 #define O_BINARY         0
 #define BMDA_NORMAL_MODE S_IRUSR | S_IWUSR
 #endif
+
+#include "version.h"
+#include "target_internal.h"
+#include "cortexm.h"
+#include "command.h"
+#include "cli.h"
+#include "bmp_hosted.h"
 
 typedef struct option getopt_option_s;
 

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -22,28 +22,29 @@
  * binary file from the command line.
  */
 
-#include "general.h"
-#include <unistd.h>
-#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <getopt.h>
 #include "version.h"
+#include "general.h"
 #include "target_internal.h"
 #include "cortexm.h"
 #include "command.h"
-
 #include "cli.h"
 #include "bmp_hosted.h"
 
-#ifndef O_BINARY
-#define O_BINARY 0
-#endif
 #if defined(_WIN32) || defined(__CYGWIN__)
+#include <io.h>
 #include <windows.h>
+#define BMDA_NORMAL_MODE _S_IWRITE | _S_IREAD
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 #else
 #include <sys/mman.h>
+#define O_BINARY         0
+#define BMDA_NORMAL_MODE S_IRUSR | S_IWUSR
 #endif
 
 typedef struct option getopt_option_s;
@@ -543,7 +544,7 @@ int cl_execute(bmda_cli_options_s *opt)
 		}
 	} else if (opt->opt_mode == BMP_MODE_FLASH_READ) {
 		/* Open as binary */
-		read_file = open(opt->opt_flash_file, O_TRUNC | O_CREAT | O_RDWR | O_BINARY, S_IRUSR | S_IWUSR);
+		read_file = open(opt->opt_flash_file, O_TRUNC | O_CREAT | O_RDWR | O_BINARY, BMDA_NORMAL_MODE);
 		if (read_file == -1) {
 			DEBUG_ERROR("Error opening flashfile %s for read: %s\n", opt->opt_flash_file, strerror(errno));
 			res = -1;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -53,18 +53,14 @@
 */
 
 #include "general.h"
-#include "gdb_if.h"
 #include "adiv5.h"
 
-#include <assert.h>
 #include <string.h>
 #ifndef _MSC_VER
 #include <unistd.h>
 #include <sys/time.h>
 #endif
 #include <stdlib.h>
-#include <signal.h>
-#include <ctype.h>
 #include <hidapi.h>
 #include <wchar.h>
 #include <sys/stat.h>
@@ -73,11 +69,8 @@
 #include "dap.h"
 #include "dap_command.h"
 #include "cmsis_dap.h"
-#include "buffer_utils.h"
 
-#include "cli.h"
 #include "target.h"
-#include "target_internal.h"
 
 #define TRANSFER_TIMEOUT_MS (100)
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -58,11 +58,13 @@
 
 #include <assert.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#include <sys/time.h>
+#endif
 #include <stdlib.h>
 #include <signal.h>
 #include <ctype.h>
-#include <sys/time.h>
 #include <hidapi.h>
 #include <wchar.h>
 #include <sys/stat.h>

--- a/src/platforms/hosted/debug.h
+++ b/src/platforms/hosted/debug.h
@@ -38,13 +38,17 @@
 // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 #define __USE_MINGW_ANSI_STDIO 1
 #endif
+
 #include <stdint.h>
-#include <stdio.h>
+
 typedef const char *debug_str_t;
-#if defined(_WIN32) || defined(__CYGWIN__)
+
+#if defined(__MINGW32__) || defined(__MINGW64__) || defined(__CYGWIN__)
 #define DEBUG_FORMAT_ATTR __attribute__((format(__MINGW_PRINTF_FORMAT, 1, 2)))
-#else
+#elif defined(__GNUC__) || defined(__clang__)
 #define DEBUG_FORMAT_ATTR __attribute__((format(printf, 1, 2)))
+#else
+#define DEBUG_FORMAT_ATTR
 #endif
 
 #define BMD_DEBUG_ERROR      (1U << 0U)
@@ -71,5 +75,13 @@ void debug_target(const char *format, ...) DEBUG_FORMAT_ATTR;
 void debug_protocol(const char *format, ...) DEBUG_FORMAT_ATTR;
 void debug_probe(const char *format, ...) DEBUG_FORMAT_ATTR;
 void debug_wire(const char *format, ...) DEBUG_FORMAT_ATTR;
+
+#if defined(_WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+#else
+#include <unistd.h>
+#endif
 
 #endif /*PLATFORMS_HOSTED_DEBUG_H*/

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -27,8 +27,10 @@
 
 #include <assert.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
 #include <sys/time.h>
+#endif
 
 #include "ftdi_bmp.h"
 #include <ftdi.h>

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -21,8 +21,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "general.h"
-#include "gdb_if.h"
-#include "target.h"
 #include "buffer_utils.h"
 
 #include <assert.h>

--- a/src/platforms/hosted/ftdi_jtag.c
+++ b/src/platforms/hosted/ftdi_jtag.c
@@ -23,7 +23,9 @@
 /* Low level JTAG implementation using FTDI parts via libftdi. */
 
 #include "general.h"
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <assert.h>
 #include <ftdi.h>
 #include "ftdi_bmp.h"

--- a/src/platforms/hosted/ftdi_jtag.c
+++ b/src/platforms/hosted/ftdi_jtag.c
@@ -26,7 +26,6 @@
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
-#include <assert.h>
 #include <ftdi.h>
 #include "ftdi_bmp.h"
 

--- a/src/platforms/hosted/ftdi_swd.c
+++ b/src/platforms/hosted/ftdi_swd.c
@@ -26,7 +26,6 @@
  */
 
 #include "general.h"
-#include <assert.h>
 #include <stdlib.h>
 
 #include <ftdi.h>

--- a/src/platforms/hosted/ftdi_swd.c
+++ b/src/platforms/hosted/ftdi_swd.c
@@ -75,6 +75,15 @@ bool ftdi_swd_possible(void)
 	return true;
 }
 
+#if defined(_MSC_VER) && !defined(__clang__)
+static inline uint32_t __builtin_ctz(uint32_t value)
+{
+	uint32_t result = 0U;
+	_BitScanForward(&result, value);
+	return result;
+}
+#endif
+
 bool ftdi_swd_init(void)
 {
 	if (!ftdi_swd_possible()) {

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -58,7 +58,9 @@ typedef int32_t socket_t;
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "gdb_if.h"
 #include "bmp_hosted.h"

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -35,10 +35,12 @@
 #include "buffer_utils.h"
 
 #include <assert.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#include <sys/time.h>
+#endif
 #include <signal.h>
 #include <ctype.h>
-#include <sys/time.h>
 #include <libusb.h>
 
 #include "cli.h"

--- a/src/platforms/hosted/jlink.c
+++ b/src/platforms/hosted/jlink.c
@@ -27,23 +27,15 @@
  */
 
 #include "general.h"
-#include "gdb_if.h"
-#include "adiv5.h"
 #include "jlink.h"
 #include "jlink_protocol.h"
-#include "exception.h"
 #include "buffer_utils.h"
 
-#include <assert.h>
 #ifndef _MSC_VER
 #include <unistd.h>
 #include <sys/time.h>
 #endif
-#include <signal.h>
-#include <ctype.h>
 #include <libusb.h>
-
-#include "cli.h"
 
 typedef struct jlink {
 	char fw_version[256U];         /* Firmware version string */

--- a/src/platforms/hosted/jlink_jtag.c
+++ b/src/platforms/hosted/jlink_jtag.c
@@ -27,7 +27,6 @@
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
-#include <assert.h>
 #include <memory.h>
 #include <stdlib.h>
 
@@ -35,7 +34,6 @@
 #include "jtagtap.h"
 #include "jlink.h"
 #include "jlink_protocol.h"
-#include "cli.h"
 
 static void jlink_jtag_reset(void);
 static void jlink_jtag_tms_seq(uint32_t tms_states, size_t clock_cycles);

--- a/src/platforms/hosted/jlink_jtag.c
+++ b/src/platforms/hosted/jlink_jtag.c
@@ -24,7 +24,9 @@
  */
 
 #include "general.h"
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <assert.h>
 #include <memory.h>
 #include <stdlib.h>

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -137,7 +137,7 @@ else
 	bmda_platform = declare_dependency(
 		include_directories: bmda_includes,
 		sources: bmda_sources,
-		compile_args: bmda_args,
+		compile_args: cc.get_supported_arguments(bmda_args),
 		link_args: bmda_link_args,
 		dependencies: [libbmd_core, bmda_deps, libftdi, hidapi, libusb],
 	)

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -72,7 +72,12 @@ cc = is_cross_build ? cc_native : cc_host
 # Determine if we're on a MSYS2 environment of some kind
 # If the compiler is MSYS2 GCC or Clang (but not Clang-cl)
 if build_machine.system() == 'windows' and cc.get_define('__MINGW32__') == '1'
+	# It needs custom location for some MinGWs
+	# See https://github.com/msys2/MINGW-packages/issues/10275
 	ucrt_check = '''
+		#ifdef __MINGW32__
+		#include <_mingw.h>
+		#endif
 		#include <stddef.h>
 		#ifndef _UCRT
 		#error "_UCRT not defined"
@@ -80,7 +85,7 @@ if build_machine.system() == 'windows' and cc.get_define('__MINGW32__') == '1'
 	'''
 
 	# Check if we're in a UCRT based environment or not
-	if cc.compiles(ucrt_check)
+	if cc.compiles(ucrt_check, name: 'the compiler links against the UCRT')
 		# Force linking against the correct C runtime DLL
 		if cc.get_id() != 'clang'
 			bmda_args += ['-mcrtdll=ucrt']

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -110,9 +110,9 @@ endif
 
 # Pick the appropriate HIDAPI depending on platform
 if build_machine.system() == 'linux'
-	hidapi = dependency('hidapi-hidraw', required: false, method: 'pkg-config', native: is_cross_build)
+	hidapi = dependency('hidapi-hidraw', method: 'pkg-config', fallback: 'hidapi', native: is_cross_build)
 else
-	hidapi = dependency('hidapi', required: false, method: 'pkg-config', native: is_cross_build)
+	hidapi = dependency('hidapi', method: 'pkg-config', fallback: 'hidapi', native: is_cross_build)
 endif
 
 libusb = dependency(

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -103,6 +103,12 @@ if build_machine.system() in ['windows', 'cygwin']
 		cc.find_library('setupapi'),
 	]
 	bmda_sources += files('serial_win.c')
+
+	if not cc.has_function('getopt_long', prefix: '#include <getopt.h>')
+		bmda_deps += [
+			libgetopt
+		]
+	endif
 else
 	libftdi = dependency('libftdi1', required: false, method: 'pkg-config', native: is_cross_build)
 	bmda_sources += files('serial_unix.c')

--- a/src/platforms/hosted/rtt_if.c
+++ b/src/platforms/hosted/rtt_if.c
@@ -25,9 +25,12 @@
  */
 
 #include <general.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <rtt_if.h>
+
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 /* maybe rewrite this as tcp server */
 

--- a/src/platforms/hosted/rtt_if.c
+++ b/src/platforms/hosted/rtt_if.c
@@ -28,7 +28,9 @@
 #include <fcntl.h>
 #include <rtt_if.h>
 
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+#include <io.h>
+#else
 #include <unistd.h>
 #endif
 

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -24,7 +24,9 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <termios.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 #include "general.h"
 #include "remote.h"

--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -31,7 +31,7 @@
 #define NT_DEV_SUFFIX     "\\\\.\\"
 #define NT_DEV_SUFFIX_LEN ARRAY_LENGTH(NT_DEV_SUFFIX)
 
-static char *format_string(const char *format, ...) __attribute__((format(printf, 1, 2)));
+static char *format_string(const char *format, ...) DEBUG_FORMAT_ATTR;
 
 static char *format_string(const char *format, ...)
 {

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -27,7 +27,6 @@
  */
 
 #include "general.h"
-#include "gdb_if.h"
 #include "adiv5.h"
 #include "bmp_hosted.h"
 #include "stlinkv2.h"
@@ -36,12 +35,6 @@
 #include "cortexm.h"
 #include "buffer_utils.h"
 #include "maths_utils.h"
-
-#include <assert.h>
-#include <signal.h>
-#include <ctype.h>
-
-#include "cli.h"
 
 #ifdef _MSC_VER
 #include <intrin.h>

--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -38,15 +38,16 @@
 #include "maths_utils.h"
 
 #include <assert.h>
-#include <unistd.h>
 #include <signal.h>
 #include <ctype.h>
-#include <sys/time.h>
 
 #include "cli.h"
 
 #ifdef _MSC_VER
 #include <intrin.h>
+#else
+#include <unistd.h>
+#include <sys/time.h>
 #endif
 
 typedef enum transport_mode {

--- a/src/platforms/hosted/utils.c
+++ b/src/platforms/hosted/utils.c
@@ -31,21 +31,6 @@
 #include "timing.h"
 #include "bmp_hosted.h"
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-int vasprintf(char **strp, const char *const fmt, va_list ap)
-{
-	const int actual_size = vsnprintf(NULL, 0, fmt, ap);
-	if (actual_size < 0)
-		return -1;
-
-	*strp = malloc(actual_size + 1);
-	if (!*strp)
-		return -1;
-
-	return vsnprintf(*strp, actual_size + 1, fmt, ap);
-}
-#endif
-
 void platform_delay(uint32_t ms)
 {
 #if defined(_WIN32) && !defined(__MINGW32__)

--- a/src/platforms/hosted/utils.c
+++ b/src/platforms/hosted/utils.c
@@ -26,9 +26,8 @@
 #include "general.h"
 
 #include <string.h>
-#include <unistd.h>
-#include <sys/time.h>
 
+#include "timeofday.h"
 #include "timing.h"
 #include "bmp_hosted.h"
 

--- a/src/platforms/hosted/utils.h
+++ b/src/platforms/hosted/utils.h
@@ -35,7 +35,6 @@
 #define PLATFORMS_HOSTED_UTILS_H
 
 #include <stdbool.h>
-#include <stdint.h>
 #include <stddef.h>
 
 bool begins_with(const char *str, size_t str_length, const char *value);

--- a/src/platforms/hosted/windows/getopt/getopt.h
+++ b/src/platforms/hosted/windows/getopt/getopt.h
@@ -1,0 +1,80 @@
+/*	$OpenBSD: getopt.h,v 1.2 2008/06/26 05:42:04 ray Exp $	*/
+/*	$NetBSD: getopt.h,v 1.4 2000/07/07 10:43:54 ad Exp $	*/
+
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+/*
+ * GNU-like getopt_long() and 4.4BSD getsubopt()/optreset extensions
+ */
+#define no_argument       0
+#define required_argument 1
+#define optional_argument 2
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct option {
+	/* name of long option */
+	const char *name;
+	/*
+	 * one of no_argument, required_argument, and optional_argument:
+	 * whether option takes an argument
+	 */
+	int has_arg;
+	/* if not NULL, set *flag to val when option found */
+	int *flag;
+	/* if flag not NULL, value to set *flag to; else return value */
+	int val;
+};
+
+int getopt_long(int, char *const *, const char *, const struct option *, int *);
+int getopt_long_only(int, char *const *, const char *, const struct option *, int *);
+#ifndef _GETOPT_DEFINED_
+#define _GETOPT_DEFINED_
+int getopt(int, char *const *, const char *);
+int getsubopt(char **, char *const *, char **);
+
+extern char *optarg; /* getopt(3) external variables */
+extern int opterr;
+extern int optind;
+extern int optopt;
+extern int optreset;
+extern char *suboptarg; /* getsubopt(3) external variable */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !_GETOPT_H_ */

--- a/src/platforms/hosted/windows/getopt/getopt_long.c
+++ b/src/platforms/hosted/windows/getopt/getopt_long.c
@@ -1,0 +1,489 @@
+/*	$OpenBSD: getopt_long.c,v 1.24 2010/07/22 19:31:53 blambert Exp $	*/
+/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+
+/*
+ * Copyright (c) 2002 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Sponsored in part by the Defense Advanced Research Projects
+ * Agency (DARPA) and Air Force Research Laboratory, Air Force
+ * Materiel Command, USAF, under agreement number F39502-99-1-0512.
+ */
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int opterr = 1;   /* if error message should be printed */
+int optind = 1;   /* index into parent argv vector */
+int optopt = '?'; /* character checked for validity */
+int optreset;     /* reset getopt */
+char *optarg;     /* argument associated with option */
+
+#define PRINT_ERROR ((opterr) && (*options != ':'))
+
+#define FLAG_PERMUTE  0x01 /* permute non-options to the end of argv */
+#define FLAG_ALLARGS  0x02 /* treat non-options as args to option "-1" */
+#define FLAG_LONGONLY 0x04 /* operate as getopt_long_only */
+
+/* return values */
+#define BADCH   (int)'?'
+#define BADARG  ((*options == ':') ? (int)':' : (int)'?')
+#define INORDER (int)1
+
+#define EMSG ""
+
+static int getopt_internal(int, char *const *, const char *, const struct option *, int *, int);
+static int parse_long_options(char *const *, const char *, const struct option *, int *, int);
+static int gcd(int, int);
+static void permute_args(int, int, int, char *const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int gcd(int a, int b)
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+
+	return (b);
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void permute_args(int panonopt_start, int panonopt_end, int opt_end, char *const *nargv)
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end + i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **)nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * parse_long_options --
+ *	Parse long options in argc/argv argument vector.
+ * Returns -1 if short_too is set and the option does not match long_options.
+ */
+static int parse_long_options(
+	char *const *nargv, const char *options, const struct option *long_options, int *idx, int short_too)
+{
+	char *current_argv, *has_equal;
+	size_t current_argv_len;
+	int i, match;
+
+	current_argv = place;
+	match = -1;
+
+	optind++;
+
+	has_equal = strchr(current_argv, '=');
+	if (has_equal != NULL) {
+		/* argument found (--option=arg) */
+		current_argv_len = has_equal - current_argv;
+		has_equal++;
+	} else
+		current_argv_len = strlen(current_argv);
+
+	for (i = 0; long_options[i].name; i++) {
+		/* find matching long option */
+		if (strncmp(current_argv, long_options[i].name, current_argv_len))
+			continue;
+
+		if (strlen(long_options[i].name) == current_argv_len) {
+			/* exact match */
+			match = i;
+			break;
+		}
+		/*
+		 * If this is a known short option, don't allow
+		 * a partial match of a single character.
+		 */
+		if (short_too && current_argv_len == 1)
+			continue;
+
+		if (match == -1) /* partial match */
+			match = i;
+		else {
+			/* ambiguous abbreviation */
+			if (PRINT_ERROR)
+				fprintf(stderr, ambig, (int)current_argv_len, current_argv);
+			optopt = 0;
+			return (BADCH);
+		}
+	}
+	if (match != -1) { /* option found */
+		if (long_options[match].has_arg == no_argument && has_equal) {
+			if (PRINT_ERROR)
+				fprintf(stderr, noarg, (int)current_argv_len, current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			return (BADARG);
+		}
+		if (long_options[match].has_arg == required_argument || long_options[match].has_arg == optional_argument) {
+			if (has_equal)
+				optarg = has_equal;
+			else if (long_options[match].has_arg == required_argument) {
+				/*
+				 * optional argument doesn't use next nargv
+				 */
+				optarg = nargv[optind++];
+			}
+		}
+		if ((long_options[match].has_arg == required_argument) && (optarg == NULL)) {
+			/*
+			 * Missing argument; leading ':' indicates no error
+			 * should be generated.
+			 */
+			if (PRINT_ERROR)
+				fprintf(stderr, recargstring, current_argv);
+			/*
+			 * XXX: GNU sets optopt to val regardless of flag
+			 */
+			if (long_options[match].flag == NULL)
+				optopt = long_options[match].val;
+			else
+				optopt = 0;
+			--optind;
+			return (BADARG);
+		}
+	} else { /* unknown option */
+		if (short_too) {
+			--optind;
+			return (-1);
+		}
+		if (PRINT_ERROR)
+			fprintf(stderr, illoptstring, current_argv);
+		optopt = 0;
+		return (BADCH);
+	}
+	if (idx)
+		*idx = match;
+	if (long_options[match].flag) {
+		*long_options[match].flag = long_options[match].val;
+		return (0);
+	} else
+		return (long_options[match].val);
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ */
+static int getopt_internal(
+	int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx, int flags)
+{
+	char *oli; /* option letter list index */
+	int optchar, short_too;
+	static int posixly_correct = -1;
+
+	if (options == NULL)
+		return (-1);
+
+	/*
+	 * Disable GNU extensions if POSIXLY_CORRECT is set or options
+	 * string begins with a '+'.
+	 */
+	if (posixly_correct == -1)
+		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+	if (posixly_correct || *options == '+')
+		flags &= ~FLAG_PERMUTE;
+	else if (*options == '-')
+		flags |= FLAG_ALLARGS;
+	if (*options == '+' || *options == '-')
+		options++;
+
+	/*
+	 * XXX Some GNU programs (like cvs) set optind to 0 instead of
+	 * XXX using optreset.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = optreset = 1;
+
+	optarg = NULL;
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) { /* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) { /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end, optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			} else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+		place = nargv[optind];
+		if (*place != '-' || (place[1] == '\0' && strchr(options, '-') == NULL)) {
+			place = EMSG; /* found non-option */
+			if (flags & FLAG_ALLARGS) {
+				/*
+				 * GNU extension:
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return (INORDER);
+			}
+			if (!(flags & FLAG_PERMUTE)) {
+				/*
+				 * If no permutation wanted, stop parsing
+				 * at first non-option.
+				 */
+				return (-1);
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end, optind, nargv);
+				nonopt_start = optind - (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+
+		/*
+		 * If we have "-" do nothing, if "--" we are done.
+		 */
+		if (place[1] != '\0' && *++place == '-' && place[1] == '\0') {
+			optind++;
+			place = EMSG;
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end, optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return (-1);
+		}
+	}
+
+	/*
+	 * Check long options if:
+	 *  1) we were passed some
+	 *  2) the arg is not just "-"
+	 *  3) either the arg starts with -- we are getopt_long_only()
+	 */
+	if (long_options != NULL && place != nargv[optind] && (*place == '-' || (flags & FLAG_LONGONLY))) {
+		short_too = 0;
+		if (*place == '-')
+			place++; /* --foo long option */
+		else if (*place != ':' && strchr(options, *place) != NULL)
+			short_too = 1; /* could be short option too */
+
+		optchar = parse_long_options(nargv, options, long_options, idx, short_too);
+		if (optchar != -1) {
+			place = EMSG;
+			return (optchar);
+		}
+	}
+
+	int separator = 0;
+
+	optchar = (int)*place++;
+	if ((optchar == (int)':') || (optchar == (int)'-' && *place != '\0')) {
+		separator = 1;
+	} else {
+		oli = strchr(options, optchar);
+		if (oli == NULL) {
+			separator = 1;
+		}
+	}
+
+	if (separator) {
+		/*
+		 * If the user specified "-" and  '-' isn't listed in
+		 * options, return -1 (non-option) as per POSIX.
+		 * Otherwise, it is an unknown option character (or ':').
+		 */
+		if (optchar == (int)'-' && *place == '\0')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (PRINT_ERROR)
+			fprintf(stderr, illoptchar, optchar);
+		optopt = optchar;
+		return (BADCH);
+	}
+	if (long_options != NULL && optchar == 'W' && oli[1] == ';') {
+		/* -W long-option */
+		if (*place) /* no space */
+			/* NOTHING */;
+		else if (++optind >= nargc) { /* no arg */
+			place = EMSG;
+			if (PRINT_ERROR)
+				fprintf(stderr, recargchar, optchar);
+			optopt = optchar;
+			return (BADARG);
+		} else /* white space */
+			place = nargv[optind];
+		optchar = parse_long_options(nargv, options, long_options, idx, 0);
+		place = EMSG;
+		return (optchar);
+	}
+	if (*++oli != ':') { /* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else { /* takes (optional) argument */
+		optarg = NULL;
+		if (*place) /* no white space */
+			optarg = place;
+		else if (oli[1] != ':') {    /* arg not optional */
+			if (++optind >= nargc) { /* no arg */
+				place = EMSG;
+				if (PRINT_ERROR)
+					fprintf(stderr, recargchar, optchar);
+				optopt = optchar;
+				return (BADARG);
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return (optchar);
+}
+
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the BSD getopt]
+ */
+int getopt(int nargc, char *const *nargv, const char *options)
+{
+	/*
+	 * We don't pass FLAG_PERMUTE to getopt_internal() since
+	 * the BSD getopt(3) (unlike GNU) has never done this.
+	 *
+	 * Furthermore, since many privileged programs call getopt()
+	 * before dropping privileges it makes sense to keep things
+	 * as simple (and bug-free) as possible.
+	 */
+	return (getopt_internal(nargc, nargv, options, NULL, NULL, 0));
+}
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int getopt_long(int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx)
+{
+	return (getopt_internal(nargc, nargv, options, long_options, idx, FLAG_PERMUTE));
+}
+
+/*
+ * getopt_long_only --
+ *	Parse argc/argv argument vector.
+ */
+int getopt_long_only(int nargc, char *const *nargv, const char *options, const struct option *long_options, int *idx)
+{
+	return (getopt_internal(nargc, nargv, options, long_options, idx, FLAG_PERMUTE | FLAG_LONGONLY));
+}

--- a/src/platforms/hosted/windows/getopt/meson.build
+++ b/src/platforms/hosted/windows/getopt/meson.build
@@ -1,7 +1,7 @@
 # This file is part of the Black Magic Debug project.
 #
 # Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
-# Written by Rachel Mant <git@dragonmux.network>
+# Written by L. E. Segovia <amy@amyspark.me>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -28,29 +28,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-ftdi_sources = files('ftdi.c')
-
-ftdi_includes = [
-	include_directories('..' / '..' / '..' / '..' / '3rdparty' / 'ftdi'),
-	include_directories('.')
-]
-
-processor = build_machine.cpu_family()
-if processor == 'x86_64'
-	processor = 'amd64'
-elif processor == 'x86'
-	processor = 'i386'
-endif
-
-ftdi_dep = cc.find_library(
-	'ftd2xx',
-	dirs: [meson.project_source_root() / '3rdparty' / 'ftdi' / processor]
+libgetopt = declare_dependency(
+	sources: files(
+		'getopt_long.c',
+	),
+	include_directories: include_directories('.', is_system: true)
 )
-
-libftdi = declare_dependency(
-	sources: ftdi_sources,
-	include_directories: ftdi_includes,
-	dependencies: ftdi_dep
-)
-
-subdir('getopt')

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -50,7 +50,7 @@ typedef struct iap_config {
 	uint32_t params[4];
 } iap_config_s;
 
-typedef struct __attribute__((aligned(4))) iap_frame {
+typedef struct BMD_ALIGN_DECL(4) iap_frame {
 	/* The start of an IAP stack frame is the opcode we set as the return point. */
 	uint16_t opcode;
 	/* There's then a hidden alignment field here, followed by the IAP call setup */

--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -22,7 +22,6 @@
 #include "target_internal.h"
 #include "cortex.h"
 #include "lpc_common.h"
-#include "adiv5.h"
 
 /*
  * For detailed documentation on how this code works and the IAP variant used here, see:

--- a/src/target/lpc40xx.c
+++ b/src/target/lpc40xx.c
@@ -52,7 +52,7 @@ typedef struct iap_config {
 	uint32_t params[4];
 } iap_config_s;
 
-typedef struct __attribute__((aligned(4))) iap_frame {
+typedef struct BMD_ALIGN_DECL(4) iap_frame {
 	/* The start of an IAP stack frame is the opcode we set as the return point. */
 	uint16_t opcode;
 	/* There's then a hidden alignment field here, followed by the IAP call setup */

--- a/src/target/lpc40xx.c
+++ b/src/target/lpc40xx.c
@@ -24,7 +24,6 @@
 #include "cortex.h"
 #include "cortexm.h"
 #include "lpc_common.h"
-#include "adiv5.h"
 
 /*
  * For detailed documentation on how this code works and the IAP variant used here, see:

--- a/src/target/lpc_common.c
+++ b/src/target/lpc_common.c
@@ -33,7 +33,7 @@ typedef struct iap_config {
 	uint32_t params[4];
 } iap_config_s;
 
-typedef struct __attribute__((aligned(4))) iap_frame {
+typedef struct BMD_ALIGN_DECL(4) iap_frame {
 	/* The start of an IAP stack frame is the opcode we set as the return point. */
 	uint16_t opcode;
 	/* There's then a hidden alignment field here, followed by the IAP call setup */

--- a/src/target/nxpke04.c
+++ b/src/target/nxpke04.c
@@ -191,7 +191,7 @@ bool ke04_probe(target_s *t)
 	case SRSID_PIN_80: {
 		/* We have either a KE04Z64 or 128 */
 		/* Try to read a flash address not available in a Z64 */
-		volatile uint32_t __attribute__((unused)) dummy = target_mem_read32(t, 0x00010000U);
+		volatile uint32_t BMD_UNUSED dummy = target_mem_read32(t, 0x00010000U);
 		if (target_check_error(t)) {
 			/* Read failed: we have a 64 */
 			t->driver = "Kinetis KE04Z64Vxxxx";

--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -45,23 +45,22 @@
 #include "target_internal.h"
 #include "gdb_main.h"
 #include "gdb_packet.h"
-#include "cortexm.h"
 #include "semihosting.h"
 #include "semihosting_internal.h"
 #include "buffer_utils.h"
+#include "timeofday.h"
 
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 #if PC_HOSTED == 1
 #include <errno.h>
 #include <time.h>
-#include <sys/time.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #ifdef _WIN32
+#include <io.h>
 #define O_BINARY _O_BINARY
 #define O_NOCTTY 0
 #else

--- a/src/target/stm32_common.h
+++ b/src/target/stm32_common.h
@@ -21,9 +21,12 @@
 #ifndef TARGET_STM32_COMMON_H
 #define TARGET_STM32_COMMON_H
 
+// IWYU pragma: begin_keep
 #include "general.h"
 #include "target_internal.h"
 #include "adiv5.h"
+
+// IWYU pragma: end_keep
 
 static inline const char *stm32_psize_to_string(const align_e psize)
 {

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -56,6 +56,7 @@
 #include "target.h"
 #include "target_internal.h"
 #include "cortexm.h"
+#include "stm32_common.h"
 
 #define STM32Lx_NVM_PECR(p)    ((p) + 0x04U)
 #define STM32Lx_NVM_PEKEYR(p)  ((p) + 0x0cU)

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -24,8 +24,11 @@
 #include "command.h"
 
 #include <stdarg.h>
-#include <unistd.h>
 #include <assert.h>
+
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 /* Fixup for when _FILE_OFFSET_BITS == 64 as unistd.h screws this up for us */
 #if defined(lseek)

--- a/src/target/target_probe.c
+++ b/src/target/target_probe.c
@@ -19,6 +19,7 @@
 
 #include "target_probe.h"
 
+#ifndef __WIN32 // PE-COFF does not allow aliases
 #ifdef __APPLE__
 // __attribute__((alias)) is not supported in AppleClang, we need to define a
 // __attribute__((weak)) placeholder body that'll get pivoted by the linker.
@@ -145,3 +146,5 @@ TARGET_PROBE_WEAK_NOP(imxrt_probe)
 TARGET_PROBE_WEAK_NOP(zynq7_probe)
 
 LPC55_DP_PREPARE_WEAK_NOP(lpc55_dp_prepare)
+
+#endif // _WIN32


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

We've been discussing with @dragonmux, that one of the last outstanding bits for building BMDA on Windows was the MSVC compatibility.

Since there's a Meson build system now, that greatly reduces the barrier to use it, so I'm making this PR to add the necessary changes.

Some features added with this PR:

- HIDAPI is now Mesonified, so I've pulled the library as a wrap. Do notice that their build calls up to CMake, so that'll be another requirement (let me know if you agree and I should document it here)
- there is a typo on one of the uses of `__popcnt` under `_MSC_VER` which I fixed here
- I added Mesa's version of OpenBSD/NetBSD's `getopt` library for Windows (BSD-3-Clause / MIT licensed)
- Fixed UCRT detection under newer MinGWs
- Changed the place of definition of `vasprintf` since gdb_packet.c also requires it

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [X] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
