### PR TITLE
Feature: Add to `blackpill-f4` an `swlink`-like alternative pinout 2

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -50,6 +50,20 @@ void platform_init(void)
 	rcc_periph_clock_enable(RCC_GPIOC);
 	rcc_periph_clock_enable(RCC_GPIOB);
 	rcc_periph_clock_enable(RCC_CRC);
+#if SWO_ENCODING == 1 || SWO_ENCODING == 3
+	/* Make sure to power up the timer used for trace */
+	rcc_periph_clock_enable(SWO_TIM_CLK);
+#endif
+#if SWO_ENCODING == 2 || SWO_ENCODING == 3
+	/* Enable relevant USART and DMA early in platform init */
+	rcc_periph_clock_enable(SWO_UART_CLK);
+	rcc_periph_clock_enable(SWO_DMA_CLK);
+	/* Deal with receiving on Tx pin by enabling Half-Duplex mode */
+#if SWO_UART_PORT == GPIOB && SWO_UART_RX_PIN == GPIO6
+	//usart_enable_halfduplex(SWO_UART);
+	USART_CR3(SWO_UART) |= USART_CR3_HDSEL;
+#endif
+#endif
 
 #ifndef BMD_BOOTLOADER
 	/* Blackpill board has a floating button on PA0. Pull it up and use as active-low. */

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -94,43 +94,45 @@ extern bool debug_bmp;
 /*
  * Important pin mappings for STM32 implementation:
  *   * JTAG/SWD
- *     * PB6 or PB5: TDI
- *     * PB7 or PB6: TDO/SWO
- *     * PB8 or PB7: TCK/SWCLK
- *     * PB9 or PB8: TMS/SWDIO
- *     * PA6 or PB3: TRST
- *     * PA5 or PB4: nRST
+ *     * PB6 or PB5 or PA15: TDI
+ *     * PB7 or PB6 or PB3: TDO/SWO
+ *     * PB8 or PB7 or PA14: TCK/SWCLK
+ *     * PB9 or PB8 or PA13: TMS/SWDIO
+ *     * PA6 or PB3 or PB4: TRST
+ *     * PA5 or PB4 or PA5: nRST
  *   * USB USART
  *     * PA2: USART TX
  *     * PA3: USART RX
  *   * +3V3
- *     * PA1 or PB9: power pin
+ *     * PA1 or PB9 or PA1: power pin
  *   * Force DFU mode button:
  *     * PA0: user button KEY
  */
 
 /* Hardware definitions... */
 /* Build the code using `make PROBE_HOST=blackpill-f4x1cx ALTERNATIVE_PINOUT=1` to select the second pinout. */
-#define TDI_PORT GPIOB
-#define TDI_PIN  PINOUT_SWITCH(GPIO6, GPIO5)
+/* `ALTERNATIVE_PINOUT=2` results in self SWJ-DP unmapped, like `swlink` */
+#define TDI_PORT PINOUT_SWITCH(GPIOB, GPIOB, GPIOA)
+#define TDI_PIN  PINOUT_SWITCH(GPIO6, GPIO5, GPIO15)
 
 #define TDO_PORT GPIOB
-#define TDO_PIN  PINOUT_SWITCH(GPIO7, GPIO6)
+#define TDO_PIN  PINOUT_SWITCH(GPIO7, GPIO6, GPIO3)
 
-#define TCK_PORT   GPIOB
-#define TCK_PIN    PINOUT_SWITCH(GPIO8, GPIO7)
+#define TCK_PORT   PINOUT_SWITCH(GPIOB, GPIOB, GPIOA)
+#define TCK_PIN    PINOUT_SWITCH(GPIO8, GPIO7, GPIO14)
 #define SWCLK_PORT TCK_PORT
 #define SWCLK_PIN  TCK_PIN
 
