### PR TITLE
Feature: BMDA libftdi1 Meson Wrap

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -396,10 +396,6 @@ jobs:
         run: |
           brew install meson ninja
 
-      # Install BMDA's non wrapped deps (libftdi1)
-      - name: Install BMDA dependencies
-        run: brew install libftdi
-
       # Record the versions of all the tools used in the build
       - name: Version tools
         run: |

--- a/deps/libftdi.wrap
+++ b/deps/libftdi.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/blackmagic-debug/libftdi
+revision = v1.5-meson
+clone-recursive = false
+
+[provide]
+libftdi1 = ftdi1_dep

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -36,7 +36,7 @@ configure_file(
 	configuration: {
 		'PLATFORM_IDENT': f'"(BlackPill-@probe_blackpill_variant@) "',
 		'PLATFORM_CLOCK_FREQ': probe == 'blackpill-f411ce' ? 'RCC_CLOCK_3V3_96MHZ' : 'RCC_CLOCK_3V3_84MHZ',
-  	},
+	},
 )
 
 probe_blackpill_includes = include_directories('.')
@@ -78,7 +78,7 @@ probe_host = declare_dependency(
 	include_directories: probe_blackpill_includes,
 	sources: probe_blackpill_sources,
 	compile_args: probe_blackpill_args,
-	link_args: [probe_blackpill_common_link_args, probe_blackpill_link_args],
+	link_args: probe_blackpill_common_link_args + probe_blackpill_link_args,
 	dependencies: [platform_common, platform_stm32f4, fixme_platform_stm32_traceswo],
 )
 

--- a/src/platforms/f4discovery/meson.build
+++ b/src/platforms/f4discovery/meson.build
@@ -56,7 +56,7 @@ probe_host = declare_dependency(
 	include_directories: probe_f4discovery_includes,
 	sources: probe_f4discovery_sources,
 	compile_args: probe_f4discovery_args,
-	link_args: [probe_f4discovery_commonn_link_args, probe_f4discovery_link_args],
+	link_args: probe_f4discovery_commonn_link_args + probe_f4discovery_link_args,
 	dependencies: [platform_common, platform_stm32f4, fixme_platform_stm32_traceswo],
 )
 

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -156,8 +156,10 @@ if build_machine.system() == 'linux'
 		bmda_sources += files('bmda_gpiod.c')
 		bmda_args += ['-DENABLE_GPIOD=1']
 
-		bmda_sources += files('../common/jtagtap.c',
-		                      '../common/swdptap.c')
+		bmda_sources += files(
+			'../common/jtagtap.c',
+			'../common/swdptap.c'
+		)
 	endif
 else
 	libgpiod = declare_dependency()

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -163,7 +163,7 @@ if build_machine.system() == 'linux'
 	hidapi = dependency(
 		'hidapi-hidraw',
 		method: 'pkg-config',
-		fallback: 'hidapi',
+		fallback: ['hidapi', 'hidapi_hidraw_dep'],
 		native: is_cross_build,
 		default_options: [
 			'default_library=static',

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -125,7 +125,7 @@ if build_machine.system() in ['windows', 'cygwin']
 		]
 	endif
 else
-	libftdi = dependency('libftdi1', required: false, method: 'pkg-config', native: is_cross_build)
+	libftdi = dependency('libftdi1', method: 'pkg-config', fallback: 'libftdi', native: is_cross_build)
 	bmda_sources += files('serial_unix.c')
 endif
 
@@ -163,16 +163,11 @@ else
 	libgpiod = declare_dependency()
 endif
 
-# If we did not find all the dependencies we need, turn this into a disabler, otherwise
-# build a dependency object that describes the sources needed to build BMDA for the build platform
-if not libftdi.found() or not hidapi.found() or not libusb.found()
-	bmda_platform = disabler()
-else
-	bmda_platform = declare_dependency(
-		include_directories: bmda_includes,
-		sources: bmda_sources,
-		compile_args: cc.get_supported_arguments(bmda_args),
-		link_args: bmda_link_args,
-		dependencies: [libbmd_core, bmda_deps, libftdi, hidapi, libusb, libgpiod],
-	)
-endif
+# Build a dependency object that describes the sources needed to build BMDA for the build platform
+bmda_platform = declare_dependency(
+	include_directories: bmda_includes,
+	sources: bmda_sources,
+	compile_args: cc.get_supported_arguments(bmda_args),
+	link_args: bmda_link_args,
+	dependencies: [libbmd_core, bmda_deps, libftdi, hidapi, libusb, libgpiod],
+)

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -125,15 +125,51 @@ if build_machine.system() in ['windows', 'cygwin']
 		]
 	endif
 else
-	libftdi = dependency('libftdi1', method: 'pkg-config', fallback: 'libftdi', native: is_cross_build)
+	libftdi = dependency(
+		'libftdi1',
+		method: 'pkg-config',
+		fallback: 'libftdi',
+		native: is_cross_build,
+		default_options: [
+			'default_library=static',
+			'install_targets=false',
+			'tests=disabled',
+			'docs=disabled',
+			'examples=disabled',
+			'ftdi_eeprom=disabled',
+			#'python_bindings=disabled',
+			'build_native=true',
+		]
+	)
 	bmda_sources += files('serial_unix.c')
 endif
 
 # Pick the appropriate HIDAPI depending on platform
 if build_machine.system() == 'linux'
