### PR TITLE
Fix: Xilinx Artix-7 IR quirk for 6-bit IR found on XC7A200T

### DIFF
--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2011  Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
  * Copyright (C) 2022  1bitsquared - Rachel Mant <git@dragonmux.network>
+ * Modified by LAK132
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -328,6 +329,18 @@ const jtag_dev_descr_s dev_descr[] = {
 			{
 				.ir_length = 6U,
 				.ir_value = 1U,
+			},
+	},
+	{
+		.idcode = 0x03636093U,
+		.idmask = 0x0fffffffU,
+#if ENABLE_DEBUG == 1
+		.descr = "Xilinx 6-bit IR.",
+#endif
+		.ir_quirks =
+			{
+				.ir_length = 6U,
+				.ir_value = 0x35U,
 			},
 	},
 	{


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

For the Artix 7 XC7A200T `./blackmagic.exe -jtv 63` would previously bail out with an unknown IR value. This PR adds the IR found on this chip.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
