### PR TITLE
riscv : fix the inverted logc interrupt-are-disabled-while-single-ste…

### DIFF
--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -132,6 +132,8 @@
 #define RV_DCSR_CAUSE_MASK     0x000001c0U
 #define RV_DCSR_STEPIE         0x00000800U
 #define RV_DCSR_EBREAK_MACHINE 0x00008000U
+#define RV_DCSR_STOP_TIME      (1U << 9)
+#define RV_DCSR_STOP_COUNT     (1U << 10)
 
 #define RV_GPRS_COUNT 32U
 
@@ -1014,9 +1016,9 @@ static void riscv_halt_resume(target_s *target, const bool step)
 	if (!riscv_csr_read(hart, RV_DCSR | RV_CSR_FORCE_32_BIT, &stepping_config))
 		return;
 	if (step)
-		stepping_config |= RV_DCSR_STEP | RV_DCSR_STEPIE;
+		stepping_config |= RV_DCSR_STEP | RV_DCSR_STOP_TIME | RV_DCSR_STOP_COUNT;
 	else {
-		stepping_config &= ~(RV_DCSR_STEP | RV_DCSR_STEPIE);
+		stepping_config &= ~(RV_DCSR_STEP);
 		stepping_config |= RV_DCSR_EBREAK_MACHINE;
 	}
 	if (!riscv_csr_write(hart, RV_DCSR | RV_CSR_FORCE_32_BIT, &stepping_config))


### PR DESCRIPTION
## Detailed description

There is a small inverted logic in the "disable-interrupt-while-single-stepping" code
The STEPIE bit actually enables the interrupt while single stepping
The change inverts the logic (and let is "off" when leaving single step mode)
With that patch you dont go into timer interrupt as soon as you hit next with gdb
(on some platforms that bit is glued to zero, so the problem may not show)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ till link] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [X] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [X] I've tested it to the best of my ability : on ch32v30x
* [x] My commit messages provide a useful short description of what the commits do

