### PR TITLE
[WIP] Feature: correct flash mappings of STM32H7Bx

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -273,6 +273,12 @@ bool stm32h7_probe(target_s *target)
 		}
 		break;
 	}
+	case ID_STM32H7Bx: {
+		/* STM32H7B0nB: 128 KiB in 16 sectors of 8 KiB */
+		stm32h7_add_flash(target, STM32H7_FLASH_BANK1_BASE, 0x20000U, 0x2000U);
+		break;
+	}
+	case ID_STM32H72x:
 	default:
 		stm32h7_add_flash(target, STM32H7_FLASH_BANK1_BASE, STM32H7_FLASH_BANK_SIZE, FLASH_SECTOR_SIZE);
 		stm32h7_add_flash(target, STM32H7_FLASH_BANK2_BASE, STM32H7_FLASH_BANK_SIZE, FLASH_SECTOR_SIZE);


### PR DESCRIPTION
## Detailed description

* This is a small new feature (target flavour support).
* The existing problem is that STM32H7Bx chips are detected by BMD with wrong (of H72x) flash mapping.
* This PR solves this problem by adding a switch-case entry for them which adds a correct flash map.

This is somewhat WIP; I would like to see CI passing. I only added the small patch/hunk from early February. If you allow some time before merging (up to next weekend), then I see an easy way to also add H7A3/H7B3 flash, which has not 16 but 128 sectors of 8 KiB. Note that I added an explicit H72x case before default case. I cannot test on any H7Bx parts.

The recently announced STM32H7Rx/H7Sx which hit General Availibility also seem to have the newer Flash IP with 64 KiB of 8-KiB pages, and a part ID I could fish out from the public reference manuals. Or this could be its own very miniature PR.
* [x] STM32H7B0
* [ ] STM32H7B3/H7A3
* [ ] STM32H7R7/H7S7

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

I have not found GH issues, but some users on Discord reported problems with H7Bx recently.