### PR TITLE
Feature: SRAM layout reorganisation

### DIFF
--- a/src/platforms/96b_carbon/96b_carbon.ld
+++ b/src/platforms/96b_carbon/96b_carbon.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 96K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
-
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/96b_carbon/Makefile.inc
+++ b/src/platforms/96b_carbon/Makefile.inc
@@ -7,8 +7,8 @@ CFLAGS += -Istm32/include -mcpu=cortex-m4 -mthumb \
 	-DSTM32F4 -D_96B_CARBON -I../deps/libopencm3/include \
 	-Iplatforms/common/stm32 -DDFU_SERIAL_LENGTH=9
 
-LDFLAGS = -lopencm3_stm32f4 -Wl,--defsym,_stack=0x20006000 \
-	-Wl,-T,platforms/96b_carbon/96b_carbon.ld -nostartfiles -lc -lnosys \
+LDFLAGS = -lopencm3_stm32f4 -Lplatforms/96b_carbon \
+	-T96b_carbon.ld -nostartfiles -lc -lnosys \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m4 -Wl,-gc-sections \
 	-mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 	-L../deps/libopencm3/lib

--- a/src/platforms/96b_carbon/meson.build
+++ b/src/platforms/96b_carbon/meson.build
@@ -42,7 +42,6 @@ probe_96b_carbon_args = [
 probe_96b_carbon_link_args = [
 	'-L@0@'.format(meson.current_source_dir()),
 	'-T@0@'.format('96b_carbon.ld'),
-	'-Wl,--defsym,_stack=0x20006000',
 ]
 
 probe_host = declare_dependency(

--- a/src/platforms/blackpill-f401cc/Makefile.inc
+++ b/src/platforms/blackpill-f401cc/Makefile.inc
@@ -1,3 +1,3 @@
-LINKER_SCRIPT=platforms/common/blackpill-f4/blackpill-f401cc.ld
+LINKER_SCRIPT=blackpill-f401cc.ld
 
 include platforms/common/blackpill-f4/Makefile.inc

--- a/src/platforms/blackpill-f401ce/Makefile.inc
+++ b/src/platforms/blackpill-f401ce/Makefile.inc
@@ -1,3 +1,3 @@
-LINKER_SCRIPT=platforms/common/blackpill-f4/blackpill-f401ce.ld
+LINKER_SCRIPT=blackpill-f401ce.ld
 
 include platforms/common/blackpill-f4/Makefile.inc

--- a/src/platforms/blackpill-f411ce/Makefile.inc
+++ b/src/platforms/blackpill-f411ce/Makefile.inc
@@ -1,3 +1,3 @@
-LINKER_SCRIPT=platforms/common/blackpill-f4/blackpill-f411ce.ld
+LINKER_SCRIPT=blackpill-f411ce.ld
 
 include platforms/common/blackpill-f4/Makefile.inc

--- a/src/platforms/common/Makefile.inc
+++ b/src/platforms/common/Makefile.inc
@@ -27,4 +27,5 @@ SRC +=             \
 	usb.c          \
 	usb_serial.c   \
 	usb_dfu_stub.c \
-	aux_serial.c
+	aux_serial.c   \
+	syscalls.c

--- a/src/platforms/common/blackmagic.ld
+++ b/src/platforms/common/blackmagic.ld
@@ -102,9 +102,10 @@ SECTIONS
 		. = ALIGN(4);
 		_ebss = .;
 		. = ALIGN(4);
-		end = .;
-		PROVIDE(_end = .);
 	} >ram
+
+	PROVIDE(heap_start = .);
+	PROVIDE(heap_end = ORIGIN(ram) + LENGTH(ram));
 
 	/*
 	 * The .eh_frame section appears to be used for C++ exception handling.

--- a/src/platforms/common/blackmagic.ld
+++ b/src/platforms/common/blackmagic.ld
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Enforce emmition of the vector table. */
+EXTERN(vector_table)
+
+/* Define the entry point of the output file. */
+ENTRY(reset_handler)
+
+/* Define sections. */
+SECTIONS
+{
+	.text : {
+		KEEP(*(.vectors)) /* Vector table */
+		*(.text*)	/* Program code */
+		. = ALIGN(4);
+		*(.rodata*)	/* Read-only data */
+		. = ALIGN(4);
+	} >rom
+
+	/* C++ Static constructors/destructors, also used for __attribute__
+	 * ((constructor)) and the likes */
+	.preinit_array : {
+		. = ALIGN(4);
+		__preinit_array_start = .;
+		KEEP (*(.preinit_array))
+		__preinit_array_end = .;
+	} >rom
+	.init_array : {
+		. = ALIGN(4);
+		__init_array_start = .;
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		__init_array_end = .;
+	} >rom
+	.fini_array : {
+		. = ALIGN(4);
+		__fini_array_start = .;
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		__fini_array_end = .;
+	} >rom
+
+	/*
+	 * Another section used by C++ stuff, appears when using newlib with
+	 * 64bit (long long) printf support
+	 */
+	.ARM.extab : {
+		*(.ARM.extab*)
+	} >rom
+	.ARM.exidx : {
+		__exidx_start = .;
+		*(.ARM.exidx*)
+		__exidx_end = .;
+	} >rom
+
+	. = ALIGN(4);
+	_etext = .;
+
+	/* Safe stack reservation (4kiB st the start of SRAM) */
+	.stack (NOLOAD) : {
+		. += 4K;
+		PROVIDE(_stack = .);
+	}
+
+	/* RAM, but not cleared on reset, eg boot/app comms */
+	.noinit (NOLOAD) : {
+		*(.noinit*)
+	} >ram
+	. = ALIGN(4);
+
+	.data : {
+		_data = .;
+		*(.data*)	/* Read-write initialized data */
+		*(.ramtext*)    /* "text" functions to run in ram */
+		. = ALIGN(4);
+		_edata = .;
+	} >ram AT >rom
+	_data_loadaddr = LOADADDR(.data);
+
+	.bss (NOLOAD) : {
+		*(.bss*)	/* Read-write zero initialized data */
+		*(COMMON)
+		. = ALIGN(4);
+		_ebss = .;
+		. = ALIGN(4);
+		end = .;
+		PROVIDE(_end = .);
+	} >ram
+
+	/*
+	 * The .eh_frame section appears to be used for C++ exception handling.
+	 * You may need to fix this if you're using C++.
+	 */
+	/DISCARD/ : { *(.eh_frame) }
+}

--- a/src/platforms/common/blackpill-f4/Makefile.inc
+++ b/src/platforms/common/blackpill-f4/Makefile.inc
@@ -15,17 +15,18 @@ CFLAGS +=                           \
 	-Iplatforms/common/stm32        \
 	-Iplatforms/common/blackpill-f4
 
-LDFLAGS_BOOT :=              \
-	-lopencm3_stm32f4       \
-	-Wl,-T,$(LINKER_SCRIPT) \
-	-nostartfiles           \
-	-lc                     \
-	-Wl,-Map=mapfile        \
-	-mthumb                 \
-	-mcpu=cortex-m4         \
-	-Wl,-gc-sections        \
-	-mfloat-abi=hard        \
-	-mfpu=fpv4-sp-d16       \
+LDFLAGS_BOOT :=                     \
+	-lopencm3_stm32f4               \
+	-Lplatforms/common/blackpill-f4 \
+	-T$(LINKER_SCRIPT)              \
+	-nostartfiles                   \
+	-lc                             \
+	-Wl,-Map=mapfile                \
+	-mthumb                         \
+	-mcpu=cortex-m4                 \
+	-Wl,-gc-sections                \
+	-mfloat-abi=hard                \
+	-mfpu=fpv4-sp-d16               \
 	-L../deps/libopencm3/lib
 
 ifeq ($(BMP_BOOTLOADER), 1)

--- a/src/platforms/common/blackpill-f4/blackpill-f401cc.ld
+++ b/src/platforms/common/blackpill-f4/blackpill-f401cc.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,5 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../blackmagic.ld

--- a/src/platforms/common/blackpill-f4/blackpill-f401ce.ld
+++ b/src/platforms/common/blackpill-f4/blackpill-f401ce.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,5 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 96K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../blackmagic.ld

--- a/src/platforms/common/blackpill-f4/blackpill-f411ce.ld
+++ b/src/platforms/common/blackpill-f4/blackpill-f411ce.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,5 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../blackmagic.ld

--- a/src/platforms/common/meson.build
+++ b/src/platforms/common/meson.build
@@ -37,6 +37,7 @@ platform_common_sources = files(
 	'usb.c',
 	'usb_dfu_stub.c',
 	'usb_serial.c',
+	'syscalls.c',
 )
 
 platform_common = declare_dependency(

--- a/src/platforms/common/syscalls.c
+++ b/src/platforms/common/syscalls.c
@@ -1,0 +1,192 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "general.h"
+#include "platform.h"
+#include "usb_serial.h"
+#if ENABLE_DEBUG != 1
+#include <sys/stat.h>
+#include <string.h>
+
+typedef struct stat stat_s;
+#endif
+#include <errno.h>
+
+extern uint8_t heap_start;
+extern uint8_t heap_end;
+static uint8_t *heap_current = NULL;
+
+#if ENABLE_DEBUG == 1
+/*
+ * newlib defines _write as a weak link'd function for user code to override.
+ *
+ * This function forms the root of the implementation of a variety of functions
+ * that can write to stdout/stderr, including printf().
+ *
+ * The result of this function is the number of bytes written.
+ */
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) int _write(const int file, const void *const ptr, const size_t len)
+{
+	(void)file;
+#ifdef PLATFORM_HAS_DEBUG
+	if (debug_bmp)
+		return debug_serial_debug_write(ptr, len);
+#else
+	(void)ptr;
+#endif
+	return len;
+}
+
+/*
+ * newlib defines isatty as a weak link'd function for user code to override.
+ *
+ * The result of this function is always 'true'.
+ */
+__attribute__((used)) int isatty(const int file)
+{
+	(void)file;
+	return true;
+}
+
+#define RDI_SYS_OPEN 0x01U
+
+typedef struct ex_frame {
+	uint32_t r0;
+	const uint32_t *params;
+	uint32_t r2;
+	uint32_t r3;
+	uint32_t r12;
+	uintptr_t lr;
+	uintptr_t return_address;
+} ex_frame_s;
+
+/*
+ * This implements the other half of the newlib syscall puzzle.
+ * When newlib is built for ARM, various calls that do file IO
+ * such as printf end up calling [_swiwrite](https://github.com/mirror/newlib-cygwin/blob/master/newlib/libc/sys/arm/syscalls.c#L317)
+ * and other similar low-level implementation functions. These
+ * generate `swi` instructions for the "RDI Monitor" and that lands us.. here.
+ *
+ * The RDI calling convention sticks the file number in r0, the buffer pointer in r1, and length in r2.
+ * ARMv7-M's SWI (SVC) instruction then takes all that and maps it into an exception frame on the stack.
+ */
+void debug_monitor_handler(void)
+{
+	ex_frame_s *frame;
+	__asm__("mov %[frame], sp" : [frame] "=r"(frame));
+
+	/* Make sure to return to the instruction after the SWI/BKPT */
+	frame->return_address += 2U;
+
+	switch (frame->r0) {
+	case RDI_SYS_OPEN:
+		frame->r0 = 1;
+		break;
+	default:
+		frame->r0 = UINT32_MAX;
+	}
+	__asm__("bx lr");
+}
+#else
+/* This defines stubs for the newlib fake file IO layer for compatibility with GCC 12 `-specs=nosys.specs` */
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) int _write(const int file, const void *const buffer, const size_t length)
+{
+	(void)file;
+	(void)buffer;
+	return length;
+}
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) int _read(const int file, void *const buffer, const size_t length)
+{
+	(void)file;
+	(void)buffer;
+	return length;
+}
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) off_t _lseek(const int file, const off_t offset, const int direction)
+{
+	(void)file;
+	(void)offset;
+	(void)direction;
+	return 0;
+}
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) int _fstat(const int file, stat_s *stats)
+{
+	(void)file;
+	memset(stats, 0, sizeof(*stats));
+	return 0;
+}
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) int _isatty(const int file)
+{
+	(void)file;
+	return true;
+}
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) int _close(const int file)
+{
+	(void)file;
+	return 0;
+}
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) pid_t _getpid(void)
+{
+	return 1;
+}
+
+/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
+__attribute__((used)) int _kill(const int pid, const int signal)
+{
+	(void)pid;
+	(void)signal;
+	return 0;
+}
+#endif
+
+__attribute__((used)) void *_sbrk(const ptrdiff_t alloc_size)
+{
+	/* If we've not yet made any heap allocations, set the heap pointer up */
+	if (heap_current == NULL)
+		heap_current = &heap_start;
+
+	/* Check if this allocation would exhaust the heap */
+	if (heap_current + alloc_size > &heap_end) {
+		errno = ENOMEM;
+		return (void *)-1;
+	}
+
+	/*
+	 * Everything is ok, so make a copy of the heap pointer to return then add the
+	 * allocation to the heap pointer
+	 */
+	void *const result = heap_current;
+	heap_current += alloc_size;
+	return result;
+}

