### PR TITLE
ci: Fix deployment of GCC < 14 under macOS

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -449,6 +449,7 @@ jobs:
           #    from ../src/include/general.h:62,
           #    from ../src/command.c:28:
           #    /opt/homebrew/Cellar/gcc@11/11.4.0/lib/gcc/11/gcc/aarch64-apple-darwin23/11/include-fixed/AvailabilityInternal.h:162:10: fatal error: AvailabilityInternalLegacy.h: No such file or directory
+          # FIXME: remove the brew unlink step once `gcc` itself works
           - os: macos-latest
       fail-fast: false
 
@@ -465,6 +466,7 @@ jobs:
       # Install a suitable system compiler for the build
       - name: Setup Homebrew GCC
         run: |
+          brew unlink gcc
           brew install ${{ matrix.compiler }}
           CC=${COMPILER/@/-}
           CXX=${CC/#gcc/g++}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

@dragonmux just shared with me a macOS build log, and I noticed that it started to fail because Homebrew has started deploying GCC 14.1.

This PR ensures that Homebrew can cleanly deploy earlier versions by unlinking the version provided by GitHub Actions, before installing the requested GCC version.

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [X] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
