### PR TITLE
Fix: macOS Homebrew CI

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -449,7 +449,6 @@ jobs:
           #    from ../src/include/general.h:62,
           #    from ../src/command.c:28:
           #    /opt/homebrew/Cellar/gcc@11/11.4.0/lib/gcc/11/gcc/aarch64-apple-darwin23/11/include-fixed/AvailabilityInternal.h:162:10: fatal error: AvailabilityInternalLegacy.h: No such file or directory
-          # FIXME: remove the brew unlink step once `gcc` itself works
           - os: macos-latest
       fail-fast: false
 
@@ -466,7 +465,6 @@ jobs:
       # Install a suitable system compiler for the build
       - name: Setup Homebrew GCC
         run: |
-          brew unlink gcc
           brew install ${{ matrix.compiler }}
           CC=${COMPILER/@/-}
           CXX=${CC/#gcc/g++}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

@amyspark very kindly fixed the macOS Homebrew CI yesterday in #1822, only GHA just rebuilt the CI image ~10h ago. This undid the image change that caused the need for the fix in the first place - this PR reverts the previous PR w/ permission and thanks from Amy as the GHA CI image has been sorted back out.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
