### PR TITLE
Fix: Tooling cleanup

### DIFF
--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -417,8 +417,6 @@ typedef struct ex_frame {
 	uintptr_t return_address;
 } ex_frame_s;
 
-void debug_monitor_handler(void) __attribute__((used)) __attribute__((naked));
-
 /*
  * This implements the other half of the newlib syscall puzzle.
  * When newlib is built for ARM, various calls that do file IO

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -236,7 +236,7 @@ void bmda_add_jtag_dev(uint32_t dev_index, const jtag_dev_s *jtag_dev);
 #endif
 
 /* Data transfer value packing/unpacking helper functions */
-void *adiv5_unpack_data(void *dest, target_addr32_t src, uint32_t val, align_e align);
+void *adiv5_unpack_data(void *dest, target_addr32_t src, uint32_t data, align_e align);
 const void *adiv5_pack_data(target_addr32_t dest, const void *src, uint32_t *data, align_e align);
 
 /* ADIv5 high-level memory write function */

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -151,7 +151,7 @@ const command_s stm32l4_cmd_list[] = {
 #define RAM_COUNT_MSK 0x07U
 
 /* TODO: add block size constants for other MCUs */
-#define STM32U5_FLASH_BLOCK_SIZE	0x2000U
+#define STM32U5_FLASH_BLOCK_SIZE 0x2000U
 
 typedef enum stm32l4_device_id {
 	/* This first block of devices uses an ID code register located in the DBG_MCU block at 0xe0042000 */
@@ -702,11 +702,14 @@ static bool stm32l4_attach(target_s *const t)
 		if (options & OR_DUALBANK) {
 			const uint32_t bank_len = flash_len * 512U;
 			if (device->family == STM32L4_FAMILY_U5xx) {
-				stm32l4_add_flash(t, STM32L4_FLASH_BANK_1_BASE, bank_len, STM32U5_FLASH_BLOCK_SIZE, STM32L4_FLASH_BANK_1_BASE + bank_len);
-				stm32l4_add_flash(t, STM32L4_FLASH_BANK_1_BASE + bank_len, bank_len, STM32U5_FLASH_BLOCK_SIZE, STM32L4_FLASH_BANK_1_BASE + bank_len);
+				stm32l4_add_flash(t, STM32L4_FLASH_BANK_1_BASE, bank_len, STM32U5_FLASH_BLOCK_SIZE,
+					STM32L4_FLASH_BANK_1_BASE + bank_len);
+				stm32l4_add_flash(t, STM32L4_FLASH_BANK_1_BASE + bank_len, bank_len, STM32U5_FLASH_BLOCK_SIZE,
+					STM32L4_FLASH_BANK_1_BASE + bank_len);
 			} else {
 				stm32l4_add_flash(t, STM32L4_FLASH_BANK_1_BASE, bank_len, 0x0800, STM32L4_FLASH_BANK_1_BASE + bank_len);
-				stm32l4_add_flash(t, STM32L4_FLASH_BANK_1_BASE + bank_len, bank_len, 0x0800, STM32L4_FLASH_BANK_1_BASE + bank_len);
+				stm32l4_add_flash(
+					t, STM32L4_FLASH_BANK_1_BASE + bank_len, bank_len, 0x0800, STM32L4_FLASH_BANK_1_BASE + bank_len);
 			}
 		} else {
 			const uint32_t bank_len = flash_len * 1024U;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes some compiler warnings and CI complaints that had crept in. This includes a clang-tidy lint, a duplicated decl warning, and the clang-format oops that crept in via PR #1807.

These fixes are preparation for the STM32H7 support fix branch.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
