### PR TITLE
Restore .clang-tidy config to valid YAML

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,13 +35,13 @@ CheckOptions:
   - key:   readability-identifier-naming.ConstantCase
     value: 'lower_case'
   - key:   readability-identifier-naming.EnumCase
-  value: 'lower_case'
-   - key:   readability-identifier-naming.StructCase
-  value: 'lower_case'
-   - key:   readability-identifier-naming.UnionCase
-  value: 'lower_case'
-   - key:   readability-identifier-naming.TypedefCase
-  value: 'lower_case'
+    value: 'lower_case'
+  - key:   readability-identifier-naming.StructCase
+    value: 'lower_case'
+  - key:   readability-identifier-naming.UnionCase
+    value: 'lower_case'
+  - key:   readability-identifier-naming.TypedefCase
+    value: 'lower_case'
   - key:   readability-identifier-naming.MacroDefinitionCase
     value: 'UPPER_CASE'
   - key:   readability-identifier-length.MinimumParameterNameLength


### PR DESCRIPTION
The .clang-tidy config file had previously been changed but left with indentation that resulted in an invalid map/sequence.

Fix the indentation so that the CheckOptions sequence is valid YAML again.

<!-- Filling this template is mandatory -->

## Detailed description

A previous change to the .clang-tidy config file in the repository messed up the whitespace resulting in invalid YAML.

Correct the whitespace back to valid YAML for a sequence containing maps.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
