### PR TITLE
s32k3xx: fix debug logging format

### DIFF
--- a/src/target/s32k3xx.c
+++ b/src/target/s32k3xx.c
@@ -221,7 +221,7 @@ static bool s32k3xx_flash_trigger_mcr(target_flash_s *const flash, uint32_t mcr_
 	}
 
 	if ((mcrs & 0xffff0000U) > 0U) {
-		DEBUG_ERROR("Operation failed, MCRS: %x\n", mcrs);
+		DEBUG_ERROR("Operation failed, MCRS: %" PRIx32 "\n", mcrs);
 		return false;
 	}
 	return true;


### PR DESCRIPTION
## Detailed description

printf-style formatting should use standard format strings in order to keep code portable across architectures.

This fixes the build on Xtensa targets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do