### PR TITLE
Feature: Cortex-A/R speedups

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -542,7 +542,7 @@ static void dap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size
 	if (len == 0)
 		return;
 	const align_e align = MIN_ALIGN(src, len);
-	DEBUG_WIRE("dap_mem_read @ %" PRIx32 " len %zu, align %d\n", src, len, align);
+	DEBUG_PROBE("dap_mem_read @ %" PRIx32 " len %zu, align %d\n", src, len, align);
 	/* If the read can be done in a single transaction, use the dap_read_single() fast-path */
 	if ((1U << align) == len) {
 		dap_read_single(ap, dest, src, align);
@@ -566,7 +566,7 @@ static void dap_mem_read(adiv5_access_port_s *ap, void *dest, uint32_t src, size
 			/* blocks - i gives how many blocks are left to transfer in this 1024 byte chunk */
 			const size_t transfer_length = MIN(blocks - i, blocks_per_transfer) << align;
 			if (!dap_read_block(ap, data + offset, src + offset, transfer_length, align)) {
-				DEBUG_WIRE("mem_read failed: %u\n", ap->dp->fault);
+				DEBUG_WIRE("dap_mem_read failed: %u\n", ap->dp->fault);
 				return;
 			}
 			offset += transfer_length;
@@ -579,7 +579,7 @@ static void dap_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *sr
 {
 	if (len == 0)
 		return;
-	DEBUG_WIRE("memwrite @ %" PRIx32 " len %zu, align %d\n", dest, len, align);
+	DEBUG_PROBE("dap_mem_write @ %" PRIx32 " len %zu, align %d\n", dest, len, align);
 	/* If the write can be done in a single transaction, use the dap_write_single() fast-path */
 	if ((1U << align) == len) {
 		dap_write_single(ap, dest, src, align);
@@ -603,13 +603,13 @@ static void dap_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *sr
 			/* blocks - i gives how many blocks are left to transfer in this 1024 byte chunk */
 			const size_t transfer_length = MIN(blocks - i, blocks_per_transfer) << align;
 			if (!dap_write_block(ap, dest + offset, data + offset, transfer_length, align)) {
-				DEBUG_WIRE("mem_write failed: %u\n", ap->dp->fault);
+				DEBUG_WIRE("dap_mem_write failed: %u\n", ap->dp->fault);
 				return;
 			}
 			offset += transfer_length;
 		}
 	}
-	DEBUG_WIRE("dap_mem_write_sized transferred %zu blocks\n", len >> align);
+	DEBUG_WIRE("dap_dap_mem_write transferred %zu blocks\n", len >> align);
 
 	/* Make sure this write is complete by doing a dummy read */
 	adiv5_dp_read(ap->dp, ADIV5_DP_RDBUFF);

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -1021,8 +1021,10 @@ void ap_mem_access_setup(adiv5_access_port_s *ap, uint32_t addr, align_e align)
 		csw |= ADIV5_AP_CSW_SIZE_WORD;
 		break;
 	}
+	/* Select AP bank 0 and write CSW */
 	adiv5_ap_write(ap, ADIV5_AP_CSW, csw);
-	adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_TAR, addr);
+	/* Then write TAR which is in the same AP bank */
+	adiv5_dp_write(ap->dp, ADIV5_AP_TAR, addr);
 }
 
 /* Unpack data from the source uint32_t value based on data alignment and source address */

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -227,6 +227,8 @@
 /* Constants for the DP's quirks field */
 #define ADIV5_DP_QUIRK_MINDP    (1U << 0U) /* DP is a minimal DP implementation */
 #define ADIV5_DP_QUIRK_DUPED_AP (1U << 1U) /* DP has only 1 AP but the address decoding is bugged */
+/* This one is not a quirk, but the field's a convinient place to store this */
+#define ADIV5_AP_ACCESS_BANKED (1U << 7U) /* Last AP access was done using the banked interface */
 
 typedef struct adiv5_access_port adiv5_access_port_s;
 typedef struct adiv5_debug_port adiv5_debug_port_s;

--- a/src/target/cortex.c
+++ b/src/target/cortex.c
@@ -66,6 +66,7 @@ uint32_t cortex_dbg_read32(target_s *const target, const uint16_t src)
 	/* Translate the offset given in the src parameter into an address in the debug address space and read */
 	const cortex_priv_s *const priv = (cortex_priv_s *)target->priv;
 	adiv5_access_port_s *const ap = cortex_ap(target);
+	ap->dp->quirks &= ~ADIV5_AP_ACCESS_BANKED;
 	uint32_t result = 0;
 	adiv5_mem_read(ap, &result, priv->base_addr + src, sizeof(result));
 	return result;
