### PR TITLE
Fix: BMP on M3 reenumeration

### DIFF
--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -413,6 +413,8 @@ void platform_request_boot(void)
 {
 	/* Disconnect USB cable */
 	gpio_set_mode(USB_PU_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_FLOAT, USB_PU_PIN);
+	gpio_set_mode(USB_PORT, GPIO_MODE_INPUT, GPIO_CNF_INPUT_PULL_UPDOWN, USB_DP_PIN | USB_DM_PIN);
+	gpio_clear(USB_PORT, USB_DP_PIN | USB_DM_PIN);
 
 	/* Drive boot request pin */
 	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_2_MHZ, GPIO_CNF_OUTPUT_PUSHPULL, GPIO12);

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -142,8 +142,12 @@ extern bool debug_bmp;
 #define TPWR_PORT   GPIOB
 #define TPWR_PIN    GPIO0
 
+/* USB pin definitions */
 #define USB_PU_PORT GPIOA
+#define USB_PORT    GPIOA
 #define USB_PU_PIN  GPIO8
+#define USB_DP_PIN  GPIO12
+#define USB_DM_PIN  GPIO11
 
 /* For HW Rev 4 and older */
 #define USB_VBUS_PORT GPIOB


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR attempts to improve the re-enumeration situation on M3 silicon powered machines as the controller built into the M3 does not properly recognise our setting up the conditions for re-enumeration for re-entry into the bootloader as reported on Discord by @xobs.

We attempt to improve things by ensuring we drive the reset condition described by the USB 2.0 specification version 20230224 §7.1.7.1 Table 7-2 pg145:
![image](https://github.com/blackmagic-debug/blackmagic/assets/691140/30c006a0-18f9-49dc-a777-5522c2212137)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
