### PR TITLE
Fix: udev rules

### DIFF
--- a/driver/99-blackmagic-plugdev.rules
+++ b/driver/99-blackmagic-plugdev.rules
@@ -2,11 +2,11 @@
 # there are two connections, one for GDB and one for UART debugging
 # copy this to /etc/udev/rules.d/99-blackmagic.rules
 # and run sudo udevadm control -R
-ACTION!="add|change", GOTO="blackmagic_rules_end"
+ACTION!="add|change|bind", GOTO="blackmagic_rules_end"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb%E{ID_SERIAL_SHORT}"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg%E{ID_SERIAL_SHORT}"
-SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6017", MODE="0666", GROUP="plugdev", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6018", MODE="0666", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6017", MODE="0666", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6018", MODE="0666", GROUP="plugdev", TAG+="uaccess"
 LABEL="blackmagic_rules_end"

--- a/driver/99-blackmagic-uucp.rules
+++ b/driver/99-blackmagic-uucp.rules
@@ -2,11 +2,11 @@
 # there are two connections, one for GDB and one for UART debugging
 # copy this to /etc/udev/rules.d/99-blackmagic.rules
 # and run sudo udevadm control -R
-ACTION!="add|change", GOTO="blackmagic_rules_end"
+ACTION!="add|change|bind", GOTO="blackmagic_rules_end"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic GDB Server", SYMLINK+="ttyBmpGdb%E{ID_SERIAL_SHORT}"
 SUBSYSTEM=="tty", ACTION=="add", ATTRS{interface}=="Black Magic UART Port", SYMLINK+="ttyBmpTarg%E{ID_SERIAL_SHORT}"
-SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6017", MODE="0666", GROUP="uucp", TAG+="uaccess"
-SUBSYSTEM=="usb", ATTR{idVendor}=="1d50", ATTR{idProduct}=="6018", MODE="0666", GROUP="uucp", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6017", MODE="0666", GROUP="uucp", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6018", MODE="0666", GROUP="uucp", TAG+="uaccess"
 LABEL="blackmagic_rules_end"


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Back in udev 247, a change was made that introduced new actions that have to be handled by rules files, breaking the rules in the repo.

This PR addresses this as this impacts Debian Stable, Arch and a slew of other distros that are all now using systemd/udev >= 247, and as there are some other silly mistakes in the rules to do with how attributes are looked up for the permissions setting component.

Tested on our Debian box and Arch boxes.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