@@ -76,6 +77,7 @@ void cortex_dbg_write32(target_s *const target, const uint16_t dest, const uint3
 	/* Translate the offset given int he dest parameter into an address int he debug address space and write */
 	const cortex_priv_s *const priv = (cortex_priv_s *)target->priv;
 	adiv5_access_port_s *const ap = cortex_ap(target);
+	ap->dp->quirks &= ~ADIV5_AP_ACCESS_BANKED;
 	adiv5_mem_write(ap, priv->base_addr + dest, &value, sizeof(value));
 }
 

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -396,11 +396,16 @@ static const char *cortexar_target_description(target_s *target);
 static bool cortexar_run_insn(target_s *const target, const uint32_t insn)
 {
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
-	/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
-	ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
+	if (!(priv->base.ap->dp->quirks & ADIV5_AP_ACCESS_BANKED)) {
+		priv->base.ap->dp->quirks |= ADIV5_AP_ACCESS_BANKED;
+		/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
+		ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
+		/* Selecting AP bank 1 to finish switching into banked mode */
+		adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
+	}
 
-	/* Issue the requested instruction to the core (selecting AP bank 1 in the process) */
-	adiv5_ap_write(priv->base.ap, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
+	/* Issue the requested instruction to the core */
+	adiv5_dp_write(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
 	/* Poll for the instruction to complete */
 	uint32_t status = 0;
 	while (!(status & CORTEXAR_DBG_DSCR_INSN_COMPLETE))
@@ -416,11 +421,16 @@ static bool cortexar_run_insn(target_s *const target, const uint32_t insn)
 static bool cortexar_run_read_insn(target_s *const target, const uint32_t insn, uint32_t *const result)
 {
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
-	/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
-	ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
+	if (!(priv->base.ap->dp->quirks & ADIV5_AP_ACCESS_BANKED)) {
+		priv->base.ap->dp->quirks |= ADIV5_AP_ACCESS_BANKED;
+		/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
+		ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
+		/* Selecting AP bank 1 to finish switching into banked mode */
+		adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
+	}
 
-	/* Issue the requested instruction to the core (selecting AP bank 1 in the process) */
-	adiv5_ap_write(priv->base.ap, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
+	/* Issue the requested instruction to the core */
+	adiv5_dp_write(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
 	/* Poll for the instruction to complete and the data to become ready in the DTR */
 	uint32_t status = 0;
 	while ((status & (CORTEXAR_DBG_DSCR_INSN_COMPLETE | CORTEXAR_DBG_DSCR_DTR_READ_READY)) !=
@@ -441,11 +451,16 @@ static bool cortexar_run_read_insn(target_s *const target, const uint32_t insn, 
 static bool cortexar_run_write_insn(target_s *const target, const uint32_t insn, const uint32_t data)
 {
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
-	/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
-	ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
+	if (!(priv->base.ap->dp->quirks & ADIV5_AP_ACCESS_BANKED)) {
+		priv->base.ap->dp->quirks |= ADIV5_AP_ACCESS_BANKED;
+		/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
+		ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
+		/* Selecting AP bank 1 to finish switching into banked mode */
+		adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
+	}
 
-	/* Set up the data in the DTR for the transaction (selecting AP bank 1 in the process) */
-	adiv5_ap_write(priv->base.ap, ADIV5_AP_DB(CORTEXAR_BANKED_DTRTX), data);
+	/* Set up the data in the DTR for the transaction */
+	adiv5_dp_write(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_DTRTX), data);
 	/* Poll for the data to become ready in the DTR */
 	while (!(adiv5_dp_read(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_DCSR)) & CORTEXAR_DBG_DSCR_DTR_WRITE_DONE))
 		continue;
@@ -1363,6 +1378,7 @@ static target_halt_reason_e cortexar_halt_poll(target_s *const target, target_ad
 static void cortexar_halt_resume(target_s *const target, const bool step)
 {
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
+	priv->base.ap->dp->quirks &= ~ADIV5_AP_ACCESS_BANKED;
 	/* Restore the core's registers so the running program doesn't know we've been in there */
 	cortexar_regs_restore(target);
 

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -398,11 +398,9 @@ static bool cortexar_run_insn(target_s *const target, const uint32_t insn)
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
 	/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
 	ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
-	/* Configure the bank selection to the appropriate AP register bank */
-	adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
 
-	/* Issue the requested instruction to the core */
-	adiv5_dp_write(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
+	/* Issue the requested instruction to the core (selecting AP bank 1 in the process) */
+	adiv5_ap_write(priv->base.ap, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
 	/* Poll for the instruction to complete */
 	uint32_t status = 0;
 	while (!(status & CORTEXAR_DBG_DSCR_INSN_COMPLETE))
@@ -420,11 +418,9 @@ static bool cortexar_run_read_insn(target_s *const target, const uint32_t insn, 
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
 	/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
 	ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
-	/* Configure the bank selection to the appropriate AP register bank */
-	adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
 
-	/* Issue the requested instruction to the core */
-	adiv5_dp_write(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
+	/* Issue the requested instruction to the core (selecting AP bank 1 in the process) */
+	adiv5_ap_write(priv->base.ap, ADIV5_AP_DB(CORTEXAR_BANKED_ITR), insn);
 	/* Poll for the instruction to complete and the data to become ready in the DTR */
 	uint32_t status = 0;
 	while ((status & (CORTEXAR_DBG_DSCR_INSN_COMPLETE | CORTEXAR_DBG_DSCR_DTR_READ_READY)) !=
@@ -447,11 +443,9 @@ static bool cortexar_run_write_insn(target_s *const target, const uint32_t insn,
 	cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
 	/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
 	ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
-	/* Configure the bank selection to the appropriate AP register bank */
-	adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
 
-	/* Set up the data in the DTR for the transaction */
-	adiv5_dp_write(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_DTRTX), data);
+	/* Set up the data in the DTR for the transaction (selecting AP bank 1 in the process) */
+	adiv5_ap_write(priv->base.ap, ADIV5_AP_DB(CORTEXAR_BANKED_DTRTX), data);
 	/* Poll for the data to become ready in the DTR */
 	while (!(adiv5_dp_read(priv->base.ap->dp, ADIV5_AP_DB(CORTEXAR_BANKED_DCSR)) & CORTEXAR_DBG_DSCR_DTR_WRITE_DONE))
 		continue;

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -974,7 +974,7 @@ static bool cortexar_check_error(target_s *const target)
 }
 
 /* Fast path for cortexar_mem_read(). Assumes the address to read data from is already loaded in r0. */
-static inline bool cortexr_mem_read_fast(target_s *const target, uint32_t *const dest, const size_t count)
+static inline bool cortexar_mem_read_fast(target_s *const target, uint32_t *const dest, const size_t count)
 {
 	/* Read each of the uint32_t's checking for failure */
 	for (size_t offset = 0; offset < count; ++offset) {
@@ -985,7 +985,7 @@ static inline bool cortexr_mem_read_fast(target_s *const target, uint32_t *const
 }
 
 /* Slow path for cortexar_mem_read(). Trashes r0 and r1. */
-static bool cortexr_mem_read_slow(target_s *const target, uint8_t *const data, target_addr_t addr, const size_t length)
+static bool cortexar_mem_read_slow(target_s *const target, uint8_t *const data, target_addr_t addr, const size_t length)
 {
 	size_t offset = 0;
 	/* If the address is odd, read a byte to get onto an even address */
@@ -1003,7 +1003,7 @@ static bool cortexr_mem_read_slow(target_s *const target, uint8_t *const data, t
 		offset += 2U;
 	}
 	/* Use the fast path to read as much as possible before doing a slow path fixup at the end */
-	if (!cortexr_mem_read_fast(target, (uint32_t *)(data + offset), (length - offset) >> 2U))
+	if (!cortexar_mem_read_fast(target, (uint32_t *)(data + offset), (length - offset) >> 2U))
 		return false;
 	const uint8_t remainder = (length - offset) & 3U;
 	/* If the remainder needs at least 2 more bytes read, do this first */
@@ -1022,7 +1022,7 @@ static bool cortexr_mem_read_slow(target_s *const target, uint8_t *const data, t
 	return true; /* Signal success */
 }
 
-static void cortexr_mem_handle_fault(target_s *const target, const char *const func)
+static void cortexar_mem_handle_fault(target_s *const target, const char *const func)
 {
 	const cortexar_priv_s *const priv = (cortexar_priv_s *)target->priv;
 	/* If we suffered a fault of some kind, grab the reason and restore DFSR/DFAR */
@@ -1061,11 +1061,11 @@ static void cortexar_mem_read(target_s *const target, void *const dest, const ta
 
 	/* If the address is 32-bit aligned and we're reading 32 bits at a time, use the fast path */
 	if ((src & 3U) == 0U && (len & 3U) == 0U)
-		cortexr_mem_read_fast(target, (uint32_t *)dest, len >> 2U);
+		cortexar_mem_read_fast(target, (uint32_t *)dest, len >> 2U);
 	else
-		cortexr_mem_read_slow(target, (uint8_t *)dest, src, len);
+		cortexar_mem_read_slow(target, (uint8_t *)dest, src, len);
 	/* Deal with any data faults that occurred */
-	cortexr_mem_handle_fault(target, __func__);
+	cortexar_mem_handle_fault(target, __func__);
 
 	DEBUG_PROTO("%s: Reading %zu bytes @0x%" PRIx32 ":", __func__, len, src);
 #ifndef DEBUG_PROTO_IS_NOOP
@@ -1082,7 +1082,7 @@ static void cortexar_mem_read(target_s *const target, void *const dest, const ta
 }
 
 /* Fast path for cortexar_mem_write(). Assumes the address to read data from is already loaded in r0. */
-static inline bool cortexr_mem_write_fast(target_s *const target, const uint32_t *const src, const size_t count)
+static inline bool cortexar_mem_write_fast(target_s *const target, const uint32_t *const src, const size_t count)
 {
 	/* Read each of the uint32_t's checking for failure */
 	for (size_t offset = 0; offset < count; ++offset) {
@@ -1093,7 +1093,7 @@ static inline bool cortexr_mem_write_fast(target_s *const target, const uint32_t
 }
 
 /* Slow path for cortexar_mem_write(). Trashes r0 and r1. */
-static bool cortexr_mem_write_slow(
+static bool cortexar_mem_write_slow(
 	target_s *const target, target_addr_t addr, const uint8_t *const data, const size_t length)
 {
 	size_t offset = 0;
@@ -1112,7 +1112,7 @@ static bool cortexr_mem_write_slow(
 		offset += 2U;
 	}
 	/* Use the fast path to write as much as possible before doing a slow path fixup at the end */
-	if (!cortexr_mem_write_fast(target, (uint32_t *)(data + offset), (length - offset) >> 2U))
+	if (!cortexar_mem_write_fast(target, (uint32_t *)(data + offset), (length - offset) >> 2U))
 		return false;
 	const uint8_t remainder = (length - offset) & 3U;
 	/* If the remainder needs at least 2 more bytes write, do this first */
@@ -1167,11 +1167,11 @@ static void cortexar_mem_write(
 
 	/* If the address is 32-bit aligned and we're writing 32 bits at a time, use the fast path */
 	if ((dest & 3U) == 0U && (len & 3U) == 0U)
-		cortexr_mem_write_fast(target, (const uint32_t *)src, len >> 2U);
+		cortexar_mem_write_fast(target, (const uint32_t *)src, len >> 2U);
 	else
-		cortexr_mem_write_slow(target, dest, (const uint8_t *)src, len);
+		cortexar_mem_write_slow(target, dest, (const uint8_t *)src, len);
 	/* Deal with any data faults that occurred */
-	cortexr_mem_handle_fault(target, __func__);
+	cortexar_mem_handle_fault(target, __func__);
 }
 
 static void cortexar_regs_read(target_s *const target, void *const data)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -793,26 +793,25 @@ static void cortexm_regs_read(target_s *const target, void *const data)
 		}
 	} else {
 #endif
-		/* Set up CSW for 32-bit access to allow us to read the target's registers */
-		adiv5_ap_write(ap, ADIV5_AP_CSW, ap->csw | ADIV5_AP_CSW_SIZE_WORD);
 		/*
 		 * Map the AP's banked data registers (0x10-0x1c) to the
 		 * debug registers DHCSR, DCRSR, DCRDR and DEMCR respectively
+		 * and do so for 32-bit access
 		 */
-		adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_TAR, CORTEXM_DHCSR);
+		ap_mem_access_setup(ap, CORTEXM_DHCSR, ALIGN_32BIT);
 		/* Configure the bank selection to the appropriate AP register bank */
 		adiv5_dp_write(ap->dp, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | 0x10U);
 
 		/* Walk the regnum_cortex_m array, reading the registers it specifies */
 		for (size_t i = 0; i < CORTEXM_GENERAL_REG_COUNT; ++i) {
-			adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR), regnum_cortex_m[i]);
+			adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRSR), regnum_cortex_m[i]);
 			regs[i] = adiv5_dp_read(ap->dp, ADIV5_AP_DB(DB_DCRDR));
 		}
 		/* If the device has a FPU, also walk the regnum_cortex_mf array */
 		if (target->target_options & CORTEXM_TOPT_FLAVOUR_V7MF) {
 			const size_t offset = CORTEXM_GENERAL_REG_COUNT;
 			for (size_t i = 0; i < CORTEX_FLOAT_REG_COUNT; ++i) {
-				adiv5_dp_low_access(ap->dp, ADIV5_LOW_WRITE, ADIV5_AP_DB(DB_DCRSR), regnum_cortex_mf[i]);
+				adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRSR), regnum_cortex_mf[i]);
 				regs[offset + i] = adiv5_dp_read(ap->dp, ADIV5_AP_DB(DB_DCRDR));
 			}
 		}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses some of the speed concern with Cortex-A/R targets by speeding up (at least for the firmware) accesses that involve instruction launches using the AP banked register interface to improve throughput by reducing ADIv5 protocol overhead for the DBG_ITR, DBG_DTR{T,R}X and DBG_DCSR core debug interface registers.

Tested against the Renesas RZ/A1LU, this delivers at least a 5x speed up in the firmware and 3.75x speed up in BMDA.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
