### PR TITLE
Fix: Update dependencies

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build the firmware for all platform variants and full BMDA
       - name: Build all platform variants firmware and Linux BMDA
@@ -201,7 +201,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build the firmware for all platform variants and full BMDA
       - name: Build all platform variants firmware and Windows BMDA

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -93,7 +93,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build the firmware for all platform variants and BMDA in BMP-only mode
       - name: Build all platform variants firmware and BMP only BMDA
@@ -186,7 +186,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build the default BMDA configuration
       - name: Build full BMDA
@@ -264,7 +264,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build BMDA in BMP-only mode
       - name: Build BMP only BMDA
@@ -350,7 +350,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -410,7 +410,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build the default BMDA configuration
       - name: Build full BMDA
@@ -469,7 +469,7 @@ jobs:
 
       # Install BMDA's deps since they cannot be compiled with GCC
       - name: Install BMDA dependencies
-        run: brew install libusb libftdi hidapi 
+        run: brew install libusb libftdi hidapi
 
       # Record the versions of all the tools used in the build
       - name: Version tools
@@ -482,7 +482,7 @@ jobs:
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build the default BMDA configuration
       - name: Build full BMDA
@@ -500,12 +500,12 @@ jobs:
         with:
           release: '12.2.Rel1'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
           path: base
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: head

--- a/deps/hidapi.wrap
+++ b/deps/hidapi.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
-url = https://github.com/libusb/hidapi
-revision = HEAD
+url = https://github.com/blackmagic-debug/hidapi
+revision = hidapi-0.14.0-meson
 clone-recursive = false
 
 [provide]

--- a/deps/libusb.wrap
+++ b/deps/libusb.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
-url = https://github.com/dragonCodecs/libusb
-revision = blackmagic/meson
+url = https://github.com/blackmagic-debug/libusb
+revision = v1.0.27-meson
 clone-recursive = false
 
 [provide]


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we update the BMDA dependencies libusb and HIDAPI. The fork of libusb we use for Meson support has been moved into the organisation and updated to v1.0.27. HIDAPI has been forked to fully Meson-ify it so we can avoid mesonbuild/meson#12761 which Xobs hit on his M3. This also locks HIDAPI to v0.14.0.

Note that in both cases, these are fallbacks for if the libraries and their build files are not found on a user's system, and so we will prefer the user's versions if possible w/ the build system allowing much older versions of both to be used.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1774 
