### PR TITLE
Fix: Replace `sprintf()` calls remaining in firmware with `snprintf()`

### DIFF
--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -960,7 +960,8 @@ bool efm32_aap_probe(adiv5_access_port_s *ap)
 	DEBUG_INFO("EFM32: AAP STATUS=%08" PRIx32 "\n", adiv5_ap_read(ap, AAP_STATUS));
 
 	efm32_aap_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
-	sprintf(priv_storage->aap_driver_string, "EFM32 Authentication Access Port rev.%hu", aap_revision);
+	snprintf(priv_storage->aap_driver_string, sizeof(priv_storage->aap_driver_string),
+		"EFM32 Authentication Access Port rev.%hu", aap_revision);
 	t->driver = priv_storage->aap_driver_string;
 	t->regs_size = 0;
 

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -407,9 +407,9 @@ bool samx7x_probe(target_s *t)
 	sam_add_flash(t, SAMX7X_EEFC_BASE, 0x00400000, priv_storage->descr.flash_size);
 	target_add_commands(t, sam_cmd_list, "SAMX7X");
 
-	sprintf(priv_storage->sam_variant_string, "SAM%c%02d%c%d%c", priv_storage->descr.product_code,
-		priv_storage->descr.product_id, priv_storage->descr.pins, priv_storage->descr.density,
-		priv_storage->descr.revision);
+	snprintf(priv_storage->sam_variant_string, sizeof(priv_storage->sam_variant_string), "SAM%c%02d%c%d%c",
+		priv_storage->descr.product_code, priv_storage->descr.product_id, priv_storage->descr.pins,
+		priv_storage->descr.density, priv_storage->descr.revision);
 
 	t->driver = priv_storage->sam_variant_string;
 	return true;

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -258,7 +258,8 @@ bool stm32l0_probe(target_s *const target)
 	const uint32_t nvm = stm32lx_nvm_phys(target);
 	const bool protected =
 		(target_mem32_read32(target, STM32Lx_NVM_OPTR(nvm)) & STM32Lx_NVM_OPTR_RDPROT_M) != STM32Lx_NVM_OPTR_RDPROT_0;
-	sprintf(priv_storage->stm32l_variant, "%s%s", target->driver, protected ? " (protected)" : "");
+	snprintf(priv_storage->stm32l_variant, sizeof(priv_storage->stm32l_variant), "%s%s", target->driver,
+		protected ? " (protected)" : "");
 	target->driver = priv_storage->stm32l_variant;
 
 	if (protected) {


### PR DESCRIPTION
## Detailed description

* Not a feature.
* The existing minor problem is inconsistency in usage of sprintf/snprintf in firmware (target drivers).
* This PR solves it by replacing (almost as-is) the three remaining `sprintf` calls as highlighted by `puncover` and `grep` / `the-silver-searcher` with `snprintf` which is used much more often.

Bonus points for bounds checking, as all touched cases deal with copying a runtime-constructed pattern into a target private storage struct, which has a fixed capacity, and it's cheap to take its size [and stuff into second argument] -- not invented by me, I was just looking at other callers of snprintf. There could be stricter bounds enforced, but I won't be researching that.
As measured on gcc-12 and `native` this drops a 64-byte `siprintf` shim function from current `main`, while retaining 104-byte `sniprintf` with 14 callers and `_svfiprintf_r` the impl proper. It may be much harder to get rid of that set of efficient newlib-nano library functions, because of e.g. existing XML builders.

I can't test against any of three touched targets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues