### PR TITLE
Feature: STM32 DESig UID decoder

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -91,6 +91,7 @@ SRC =              \
 	stm32l0.c      \
 	stm32l4.c      \
 	stm32g0.c      \
+	stm32_common.c \
 	renesas_ra.c   \
 	target.c       \
 	target_flash.c \

--- a/src/target/meson.build
+++ b/src/target/meson.build
@@ -252,6 +252,7 @@ target_stm = declare_dependency(
 		'stm32l0.c',
 		'stm32l4.c',
 		'stm32mp15.c',
+		'stm32_common.c',
 	),
 	dependencies: target_stm_deps,
 )

--- a/src/target/stm32_common.c
+++ b/src/target/stm32_common.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+ * Written by ALTracer <tolstov_den@mail.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "stm32_common.h"
+#include "buffer_utils.h"
+
+typedef struct stm32_uid_fields {
+	uint16_t wafer_xcoord;
+	uint16_t wafer_ycoord;
+	uint8_t wafer_number;
+	uint8_t lot_number[7];
+} stm32_uid_s;
+
+/*
+ * Print the Unique device ID.
+ * Can be reused for other STM32 devices with uid_base as parameter.
+ */
+bool stm32_uid(target_s *const target, const target_addr_t uid_base)
+{
+	char uid_hex[25] = {0};
+	uint8_t uid_bytes[12] = {0};
+	if (target_mem32_read(target, uid_bytes, uid_base, 12))
+		return false;
+
+	for (size_t i = 0; i < 12U; i += 4U) {
+		const uint32_t value = read_le4(uid_bytes, i);
+		//utoa_upper(value, &uid_hex[i * 2U], 16);
+		snprintf(uid_hex + i * 2U, 9, "%08" PRIX32, value);
+	}
+	tc_printf(target, "0x%s\n", uid_hex);
+
+	stm32_uid_s uid;
+	uid.wafer_xcoord = read_le2(uid_bytes, 0);
+	uid.wafer_ycoord = read_le2(uid_bytes, 2);
+	uid.wafer_number = uid_bytes[4];
+	memcpy(uid.lot_number, &uid_bytes[5], 7);
+
+	tc_printf(target, "Wafer coords X=%u, Y=%u, number %u; Lot number %.7s\n", uid.wafer_xcoord, uid.wafer_ycoord,
+		uid.wafer_number, uid.lot_number);
+	return true;
+}

--- a/src/target/stm32_common.h
+++ b/src/target/stm32_common.h
@@ -59,4 +59,6 @@ static inline bool stm32_psize_from_string(target_s *t, const char *const str, a
 	return true;
 }
 
+bool stm32_uid(target_s *const target, target_addr_t uid_base);
+
 #endif /*TARGET_STM32_COMMON_H*/

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -42,11 +42,14 @@
 #include "target_internal.h"
 #include "cortexm.h"
 #include "jep106.h"
+#include "stm32_common.h"
 
 static bool stm32f1_cmd_option(target_s *target, int argc, const char **argv);
+static bool stm32f1_cmd_uid(target_s *target, int argc, const char **argv);
 
 const command_s stm32f1_cmd_list[] = {
 	{"option", stm32f1_cmd_option, "Manipulate option bytes"},
+	{"uid", stm32f1_cmd_uid, "Print unique device ID"},
 	{NULL, NULL, NULL},
 };
 
@@ -97,6 +100,9 @@ static bool stm32f1_mass_erase(target_s *target);
 #define DBGMCU_IDCODE        0xe0042000U
 #define DBGMCU_IDCODE_F0     0x40015800U
 #define DBGMCU_IDCODE_GD32E5 0xe0044000U
+
+#define STM32F3_UID_BASE 0x1ffff7acU
+#define STM32F1_UID_BASE 0x1ffff7e8U
 
 #define GD32Fx_FLASHSIZE 0x1ffff7e0U
 #define GD32F0_FLASHSIZE 0x1ffff7ccU
@@ -922,4 +928,15 @@ static bool stm32f1_cmd_option(target_s *target, int argc, const char **argv)
 	}
 
 	return true;
+}
+
+static bool stm32f1_cmd_uid(target_s *target, int argc, const char **argv)
+{
+	(void)argc;
+	(void)argv;
+	target_addr_t uid_base = STM32F1_UID_BASE;
+	/* These parts have their UID elsewhere */
+	if (stm32f1_flash_readable_key(target) == FLASH_OBP_RDP_KEY_F3)
+		uid_base = STM32F3_UID_BASE;
+	return stm32_uid(target, uid_base);
 }

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -40,10 +40,12 @@
 
 static bool stm32f4_cmd_option(target_s *target, int argc, const char **argv);
 static bool stm32f4_cmd_psize(target_s *target, int argc, const char **argv);
