### PR TITLE
Remove usage of sscanf in firmware code to reduce code size

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -42,6 +42,7 @@
 
 #ifdef ENABLE_RTT
 #include "rtt.h"
+#include "hex_utils.h"
 #endif
 
 #ifdef PLATFORM_HAS_TRACESWO
@@ -574,11 +575,12 @@ static bool cmd_rtt(target_s *t, int argc, const char **argv)
 	} else if (argc == 2 && strncmp(argv[1], "ram", command_len) == 0)
 		rtt_flag_ram = false;
 	else if (argc == 4 && strncmp(argv[1], "ram", command_len) == 0) {
-		const int cnt1 = sscanf(argv[2], "%" SCNx32, &rtt_ram_start);
-		const int cnt2 = sscanf(argv[3], "%" SCNx32, &rtt_ram_end);
-		rtt_flag_ram = cnt1 == 1 && cnt2 == 1 && rtt_ram_end > rtt_ram_start;
-		if (!rtt_flag_ram)
-			gdb_out("address?\n");
+		if (read_hex32(argv[2], NULL, &rtt_ram_start, READ_HEX_NO_FOLLOW) &&
+			read_hex32(argv[3], NULL, &rtt_ram_end, READ_HEX_NO_FOLLOW)) {
+			rtt_flag_ram = rtt_ram_end > rtt_ram_start;
+			if (!rtt_flag_ram)
+				gdb_out("address?\n");
+		}
 	} else if (argc == 5 && strncmp(argv[1], "poll", command_len) == 0) {
 		/* set polling params */
 		rtt_max_poll_ms = strtoul(argv[2], NULL, 0);

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -801,23 +801,27 @@ static void handle_z_packet(char *packet, const size_t plen)
 	uint32_t type;
 	uint32_t len;
 	uint32_t addr;
-	sscanf(packet, "%*[zZ]%" PRIu32 ",%08" PRIx32 ",%" PRIu32, &type, &addr, &len);
+	const char *rest = NULL;
 
-	int ret = 0;
-	if (packet[0] == 'Z')
-		ret = target_breakwatch_set(cur_target, type, addr, len);
-	else
-		ret = target_breakwatch_clear(cur_target, type, addr, len);
+	if (read_dec32(packet + 1, &rest, &type, ',') && read_hex32(rest, &rest, &addr, ',') &&
+		read_dec32(rest, NULL, &len, READ_HEX_NO_FOLLOW)) {
+		int ret = 0;
+		if (packet[0] == 'Z')
+			ret = target_breakwatch_set(cur_target, type, addr, len);
+		else
+			ret = target_breakwatch_clear(cur_target, type, addr, len);
 
-	/* If the target handler was unable to set/clear the break/watch-point, return an error */
-	if (ret < 0)
+		/* If the target handler was unable to set/clear the break/watch-point, return an error */
+		if (ret < 0)
+			gdb_putpacketz("E01");
+		/* If the handler does not support the kind requested, return empty string */
+		else if (ret > 0)
+			gdb_putpacketz("");
+		/* Otherwise let GDB know that everything went well */
+		else
+			gdb_putpacketz("OK");
+	} else
 		gdb_putpacketz("E01");
-	/* If the handler does not support the kind requested, return empty string */
-	else if (ret > 0)
-		gdb_putpacketz("");
-	/* Otherwise let GDB know that everything went well */
-	else
-		gdb_putpacketz("OK");
 }
 
 void gdb_main(char *pbuf, size_t pbuf_size, size_t size)

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -491,7 +491,8 @@ static void exec_q_crc(const char *packet, const size_t length)
 	(void)length;
 	uint32_t addr;
 	uint32_t addr_length;
