### PR TITLE
Fix remaining length calculation for 'X' 'M' and 'vFlashWrite'

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -168,7 +168,7 @@ int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, siz
 		uint32_t len = 0;
 		ERROR_IF_NO_TARGET();
 		if (read_hex32(pbuf + 1, &rest, &addr, ',') && read_hex32(rest, &rest, &len, ':')) {
-			if (len > (size - (size_t)(pbuf - rest)) / 2U) {
+			if (len > (size - (size_t)(rest - pbuf)) / 2U) {
 				gdb_putpacketz("E02");
 				break;
 			}
@@ -344,7 +344,7 @@ int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, siz
 		uint32_t addr, len;
 		ERROR_IF_NO_TARGET();
 		if (read_hex32(pbuf + 1, &rest, &addr, ',') && read_hex32(rest, &rest, &len, ':')) {
-			if (len > (size - (size_t)(pbuf - rest))) {
+			if (len > (size - (size_t)(rest - pbuf))) {
 				gdb_putpacketz("E02");
 				break;
 			}
@@ -789,7 +789,7 @@ static void exec_v_flash_write(const char *packet, const size_t length)
 	const char *rest = NULL;
 	if (read_hex32(packet, &rest, &addr, ':')) {
 		/* Write Flash Memory */
-		const uint32_t count = length - (packet - rest);
+		const uint32_t count = length - (size_t)(rest - packet);
 		DEBUG_GDB("Flash Write %08" PRIX32 " %08" PRIX32 "\n", addr, count);
 		if (cur_target && target_flash_write(cur_target, addr, (uint8_t *)rest, count))
 			gdb_putpacketz("OK");


### PR DESCRIPTION
## Detailed description

When removing use of sscanf from gdb_main the calculation of the length of the remaining data portion of the 'X', 'M', and 'vFlashWrite' packet types was done wrongly. The difference between the start of data pointer and start of buffer pointer was reversed resulting in adding this to the total length rather than subtracting it.  For the 'X' and 'M' packets this causes them to accept lengths longer than the supplied data but correct packets would still function as expected. For the 'vFlashWrite' packet the length passed to the flash write function was about 8 larger than it should have been which could cause problems.

The calculation of the data length portion of the packets has been corrected so all three now work as expected.

Tested vFlashWrite with '-v 2' on BMDA to confirm the correct lengths.
Tested the 'M' and 'X' packets on both BMDA and native firmware by attempting packets with overly long length field for how much data is present and checking that they fail now while the correct length produces no errors.

<!-- Filling this template is mandatory -->


<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
