### PR TITLE
libgpiod based BMDA gpio bitbang backend

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -84,3 +84,8 @@ option(
 	value: '0',
 	description: 'Alternative pinout for probe (only applicable to blackpill-f4*)'
 )
+option(
+	'enable_gpiod',
+	type: 'feature',
+	value: 'auto'
+)

--- a/src/include/jtagtap.h
+++ b/src/include/jtagtap.h
@@ -75,8 +75,7 @@ extern jtag_proc_s jtag_proc;
 
 #if PC_HOSTED == 1
 bool bmda_jtag_init(void);
-#else
-void jtagtap_init(void);
 #endif
+void jtagtap_init(void);
 
 #endif /* INCLUDE_JTAGTAP_H */

--- a/src/platforms/hosted/bmda_gpiod.c
+++ b/src/platforms/hosted/bmda_gpiod.c
@@ -117,3 +117,11 @@ void bmda_gpiod_mode_output(struct gpiod_line *pin)
 	} else
 		DEBUG_ERROR("BUG! attempt to set uninit GPIO to output");
 }
+
+bool bmda_gpiod_init(bmda_cli_options_s *const cl_opts)
+{
+	if (!cl_opts->opt_gpio_map)
+		return false;
+
+	return false;
+}

--- a/src/platforms/hosted/bmda_gpiod.c
+++ b/src/platforms/hosted/bmda_gpiod.c
@@ -237,3 +237,13 @@ bool bmda_gpiod_init(bmda_cli_options_s *const cl_opts)
 
 	return bmda_gpiod_jtag_ok || bmda_gpiod_swd_ok;
 }
+
+bool bmda_gpiod_swd_init(void)
+{
+	if (!bmda_gpiod_swd_ok)
+		return false;
+
+	swdptap_init();
+
+	return true;
+}

--- a/src/platforms/hosted/bmda_gpiod.c
+++ b/src/platforms/hosted/bmda_gpiod.c
@@ -51,9 +51,25 @@ struct gpiod_line *bmda_gpiod_swclk_pin;
 
 uint32_t target_clk_divider = UINT32_MAX;
 
