### PR TITLE
Fix: use v0.3.1 perigoso/pre-commit-hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     types_or: [c++, c]  # override default file types to only C and CPP files
 
 - repo: https://github.com/perigoso/pre-commit-hooks
-  rev: v0.3
+  rev: v0.3.1
   hooks:
   - id: check-hex-case
     args: [--lower-digits] # edit-in-place, hex number digits to lower case (defaults to upper case), i.e. 0x55aa


### PR DESCRIPTION
v0.3.1 fixed a default encoding issue when running the pre-commit hooks on windows

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

Bump the pre-commit hooks to the new minor version, tagged after https://github.com/perigoso/pre-commit-hooks/pull/3

This should have no impact on the CICD or linux users

## Your checklist for this pull request

* [ ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [ ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [ ] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
