### PR TITLE
Fix dual stack listening

### DIFF
--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -252,6 +252,12 @@ int gdb_if_init(void)
 			!socket_set_int_opt(gdb_if_serv, IPPROTO_TCP, TCP_NODELAY, 1))
 			continue;
 
+		if (addr.ss_family == AF_INET6) {
+			DEBUG_INFO("Setting V6ONLY to off for dual stack listening.\n");
+			if (!socket_set_int_opt(gdb_if_serv, IPPROTO_IPV6, IPV6_V6ONLY, 0))
+				DEBUG_WARN("Listening on IPv6 only.\n");
+		}
+
 		if (bind(gdb_if_serv, (sockaddr_s *)&addr, family_to_size(addr.ss_family)) == -1) {
 			handle_error(gdb_if_serv, "binding socket");
 			continue;

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -140,9 +140,16 @@ static sockaddr_storage_s sockaddr_prepare(const uint16_t port)
 		return (sockaddr_storage_s){AF_UNSPEC};
 	}
 
-	/* Pick the first result, copy it and free the list structure getaddrinfo() returns */
+	/* Try to find an IPv6 result but fall back to the first result if none can be found */
 	sockaddr_storage_s service;
 	memcpy(&service, results->ai_addr, family_to_size(results->ai_addr->sa_family));
+	for (addrinfo_s *curr = results; curr; curr = curr->ai_next) {
+		if (curr->ai_addr->sa_family == AF_INET6) {
+			memcpy(&service, curr->ai_addr, family_to_size(curr->ai_addr->sa_family));
+			break;
+		}
+	}
+	/* Free the getaddrinfo result list */
 	freeaddrinfo(results);
 
 	/* Copy in the port number as appropriate for the returned structure */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

BMDA is supposed to listen for connections on both IPv6 and IPv4 if possible, this is accomplished by dual stack support when using an IPv6 listening socket.  However there are two problems that prevent this from working as intended.

* When `getaddrinfo` returns results the first result is not always the IPv6 address to bind to if one is returned.  To fix this the results are walked over to select the first IPv6 result if one exists.  The first result is used if no IPv6 address can be found.
* An IPv6 listening socket accepting IPv4 connections relies on the `IPV6_V6ONLY ` socket option being set to 0 (off, dual stack) on the socket before it is bound.  On windows this option defaults to 1 (on, v6 only) and must be explicitly disabled to allow dual stack listening sockets.  On linux this option gets it's default from a sysctl setting (`net.ipv6.bindv6only`) and so explicitly setting it there is also ideal.  The option exists on Mac OS but I do not know it's default state.  Searching suggests that if a system is IPv6 only (no v4 support at all) then disabling this option will fail, however in that case v6 only listening is the only possible option.  So to resolve this when binding to an IPv6 address attempt to disable this socket option and print a warning that IPv6 only listening will occur if setting fails.


<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