-	if (sscanf(packet, "%" PRIx32 ",%" PRIx32, &addr, &addr_length) == 2) {
+	const char *rest = NULL;
+	if (read_hex32(packet, &rest, &addr, ',') && read_hex32(rest, NULL, &addr_length, READ_HEX_NO_FOLLOW)) {
 		if (!cur_target) {
 			gdb_putpacketz("E01");
 			return;

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -237,13 +237,16 @@ int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, siz
 		ERROR_IF_NO_TARGET();
 		if (cur_target->reg_read) {
 			uint32_t reg;
-			sscanf(pbuf, "p%" SCNx32, &reg);
-			uint8_t val[8];
-			size_t s = target_reg_read(cur_target, reg, val, sizeof(val));
-			if (s != 0)
-				gdb_putpacket(hexify(pbuf, val, s), s * 2U);
-			else
+			if (!read_hex32(pbuf + 1, NULL, &reg, READ_HEX_NO_FOLLOW))
 				gdb_putpacketz("EFF");
+			else {
+				uint8_t val[8];
+				size_t s = target_reg_read(cur_target, reg, val, sizeof(val));
+				if (s != 0)
+					gdb_putpacket(hexify(pbuf, val, s), s * 2U);
+				else
+					gdb_putpacketz("EFF");
+			}
 		} else {
 			gdb_putpacketz("00");
 		}

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -615,8 +615,8 @@ static void exec_v_attach(const char *packet, const size_t length)
 {
 	(void)length;
 
-	uint32_t addr = 0;
-	if (sscanf(packet, "%08" PRIx32, &addr) == 1) {
+	uint32_t addr;
+	if (read_hex32(packet, NULL, &addr, READ_HEX_NO_FOLLOW)) {
 		/* Attach to remote target processor */
 		cur_target = target_attach_n(addr, &gdb_controller);
 		if (cur_target) {

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -416,8 +416,9 @@ static void handle_q_string_reply(const char *reply, const char *param)
 	const size_t reply_length = strlen(reply);
 	uint32_t addr = 0;
 	uint32_t len = 0;
+	const char *rest = NULL;
 
-	if (sscanf(param, "%08" PRIx32 ",%08" PRIx32, &addr, &len) != 2) {
+	if (!read_hex32(param, &rest, &addr, ',') || !read_hex32(rest, NULL, &len, READ_HEX_NO_FOLLOW)) {
 		gdb_putpacketz("E01");
 		return;
 	}

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -114,7 +114,7 @@ target_controller_s gdb_controller = {
 };
 
 /* execute gdb remote command stored in 'pbuf'. returns immediately, no busy waiting. */
-int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t size, bool in_syscall)
+int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t size, bool in_syscall)
 {
 	bool single_step = false;
 
@@ -284,7 +284,8 @@ int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t 
 
 	case 'F': /* Semihosting call finished */
 		if (in_syscall)
-			return semihosting_reply(tc, pbuf, size);
+			/* Trim off the 'F' before calling semihosting_reply so that it doesn't have to skip it */
+			return semihosting_reply(tc, pbuf + 1);
 		else {
 			DEBUG_GDB("*** F packet when not in syscall! '%s'\n", pbuf);
 			gdb_putpacketz("");

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -761,10 +761,11 @@ static void exec_v_cont(const char *packet, const size_t length)
 static void exec_v_flash_erase(const char *packet, const size_t length)
 {
 	(void)length;
-	uint32_t addr = 0;
-	uint32_t len = 0;
+	uint32_t addr;
+	uint32_t len;
+	const char *rest = NULL;
 
-	if (sscanf(packet, "%08" PRIx32 ",%08" PRIx32, &addr, &len) == 2) {
+	if (read_hex32(packet, &rest, &addr, ',') && read_hex32(rest, NULL, &len, READ_HEX_NO_FOLLOW)) {
 		/* Erase Flash Memory */
 		DEBUG_GDB("Flash Erase %08" PRIX32 " %08" PRIX32 "\n", addr, len);
 		if (!cur_target) {
@@ -778,7 +779,8 @@ static void exec_v_flash_erase(const char *packet, const size_t length)
 			target_flash_complete(cur_target);
 			gdb_putpacketz("EFF");
 		}
-	}
+	} else
+		gdb_putpacketz("EFF");
 }
 
 static void exec_v_flash_write(const char *packet, const size_t length)

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -785,20 +785,20 @@ static void exec_v_flash_erase(const char *packet, const size_t length)
 
 static void exec_v_flash_write(const char *packet, const size_t length)
 {
-	uint32_t addr = 0;
-	int bin;
-
-	if (sscanf(packet, "%08" PRIx32 ":%n", &addr, &bin) == 1) {
+	uint32_t addr;
+	const char *rest = NULL;
+	if (read_hex32(packet, &rest, &addr, ':')) {
 		/* Write Flash Memory */
-		const uint32_t count = length - bin;
+		const uint32_t count = length - (packet - rest);
 		DEBUG_GDB("Flash Write %08" PRIX32 " %08" PRIX32 "\n", addr, count);
-		if (cur_target && target_flash_write(cur_target, addr, (uint8_t *)packet + bin, count))
+		if (cur_target && target_flash_write(cur_target, addr, (uint8_t *)rest, count))
 			gdb_putpacketz("OK");
 		else {
 			target_flash_complete(cur_target);
 			gdb_putpacketz("EFF");
 		}
-	}
+	} else
+		gdb_putpacketz("EFF");
 }
 
 static void exec_v_flash_done(const char *packet, const size_t length)

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -188,10 +188,12 @@ int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, siz
 	 * (we don't actually care which as we only care about the TID for whether to send OK or an error)
 	 */
 	case 'H': {
-		char operation = 0;
 		uint32_t thread_id = 0;
-		sscanf(pbuf, "H%c%" SCNx32, &operation, &thread_id);
-		if (thread_id <= 1)
+		/*
+		 * Since we don't care about the operation just skip it but check there is at least 3 characters
+		 * in the packet.
+		 */
+		if (size >= 3 && read_hex32(pbuf + 2, NULL, &thread_id, READ_HEX_NO_FOLLOW) && thread_id <= 1)
 			gdb_putpacketz("OK");
 		else
 			gdb_putpacketz("E01");

--- a/src/hex_utils.c
+++ b/src/hex_utils.c
@@ -78,3 +78,44 @@ uint64_t hex_string_to_num(const size_t max_digits, const char *const str)
 	}
 	return ret;
 }
+
+/*
+ * This function attempts to read a number, starting from the given input pointer and stores the
+ * result in val.
+ * It performs a number of helpful additional tasks needed for number parsing in BMD.
+ * It stores the location of the character after the last one considered into rest if non-NULL
+ * this is useful for chaining these calls or to parse mutliple fields.
+ * It accepts a char parameter called follow, which if not set to READ_HEX_NO_FOLLOW will check
+ * the character after the number is equal to that character and report failure if it is not.
+ * If the follow character is matched then the value stored into the rest pointer will be after
+ * this following character.
+ * This routine also accepts a base to operate on as it is the common function used by the two
+ * wrappers read_hex32 and read_dec32 for hexadecimal and decimal numbers respectively.
+ * 
+ * This routine uses strtoul internally so all the number parsing behaviour of that apply,
+ * it will accept a leading + or - and perform negation of the read number correctly.
+ * If passed 0 as the base it will accept hex numbers prefixed with 0x or 0X and octal numbers
+ * prefixed with 0, otherwise it will assume decimal.
+ * It will skip white space preceding the number to be read.
+ * 
+ * The resturn value indicates whether a number has been successfully read, if the function returns
+ * true then rest and val have been assigned if non-NULL.
+ */
+bool read_unum32(const char *input, const char **rest, uint32_t *val, char follow, int base)
+{
+	char *end = NULL;
+	uint32_t result = strtoul(input, &end, base);
+	if (end == NULL || end == input)
+		return false;
+	if (follow != READ_HEX_NO_FOLLOW) {
+		if (*end == follow)
+			end++;
+		else
+			return false;
+	}
+	if (rest)
+		*rest = end;
+	if (val)
+		*val = result;
+	return true;
+}

--- a/src/include/gdb_main.h
+++ b/src/include/gdb_main.h
@@ -30,7 +30,7 @@ extern target_s *cur_target;
 
 void gdb_poll_target(void);
 void gdb_main(char *pbuf, size_t pbuf_size, size_t size);
-int gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t size, bool in_syscall);
+int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, size_t size, bool in_syscall);
 char *gdb_packet_buffer(void);
 
 #endif /* INCLUDE_GDB_MAIN_H */

--- a/src/include/hex_utils.h
+++ b/src/include/hex_utils.h
@@ -39,4 +39,18 @@ static inline bool is_hex(const char x)
 	return (x >= '0' && x <= '9') || (x >= 'A' && x <= 'F') || (x >= 'a' && x <= 'f');
 }
 
+#define READ_HEX_NO_FOLLOW '\xff'
+
+bool read_unum32(const char *input, const char **rest, uint32_t *val, char follow, int base);
+
+static inline bool read_hex32(const char *input, const char **rest, uint32_t *val, char follow)
+{
+	return read_unum32(input, rest, val, follow, 16);
+}
+
+static inline bool read_dec32(const char *input, const char **rest, uint32_t *val, char follow)
+{
+	return read_unum32(input, rest, val, follow, 10);
+}
+
 #endif /* INCLUDE_HEX_UTILS_H */

--- a/src/target/samd.c
+++ b/src/target/samd.c
@@ -730,17 +730,11 @@ static bool samd_set_flashlock(target_s *t, uint16_t value, const char **argv)
 
 static bool parse_unsigned(const char *str, uint32_t *val)
 {
-	int result;
+	char *end = NULL;
 	unsigned long num;
 
-	size_t len = strlen(str);
-	// TODO: port to use substrate::toInt_t<> style parser for robustness and smaller code size
-	if (len > 2U && str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
-		result = sscanf(str + 2, "%lx", &num);
-	else
-		result = sscanf(str, "%lu", &num);
-
-	if (result < 1)
+	num = strtoul(str, &end, 0);
+	if (end == NULL || end == str)
 		return false;
 
 	*val = (uint32_t)num;

--- a/src/target/semihosting.h
+++ b/src/target/semihosting.h
@@ -28,6 +28,6 @@
 extern uint32_t semihosting_wallclock_epoch;
 
 int32_t semihosting_request(target_s *target, uint32_t syscall, uint32_t r1);
-int semihosting_reply(target_controller_s *tc, char *packet, int len);
+int32_t semihosting_reply(target_controller_s *tc, char *packet);
 
 #endif /* TARGET_SEMIHOSTING_H */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

The gdb packet parsing and some other firmware relevant code makes use of sscanf.  This is both somewhat prone to mistakes in usage which can result in undefined behaviour and constitutes a significant size of code in flash.

This set of changes removes usage of sscanf from the firmware relevant code, these are still a few uses in purely BMDA code but as that does not have the same space constraints I have not removed it at this time.

Most of the use cases for sscanf in the existing code has been for integer parsing, to fulfill this need with much less code required I have added a helper function read_unum32 which will read an unsigned 32 bit integer of arbitrary base from the given string.  This function provides a pointer to the rest of the string upon success.  It also includes an optional check that the character immediately following the number is a given character, as this was a common need in the gdb packet parsing code. In the case a character to check is supplied the rest pointer returned will be after it if the parsing and check is successful.  The function uses `'\xff'` to mean that no follow character is to be checked.

Two static inline wrapper functions exist for read_unum32, read_hex32 and read_dec32 which cover the most common case of hex number parsing and the few places in the break point code where decimals are needed.

After this the various uses of sscanf are replaced by other means, numbers are read with the helper function, potentially with follow character checking.  Some cases of note: 
* The semihosting code used sscanf in a somewhat more complex way than most, this has been converted to a conditional chain using read_hex32 and just checking the character from the buffer for the control C indication.  The return code of semihosting_reply and gdb_main_loop is also changed to `int32_t` both to ensure correctness given the read_hex32 and also to better match it's use elsewhere.
* The 'v' family of packets was a big chain of if-else to match the various sub commands, some of which were matched with sscanf.  In order to make this easier to convert it has first been converted to use exec_command like the 'q' family of packets, with separate functions for each sub-command, then the ones which used sscanf were converted to read_hex32.
* The samd target was using sscanf to parse an integer in a manner in which strtoul would work suitably so this was just replaced with strtoul.
* The 'H' packet code skips over the character specifying which other operation it is setting the thread ID for as the code doesn't care about that just that the thread ID is acceptable.
* The RTT command is converted to use read_hex32 for parsing it's arguments into numbers.

## Required Testing

While I have tested basic gdb interaction, attaching, register dumping and memory reading, I have not been able to exhaustively test all of the gdb server remote protocol, as such this PR should not be merged until it has been extensively reviewed and tested, preferably we can develop some unit tests for the gdb_main code to help ensure it still works as expected.

Semihosting and RTT should be tested as well, although RTT should only be impacted by the command changing how it parses numbers for the addresses.

## Results

When building main `commit 5ac7f1e287f673738f5b63bd08ea958da56d215b` with `arm-none-eabi-gcc (Arm GNU Toolchain 12.2.Rel1 (Build arm-12.24)) 12.2.1 20221205` I get the following flash and ram usage:

```
Memory region         Used Size  Region Size  %age Used
             rom:      130564 B       128 KB     99.61%
             ram:        3872 B        20 KB     18.91%
```

After these changes I get the following flash and ram usage:

```
Memory region         Used Size  Region Size  %age Used
             rom:      128584 B       128 KB     98.10%
             ram:        3872 B        20 KB     18.91%
```

Here we can see that almost 2 KiB of flash space has been saved by removing all sscanf usage.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
