### PR TITLE
riscv: make the debugger stop on ebreak

### DIFF
--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -107,9 +107,10 @@
 #define RV_VENDOR_JEP106_CONT_MASK 0x7fffff80U
 #define RV_VENDOR_JEP106_CODE_MASK 0x7fU
 
-#define RV_DCSR_STEP       0x00000004U
-#define RV_DCSR_CAUSE_MASK 0x000001c0U
-#define RV_DCSR_STEPIE     0x00000800U
+#define RV_DCSR_STEP           0x00000004U
+#define RV_DCSR_CAUSE_MASK     0x000001c0U
+#define RV_DCSR_STEPIE         0x00000800U
+#define RV_DCSR_EBREAK_MACHINE 0x00008000U
 
 #define RV_GPRS_COUNT 32U
 
@@ -832,8 +833,10 @@ static void riscv_halt_resume(target_s *target, const bool step)
 		return;
 	if (step)
 		stepping_config |= RV_DCSR_STEP | RV_DCSR_STEPIE;
-	else
+	else {
 		stepping_config &= ~(RV_DCSR_STEP | RV_DCSR_STEPIE);
+		stepping_config |= RV_DCSR_EBREAK_MACHINE;
+	}
 	if (!riscv_csr_write(hart, RV_DCSR | RV_CSR_FORCE_32_BIT, &stepping_config))
 		return;
 	/* Request the hart to resume */


### PR DESCRIPTION
riscv: make the debugger stop on ebreak


## Detailed description

This is a temptative bugfix for the (*)ebreak statement not working with the blackmagic probe
Without the modification, the ebreak is completely ignored.
This is problematic for flashstub and for chips that do not have triggers at all  (e.g. ch32v20x and ch32v00x)
The patch just enables the ebreak stop in the debug register. Not sure it is the righ way to do it but it works for me.

## Your checklist for this pull request

* [x ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [ x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ out of flash but not related to my patch ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
I'm using a custom blackmagic build which has native support for the CH32Vxxx chips. Cannot test that with normal BMP at the moment. It works with my build.
* [ x] My commit messages provide a useful short description of what the commits do
