### PR TITLE
Fix: SAMD/SAMx5x part idententification

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -377,7 +377,7 @@ static uint32_t adiv5_ap_read_id(adiv5_access_port_s *ap, uint32_t addr)
 	return res;
 }
 
-uint64_t adiv5_ap_read_pidr(adiv5_access_port_s *ap, uint32_t addr)
+static uint64_t adiv5_ap_read_pidr(adiv5_access_port_s *ap, uint32_t addr)
 {
 	uint64_t pidr = adiv5_ap_read_id(ap, addr + PIDR4_OFFSET);
 	pidr = pidr << 32U | adiv5_ap_read_id(ap, addr + PIDR0_OFFSET);

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -396,7 +396,6 @@ bool bmda_swd_dp_init(adiv5_debug_port_s *dp);
 #endif
 
 void adiv5_mem_write(adiv5_access_port_s *ap, uint32_t dest, const void *src, size_t len);
-uint64_t adiv5_ap_read_pidr(adiv5_access_port_s *ap, uint32_t addr);
 void *adiv5_unpack_data(void *dest, uint32_t src, uint32_t val, align_e align);
 const void *adiv5_pack_data(uint32_t dest, const void *src, uint32_t *data, align_e align);
 

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -115,8 +115,6 @@ const command_s samd_cmd_list[] = {
 #define SAMD_DSU_ADDRESS    (SAMD_DSU_EXT_ACCESS + 0x4U)
 #define SAMD_DSU_LENGTH     (SAMD_DSU_EXT_ACCESS + 0x8U)
 #define SAMD_DSU_DID        (SAMD_DSU_EXT_ACCESS + 0x018U)
-#define SAMD_DSU_PID        (SAMD_DSU + 0x1000U)
-#define SAMD_DSU_CID        (SAMD_DSU + 0x1010U)
 
 /* Control and Status Register (CTRLSTAT) */
 #define SAMD_CTRL_CHIP_ERASE (1U << 4U)
@@ -141,12 +139,7 @@ const command_s samd_cmd_list[] = {
 #define SAMD_DID_FAMILY_MASK   0x1fU
 #define SAMD_DID_FAMILY_POS    23U
 
-/* Peripheral ID */
-#define SAMD_PID_MASK        0x00f7ffffU
-#define SAMD_PID_CONST_VALUE 0x0001fcd0U
-
-/* Component ID */
-#define SAMD_CID_VALUE 0xb105100dU
+#define ID_SAMD 0xcd0U
 
 /* Family parts */
 typedef struct samd_part {
@@ -516,12 +509,8 @@ typedef struct samd_priv {
 
 bool samd_probe(target_s *t)
 {
-	adiv5_access_port_s *ap = cortex_ap(t);
-	const uint32_t cid = adiv5_ap_read_pidr(ap, SAMD_DSU_CID);
-	const uint32_t pid = adiv5_ap_read_pidr(ap, SAMD_DSU_PID);
-
-	/* Check the ARM Coresight Component and Peripheral IDs */
-	if (cid != SAMD_CID_VALUE || (pid & SAMD_PID_MASK) != SAMD_PID_CONST_VALUE)
+	/* Check the part number is the SAMD part number */
+	if (t->part_id != ID_SAMD)
 		return false;
 
 	/* Read the Device ID */

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -111,9 +111,9 @@ const command_s samd_cmd_list[] = {
 
 #define SAMD_DSU            0x41002000U
 #define SAMD_DSU_EXT_ACCESS (SAMD_DSU + 0x100U)
-#define SAMD_DSU_CTRLSTAT   (SAMD_DSU_EXT_ACCESS + 0x0U)
-#define SAMD_DSU_ADDRESS    (SAMD_DSU_EXT_ACCESS + 0x4U)
-#define SAMD_DSU_LENGTH     (SAMD_DSU_EXT_ACCESS + 0x8U)
+#define SAMD_DSU_CTRLSTAT   (SAMD_DSU_EXT_ACCESS + 0x000U)
+#define SAMD_DSU_ADDRESS    (SAMD_DSU_EXT_ACCESS + 0x004U)
+#define SAMD_DSU_LENGTH     (SAMD_DSU_EXT_ACCESS + 0x008U)
 #define SAMD_DSU_DID        (SAMD_DSU_EXT_ACCESS + 0x018U)
 
 /* Control and Status Register (CTRLSTAT) */

--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -141,8 +141,6 @@ const command_s samx5x_cmd_list[] = {
 #define SAMX5X_DSU_LENGTH     (SAMX5X_DSU_EXT_ACCESS + 0x08U)
 #define SAMX5X_DSU_DATA       (SAMX5X_DSU_EXT_ACCESS + 0x0cU)
 #define SAMX5X_DSU_DID        (SAMX5X_DSU_EXT_ACCESS + 0x18U)
-#define SAMX5X_DSU_PID        (SAMX5X_DSU + 0x1000U)
-#define SAMX5X_DSU_CID        (SAMX5X_DSU + 0x1010U)
 
 /* Control and Status Register (CTRLSTAT) */
 #define SAMX5X_CTRL_CHIP_ERASE (1U << 4U)
@@ -180,12 +178,7 @@ const command_s samx5x_cmd_list[] = {
 #define SAMX5X_DID_SERIES_MASK   0x3fU
 #define SAMX5X_DID_SERIES_POS    16U
 
-/* Peripheral ID */
-#define SAMX5X_PID_MASK        0x00f7ffffU
-#define SAMX5X_PID_CONST_VALUE 0x0001fcd0U
-
-/* Component ID */
-#define SAMX5X_CID_VALUE 0xb105100dU
+#define ID_SAMX5X 0xcd0U
 
 /*
  * Overloads the default cortexm reset function with a version that
@@ -318,12 +311,8 @@ typedef struct samx5x_priv {
 
 bool samx5x_probe(target_s *t)
 {
-	adiv5_access_port_s *ap = cortex_ap(t);
-	const uint32_t cid = adiv5_ap_read_pidr(ap, SAMX5X_DSU_CID);
-	const uint32_t pid = adiv5_ap_read_pidr(ap, SAMX5X_DSU_PID);
-
-	/* Check the ARM Coresight Component and Peripheral IDs */
-	if (cid != SAMX5X_CID_VALUE || (pid & SAMX5X_PID_MASK) != SAMX5X_PID_CONST_VALUE)
+	/* Check the part number is the SAMx5x part number */
+	if (t->part_id != ID_SAMX5X)
 		return false;
 
 	/* Read the Device ID */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In response to a user report in Discord of troubles with part identification on an ATSAMD21E18A, we took a look into how the SAMD support code identifies parts that might be ATSAMD's and saw it manually reading out the DSU component and peripheral identifiers rather than using the information already in the target structure.

This PR replaces this logic by the normal target structure values which match up and are already checked. It does the same for the SAMx5x support as this does identical things to check for those devices.

Tested working on an ATSAMD11D14AM. We have no reason to suspect this will create any kind of regressions.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
