### PR TITLE
Fix: Simplify debug log guard in imxrt.c

### DIFF
--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -218,7 +218,7 @@ bool imxrt_probe(target_s *const target)
 	snprintf(priv->name, IMXRT_NAME_MAX_LENGTH, "i.MXRT%u", priv->chip_id);
 	target->driver = priv->name;
 
-#if ENABLE_DEBUG == 1 && (PC_HOSTED == 1 || defined(ESP_LOGD))
+#ifndef DEBUG_TARGET_IS_NOOP
 	const uint8_t boot_mode = (target_mem32_read32(target, IMXRT_SRC_BOOT_MODE2) >> 24U) & 3U;
 #endif
 	DEBUG_TARGET("i.MXRT boot mode is %x\n", boot_mode);


### PR DESCRIPTION
## Detailed description

* Not a feature.
* Existing problem is a compiler error for *firmware builds* with `DEBUG_TARGET()` log statements enabled (unusual configuration, unreachable through meson/Makefiles alone).
* The PR solves this problem by updating one macro guard.

This is a contextual follow-up to #1517, also see PR1533-PR1534, and really it's #1684 which enables *this* PR.
```c
In file included from ../src/target/imxrt.c:34:
../src/target/imxrt.c: In function 'imxrt_probe':
../src/target/imxrt.c:224:50: error: 'boot_mode' undeclared (first use in this function)
  224 |         DEBUG_TARGET("i.MXRT boot mode is %x\n", boot_mode);
      |                                                  ^~~~~~~~~
```

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues