### PR TITLE
stlink: replace odr register for the isol variant

### DIFF
--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -82,19 +82,20 @@ extern bool debug_bmp;
 #define SWD_CR      GPIO_CRH(SWDIO_PORT)
 #define SWD_CR_MULT (1U << ((14U - 8U) << 2U))
 
-#define SWDIODIR_ODR GPIO_ODR(GPIOA)
+#define SWDIODIR_BSRR GPIO_BSRR(GPIOA)
+#define SWDIODIR_BRR  GPIO_BRR(GPIOA)
 
 #define TMS_SET_MODE() gpio_set_mode(TMS_PORT, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, TMS_PIN);
 
 #ifdef STLINK_V2_ISOL
 /* The ISOL variant floats SWDIO with GPIO A1 */
-#define SWDIO_MODE_FLOAT()       \
-	do {                         \
-		SWDIODIR_ODR |= (GPIO1); \
+#define SWDIO_MODE_FLOAT()     \
+	do {                       \
+		SWDIODIR_BSRR = GPIO1; \
 	} while (0)
-#define SWDIO_MODE_DRIVE()        \
-	do {                          \
-		SWDIODIR_ODR &= ~(GPIO1); \
+#define SWDIO_MODE_DRIVE()    \
+	do {                      \
+		SWDIODIR_BRR = GPIO1; \
 	} while (0)
 #else
 /* All other variants just set SWDIO_PIN to floating */


### PR DESCRIPTION
## Detailed description
This is a follow up to [PR1720](https://github.com/blackmagic-debug/blackmagic/pull/1720) where I used the Output Data Register of the GPIO peripheral, causing read modify write. Now we use BSRR and BRR which only require a single write. I benchmarked the speed(when flashing 128kb firmware file) of the probe after this patch and it seems to be very similar, however the code size is reduced by a few bytes and as we know - every byte counts

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (`make PROBE_HOST=native`)
* [x] It builds as BMDA (`make PROBE_HOST=hosted`)
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
N/A