-#define TMS_PORT   GPIOB
-#define TMS_PIN    PINOUT_SWITCH(GPIO9, GPIO8)
+#define TMS_PORT   PINOUT_SWITCH(GPIOB, GPIOB, GPIOA)
+#define TMS_PIN    PINOUT_SWITCH(GPIO9, GPIO8, GPIO13)
 #define SWDIO_PORT TMS_PORT
 #define SWDIO_PIN  TMS_PIN
 
-#define SWDIO_MODE_REG_MULT_PB9 (1U << (9U << 1U))
-#define SWDIO_MODE_REG_MULT_PB8 (1U << (8U << 1U))
+#define SWDIO_MODE_REG_MULT_PB9  (1U << (9U << 1U))
+#define SWDIO_MODE_REG_MULT_PB8  (1U << (8U << 1U))
+#define SWDIO_MODE_REG_MULT_PA13 (1U << (13U << 1U))
 /* Update when adding more alternative pinouts */
-#define SWDIO_MODE_REG_MULT PINOUT_SWITCH(SWDIO_MODE_REG_MULT_PB9, SWDIO_MODE_REG_MULT_PB8)
+#define SWDIO_MODE_REG_MULT PINOUT_SWITCH(SWDIO_MODE_REG_MULT_PB9, SWDIO_MODE_REG_MULT_PB8, SWDIO_MODE_REG_MULT_PA13)
 #define SWDIO_MODE_REG      GPIO_MODER(TMS_PORT)
 
 #define TMS_SET_MODE()                                                    \
@@ -152,18 +154,18 @@ extern bool debug_bmp;
 		SWDIO_MODE_REG = mode_reg;              \
 	} while (0)
 
-#define TRST_PORT PINOUT_SWITCH(GPIOA, GPIOB)
-#define TRST_PIN  PINOUT_SWITCH(GPIO6, GPIO3)
+#define TRST_PORT PINOUT_SWITCH(GPIOA, GPIOB, GPIOB)
+#define TRST_PIN  PINOUT_SWITCH(GPIO6, GPIO3, GPIO4)
 
-#define NRST_PORT PINOUT_SWITCH(GPIOA, GPIOB)
-#define NRST_PIN  PINOUT_SWITCH(GPIO5, GPIO4)
+#define NRST_PORT PINOUT_SWITCH(GPIOA, GPIOB, GPIOA)
+#define NRST_PIN  PINOUT_SWITCH(GPIO5, GPIO4, GPIO5)
 
-/* SWO comes in on the same pin as TDO */
+/* SWO comes in on the same pin as TDO (FIXME: PB6 TX. Half-duplex?) */
 #define SWO_PORT GPIOB
-#define SWO_PIN  PINOUT_SWITCH(GPIO7, GPIO6)
+#define SWO_PIN  PINOUT_SWITCH(GPIO7, GPIO6, GPIO3)
 
-#define PWR_BR_PORT PINOUT_SWITCH(GPIOA, GPIOB)
-#define PWR_BR_PIN  PINOUT_SWITCH(GPIO1, GPIO9)
+#define PWR_BR_PORT PINOUT_SWITCH(GPIOA, GPIOB, GPIOA)
+#define PWR_BR_PIN  PINOUT_SWITCH(GPIO1, GPIO9, GPIO1)
 
 #define USER_BUTTON_KEY_PORT GPIOA
 #define USER_BUTTON_KEY_PIN  GPIO0
@@ -174,7 +176,7 @@ extern bool debug_bmp;
 #define LED_BOOTLOADER GPIO15
 
 #define LED_PORT_UART GPIOA
-#define LED_UART      PINOUT_SWITCH(GPIO4, GPIO1)
+#define LED_UART      PINOUT_SWITCH(GPIO4, GPIO1, GPIO4)
 
 /* SPI2: PB12/13/14/15 to external chips */
 #define EXT_SPI         SPI2

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -160,7 +160,7 @@ extern bool debug_bmp;
 #define NRST_PORT PINOUT_SWITCH(GPIOA, GPIOB, GPIOA)
 #define NRST_PIN  PINOUT_SWITCH(GPIO5, GPIO4, GPIO5)
 
