### PR TITLE
Fix: Timeout mishandling issue

### DIFF
--- a/src/platforms/common/stm32/timing_stm32.c
+++ b/src/platforms/common/stm32/timing_stm32.c
@@ -62,8 +62,8 @@ void platform_timing_init(void)
 {
 	/* Setup heartbeat timer */
 	systick_set_clocksource(STK_CSR_CLKSOURCE_AHB_DIV8);
-	/* Interrupt us at 100 Hz */
-	systick_set_reload(rcc_ahb_frequency / (8U * SYSTICKHZ));
+	/* Interrupt us at 1kHz */
+	systick_set_reload((rcc_ahb_frequency / (8U * SYSTICKHZ)) - 1U);
 	/* SYSTICK_IRQ with low priority */
 	nvic_set_priority(NVIC_SYSTICK_IRQ, 14U << 4U);
 	systick_interrupt_enable();

--- a/src/timing.c
+++ b/src/timing.c
@@ -29,5 +29,17 @@ void platform_timeout_set(platform_timeout_s *const t, uint32_t ms)
 
 bool platform_timeout_is_expired(const platform_timeout_s *const t)
 {
-	return platform_time_ms() > t->time;
+	/* Cache the current time for the whole calculation */
+	const uint32_t counter = platform_time_ms();
+	/*
+	 * Check for the tricky overflow condition and handle that properly -
+	 * when time_ms approaches UINT32_MAX and we try to set a timeout that
+	 * overflows to a low t->time value, if we simply compare with `<`, we will
+	 * erroneously consider the timeout expired for a few ms right at the start of
+	 * the valid interval. Instead, force that region of time to be considered
+	 * not expired by checking the MSb's of the two values and handling that specially.
+	 */
+	if ((counter & UINT32_C(0x80000000)) && !(t->time & UINT32_C(0x80000000)))
+		return false;
+	return counter > t->time;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses an issue in the platform timeouts subsystem where the firmware will execute and handle timeouts very wrongly for a few seconds after ~49.7 days of uptime.

The gist of the bug is that as the time_ms counter approaches UINT32_MAX and platform_timeout_set() starts generating expiration times close to 0, the comparison for whether the timeout has expired will incorrectly determine that it has at the start of the timeout validity interval. This is incredibly wrong and will cause all manner of broken behaviour in anything that depends on timeouts to function properly.

We fix this by detecting this edge condition where the uptime counter has the MSb set and the expiration time does not and force the comparison to false. This is wrong if a timeout is requested that is exceedingly large (~2<sup>31</sup>ms) but as the firmware never does that and that would be a ~25.8 day timeout, this edge-case is irrelevant.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