--- a/src/platforms/common/syscalls.c
+++ b/src/platforms/common/syscalls.c
@@ -31,7 +31,7 @@ typedef struct stat stat_s;
 
 extern uint8_t heap_start;
 extern uint8_t heap_end;
-static uint8_t *heap_current = NULL;
+static uint8_t *heap_current = &heap_start;
 
 #if ENABLE_DEBUG == 1
 /*
@@ -172,10 +172,6 @@ __attribute__((used)) int _kill(const int pid, const int signal)
 
 __attribute__((used)) void *_sbrk(const ptrdiff_t alloc_size)
 {
-	/* If we've not yet made any heap allocations, set the heap pointer up */
-	if (heap_current == NULL)
-		heap_current = &heap_start;
-
 	/* Check if this allocation would exhaust the heap */
 	if (heap_current + alloc_size > &heap_end) {
 		errno = ENOMEM;

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2011 Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
- * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2022-2024 1BitSquared <info@1bitsquared.com>
  * Written by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -20,7 +20,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* This file implements a the USB Communications Device Class - Abstract
+/*
+ * This file implements a the USB Communications Device Class - Abstract
  * Control Model (CDC-ACM) as defined in CDC PSTN subclass 1.2.
  * A Device Firmware Upgrade (DFU 1.1) class interface is provided for
  * field firmware upgrade.
@@ -40,12 +41,6 @@
  *
  */
 
-#if ENABLE_DEBUG != 1
-#include <sys/stat.h>
-#include <string.h>
-
-typedef struct stat stat_s;
-#endif
 #include "general.h"
 #include "platform.h"
 #include "gdb_if.h"
@@ -57,7 +52,6 @@ typedef struct stat stat_s;
 #include "rtt.h"
 #include "rtt_if.h"
 #include "usb_types.h"
-#include <errno.h>
 
 #include <libopencm3/cm3/cortex.h>
 #include <libopencm3/cm3/nvic.h>
@@ -91,10 +85,6 @@ static char debug_serial_debug_buffer[AUX_UART_BUFFER_SIZE];
 static uint8_t debug_serial_debug_write_index;
 static uint8_t debug_serial_debug_read_index;
 #endif
-
-extern uint8_t heap_start;
-extern uint8_t heap_end;
-static uint8_t *heap_current = NULL;
 
 static usbd_request_return_codes_e gdb_serial_control_request(usbd_device *dev, usb_setup_data_s *req, uint8_t **buf,
 	uint16_t *const len, void (**complete)(usbd_device *dev, usb_setup_data_s *req))
@@ -344,8 +334,7 @@ static void debug_serial_receive_callback(usbd_device *dev, uint8_t ep)
 #endif
 }
 
-#if ENABLE_DEBUG == 1
-#ifdef PLATFORM_HAS_DEBUG
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 static void debug_serial_append_char(const char c)
 {
 	debug_serial_debug_buffer[debug_serial_debug_write_index] = c;
@@ -353,7 +342,7 @@ static void debug_serial_append_char(const char c)
 	debug_serial_debug_write_index %= AUX_UART_BUFFER_SIZE;
 }
 
-static size_t debug_serial_debug_write(const char *buf, const size_t len)
+size_t debug_serial_debug_write(const char *buf, const size_t len)
 {
 	if (nvic_get_active_irq(USB_IRQ) || nvic_get_active_irq(USBUSART_IRQ) || nvic_get_active_irq(USBUSART_DMA_RX_IRQ))
 		return 0;
@@ -377,160 +366,3 @@ static size_t debug_serial_debug_write(const char *buf, const size_t len)
 	return offset;
 }
 #endif
-
-/*
- * newlib defines _write as a weak link'd function for user code to override.
- *
- * This function forms the root of the implementation of a variety of functions
- * that can write to stdout/stderr, including printf().
- *
- * The result of this function is the number of bytes written.
- */
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) int _write(const int file, const void *const ptr, const size_t len)
-{
-	(void)file;
-#ifdef PLATFORM_HAS_DEBUG
-	if (debug_bmp)
-		return debug_serial_debug_write(ptr, len);
-#else
-	(void)ptr;
-#endif
-	return len;
-}
-
-/*
- * newlib defines isatty as a weak link'd function for user code to override.
- *
- * The result of this function is always 'true'.
- */
-__attribute__((used)) int isatty(const int file)
-{
-	(void)file;
-	return true;
-}
-
-#define RDI_SYS_OPEN 0x01U
-
-typedef struct ex_frame {
-	uint32_t r0;
-	const uint32_t *params;
-	uint32_t r2;
-	uint32_t r3;
-	uint32_t r12;
-	uintptr_t lr;
-	uintptr_t return_address;
-} ex_frame_s;
-
-/*
- * This implements the other half of the newlib syscall puzzle.
- * When newlib is built for ARM, various calls that do file IO
- * such as printf end up calling [_swiwrite](https://github.com/mirror/newlib-cygwin/blob/master/newlib/libc/sys/arm/syscalls.c#L317)
- * and other similar low-level implementation functions. These
- * generate `swi` instructions for the "RDI Monitor" and that lands us.. here.
- *
- * The RDI calling convention sticks the file number in r0, the buffer pointer in r1, and length in r2.
- * ARMv7-M's SWI (SVC) instruction then takes all that and maps it into an exception frame on the stack.
- */
-void debug_monitor_handler(void)
-{
-	ex_frame_s *frame;
-	__asm__("mov %[frame], sp" : [frame] "=r"(frame));
-
-	/* Make sure to return to the instruction after the SWI/BKPT */
-	frame->return_address += 2U;
-
-	switch (frame->r0) {
-	case RDI_SYS_OPEN:
-		frame->r0 = 1;
-		break;
-	default:
-		frame->r0 = UINT32_MAX;
-	}
-	__asm__("bx lr");
-}
-#else
-/* This defines stubs for the newlib fake file IO layer for compatibility with GCC 12 `-specs=nosys.specs` */
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) int _write(const int file, const void *const buffer, const size_t length)
-{
-	(void)file;
-	(void)buffer;
-	return length;
-}
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) int _read(const int file, void *const buffer, const size_t length)
-{
-	(void)file;
-	(void)buffer;
-	return length;
-}
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) off_t _lseek(const int file, const off_t offset, const int direction)
-{
-	(void)file;
-	(void)offset;
-	(void)direction;
-	return 0;
-}
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) int _fstat(const int file, stat_s *stats)
-{
-	(void)file;
-	memset(stats, 0, sizeof(*stats));
-	return 0;
-}
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) int _isatty(const int file)
-{
-	(void)file;
-	return true;
-}
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) int _close(const int file)
-{
-	(void)file;
-	return 0;
-}
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) pid_t _getpid(void)
-{
-	return 1;
-}
-
-/* NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp) */
-__attribute__((used)) int _kill(const int pid, const int signal)
-{
-	(void)pid;
-	(void)signal;
-	return 0;
-}
-#endif
-
-__attribute__((used)) void *_sbrk(const ptrdiff_t alloc_size)
-{
-	/* If we've not yet made any heap allocations, set the heap pointer up */
-	if (heap_current == NULL)
-		heap_current = &heap_start;
-
-	/* Check if this allocation would exhaust the heap */
-	if (heap_current + alloc_size > &heap_end) {
-		errno = ENOMEM;
-		return (void *)-1;
-	}
-
-	/*
-	 * Everything is ok, so make a copy of the heap pointer to return then add the
-	 * allocation to the heap pointer
-	 */
-	void *const result = heap_current;
-	heap_current += alloc_size;
-	return result;
-}

--- a/src/platforms/common/usb_serial.h
+++ b/src/platforms/common/usb_serial.h
@@ -32,4 +32,8 @@ bool gdb_serial_get_dtr(void);
 void debug_serial_run(void);
 uint32_t debug_serial_fifo_send(const char *fifo, uint32_t fifo_begin, uint32_t fifo_end);
 
+#if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
+size_t debug_serial_debug_write(const char *buf, const size_t len);
+#endif
+
 #endif /* PLATFORMS_COMMON_USB_SERIAL_H */

--- a/src/platforms/f072/Makefile.inc
+++ b/src/platforms/f072/Makefile.inc
@@ -6,8 +6,8 @@ CFLAGS += -Istm32/include -mcpu=cortex-m0 -mthumb \
 	-DSTM32F0 -I../deps/libopencm3/include \
 	-DDFU_SERIAL_LENGTH=13 -Iplatforms/common/stm32
 
-LDFLAGS = --specs=nano.specs -lopencm3_stm32f0 \
-	-Wl,-T,platforms/f072/stm32f07xzb.ld \
+LDFLAGS = -lopencm3_stm32f0 -Lplatforms/f072 \
+	-Tstm32f07xzb.ld --specs=nano.specs \
 	-nostartfiles -lc -lnosys -Wl,-Map=mapfile -mthumb \
 	-mcpu=cortex-m0 -Wl,-gc-sections -L../deps/libopencm3/lib
 