+static bool stm32f4_cmd_uid(target_s *target, int argc, const char **argv);
 
 const command_s stm32f4_cmd_list[] = {
 	{"option", stm32f4_cmd_option, "Manipulate option bytes"},
 	{"psize", stm32f4_cmd_psize, "Configure flash write parallelism: (x8|x16|x32(default)|x64)"},
+	{"uid", stm32f4_cmd_uid, "Print unique device ID"},
 	{NULL, NULL, NULL},
 };
 
@@ -97,8 +99,11 @@ static bool stm32f4_mass_erase(target_s *target);
 #define SR_ERROR_MASK 0xf2U
 #define SR_EOP        0x01U
 
+#define F4_UID_BASE    0x1fff7a10U
 #define F4_FLASHSIZE   0x1fff7a22U
+#define F7_UID_BASE    0x1ff0f420U
 #define F7_FLASHSIZE   0x1ff0f442U
+#define F72X_UID_BASE  0x1ff07a10U
 #define F72X_FLASHSIZE 0x1ff07a22U
 
 #define STM32F4_DBGMCU_BASE   0xe0042000U
@@ -791,4 +796,25 @@ static bool stm32f4_cmd_psize(target_s *target, int argc, const char **argv)
 		((stm32f4_priv_s *)target->target_storage)->psize = psize;
 	}
 	return true;
+}
+
+static bool stm32f4_cmd_uid(target_s *target, int argc, const char **argv)
+{
+	(void)argc;
+	(void)argv;
+	target_addr_t uid_base = 0;
+
+	switch (target->part_id) {
+	case ID_STM32F72X:
+		uid_base = F72X_UID_BASE;
+		break;
+	case ID_STM32F74X:
+	case ID_STM32F76X:
+		uid_base = F7_UID_BASE;
+		break;
+	default: /* including STM32F2, STM32F4; and GD32F4 */
+		uid_base = F4_UID_BASE;
+		break;
+	}
+	return stm32_uid(target, uid_base);
 }

--- a/src/target/stm32h5.c
+++ b/src/target/stm32h5.c
@@ -46,6 +46,7 @@
 #include "target.h"
 #include "target_internal.h"
 #include "cortex.h"
+#include "stm32_common.h"
 
 /* Memory map constants for STM32H5xx */
 #define STM32H5_FLASH_BANK1_BASE 0x08000000U
@@ -304,14 +305,7 @@ static bool stm32h5_cmd_uid(target_s *target, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
-	tc_printf(target, "0x");
-	for (size_t i = 0U; i < 12U; i += 4U) {
-		const uint32_t value = target_mem32_read32(target, STM32H5_UID_BASE + i);
-		tc_printf(target, "%02X%02X%02X%02X", (value >> 24U) & 0xffU, (value >> 16U) & 0xffU, (value >> 8U) & 0xffU,
-			value & 0xffU);
-	}
-	tc_printf(target, "\n");
-	return true;
+	return stm32_uid(target, STM32H5_UID_BASE);
 }
 
 static const struct {

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -619,25 +619,12 @@ static uint32_t stm32h7_part_uid_addr(target_s *const target)
 	return 0x1ff1e800U;
 }
 
-/*
- * Print the Unique device ID.
- * Can be reused for other STM32 devices with uid as parameter.
- */
 static bool stm32h7_uid(target_s *target, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
-
 	const uint32_t uid_addr = stm32h7_part_uid_addr(target);
-
-	tc_printf(target, "0x");
-	for (size_t i = 0; i < 12U; i += 4U) {
-		const uint32_t value = target_mem32_read32(target, uid_addr + i);
-		tc_printf(target, "%02X%02X%02X%02X", (value >> 24U) & 0xffU, (value >> 16U) & 0xffU, (value >> 8U) & 0xffU,
-			value & 0xffU);
-	}
-	tc_printf(target, "\n");
-	return true;
+	return stm32_uid(target, uid_addr);
 }
 
 static bool stm32h7_crc_bank(target_s *target, uint32_t addr)

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -52,7 +52,6 @@
 #include "target.h"
 #include "target_internal.h"
 #include "cortexm.h"
-#include "gdb_packet.h"
 
 static bool stm32l4_cmd_erase_bank1(target_s *t, int argc, const char **argv);
 static bool stm32l4_cmd_erase_bank2(target_s *t, int argc, const char **argv);
