### PR TITLE
Fix: ADIv5 handling issues

### DIFF
--- a/src/platforms/hosted/stlinkv2.c
+++ b/src/platforms/hosted/stlinkv2.c
@@ -502,6 +502,15 @@ int stlink_hwversion(void)
 	return stlink.ver_stlink;
 }
 
+static void stlink_line_reset(void)
+{
+	stlink_simple_query(STLINK_DEBUG_COMMAND, STLINK_DEBUG_EXIT, NULL, 0);
+	uint8_t data[2];
+	stlink_simple_request(
+		STLINK_DEBUG_COMMAND, STLINK_DEBUG_APIV2_ENTER, STLINK_DEBUG_ENTER_SWD_NO_RESET, data, sizeof(data));
+	stlink_usb_error_check(data, true);
+}
+
 uint32_t stlink_adiv5_clear_error(adiv5_debug_port_s *const dp, const bool protocol_recovery)
 {
 	DEBUG_PROBE("%s (protocol recovery: %s)\n", __func__, protocol_recovery ? "true" : "false");
@@ -512,9 +521,16 @@ uint32_t stlink_adiv5_clear_error(adiv5_debug_port_s *const dp, const bool proto
 		 * we must then re-select the target to bring the device back
 		 * into the expected state.
 		 */
-		stlink_reset_adaptor();
+		stlink_line_reset();
 		if (dp->version >= 2)
-			adiv5_dp_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+			/*
+			 * The correct thing to do here is some form of this:
+			 * adiv5_dp_write(dp, ADIV5_DP_TARGETSEL, dp->targetsel);
+			 * but ST-Link adaptors cannot handle this properly right now, so warn instead.
+			 */
+			DEBUG_WARN("ST-Link v2/v3 adaptors cannot handle multi-drop correctly, pretending everything's fine\n");
+		/* Re-select the current AP on completion so we keep talking with the same thing */
+		stlink_ap_setup(stlink.apsel);
 		adiv5_dp_read(dp, ADIV5_DP_DPIDR);
 	}
 	const uint32_t err = adiv5_dp_read(dp, ADIV5_DP_CTRLSTAT) &

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -1289,7 +1289,7 @@ void advi5_mem_read_bytes(adiv5_access_port_s *const ap, void *dest, const targe
 		 * Check if the address doesn't overflow the 10-bit auto increment bound for TAR,
 		 * if it's not the first transfer (offset == 0)
 		 */
-		if (begin != src && (begin & 0x00000effU) == 0U) {
+		if (begin != src && (begin & 0x000003ffU) == 0U) {
 			/* Update TAR to adjust the upper bits */
 			if (ap->flags & ADIV5_AP_FLAGS_64BIT)
 				adiv5_dp_write(ap->dp, ADIV5_AP_TAR_HIGH, (uint32_t)(begin >> 32));
@@ -1321,7 +1321,7 @@ void adiv5_mem_write_bytes(
 		 * Check if the address doesn't overflow the 10-bit auto increment bound for TAR,
 		 * if it's not the first transfer (offset == 0)
 		 */
-		if (begin != dest && (begin & 0x00000effU) == 0U) {
+		if (begin != dest && (begin & 0x000003ffU) == 0U) {
 			/* Update TAR to adjust the upper bits */
 			if (ap->flags & ADIV5_AP_FLAGS_64BIT)
 				adiv5_dp_write(ap->dp, ADIV5_AP_TAR_HIGH, (uint32_t)(begin >> 32));

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -312,7 +312,7 @@ void adiv5_swd_multidrop_scan(adiv5_debug_port_s *const dp, const uint32_t targe
 
 		/* Allocate a new target DP for this instance */
 		adiv5_debug_port_s *const target_dp = calloc(1, sizeof(*dp));
-		if (!dp) { /* calloc failed: heap exhaustion */
+		if (!target_dp) { /* calloc failed: heap exhaustion */
 			DEBUG_ERROR("calloc: failed in %s\n", __func__);
 			break;
 		}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes a couple of bugs that were accidentally introduced a while back in the ADIv5 implementation, and provides a workaround for the ST-Link firmware not supporting multi-drop at all, unlike what the release notes advertise.

The first of the regressions that this fixes is in the ADIv5 memory I/O code where the handling for TAR wrap-around got botched by typo in aa9bb48d (as much as the keys are right next to each other, e is not 3!).

The second regression was accidentally introduced in 44422c9f when SWD multi-drop was refactored and rewritten - most likely due to an oversight.

The ST-Link component of this PR partially fixes/alleviates #1813 but does not resolve the issue laid out in that issue.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