--- a/src/platforms/f072/stm32f07xzb.ld
+++ b/src/platforms/f072/stm32f07xzb.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopencm3 project.
  *
  * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,5 +28,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
 }
 
-/* Include the common ld script. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/f3/Makefile.inc
+++ b/src/platforms/f3/Makefile.inc
@@ -7,8 +7,8 @@ CFLAGS += -Istm32/include -mcpu=cortex-m4 -mthumb \
 	-DSTM32F3 -I../deps/libopencm3/include \
 	-DDFU_SERIAL_LENGTH=13 -Iplatforms/common/stm32
 
-LDFLAGS =  --specs=nano.specs -lopencm3_stm32f3 \
-	-Wl,-T,platforms/f3/stm32f303xc.ld -nostartfiles -lc -lnosys \
+LDFLAGS =  --specs=nano.specs -lopencm3_stm32f3 -Lplatforms/f3 \
+	-Tstm32f303xc.ld -nostartfiles -lc -lnosys \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m4 -Wl,-gc-sections \
 	-mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 	-L../deps/libopencm3/lib

--- a/src/platforms/f3/stm32f303xc.ld
+++ b/src/platforms/f3/stm32f303xc.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopencm3 project.
  *
  * Copyright (C) 2015 Karl Palsson <karlp@tweak.net.au>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This library is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,5 +28,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 40K
 }
 
-/* Include the common ld script. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/f4discovery/Makefile.inc
+++ b/src/platforms/f4discovery/Makefile.inc
@@ -8,10 +8,8 @@ CFLAGS += -Istm32/include -mcpu=cortex-m4 -mthumb \
 	-DSTM32F4 -I../deps/libopencm3/include \
 	-Iplatforms/common/stm32
 
-LINKER_SCRIPT=platforms/f4discovery/f4discovery.ld
-
-LDFLAGS_BOOT = -lopencm3_stm32f4 \
-	-Wl,-T,$(LINKER_SCRIPT) -nostartfiles -lc -lnosys \
+LDFLAGS_BOOT = -lopencm3_stm32f4 -Lplatforms/f4discovery \
+	-Tf4discovery.ld -nostartfiles -lc -lnosys \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m4 -Wl,-gc-sections \
 	-mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 	-L../deps/libopencm3/lib

--- a/src/platforms/f4discovery/f4discovery.ld
+++ b/src/platforms/f4discovery/f4discovery.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
-
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/hydrabus/Makefile.inc
+++ b/src/platforms/hydrabus/Makefile.inc
@@ -7,8 +7,8 @@ CFLAGS += -Istm32/include -mcpu=cortex-m4 -mthumb \
 	-DSTM32F4 -I../deps/libopencm3/include \
 	-Iplatforms/common/stm32 -DDFU_SERIAL_LENGTH=9
 
-LDFLAGS = -lopencm3_stm32f4 \
-	-Wl,-T,platforms/hydrabus/hydrabus.ld -nostartfiles -lc -lnosys \
+LDFLAGS = -lopencm3_stm32f4 -Lplatforms/hydrabus \
+	-Thydrabus.ld -nostartfiles -lc -lnosys \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m4 -Wl,-gc-sections \
 	-mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 	-L../deps/libopencm3/lib

--- a/src/platforms/hydrabus/hydrabus.ld
+++ b/src/platforms/hydrabus/hydrabus.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
-
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/launchpad-icdi/Makefile.inc
+++ b/src/platforms/launchpad-icdi/Makefile.inc
@@ -9,9 +9,10 @@ CPU_FLAGS = -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 CFLAGS += $(INCLUDES) $(CPU_FLAGS) -DSERIAL_NO=$(SERIAL_NO) -DTARGET_IS_BLIZZARD_RB1 -DLM4F -DPART_TM4C123GH6PM
 CFLAGS += -DDFU_SERIAL_LENGTH=9
 
-LINKER_SCRIPT="platforms/launchpad-icdi/launchpad-icdi.ld"
-LDFLAGS = -nostartfiles -lc $(CPU_FLAGS) -nodefaultlibs -T$(LINKER_SCRIPT) -Wl,--gc-sections \
-	-L../deps/libopencm3/lib -lopencm3_lm4f -lnosys -lm -lgcc
+LDFLAGS = -lopencm3_lm4f -Lplatforms/launchpad-icdi \
+	-Tlaunchpad-icdi.ld -nostartfiles -nodefaultlibs -lc \
+	-lnosys -lm -lgcc -Wl,--gc-sections $(CPU_FLAGS) \
+	-L../deps/libopencm3/lib
 
 VPATH += platforms/common/tm4c
 

--- a/src/platforms/launchpad-icdi/launchpad-icdi.ld
+++ b/src/platforms/launchpad-icdi/launchpad-icdi.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,9 +23,8 @@
 MEMORY
 {
 	rom (rx) : ORIGIN = 0x00000000, LENGTH = 256K
-	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 32K 
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
-
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -6,8 +6,8 @@ CFLAGS += -Istm32/include -mcpu=cortex-m3 -mthumb \
 	-DSTM32F1 -DBLACKMAGIC -I../deps/libopencm3/include \
 	-Iplatforms/common/stm32 -DDFU_SERIAL_LENGTH=9
 
-LDFLAGS_BOOT := $(LDFLAGS) --specs=nano.specs -lopencm3_stm32f1 \
-	-Wl,-T,platforms/native/native.ld -nostartfiles -lc \
+LDFLAGS_BOOT := $(LDFLAGS) -lopencm3_stm32f1 -Lplatforms/native \
+	-Tnative.ld --specs=nano.specs -nostartfiles -lc \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m3 -Wl,-gc-sections \
 	-L../deps/libopencm3/lib
 LDFLAGS = $(LDFLAGS_BOOT) -Wl,-Ttext=0x8002000

--- a/src/platforms/native/native.ld
+++ b/src/platforms/native/native.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,9 +23,8 @@
 MEMORY
 {
 	rom (rx) : ORIGIN = 0x08000000, LENGTH = 128K
-	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K 
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
-
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -6,8 +6,8 @@ OBJCOPY = $(CROSS_COMPILE)objcopy
 OPT_FLAGS = -Os
 CFLAGS += -mcpu=cortex-m3 -mthumb -DSTM32F1 -I../deps/libopencm3/include \
 	-I platforms/common/stm32
-LDFLAGS_BOOT := $(LDFLAGS) --specs=nano.specs -lopencm3_stm32f1 \
-	-Wl,-T,platforms/stlink/stlink.ld -nostartfiles -lc \
+LDFLAGS_BOOT := $(LDFLAGS) -lopencm3_stm32f1 -Lplatforms/stlink \
+	-Tstlink.ld --specs=nano.specs -nostartfiles -lc \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m3 -Wl,-gc-sections \
 	-L../deps/libopencm3/lib
 ifeq ($(ST_BOOTLOADER), 1)

--- a/src/platforms/stlink/stlink.ld
+++ b/src/platforms/stlink/stlink.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,5 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/stlinkv3/Makefile.inc
+++ b/src/platforms/stlinkv3/Makefile.inc
@@ -7,8 +7,8 @@ CFLAGS += -mcpu=cortex-m7 -mthumb -mfpu=fpv5-sp-d16 -mfloat-abi=hard \
 	-DSTM32F7 -DDFU_SERIAL_LENGTH=25 -I../deps/libopencm3/include \
 	-I platforms/common/stm32
 LDFLAGS_BOOT := $(LDFLAGS) -mfpu=fpv5-sp-d16 -mfloat-abi=hard \
-	--specs=nano.specs -lopencm3_stm32f7 \
-	-Wl,-T,platforms/stlinkv3/stlinkv3.ld -nostartfiles -lc \
+	--specs=nano.specs -lopencm3_stm32f7 -Lplatforms/stlinkv3 \
+	-Tstlinkv3.ld -nostartfiles -lc \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m7 -Wl,-gc-sections \
 	-L../deps/libopencm3/lib
 

--- a/src/platforms/stlinkv3/stlinkv3.ld
+++ b/src/platforms/stlinkv3/stlinkv3.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,5 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld

--- a/src/platforms/swlink/Makefile.inc
+++ b/src/platforms/swlink/Makefile.inc
@@ -5,8 +5,8 @@ OBJCOPY = $(CROSS_COMPILE)objcopy
 CFLAGS += -mcpu=cortex-m3 -mthumb \
 	-DSTM32F1  -DDFU_SERIAL_LENGTH=9 -I../deps/libopencm3/include \
 	-I platforms/common/stm32
-LDFLAGS_BOOT := $(LDFLAGS) --specs=nano.specs -lopencm3_stm32f1 \
-	-Wl,-T,platforms/swlink/swlink.ld -nostartfiles -lc\
+LDFLAGS_BOOT := $(LDFLAGS) -lopencm3_stm32f1 -Lplatforms/swlink \
+	-Tswlink.ld --specs=nano.specs -nostartfiles -lc\
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m3 -Wl,-gc-sections \
 	-L../deps/libopencm3/lib
 LDFLAGS = $(LDFLAGS_BOOT) -Wl,-Ttext=0x8002000

--- a/src/platforms/swlink/swlink.ld
+++ b/src/platforms/swlink/swlink.ld
@@ -2,6 +2,8 @@
  * This file is part of the libopenstm32 project.
  *
  * Copyright (C) 2010 Thomas Otto <tommi@viadmin.org>
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,5 +26,5 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
 }
 
-/* Include the common ld script from libopenstm32. */
-INCLUDE cortex-m-generic.ld
+/* Include the platform common linker script. */
+INCLUDE ../common/blackmagic.ld


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR implements a change to the SRAM layout designed to improve the diagnostics and detectability of heap and stack overflows by placing them at the ends of SRAM. This is done such that when each get exhausted, the cause of that exhaustion will become evident by the probe crashing and entering the hard fault handler.

This gives us free diagnostics for when these conditions occur and, with some changes to the hard fault handler that can be done in a follow-up, the ability to automatically reboot a probe when this happens, or catch it and halt if a debugger is attached. Alternatively, we can use a blink pattern on the LEDs designed to indicate this kind of crash.

This should prevent any further "maybe it crashed, but we're not sure, it's acting real strange" kind of issues.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
