### PR TITLE
Fix STLINK/V2 operation with multi-AP chips and block reads

### DIFF
--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -732,11 +732,14 @@ static void stlink_mem_write(
 	if (!stlink_ensure_ap(ap->apsel))
 		raise_exception(EXCEPTION_ERROR, "ST-Link AP selection error");
 
+	DEBUG_PROBE("%s: @0x%08" PRIx32 "+%zu\n", __func__, dest, len);
+
 	const uint8_t *const data = (const uint8_t *)src;
-	/* Chunk the write up into stlink.block_size blocks */
-	for (size_t offset = 0; offset < len; offset += stlink.block_size) {
+	const uint16_t block_size = (align == ALIGN_8BIT) ? stlink.block_size : STLINK_READMEM_32BIT_MAX_SIZE;
+	/* Chunk the write up into firmware-digestible blocks */
+	for (size_t offset = 0; offset < len; offset += block_size) {
 		/* Figure out how many bytes are in the block and at what start address */
-		const size_t amount = MIN(len - offset, stlink.block_size);
+		const size_t amount = MIN(len - offset, block_size);
 		const uint32_t addr = dest + offset;
 		/* Now generate an appropriate access packet */
 		stlink_mem_command_s command;

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -150,6 +150,7 @@
 
 #define STLINK_V3_FREQ_ENTRY_COUNT 10U
 
+/* APsel value for DP accesses */
 #define STLINK_DEBUG_PORT 0xffffU
 
 /* Tested on V2J33M25 and V2J45M30 */

--- a/src/platforms/hosted/stlinkv2_protocol.h
+++ b/src/platforms/hosted/stlinkv2_protocol.h
@@ -152,6 +152,9 @@
 
 #define STLINK_DEBUG_PORT 0xffffU
 
+/* Tested on V2J33M25 and V2J45M30 */
+#define STLINK_READMEM_32BIT_MAX_SIZE 6144U
+
 typedef struct stlink_simple_command {
 	uint8_t command;
 	uint8_t operation;


### PR DESCRIPTION
## Detailed description

* This is not a feature.
* The existing problems are 1) BMDA over STLINK/V2 (incl. onboard) adapter with original firmware failing to scan/attach to STM32MP15x; 2) RTT not working over these adapters (with errors "Too large!").
* The PR solves that by carefully using what's already there (apsel) and raising the block read limit to at least 4096.

On DK1, its onboard V2-1 is the only way to access and debug the SoC, but BMDA's support for that adapter used to assume AP 0 is the only one usable, which flies for simpler MCUs but not for this MPU -- it has AXI-AP at 0 with no debug components. A bug in the backend then resets `stlink.apsel` to 0 and next accesses targeted at Cortex-A (halt and) detection via APB-D AP 1 land at AP 0 and lock it up, rendering further debug impossible until next power-on reset.
On many Discovery Kits and (cheaper/older) Nucleo-64 boards their V2-1 is a convenient way to collect RTT logs even when the target MCU does not implement TraceSWO (CM0+) or the wire is not connected by default (32F429i-DISC1). However, it issues block reads longer than 64 bytes, which triggers an unexplained failsafe in the backend. I first encountered this in July 2023 when I was benchmarking BMF-internal RTT.
The two patches allow using onboard stlinks with BMDA again out-of-the-box, without resorting to reflashing them to any alternative firmware.
Caveat SWD multidrop, I don't have a working solution for LINERESET+TARGETSEL+READ DPIDR sequence, where the second operation currently throws an uncaught C sjlj "exception" from stlink not seeing an "expected" DP Ack. Hence SWD with F7, H7, L5, MP15 is still broken (JTAG is not, unless some chip errata render it incompatible).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes support of MP15. Should fix support of H7 and others. Fixes support of RTT.