### PR TITLE
Fix: Missed changes

### DIFF
--- a/src/target/flashstub/rp.ld
+++ b/src/target/flashstub/rp.ld
@@ -1,0 +1,10 @@
+MEMORY { sram (rwx): ORIGIN = 0x20000000, LENGTH = 0x00001000 }
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.entry))
+		*(.text.*, .text)
+	} > sram
+}

--- a/src/target/renesas_rz.c
+++ b/src/target/renesas_rz.c
@@ -159,6 +159,9 @@ static void renesas_rz_add_flash(target_s *const target)
 	/* Put the controller back into bus usage mode */
 	target_mem_write32(target, RENESAS_MULTI_IO_SPI_COMMON_CTRL,
 		target_mem_read32(target, RENESAS_MULTI_IO_SPI_COMMON_CTRL) & ~RENESAS_MULTI_IO_SPI_COMMON_CTRL_MODE_SPI);
+
+	/* Register the SPI Flash mass erase implementation for mass erase */
+	target->mass_erase = bmp_spi_mass_erase;
 }
 
 bool renesas_rz_probe(target_s *const target)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a couple of missed changes from two earlier PRs. The first is from the RP2040 Flash stub PR where the linker script used was forgotten. The second is from the RZ/A1LU PR where the mass erase handler was forgotten.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
