### PR TITLE
Added support for kinetis MK20DX256 chip

### DIFF
--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -327,7 +327,16 @@ bool kinetis_probe(target_s *const t)
 			}
 			break;
 		case 0x010U: /* K20 Family, DIEID=0x0 */
+			return false;
 		case 0x090U: /* K20 Family, DIEID=0x1 */
+			t->driver = "MK20DX256";
+			target_add_ram(t, 0x1fff8000, 0x00008000);	/* SRAM_L, 32 KB */
+			target_add_ram(t, 0x20000000, 0x00008000);	/* SRAM_H, 32 KB */
+
+			kinetis_add_flash(t, 0x00000000, 0x40000, 0x800, KL_WRITE_LEN); /* P-Flash, 256 KB, 2 KB Sectors */
+			kinetis_add_flash(t, 0x10000000, 0x8000, 0x400, KL_WRITE_LEN); /* FlexNVM, 32 KB, 1 KB Sectors */
+
+			break;
 		case 0x110U: /* K20 Family, DIEID=0x2 */
 		case 0x190U: /* K20 Family, DIEID=0x3 */
 		case 0x230U: /* K21 Family, DIEID=0x4 */

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -95,6 +95,19 @@
 /* 8 byte phrases need to be written to the k64 flash */
 #define K64_WRITE_LEN 8U
 
+/* Target registers */
+#define MK20DX256_FLASH_BASE        0x00000000U
+#define MK20DX256_FLASH_SIZE        0x00040000U
+#define MK20DX256_FLASH_BLK_SIZE    0x00000800U
+#define MK20DX256_FLEXNVM_BASE      0x10000000U
+#define MK20DX256_FLEXNVM_SIZE      0x00008000U
+#define MK20DX256_FLEXNVM_BLK_SIZE  0x00000400U
+#define MK20DX256_SRAM_L_BASE       0x1fff8000U
+#define MK20DX256_SRAM_L_SIZE       0x00008000U
+#define MK20DX256_SRAM_H_BASE       0x20000000U
+#define MK20DX256_SRAM_H_SIZE       0x00008000U
+
+
 static bool kinetis_cmd_unsafe(target_s *t, int argc, const char **argv);
 
 const command_s kinetis_cmd_list[] = {
@@ -330,12 +343,10 @@ bool kinetis_probe(target_s *const t)
 			return false;
 		case 0x090U: /* K20 Family, DIEID=0x1 */
 			t->driver = "MK20DX256";
-			target_add_ram(t, 0x1fff8000, 0x00008000);	/* SRAM_L, 32 KB */
-			target_add_ram(t, 0x20000000, 0x00008000);	/* SRAM_H, 32 KB */
-
-			kinetis_add_flash(t, 0x00000000, 0x40000, 0x800, KL_WRITE_LEN); /* P-Flash, 256 KB, 2 KB Sectors */
-			kinetis_add_flash(t, 0x10000000, 0x8000, 0x400, KL_WRITE_LEN); /* FlexNVM, 32 KB, 1 KB Sectors */
-
+			target_add_ram(t, MK20DX256_SRAM_L_BASE, MK20DX256_SRAM_L_SIZE);	/* SRAM_L, 32 KB */
+			target_add_ram(t, MK20DX256_SRAM_H_BASE, MK20DX256_SRAM_H_SIZE);	/* SRAM_H, 32 KB */
+			kinetis_add_flash(t, MK20DX256_FLASH_BASE, MK20DX256_FLASH_SIZE, MK20DX256_FLASH_BLK_SIZE, KL_WRITE_LEN);       /* P-Flash, 256 KB, 2 KB Sectors */
+			kinetis_add_flash(t, MK20DX256_FLEXNVM_BASE, MK20DX256_FLEXNVM_SIZE, MK20DX256_FLEXNVM_BLK_SIZE, KL_WRITE_LEN); /* FlexNVM, 32 KB, 1 KB Sectors */
 			break;
 		case 0x110U: /* K20 Family, DIEID=0x2 */
 		case 0x190U: /* K20 Family, DIEID=0x3 */


### PR DESCRIPTION
## Detailed description

This PR adds support for a MK20DX256 chip in `kinetis.c`. It specifies flash region, both RAM segments and FlexNVM. It doesn't, however, add support for FlexRAM that this chip features. That support seems to lack from all other kinetis targets too, I guess due to the complication that this region can be configured both as RAM and EEPROM.

One of the comments made on the branch was to use defines instead of addresses directly, which doesn't seem to be common practice in `kinetis.c`. So for now I added the values directly as function arguments. If that's still desired, I can make a change :)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware)) - Linker fails with ROM overflowing (arm-none-eabi-gcc (15:10.3-2021.07-4) 10.3.1 20210621, but building main branch fails with the same error). This PR increases ROM consumption by 0.03%.
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

The following was tested on Tiva ICDI platform, with GDB 8.3.1:
* load firmware to a MK20 target
* run target
* set & remove breakpoint
* set & remove watchpoint
* pause target, and while paused
  * get general registers
  * get stack trace
  * watch code variable
  * inspect hardware peripheral registers
  * read out 1k of random RAM
  * read out 1k of random flash
* resume target
* disconnect & confirm target continues to run

## Closing issues

No known open issues.