-	hidapi = dependency('hidapi-hidraw', method: 'pkg-config', fallback: 'hidapi', native: is_cross_build)
+	hidapi = dependency(
+		'hidapi-hidraw',
+		method: 'pkg-config',
+		fallback: 'hidapi',
+		native: is_cross_build,
+		default_options: [
+			'default_library=static',
+			'install_targets=false',
+			'with_libusb=false',
+			'build_native=true',
+		]
+	)
 else
-	hidapi = dependency('hidapi', method: 'pkg-config', fallback: 'hidapi', native: is_cross_build)
+	hidapi = dependency(
+		'hidapi',
+		method: 'pkg-config',
+		fallback: 'hidapi',
+		native: is_cross_build,
+		default_options: [
+			'default_library=static',
+			'install_targets=false',
+			'build_native=true',
+		]
+	)
 endif
 
 libusb = dependency(
@@ -142,6 +178,12 @@ libusb = dependency(
 	method: 'pkg-config',
 	fallback: 'libusb',
 	native: is_cross_build,
+	default_options: [
+		'default_library=static',
+		'install_targets=false',
+		'docs=disabled',
+		'build_native=true',
+	]
 )
 
 if build_machine.system() == 'linux'

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -118,7 +118,9 @@ libusb = dependency(
 		'install_targets=false',
 		'docs=disabled',
 		'build_native=true',
-	]
+	],
+	required: not is_cross_build,
+	disabler: true,
 )
 
 if build_machine.system() in ['windows', 'cygwin']
@@ -153,7 +155,9 @@ else
 			'ftdi_eeprom=disabled',
 			#'python_bindings=disabled',
 			'build_native=true',
-		]
+		],
+		required: not is_cross_build,
+		disabler: true,
 	)
 	bmda_sources += files('serial_unix.c')
 endif
@@ -170,7 +174,9 @@ if build_machine.system() == 'linux'
 			'install_targets=false',
 			'with_libusb=false',
 			'build_native=true',
-		]
+		],
+		required: not is_cross_build,
+		disabler: true,
 	)
 else
 	hidapi = dependency(
@@ -182,7 +188,9 @@ else
 			'default_library=static',
 			'install_targets=false',
 			'build_native=true',
-		]
+		],
+		required: not is_cross_build,
+		disabler: true,
 	)
 endif
 

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -107,6 +107,20 @@ if build_machine.system() == 'windows' and cc.get_define('__MINGW32__') == '1'
 	endif
 endif
 
+libusb = dependency(
+	'libusb-1.0',
+	version: '>=1.0.13',
+	method: 'pkg-config',
+	fallback: 'libusb',
+	native: is_cross_build,
+	default_options: [
+		'default_library=static',
+		'install_targets=false',
+		'docs=disabled',
+		'build_native=true',
+	]
+)
+
 if build_machine.system() in ['windows', 'cygwin']
 	subdir('windows')
 
@@ -171,20 +185,6 @@ else
 		]
 	)
 endif
-
-libusb = dependency(
-	'libusb-1.0',
-	version: '>=1.0.13',
-	method: 'pkg-config',
-	fallback: 'libusb',
-	native: is_cross_build,
-	default_options: [
-		'default_library=static',
-		'install_targets=false',
-		'docs=disabled',
-		'build_native=true',
-	]
-)
 
 if build_machine.system() == 'linux'
 	libgpiod = dependency(

--- a/src/platforms/native/meson.build
+++ b/src/platforms/native/meson.build
@@ -52,7 +52,7 @@ probe_host = declare_dependency(
 	include_directories: probe_native_includes,
 	sources: probe_native_sources,
 	compile_args: probe_native_args,
-	link_args: [probe_native_common_link_args, probe_native_link_args],
+	link_args: probe_native_common_link_args + probe_native_link_args,
 	dependencies: [platform_common, platform_stm32f1, fixme_platform_stm32_traceswo],
 )
 

--- a/src/platforms/stlink/meson.build
+++ b/src/platforms/stlink/meson.build
@@ -79,7 +79,7 @@ probe_host = declare_dependency(
 	include_directories: probe_stlink_includes,
 	sources: probe_stlink_sources,
 	compile_args: probe_stlink_args,
-	link_args: [probe_stlink_common_link_args, probe_stlink_link_args],
+	link_args: probe_stlink_common_link_args + probe_stlink_link_args,
 	dependencies: probe_stlink_dependencies,
 )
 

--- a/src/platforms/stlinkv3/meson.build
+++ b/src/platforms/stlinkv3/meson.build
@@ -62,7 +62,7 @@ probe_host = declare_dependency(
 	include_directories: probe_stlinkv3_includes,
 	sources: probe_stlinkv3_sources,
 	compile_args: probe_stlinkv3_args,
-	link_args: [probe_stlinkv3_common_link_args, probe_stlinkv3_link_args],
+	link_args: probe_stlinkv3_common_link_args + probe_stlinkv3_link_args,
 	dependencies: [platform_common, platform_stm32f7, fixme_platform_stm32f7_traceswoasync],
 )
 

--- a/src/platforms/swlink/meson.build
+++ b/src/platforms/swlink/meson.build
@@ -57,7 +57,7 @@ probe_host = declare_dependency(
 	include_directories: probe_swlink_includes,
 	sources: probe_swlink_sources,
 	compile_args: probe_swlink_args,
-	link_args: [probe_swlink_common_link_args, probe_swlink_link_args],
+	link_args: probe_swlink_common_link_args + probe_swlink_link_args,
 	dependencies: [platform_common, platform_stm32f1, fixme_platform_stm32_traceswoasync],
 )
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR adds a Meson Wrap for libftdi1 to act as fallback if the user's system doesn't have the library. This completes the Wraps necessary for BMDA to always be enabled and always done as a full build.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
