### PR TITLE
target/nxp: Re-enable ke04 support.

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -570,6 +570,7 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 		PROBE(imxrt_probe);
 		PROBE(kinetis_probe);
 		PROBE(s32k3xx_probe);
+		PROBE(ke04_probe);
 		break;
 	case JEP106_MANUFACTURER_GIGADEVICE:
 		PROBE(gd32f1_probe);


### PR DESCRIPTION
## Detailed description

Support for NXP ke04 series part is a little broken. More specifically, I tested the following for a S9KEAZN8* part:

Built with:
```shell
meson setup --wipe build --cross-file cross-file/native.ini -Ddebug_output=true -Dtargets=corte
xm,nxp
meson compile -C build
```

Flashed with:
```shell
sudo dfu-util -d 1d50:6018,:6017 -s 0x08002000:leave -D build/blackmagic_native_firmware.bin
```

Debugged with gdb-multiarch:
```shell
(gdb) mon tpwr enable
Enabling target power
(gdb) mon debug_bmp enable
Debug mode is enabled
(gdb) mon swdp_scan
Target voltage: 3.3V
Please report unknown device with Designer 0xe Part ID 0x0
Available Targets:
No. Att Driver
*** 1   Unknown ARM Cortex-M Designer 0xe Part ID 0x0 M0+
 2      Kinetis Recovery (MDM-AP)
 ```

Virtual Serial Port Output:
```shell
Switching out of dormant state into SWD
DP DPIDR 0x0bc11477 (v1 MINDP rev0) designer 0x43b partno 0xbc
AP   0: IDR=04770031 CFG=00000000 BASE=f0002003 CSW=83000040 (AHB3-AP var3 rev0)
Halt via DHCSR(01030003): success after 0ms
ROM: Table BASE=0xf0002000 SYSMEM=0x00000001, Manufacturer 00e Partno 000
ROM: Table BASE=0xe00ff000 SYSMEM=0x00000001, Manufacturer 43b Partno 4c0
 0 0xe000e000: Generic IP component - Cortex-M0 SCS (System Control Space) (PIDR = 0x00000004000bb008 DEVTYPE = 0x00 ARCHID = 0x0000)
 -> cortexm_probe
CPUID 0x410cc600 (M0+ var 0 rev 0)
SWD access resulted in fault, retrying
SWD access resulted in fault, retrying
SWD access resulted in fault, retrying
 1 0xe0001000: Generic IP component - Cortex-M0 DWT (Data Watchpoint and Trace) (PIDR = 0x00000004000bb00a DEVTYPE = 0x00 ARCHID = 0x0000)
 2 0xe0002000: Generic IP component - Cortex-M0 BPU (Breakpoint Unit) (PIDR = 0x00000004000bb00b DEVTYPE = 0x00 ARCHID = 0x0000)
 ROM: Table END
ROM: Table END
AP   1: IDR=001c0020 CFG=00000000 BASE=00000000 CSW=80000008 (Unknown var2 rev0)
```

...and now after the change...

Debugged with gdb-multiarch:
```shell
(gdb) mon tpwr enable
Enabling target power
(gdb) mon debug_bmp enable
Debug mode is enabled
(gdb) mon swdp_scan
Target voltage: 3.3V
Available Targets:
No. Att Driver
 1      Kinetis KE04Z8Vxxxx M0+
 2      Kinetis Recovery (MDM-AP)
```

Virtual Serial Port Output:
```shell
Switching out of dormant state into SWD
DP DPIDR 0x0bc11477 (v1 MINDP rev0) designer 0x43b partno 0xbc
AP   0: IDR=04770031 CFG=00000000 BASE=f0002003 CSW=83000040 (AHB3-AP var3 rev0)
Halt via DHCSR(00030003): success after 1ms
ROM: Table BASE=0xf0002000 SYSMEM=0x00000001, Manufacturer 00e Partno 000
ROM: Table BASE=0xe00ff000 SYSMEM=0x00000001, Manufacturer 43b Partno 4c0
 0 0xe000e000: Generic IP component - Cortex-M0 SCS (System Control Space) (PIDR = 0x00000004000bb008 DEVTYPE = 0x00 ARCHID = 0x0000)
 -> cortexm_probe
CPUID 0x410cc600 (M0+ var 0 rev 0)
SWD access resulted in fault, retrying
SWD access resulted in fault, retrying
SWD access resulted in fault, retrying
 1 0xe0001000: Generic IP component - Cortex-M0 DWT (Data Watchpoint and Trace) (PIDR = 0x00000004000bb00a DEVTYPE = 0x00 ARCHID = 0x0000)
 2 0xe0002000: Generic IP component - Cortex-M0 BPU (Breakpoint Unit) (PIDR = 0x00000004000bb00b DEVTYPE = 0x00 ARCHID = 0x0000)
 ROM: Table END
ROM: Table END
AP   1: IDR=001c0020 CFG=00000000 BASE=00000000 CSW=80000008 (Unknown var2 rev0)
```

I was able to `load` the device's memory and `compare-sections` and I can see that the contents match.

> NOTE: I currently receive an error when attempting to load a second time. I am digging into this but, at the discretion of the reviewer, I am considering making that a follow-on pull-request.

## Related Issues

- https://github.com/blackmagic-debug/blackmagic/pull/360
- https://github.com/blackmagic-debug/blackmagic/issues/352