### PR TITLE
Please report unknown device with Designer 0x8055 Part ID 0x29b - Add support for another STM32F01 clone

### DIFF
--- a/src/target/jep106.h
+++ b/src/target/jep106.h
@@ -79,7 +79,8 @@
  * This code is not listed in the JEP106 standard, but is used by some stm32f1 clones
  * since we're not using this code elsewhere let's switch to the stm code.
  */
-#define JEP106_MANUFACTURER_ERRATA_CS 0x555U
+#define JEP106_MANUFACTURER_ERRATA_CS       0x555U
+#define JEP106_MANUFACTURER_ERRATA_CS_ASCII 0x8055U
 
 /*
  * CPU2 for STM32W(L|B) uses ARM's JEP-106 continuation code (4) instead of


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Tried to use blackmagic to program/debug one of the infamous "bluepill" boards with a counterfeit STM32F103C8 MCU. BMDA reports `Please report unknown device with Designer 0x8055 Part ID 0x29b` and is not able to flash the board.

I had a deeper look, added a `DEBUG_INFO`to print the PIDR before processing and figured that the PIDR is apparently 0x000000050005529b, which would indicate a manufacturer code of 0x555 and part id 0x29b, which would actually already be recognized if the `PIDR_JEP106_USED` bit would be set. Which is sadly missing. Therefore in `adiv5_component_probe()` the if-clause where the designer code would be re-written to STM is not entered, instead the code is handled as "legacy ascii code" and extended to 0x8055.

To allow recognition of this chip as an STM32F103C8, this pull request adds a code snippet in `cortexm_probe()` to re-map the 0x8055 designer code to `JEP106_MANUFACTURER_STM`.

At time of creation, this PR also contains the additional DEBUG_INFO I added. If you think this is too noisy to be kept I can remove that commit from the PR.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

Notes:
* Native build testen on blackpill STM401CC, that's all I have 
* I've read the contributing guidelines, but was unsure if that few lines of code would justify adding my name to the list of contributors in the file header, as in the git history there are far more significant contributions by people not mentioned there.

## Closing issues

None.

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