-/* SWO comes in on the same pin as TDO (FIXME: PB6 TX. Half-duplex?) */
+/* SWO comes in on the same pin as TDO */
 #define SWO_PORT GPIOB
 #define SWO_PIN  PINOUT_SWITCH(GPIO7, GPIO6, GPIO3)
 
@@ -291,29 +291,35 @@ extern bool debug_bmp;
 #define IRQ_PRI_SWO_TIM      (0U << 4U)
 #define IRQ_PRI_SWO_DMA      (0U << 4U)
 
-/* Use TIM4 Input 2 (from PB7/TDO) or Input 1 (from PB6/TDO), AF2, triggered on rising edge */
-#define SWO_TIM             TIM4
-#define SWO_TIM_CLK_EN()    rcc_periph_clock_enable(RCC_TIM4)
-#define SWO_TIM_IRQ         NVIC_TIM4_IRQ
-#define SWO_TIM_ISR(x)      tim4_isr(x)
-#define SWO_IC_IN           PINOUT_SWITCH(TIM_IC_IN_TI2, TIM_IC_IN_TI1)
-#define SWO_IC_RISING       PINOUT_SWITCH(TIM_IC2, TIM_IC1)
-#define SWO_CC_RISING       PINOUT_SWITCH(TIM4_CCR2, TIM4_CCR1)
-#define SWO_ITR_RISING      PINOUT_SWITCH(TIM_DIER_CC2IE, TIM_DIER_CC1IE)
-#define SWO_STATUS_RISING   PINOUT_SWITCH(TIM_SR_CC2IF, TIM_SR_CC1IF)
-#define SWO_IC_FALLING      PINOUT_SWITCH(TIM_IC1, TIM_IC2)
-#define SWO_CC_FALLING      PINOUT_SWITCH(TIM4_CCR1, TIM4_CCR2)
-#define SWO_STATUS_FALLING  PINOUT_SWITCH(TIM_SR_CC1IF, TIM_SR_CC2IF)
+/*
+ * Use general-purpose timer input capture triggered on rising edge
+ * TIM4 Input 2 from PB7 AF2, or
+ * TIM4 Input 1 from PB6 AF2, or
+ * TIM2 Input 2 from PB3 AF1
+ */
+#define SWO_TIM_CLK_EN()
+#define SWO_TIM_CLK         PINOUT_SWITCH(RCC_TIM4, RCC_TIM4, RCC_TIM2)
+#define SWO_TIM             PINOUT_SWITCH(TIM4, TIM4, TIM2)
+#define SWO_TIM_IRQ         PINOUT_SWITCH(NVIC_TIM4_IRQ, NVIC_TIM4_IRQ, NVIC_TIM2_IRQ)
+#define SWO_TIM_ISR(x)      PINOUT_SWITCH(tim4_isr(x), tim4_isr(x), tim2_isr(x))
+#define SWO_IC_IN           PINOUT_SWITCH(TIM_IC_IN_TI2, TIM_IC_IN_TI1, TIM_IC_IN_TI2)
+#define SWO_IC_RISING       PINOUT_SWITCH(TIM_IC2, TIM_IC1, TIM_IC2)
+#define SWO_CC_RISING       PINOUT_SWITCH(TIM4_CCR2, TIM4_CCR1, TIM2_CCR2)
+#define SWO_ITR_RISING      PINOUT_SWITCH(TIM_DIER_CC2IE, TIM_DIER_CC1IE, TIM_DIER_CC2IE)
+#define SWO_STATUS_RISING   PINOUT_SWITCH(TIM_SR_CC2IF, TIM_SR_CC1IF, TIM_SR_CC2IF)
+#define SWO_IC_FALLING      PINOUT_SWITCH(TIM_IC1, TIM_IC2, TIM_IC1)
+#define SWO_CC_FALLING      PINOUT_SWITCH(TIM4_CCR1, TIM4_CCR2, TIM2_CCR1)
+#define SWO_STATUS_FALLING  PINOUT_SWITCH(TIM_SR_CC1IF, TIM_SR_CC2IF, TIM_SR_CC1IF)
 #define SWO_STATUS_OVERFLOW (TIM_SR_CC1OF | TIM_SR_CC2OF)
-#define SWO_TRIG_IN         PINOUT_SWITCH(TIM_SMCR_TS_TI2FP2, TIM_SMCR_TS_TI1FP1)
-#define SWO_TIM_PIN_AF      GPIO_AF2
+#define SWO_TRIG_IN         PINOUT_SWITCH(TIM_SMCR_TS_TI2FP2, TIM_SMCR_TS_TI1FP1, TIM_SMCR_TS_TI2FP2)
+#define SWO_TIM_PIN_AF      PINOUT_SWITCH(GPIO_AF2, GPIO_AF2, GPIO_AF1)
 
-/* On F411 use USART1_RX mapped on PB7 for async capture */
+/* On F411 use USART1_RX mapped on PB7/PB6/PB3 for async capture */
 #define SWO_UART        USBUSART1
 #define SWO_UART_CLK    USBUSART1_CLK
 #define SWO_UART_DR     USBUSART1_DR
 #define SWO_UART_PORT   GPIOB
-#define SWO_UART_RX_PIN GPIO7
+#define SWO_UART_RX_PIN PINOUT_SWITCH(GPIO7, GPIO6, GPIO3)
 #define SWO_UART_PIN_AF GPIO_AF7
 
 /* Bind to the same DMA Rx channel */


### PR DESCRIPTION
## Detailed description

* This is a new feature (no new code, just opt-in config/macro extension).
* Some users of BMP-compatibles expect BMF's jtagtap pins on self SWJ-DP pins of `blackpill-f4` probe (since `swlink`).
* The PR solves this by adding some pins to `PINOUT_SWITCH()` macros and a third `SWDIO_MODE_REG_MULT`.

Build this via `make PROBE_HOST=blackpill-f411ce ALTERNATIVE_PINOUT=2` (...optionally `ENABLE_RTT=1 ENABLE_DEBUG=1 BMP_BOOTLOADER=1)`, or, under meson, 
`meson setup build --cross-file cross-file/blackpill-f411ce.ini -Dalternative_pinout=2` (...optionally `-Drtt_support=true -Ddebug_output=true -Dbmd_bootloader=true` and flash using `dfu-util` (`bmputil` is untested and may be incompatible). 
Then your WeActStudio MiniSTM32F4x1 board 1) unmaps its entire SWJ-DP away from SYS_AF AF0 so you can no longer inception-debug BMF; 2) maps said pins to digital inputs/outputs of swdptap/jtagtap and performs proper SWD turnarounds. Use a 4-wire cable between 4-pin header and any other random bluepill that still has its SW(J)-DP mapped. I also tested that PA15/PB3 are under control of jtagtap now and BMF still works in JTAG transport mode over these pins (this also means that SWO *output* from BMF for non-invasive profiling reasons is inaccessible). 
Due to the bitbanging nature of current firmware, pinout choice has no obvious impact on performance (compared to SPI acceleration). I did not test extended pins like JTRST or SRST, but I imagine they're trivial. TraceSWO capture does not work, be it TIM-based Manchester (sync) or USART-based NRZ/Async.

To recover the DP, reflash pinouts 0 or 1, or at least stay in BMPBootloader (by pressing PA0), or enter MaskROM DFU (by pressing BOOT0) on reset. An external debugger can connect-under-reset (where the important pins get into AF0 again and DP works). Current BMF does not have a fallback where it would re-map DP pins back upon crashing.

Tested against a second blackpill-f4, i.e. inception debug.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native *and does not affect it*
* [x] It builds as BMDA *and does not affect it*
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1791.