@@ -820,9 +819,9 @@ static bool stm32l4_cmd_erase_bank1(target_s *const t, const int argc, const cha
 {
 	(void)argc;
 	(void)argv;
-	gdb_outf("Erasing bank %u: ", 1U);
+	tc_printf(t, "Erasing bank %u: ", 1U);
 	const bool result = stm32l4_cmd_erase(t, FLASH_CR_MER1);
-	gdb_out("done\n");
+	tc_printf(t, "done\n");
 	return result;
 }
 
@@ -830,9 +829,9 @@ static bool stm32l4_cmd_erase_bank2(target_s *const t, const int argc, const cha
 {
 	(void)argc;
 	(void)argv;
-	gdb_outf("Erasing bank %u: ", 2U);
+	tc_printf(t, "Erasing bank %u: ", 2U);
 	const bool result = stm32l4_cmd_erase(t, FLASH_CR_MER2);
-	gdb_out("done\n");
+	tc_printf(t, "done\n");
 	return result;
 }
 

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -46,16 +46,18 @@
  * - https://www.st.com/resource/en/reference_manual/rm0434-multiprotocol-wireless-32bit-mcu-armbased-cortexm4-with-fpu-bluetooth-lowenergy-and-802154-radio-solution-stmicroelectronics.pdf
  */
 
-#include <limits.h>
-#include <assert.h>
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
 #include "cortexm.h"
+#include "stm32_common.h"
+#include <limits.h>
+#include <assert.h>
 
 static bool stm32l4_cmd_erase_bank1(target_s *t, int argc, const char **argv);
 static bool stm32l4_cmd_erase_bank2(target_s *t, int argc, const char **argv);
 static bool stm32l4_cmd_option(target_s *t, int argc, const char **argv);
+static bool stm32l4_cmd_uid(target_s *t, int argc, const char **argv);
 
 static bool stm32l4_attach(target_s *t);
 static void stm32l4_detach(target_s *t);
@@ -67,6 +69,7 @@ const command_s stm32l4_cmd_list[] = {
 	{"erase_bank1", stm32l4_cmd_erase_bank1, "Erase entire bank1 flash memory"},
 	{"erase_bank2", stm32l4_cmd_erase_bank2, "Erase entire bank2 flash memory"},
 	{"option", stm32l4_cmd_option, "Manipulate option bytes"},
+	{"uid", stm32l4_cmd_uid, "Print unique device ID"},
 	{NULL, NULL, NULL},
 };
 
@@ -137,6 +140,7 @@ const command_s stm32l4_cmd_list[] = {
 #define STM32L4_DBGMCU_IDCODE_PHYS 0xe0042000U
 #define STM32L5_DBGMCU_IDCODE_PHYS 0xe0044000U
 
+#define STM32L4_UID_BASE       0x1fff7590U
 #define STM32L4_FLASH_SIZE_REG 0x1fff75e0U
 #define STM32L5_FLASH_SIZE_REG 0x0bfa05e0U
 #define STM32U5_FLASH_SIZE_REG 0x0bfa07a0U
@@ -983,4 +987,12 @@ static bool stm32l4_cmd_option(target_s *t, int argc, const char **argv)
 		tc_printf(t, "0x%08X: 0x%08X\n", addr, val);
 	}
 	return true;
+}
+
+/* Read and decode Unique Device ID register of L4 and G4 */
+static bool stm32l4_cmd_uid(target_s *t, int argc, const char **argv)
+{
+	(void)argc;
+	(void)argv;
+	return stm32_uid(t, STM32L4_UID_BASE);
 }

--- a/src/target/stm32mp15.c
+++ b/src/target/stm32mp15.c
@@ -186,14 +186,16 @@ static bool stm32mp15_uid(target_s *const target, const int argc, const char **c
 	(void)argc;
 	(void)argv;
 	uint32_t values[3] = {0};
-	tc_printf(target, "0x");
+	char uid_hex[25] = {0};
+
 	for (size_t i = 0; i < 12U; i += 4U) {
 		const uint32_t value = target_mem32_read32(target, STM32MP15_UID_BASE + i);
-		tc_printf(target, "%02X%02X%02X%02X", (value >> 24U) & 0xffU, (value >> 16U) & 0xffU, (value >> 8U) & 0xffU,
-			value & 0xffU);
+		/* XXX: use utoa_upper? */
+		snprintf(uid_hex + i * 2U, 9, "%02" PRIX32 "%02" PRIX32 "%02" PRIX32 "%02" PRIX32, (value >> 24U) & 0xffU,
+			(value >> 16U) & 0xffU, (value >> 8U) & 0xffU, value & 0xffU);
 		values[i / 4U] = value;
 	}
-	tc_printf(target, "\n");
+	tc_printf(target, "0x%s\n", uid_hex);
 
 	stm32mp15x_uid_s uid;
 	memcpy(&uid, values, 12U);


### PR DESCRIPTION
## Detailed description

* This is a new feature expanding the existing stm32{h7,mp15} (potentially h5) UID-printing targe commands.
* The existing problems are plain hex in multiple O-packet and unused pattern/decode info.
* This PR solves these by buffering hex into a stack `char[]` (sprintf) and adding a small parser/decoder based on info from RMs.

TODO includes migrating sprintf usage to utoa (upper or lower) and testing the decoder on other families like STM32F4/F2/F7 which also include a Digital Electronic Signature containing Lot and Wafer info.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