+static void bmda_gpiod_debug_pin(struct gpiod_line *line, const char *op, bool print, bool val)
+{
+#ifdef DEBUG
+	DEBUG_WIRE("GPIO %s %s", gpiod_line_consumer(line), op);
+	if (print)
+		DEBUG_WIRE("=%d", val);
+	DEBUG_WIRE("\n");
+#else
+	(void)line;
+	(void)op;
+	(void)print;
+	(void)val;
+#endif
+}
+
 void bmda_gpiod_set_pin(struct gpiod_line *pin, bool val)
 {
 	if (pin) {
+		bmda_gpiod_debug_pin(pin, "set", true, val);
 		if (gpiod_line_set_value(pin, val ? 1 : 0)) {
 			DEBUG_ERROR("Failed to set pin to value %d errno: %d", val, errno);
 			exit(1);
@@ -70,6 +86,7 @@ bool bmda_gpiod_get_pin(struct gpiod_line *pin)
 			DEBUG_ERROR("Failed to get pin value errno: %d", errno);
 			exit(1);
 		}
+		bmda_gpiod_debug_pin(pin, "read", true, ret);
 		return ret;
 	} else {
 		DEBUG_ERROR("BUG! attempt to read uninit GPIO");
@@ -80,6 +97,7 @@ bool bmda_gpiod_get_pin(struct gpiod_line *pin)
 void bmda_gpiod_mode_input(struct gpiod_line *pin)
 {
 	if (pin) {
+		bmda_gpiod_debug_pin(pin, "input", false, false);
 		if (gpiod_line_set_direction_input(pin)) {
 			DEBUG_ERROR("Failed to set pin to input errno: %d", errno);
 			exit(1);
@@ -91,6 +109,7 @@ void bmda_gpiod_mode_input(struct gpiod_line *pin)
 void bmda_gpiod_mode_output(struct gpiod_line *pin)
 {
 	if (pin) {
+		bmda_gpiod_debug_pin(pin, "output", false, false);
 		if (gpiod_line_set_direction_output(pin, 0)) {
 			DEBUG_ERROR("Failed to set pin to output errno: %d", errno);
 			exit(1);

--- a/src/platforms/hosted/bmda_gpiod.c
+++ b/src/platforms/hosted/bmda_gpiod.c
@@ -238,6 +238,16 @@ bool bmda_gpiod_init(bmda_cli_options_s *const cl_opts)
 	return bmda_gpiod_jtag_ok || bmda_gpiod_swd_ok;
 }
 
+bool bmda_gpiod_jtag_init(void)
+{
+	if (!bmda_gpiod_jtag_ok)
+		return false;
+
+	jtagtap_init();
+
+	return true;
+}
+
 bool bmda_gpiod_swd_init(void)
 {
 	if (!bmda_gpiod_swd_ok)

--- a/src/platforms/hosted/bmda_gpiod.c
+++ b/src/platforms/hosted/bmda_gpiod.c
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Written by OmniTechnoMancer <OmniTechnoMancer@wah.quest>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Implement libgpiod based GPIO backend */
+
+#include "bmda_gpiod.h"

--- a/src/platforms/hosted/bmda_gpiod.h
+++ b/src/platforms/hosted/bmda_gpiod.h
@@ -38,6 +38,7 @@
 
 bool bmda_gpiod_init(bmda_cli_options_s *const cl_opts);
 
+bool bmda_gpiod_jtag_init(void);
 bool bmda_gpiod_swd_init(void);
 
 #endif

--- a/src/platforms/hosted/bmda_gpiod.h
+++ b/src/platforms/hosted/bmda_gpiod.h
@@ -34,4 +34,8 @@
 #ifndef BMDA_GPIOD_H
 #define BMDA_GPIOD_H
 
+#include "cli.h"
+
+bool bmda_gpiod_init(bmda_cli_options_s *const cl_opts);
+
 #endif

--- a/src/platforms/hosted/bmda_gpiod.h
+++ b/src/platforms/hosted/bmda_gpiod.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Written by OmniTechnoMancer <OmniTechnoMancer@wah.quest>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef BMDA_GPIOD_H
+#define BMDA_GPIOD_H
+
+#endif

--- a/src/platforms/hosted/bmda_gpiod.h
+++ b/src/platforms/hosted/bmda_gpiod.h
@@ -38,4 +38,6 @@
 
 bool bmda_gpiod_init(bmda_cli_options_s *const cl_opts);
 
+bool bmda_gpiod_swd_init(void);
+
 #endif

--- a/src/platforms/hosted/bmda_gpiod_platform.h
+++ b/src/platforms/hosted/bmda_gpiod_platform.h
@@ -31,70 +31,43 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Implement libgpiod based GPIO backend */
+#ifndef BMDA_GPIOD_PLATFORM_H
+#define BMDA_GPIOD_PLATFORM_H
 
-#include <gpiod.h>
-#include "general.h"
-#include <errno.h>
-#include <limits.h>
 #include <stdbool.h>
 
-#include "bmda_gpiod.h"
+typedef struct gpiod_line gpiod_line_s;
 
-struct gpiod_line *bmda_gpiod_tck_pin;
-struct gpiod_line *bmda_gpiod_tms_pin;
-struct gpiod_line *bmda_gpiod_tdi_pin;
-struct gpiod_line *bmda_gpiod_tdo_pin;
+void bmda_gpiod_set_pin(gpiod_line_s *pin, bool val);
+bool bmda_gpiod_get_pin(gpiod_line_s *pin);
 
-struct gpiod_line *bmda_gpiod_swdio_pin;
-struct gpiod_line *bmda_gpiod_swclk_pin;
+void bmda_gpiod_mode_input(gpiod_line_s *pin);
+void bmda_gpiod_mode_output(gpiod_line_s *pin);
 
-uint32_t target_clk_divider = UINT32_MAX;
+#define TMS_SET_MODE() \
+	do {               \
+	} while (false)
 
-void bmda_gpiod_set_pin(struct gpiod_line *pin, bool val)
-{
-	if (pin) {
-		if (gpiod_line_set_value(pin, val ? 1 : 0)) {
-			DEBUG_ERROR("Failed to set pin to value %d errno: %d", val, errno);
-			exit(1);
-		}
-	} else
-		DEBUG_ERROR("BUG! attempt to write uninit GPIO");
-}
+#define gpio_set(port, pin)          bmda_gpiod_set_pin(pin, true)
+#define gpio_clear(port, pin)        bmda_gpiod_set_pin(pin, false)
+#define gpio_get(port, pin)          bmda_gpiod_get_pin(pin)
+#define gpio_set_val(port, pin, val) bmda_gpiod_set_pin(pin, val)
 
-bool bmda_gpiod_get_pin(struct gpiod_line *pin)
-{
-	if (pin) {
-		int ret = gpiod_line_get_value(pin);
-		if (ret < 0) {
-			DEBUG_ERROR("Failed to get pin value errno: %d", errno);
-			exit(1);
-		}
-		return ret;
-	} else {
-		DEBUG_ERROR("BUG! attempt to read uninit GPIO");
-		exit(1);
-	}
-}
+extern gpiod_line_s *bmda_gpiod_tck_pin;
+#define TCK_PIN bmda_gpiod_tck_pin
+extern gpiod_line_s *bmda_gpiod_tms_pin;
+#define TMS_PIN bmda_gpiod_tms_pin
+extern gpiod_line_s *bmda_gpiod_tdi_pin;
+#define TDI_PIN bmda_gpiod_tdi_pin
+extern gpiod_line_s *bmda_gpiod_tdo_pin;
+#define TDO_PIN bmda_gpiod_tdo_pin
 
-void bmda_gpiod_mode_input(struct gpiod_line *pin)
-{
-	if (pin) {
-		if (gpiod_line_set_direction_input(pin)) {
-			DEBUG_ERROR("Failed to set pin to input errno: %d", errno);
-			exit(1);
-		}
-	} else
-		DEBUG_ERROR("BUG! attempt to set uninit GPIO to input");
-}
+extern gpiod_line_s *bmda_gpiod_swdio_pin;
+#define SWDIO_PIN bmda_gpiod_swdio_pin
+extern gpiod_line_s *bmda_gpiod_swclk_pin;
+#define SWCLK_PIN bmda_gpiod_swclk_pin
 
-void bmda_gpiod_mode_output(struct gpiod_line *pin)
-{
-	if (pin) {
-		if (gpiod_line_set_direction_output(pin, 0)) {
-			DEBUG_ERROR("Failed to set pin to output errno: %d", errno);
-			exit(1);
-		}
-	} else
-		DEBUG_ERROR("BUG! attempt to set uninit GPIO to output");
-}
+#define SWDIO_MODE_DRIVE() bmda_gpiod_mode_output(SWDIO_PIN)
+#define SWDIO_MODE_FLOAT() bmda_gpiod_mode_input(SWDIO_PIN)
+
+#endif

--- a/src/platforms/hosted/cli.h
+++ b/src/platforms/hosted/cli.h
@@ -67,6 +67,7 @@ typedef struct bmda_cli_options {
 	uint32_t opt_flash_start;
 	uint32_t opt_max_frequency;
 	size_t opt_flash_size;
+	char *opt_gpio_map;
 } bmda_cli_options_s;
 
 void cl_init(bmda_cli_options_s *opt, int argc, char **argv);

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -155,6 +155,9 @@ if build_machine.system() == 'linux'
 	if libgpiod.found()
 		bmda_sources += files('bmda_gpiod.c')
 		bmda_args += ['-DENABLE_GPIOD=1']
+
+		bmda_sources += files('../common/jtagtap.c',
+		                      '../common/swdptap.c')
 	endif
 else
 	libgpiod = declare_dependency()

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -144,6 +144,21 @@ libusb = dependency(
 	native: is_cross_build,
 )
 
+if build_machine.system() == 'linux'
+	libgpiod = dependency(
+		'libgpiod',
+		version: ['>=1.0.0', '<2.0.0'],
+		required: get_option('enable_gpiod'),
+		native: is_cross_build,
+	)
+
+	if libgpiod.found()
+		bmda_args += ['-DENABLE_GPIOD=1']
+	endif
+else
+	libgpiod = declare_dependency()
+endif
+
 # If we did not find all the dependencies we need, turn this into a disabler, otherwise
 # build a dependency object that describes the sources needed to build BMDA for the build platform
 if not libftdi.found() or not hidapi.found() or not libusb.found()
@@ -154,6 +169,6 @@ else
 		sources: bmda_sources,
 		compile_args: cc.get_supported_arguments(bmda_args),
 		link_args: bmda_link_args,
-		dependencies: [libbmd_core, bmda_deps, libftdi, hidapi, libusb],
+		dependencies: [libbmd_core, bmda_deps, libftdi, hidapi, libusb, libgpiod],
 	)
 endif

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -153,6 +153,7 @@ if build_machine.system() == 'linux'
 	)
 
 	if libgpiod.found()
+		bmda_sources += files('bmda_gpiod.c')
 		bmda_args += ['-DENABLE_GPIOD=1']
 	endif
 else

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -53,6 +53,10 @@
 #include "cmsis_dap.h"
 #endif
 
+#ifdef ENABLE_GPIOD
+#include "bmda_gpiod.h"
+#endif
+
 bmda_probe_s bmda_probe_info;
 
 jtag_proc_s jtag_proc;
@@ -116,6 +120,8 @@ void platform_init(int argc, char **argv)
 
 	if (cl_opts.opt_device)
 		bmda_probe_info.type = PROBE_TYPE_BMP;
+	else if (cl_opts.opt_gpio_map)
+		bmda_probe_info.type = PROBE_TYPE_GPIOD;
 	else if (find_debuggers(&cl_opts, &bmda_probe_info))
 		exit(1);
 
@@ -148,6 +154,13 @@ void platform_init(int argc, char **argv)
 
 	case PROBE_TYPE_JLINK:
 		if (!jlink_init())
+			exit(1);
+		break;
+#endif
+
+#ifdef ENABLE_GPIOD
+	case PROBE_TYPE_GPIOD:
+		if (!bmda_gpiod_init(&cl_opts))
 			exit(1);
 		break;
 #endif

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -259,6 +259,9 @@ bool bmda_jtag_scan(void)
 	case PROBE_TYPE_FTDI:
 	case PROBE_TYPE_JLINK:
 	case PROBE_TYPE_CMSIS_DAP:
+#ifdef ENABLE_GPIOD
+	case PROBE_TYPE_GPIOD:
+#endif
 		return jtag_scan();
 
 #if HOSTED_BMP_ONLY == 0
@@ -289,6 +292,11 @@ bool bmda_jtag_init(void)
 
 	case PROBE_TYPE_CMSIS_DAP:
 		return dap_jtag_init();
+#endif
+
+#ifdef ENABLE_GPIOD
+	case PROBE_TYPE_GPIOD:
+		return bmda_gpiod_jtag_init();
 #endif
 
 	default:

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -338,6 +338,9 @@ char *bmda_adaptor_ident(void)
 	case PROBE_TYPE_JLINK:
 		return "J-Link";
 
+	case PROBE_TYPE_GPIOD:
+		return "GPIOD";
+
 	default:
 		return NULL;
 	}

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -59,8 +59,10 @@
 
 bmda_probe_s bmda_probe_info;
 
+#ifndef ENABLE_GPIOD
 jtag_proc_s jtag_proc;
 swd_proc_s swd_proc;
+#endif
 
 static uint32_t max_frequency = 4000000U;
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -195,6 +195,9 @@ bool bmda_swd_scan(const uint32_t targetid)
 	case PROBE_TYPE_FTDI:
 	case PROBE_TYPE_CMSIS_DAP:
 	case PROBE_TYPE_JLINK:
+#ifdef ENABLE_GPIOD
+	case PROBE_TYPE_GPIOD:
+#endif
 		return adiv5_swd_scan(targetid);
 
 #if HOSTED_BMP_ONLY == 0
@@ -228,6 +231,11 @@ bool bmda_swd_dp_init(adiv5_debug_port_s *dp)
 
 	case PROBE_TYPE_FTDI:
 		return ftdi_swd_init();
+#endif
+
+#ifdef ENABLE_GPIOD
+	case PROBE_TYPE_GPIOD:
+		return bmda_gpiod_swd_init();
 #endif
 
 	default:

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -83,7 +83,8 @@ typedef enum probe_type {
 	PROBE_TYPE_STLINK_V2,
 	PROBE_TYPE_FTDI,
 	PROBE_TYPE_CMSIS_DAP,
-	PROBE_TYPE_JLINK
+	PROBE_TYPE_JLINK,
+	PROBE_TYPE_GPIOD,
 } probe_type_e;
 
 void gdb_ident(char *p, int count);

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -89,4 +89,8 @@ typedef enum probe_type {
 
 void gdb_ident(char *p, int count);
 
+#ifdef ENABLE_GPIOD
+#include "bmda_gpiod_platform.h"
+#endif
+
 #endif /* PLATFORMS_HOSTED_PLATFORM_H */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This change adds a new backend/probe type to the "hosted"/BMDA platform which uses libgpiod to connect up the `jtagtap.c` and `swdptap.c` bitbanging routines to gpios.  This is of course linux specific.

* A meson build option is added to enable this backend, this only has an effect on linux and defaults to attempting to find the dependency but disabling the feature if libgpiod is not found.
* A new probe type for gpiod is added in the BMDA code.
* An include file is added which provides mappings from the `gpio_set`, `gpio_clear`, `gpio_get`, `gpio_set_val` routines to the libgpiod backed routines for compiling the jtagtap and swdptap code.
* A new cli option is added when the feature is enabled which allows the user to set a mapping of debug signals to GPIOs if this is specified then it is assumed that the gpio bitbanging backend is to be used.  The format of the mapping is as follows:
    <gpio_mapping>=<signal_mapping>(`,`<signal_mapping>)*
    <signal_mapping>=<debug_signal>`=`<gpio_chip_name>`:`<gpio_offset>
    Where the debug signals are `swdio`, `swclk`, `tms`, `tck`, `tdi`, `tdo` and gpio_chip_name is the name of a gpiochip character device to use and gpio_offset is the numeric offset to the required gpio on that chip.
* The swdptap and jtagtap routines in `/src/platform/common` are built into the BMDA.  This requires conditionally removing the definition of `swd_proc` and `jtag_proc` in the `hosted/platform.c` file as these are usually defined in the relevant tap files.
* The required calls to init and use the relevant routines are added to the BMDA code, this requires the `jtagtap_init` routine to be unconditionally declared by `jtagtap.h`
* The required calls to perform swd or jtag scan are added to the BMDA code.
* This backend sets `target_clk_divider` to `UINT32_MAX` in order to disable delays, the calls to the kernel to change the GPIO status appear to have somewhat significant overhead anyway so the maximum clock rate observed was on the order of kilohertz.
* Similarly no support for getting or setting a debug clock frequency is provided.
* No support for a reset line is included but could be added with a little effort.
* JTAG and SWD lines are assumed disjoint, support for sharing similarly to probe hardware could be implemented later but requires more effort.

The backend has been tested with SWD on a Radxa Rock 4 C+ to a Raspberry Pi Pico.  JTAG has not been tested at time of submitting this PR.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

fixes #1063
