### PR TITLE
add voltage sensor on stm32f3 and correct the readme

### DIFF
--- a/src/platforms/f3/README.md
+++ b/src/platforms/f3/README.md
@@ -7,9 +7,10 @@ For simpicity, the ST system bootloader is used. This saves additional 4 kB for 
 ## Connections
 
 * PA2: UART RX
-* PS3: UART TX
-* PA0: TDI
+* PA3: UART TX
+* PA0: VTref
 * PA1: TMS/SWDIO
+* PA4: TDI
 * PA7: TCK/SWCLK
 * PA6: TDO/TRACESWO
 * PA5: TRST

--- a/src/platforms/f3/platform.h
+++ b/src/platforms/f3/platform.h
@@ -37,8 +37,9 @@
  * LED1 = 	PB6	(Orange LED : Idle)
  * LED2 = 	PB7	(Red LED    : Error)
  *
- * TDI = 	PA0
+ * VTref =  PA0 
  * TMS = 	PA1 (input for SWDP)
+ * TDI = 	PA4
  * TCK = 	PA7/SWCLK
  * TDO = 	PA6 (input for TRACESWO
  * nRST =	PA5
@@ -48,11 +49,13 @@
 
 /* Hardware definitions... */
 #define JTAG_PORT GPIOA
+#define VTREF_PORT  JTAG_PORT
 #define TDI_PORT  JTAG_PORT
 #define TMS_PORT  JTAG_PORT
 #define TCK_PORT  JTAG_PORT
 #define TDO_PORT  JTAG_PORT
-#define TDI_PIN   GPIO0
+#define VTREF_PIN GPIO0
+#define TDI_PIN   GPIO4
 #define TMS_PIN   GPIO1
 #define TCK_PIN   GPIO7
 #define TDO_PIN   GPIO6


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

I implemented the ability of having a voltage sensor when flashing BM firmware on a stm32f3.
The STM32f3 isn't able of calculating voltage highter than 3.6V, when the voltage is highter it anwser 4.95V every time.

I used the libcm3 adc interface to open an adc gpio and read it when voltage is asked

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [X] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do


