### PR TITLE
Feature: STM32F410 support

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -1,10 +1,11 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Copyright (C) 2011 Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
- * Copyright (C) 2017, 2018  Uwe Bonnes
- *                           <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Copyright (C) 2017, 2018 Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,16 +22,12 @@
  */
 
 /*
- * This file implements STM32F4 target specific functions for detecting
- * the device, providing the XML memory map and Flash memory programming.
+ * This file implements support for STM32F4xx, STM32F20x and GD32F4x series
+ * devices, providing memory maps and Flash programming routines.
  *
  * References:
- * ST doc - RM0090
- *   Reference manual - STM32F405xx, STM32F407xx, STM32F415xx and STM32F417xx
- *   advanced ARM-based 32-bit MCUs
- * ST doc - PM0081
- *   Programming manual - STM32F40xxx and STM32F41xxx Flash programming
- *    manual
+ * RM0090 - STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439 advanced Arm®-based 32-bit MCUs, Rev. 20
+ * https://www.st.com/resource/en/reference_manual/rm0090-stm32f405415-stm32f407417-stm32f427437-and-stm32f429439-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
  */
 
 #include "general.h"

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -28,6 +28,8 @@
  * References:
  * RM0090 - STM32F405/415, STM32F407/417, STM32F427/437 and STM32F429/439 advanced Arm®-based 32-bit MCUs, Rev. 20
  * https://www.st.com/resource/en/reference_manual/rm0090-stm32f405415-stm32f407417-stm32f427437-and-stm32f429439-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * RM0401 - STM32F410 advanced Arm®-based 32-bit MCUs
+ * https://www.st.com/resource/en/reference_manual/rm0401-stm32f410-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
  */
 
 #include "general.h"
@@ -180,6 +182,8 @@ static char *stm32f4_get_chip_name(const uint32_t device_id)
 		return "STM32F446";
 	case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
 		return "STM32F401C";
+	case ID_STM32F410: /* F410 RM0401 Rev.3 */
+		return "STM32F410";
 	case ID_STM32F411: /* F411 xC/E  RM0383 Rev.4 */
 		return "STM32F411";
 	case ID_STM32F412: /* F412 xG/I  RM0402 Rev.4, 256 kB Ram */
@@ -229,6 +233,7 @@ bool stm32f4_probe(target_s *target)
 	case ID_STM32F40X:
 	case ID_STM32F446:  /* F446 */
 	case ID_STM32F401C: /* F401 B/C RM0368 Rev.3 */
+	case ID_STM32F410:  /* F410     RM0401 Rev.3 */
 	case ID_STM32F411:  /* F411     RM0383 Rev.4 */
 	case ID_STM32F412:  /* F412     RM0402 Rev.4, 256 kB Ram */
 	case ID_STM32F401E: /* F401 D/E RM0368 Rev.3 */
@@ -319,6 +324,9 @@ static bool stm32f4_attach(target_s *target)
 	/* First try and figure out the Flash size (if we don't know the part ID, warn and return false) */
 	uint16_t max_flashsize = 0;
 	switch (target->part_id) {
+	case ID_STM32F410: /* F410 RM0401 Rev.3 */
+		max_flashsize = 128;
+		break;
 	case ID_STM32F401E: /* F401D/E RM0368 Rev.3 */
 	case ID_STM32F411:  /* F411 RM0383 Rev.4 */
 	case ID_STM32F446:  /* F446 */

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -336,6 +336,10 @@ static uint32_t stm32f4_remaining_bank_length(const uint32_t bank_length, const 
 	return 0;
 }
 
+/*
+ * XXX: It would definitely be nice if all this soup of logic could reasonably be refactored and moved into
+ * the stm32f4_probe() routine as this is doing work that should not be repeated every attach.
+ */
 static bool stm32f4_attach(target_s *target)
 {
 	/* First try and figure out the Flash size (if we don't know the part ID, warn and return false) */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR adds support for the STM32F410 which, while the ID existed in the implementation, was not plumbed in at all.

We have also taken the opportunity to address and sort out the write parallelism handling mess in the support implementation, greatly simplifying the whole lot and saving a good amount of Flash. It turned out our earlier suspicions (noted in comments in the code) about the psize handling were in fact correct.

Full debug and Flash support tested on the Nucleo-F410RB where all seems to be working properly even after a week straight of using the support to debug code on the board.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
