### PR TITLE
Fix UART TX and NRST pin conflict  on stlink clones with SWIM_AS_UART

### DIFF
--- a/cross-file/stlink.ini
+++ b/cross-file/stlink.ini
@@ -20,5 +20,5 @@ endian = 'little'
 probe = 'stlink'
 targets = 'cortexm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
 rtt_support = false
-stlink_swim_as_uart = false
+stlink_swim_nrst_as_uart = false
 bmd_bootloader = false

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -67,10 +67,10 @@ option(
 )
 option('bmd_bootloader', type: 'boolean', value: true, description: 'Use the BMD bootloader (not always applicable)')
 option(
-	'stlink_swim_as_uart',
+	'stlink_swim_nrst_as_uart',
 	type: 'boolean',
 	value: false,
-	description: 'Repurpose the SWIM pins as the UART (only applicable to stlink)'
+	description: 'Repurpose the SWIM and NRST pins as the UART RX and TX (only applicable to stlink)'
 )
 option('serialno', type: 'string', value: '1', description: 'Serial number to report (only applicable to some probes)')
 option(

--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -26,7 +26,12 @@ LDFLAGS += --specs=nosys.specs
 endif
 
 ifeq ($(SWIM_AS_UART), 1)
-CFLAGS += -DSWIM_AS_UART=1
+SWIM_NRST_AS_UART=1
+$(warning Deprecation: SWIM_AS_UART has been renamed to SWIM_NRST_AS_UART; it might be ignored in the future)
+endif
+
+ifeq ($(SWIM_NRST_AS_UART), 1)
+CFLAGS += -DSWIM_NRST_AS_UART=1
 else
 SRC += traceswoasync.c
 endif

--- a/src/platforms/stlink/README.md
+++ b/src/platforms/stlink/README.md
@@ -12,9 +12,15 @@ Running the BMP firmware on ST-Link v2 and ST-Link v2-1 provides:
 
 For all commands below, unplug all other BMP/ST-Link beside the target(*1)
 
-If your adaptor offers SWIM pins on the connector (many of clones of the official adaptors do this)
-then they often don't provide a UART interface. In this case, build the firmware with
-`SWIM_AS_UART=1` to repurpose the pins as the UART interface provided to the host over USB.
+This build provides a UART interface over USB to the host.
+By default, it's USART2 with pins PA2 and PA3 used as TX and RX.
+Many clones of the official adaptors provide SWIM pins on the connector and don't provide a UART interface. 
+In this case, the firmware can be built with `SWIM_NRST_AS_UART=1` flag to repurpose the SWIM pins as the UART.
+In particular, USART1 will be provided to the host and pins PB6 and PB7 will be used as TX and RX. 
+
+Note: on some clones PB6 is used as nRST pin, so with `SWIM_NRST_AS_UART=1` the UART will take up both SWIM (PB7) and RST (PB6) pins.
+In this case nRST function is moved to PB0 pin and, if this pin is not on the connector, reset functionality will be lost.
+On other devices where nRST pin is PB0, reset feature will remain functional.
 
 Note: on some clones, SWIM is strongly pulled up by a 680 Ohm resistor.
 

--- a/src/platforms/stlink/meson.build
+++ b/src/platforms/stlink/meson.build
@@ -67,10 +67,10 @@ endif
 
 probe_stlink_dependencies = [platform_common, platform_stm32f1]
 
-stlink_swim_as_uart = get_option('stlink_swim_as_uart')
+stlink_swim_nrst_as_uart = get_option('stlink_swim_nrst_as_uart')
 
-if probe == 'stlink' and stlink_swim_as_uart
-	probe_stlink_args += ['-DSWIM_AS_UART=1']
+if probe == 'stlink' and stlink_swim_nrst_as_uart
+	probe_stlink_args += ['-DSWIM_NRST_AS_UART=1']
 else
 	probe_stlink_dependencies += fixme_platform_stm32_traceswoasync
 endif
@@ -97,7 +97,7 @@ summary(
 		'Platform': 'STM32F1',
 		'Bootloader': bmd_bootloader ? 'Black Magic Debug Bootloader' : 'OEM ST Bootloader',
 		'Load Address': probe_stlink_load_address,
-		'SWIM as UART': probe == 'stlink' and stlink_swim_as_uart,
+		'SWIM as UART': probe == 'stlink' and stlink_swim_nrst_as_uart,
 	},
 	bool_yn: true,
 	section: 'Probe',

--- a/src/platforms/stlink/platform.c
+++ b/src/platforms/stlink/platform.c
@@ -104,7 +104,7 @@ void platform_init(void)
 		gpio_set(GPIOA, GPIO15);
 	blackmagic_usb_init();
 
-#ifdef SWIM_AS_UART
+#ifdef SWIM_NRST_AS_UART
 	gpio_primary_remap(AFIO_MAPR_SWJ_CFG_FULL_SWJ, AFIO_MAPR_USART1_REMAP);
 #endif
 

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -58,10 +58,14 @@ extern bool debug_bmp;
 #define SWDIO_IN_PIN  GPIO12
 #endif
 
-#define NRST_PORT      GPIOB
-#define NRST_PIN_V1    GPIO1
-#define NRST_PIN_V2    GPIO0
+#define NRST_PORT   GPIOB
+#define NRST_PIN_V1 GPIO1
+#define NRST_PIN_V2 GPIO0
+#ifdef SWIM_NRST_AS_UART
+#define NRST_PIN_CLONE GPIO0
+#else
 #define NRST_PIN_CLONE GPIO6
+#endif
 
 #ifdef BLUEPILL
 #define LED_PORT GPIOC
@@ -72,7 +76,7 @@ extern bool debug_bmp;
 #define LED_PORT_UART GPIOA
 #define LED_UART      GPIO9
 
-#ifndef SWIM_AS_UART
+#ifndef SWIM_NRST_AS_UART
 #define PLATFORM_HAS_TRACESWO 1
 #endif
 
@@ -131,7 +135,7 @@ extern bool debug_bmp;
 #define IRQ_PRI_USB_VBUS     (14U << 4U)
 #define IRQ_PRI_SWO_DMA      (0U << 4U)
 
-#ifdef SWIM_AS_UART
+#ifdef SWIM_NRST_AS_UART
 #define USBUSART               USART1
 #define USBUSART_CR1           USART1_CR1
 #define USBUSART_DR            USART1_DR


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Adding UART to stlink probe introduced in #1087 has created a conflict between UART TX and NRST pins on stlink clones
(both are PB6). More discussion here: https://github.com/blackmagic-debug/blackmagic/pull/1087#issuecomment-2053975402

This PR fixes this by moving NRST pin to PB0 on stlink clones (same one as on original stlink). 

Note that PB0 is not present on the header itself, so NRST functionality is lost (However this seems to be the intention of the original PR).

Also this PR renames build option from SWIM_AS_UART to SWIM_NRST_AS_UART for better clarity that it occupies both SWIM and NRST header pins. 
This is also changed for meson configs.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

