### PR TITLE
Restore TraceSWO capture in Manchester mode

### DIFF
--- a/src/platforms/96b_carbon/Makefile.inc
+++ b/src/platforms/96b_carbon/Makefile.inc
@@ -17,8 +17,6 @@ VPATH += platforms/common/stm32
 
 SRC +=               \
 	platform.c \
-	traceswodecode.c \
-	traceswo.c	\
 	serialno.c	\
 	timing.c	\
 	timing_stm32.c

--- a/src/platforms/96b_carbon/meson.build
+++ b/src/platforms/96b_carbon/meson.build
@@ -49,7 +49,7 @@ probe_host = declare_dependency(
 	sources: probe_96b_carbon_sources,
 	compile_args: probe_96b_carbon_args,
 	link_args: probe_96b_carbon_link_args,
-	dependencies: [platform_common, platform_stm32f4, fixme_platform_stm32_traceswo],
+	dependencies: [platform_common, platform_stm32f4],
 )
 
 probe_bootloader = declare_dependency(

--- a/src/platforms/96b_carbon/platform.h
+++ b/src/platforms/96b_carbon/platform.h
@@ -28,7 +28,6 @@
 #include "timing_stm32.h"
 #include "version.h"
 
-#define PLATFORM_HAS_TRACESWO
 #define PLATFORM_IDENT "(Carbon)"
 
 /*
@@ -86,14 +85,12 @@
 #define USB_ISR    otg_fs_isr
 /*
  * Interrupt priorities. Low numbers are high priority.
- * TIM3 is used for traceswo capture and must be highest priority.
  * USBUSART can be lowest priority as it is using DMA to transfer
  * data to the buffer and thus is less critical than USB.
  */
 #define IRQ_PRI_USB          (1U << 4U)
 #define IRQ_PRI_USBUSART     (2U << 4U)
 #define IRQ_PRI_USBUSART_DMA (2U << 4U)
-#define IRQ_PRI_TRACE        (0U << 4U)
 
 #define USBUSART               USART2
 #define USBUSART_CR1           USART2_CR1
@@ -122,11 +119,6 @@
 		gpio_set_af(USBUSART_TX_PORT, GPIO_AF7, USBUSART_TX_PIN);                         \
 		gpio_set_af(USBUSART_RX_PORT, GPIO_AF7, USBUSART_RX_PIN);                         \
 	} while (0)
-
-#define TRACE_TIM          TIM3
-#define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
-#define TRACE_IRQ          NVIC_TIM3_IRQ
-#define TRACE_ISR(x)       tim3_isr(x)
 
 #define DEBUG(...) \
 	do {           \

--- a/src/platforms/common/blackpill-f4/Makefile.inc
+++ b/src/platforms/common/blackpill-f4/Makefile.inc
@@ -58,10 +58,17 @@ VPATH +=                          \
 SRC +=               \
 	blackpill-f4.c   \
 	traceswodecode.c \
-	traceswoasync.c  \
 	serialno.c       \
 	timing.c         \
 	timing_stm32.c
+
+ifeq ($(TRACESWO_PROTOCOL), 1)
+SRC += traceswo.c
+CFLAGS += -DTRACESWO_PROTOCOL=1
+else
+SRC += traceswoasync.c
+CFLAGS += -DTRACESWO_PROTOCOL=2
+endif
 
 ifneq ($(BMD_BOOTLOADER), 1)
 all:	blackmagic.bin

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -299,12 +299,12 @@ extern bool debug_bmp;
 #define SWO_UART_PIN_AF GPIO_AF7
 
 /* Bind to the same DMA Rx channel */
-#define SWO_DMA_BUS    USBUSART1_DMA_BUS
-#define SWO_DMA_CLK    USBUSART1_DMA_CLK
-#define SWO_DMA_CHAN   USBUSART1_DMA_RX_CHAN
-#define SWO_DMA_IRQ    USBUSART1_DMA_RX_IRQ
-#define SWO_DMA_ISR(x) USBUSART1_DMA_RX_ISRx(x)
-#define SWO_DMA_TRG    DMA_SxCR_CHSEL_4
+#define SWO_DMA_BUS     USBUSART1_DMA_BUS
+#define SWO_DMA_CLK     USBUSART1_DMA_CLK
+#define SWO_DMA_CHAN    USBUSART1_DMA_RX_CHAN
+#define SWO_DMA_IRQ     USBUSART1_DMA_RX_IRQ
+#define SWO_DMA_ISR(x)  USBUSART1_DMA_RX_ISRx(x)
+#define SWO_DMA_TRG     DMA_SxCR_CHSEL_4
 
 #define SET_RUN_STATE(state)      \
 	{                             \

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -53,6 +53,7 @@ probe_blackpill_load_address = bmd_bootloader ? '0x08004000' : '0x08000000'
 probe_blackpill_args = [
 	f'-DDFU_SERIAL_LENGTH=@probe_blackpill_dfu_serial_length@',
 	f'-DAPP_START=@probe_blackpill_load_address@',
+	'-DTRACESWO_PROTOCOL=2',
 ]
 
 blackpill_alternative_pinout = get_option('alternative_pinout')

--- a/src/platforms/common/stm32/traceswo.c
+++ b/src/platforms/common/stm32/traceswo.c
@@ -57,15 +57,15 @@ void traceswo_init(uint32_t swo_chan_bitmask)
 	 */
 
 	/* Use TI1 as capture input for CH1 and CH2 */
-	timer_ic_set_input(TRACE_TIM, TIM_IC1, TIM_IC_IN_TI1);
-	timer_ic_set_input(TRACE_TIM, TIM_IC2, TIM_IC_IN_TI1);
+	timer_ic_set_input(TRACE_TIM, TIM_IC1, TRACE_IC_IN);
+	timer_ic_set_input(TRACE_TIM, TIM_IC2, TRACE_IC_IN);
 
 	/* Capture CH1 on rising edge, CH2 on falling edge */
 	timer_ic_set_polarity(TRACE_TIM, TIM_IC1, TIM_IC_RISING);
 	timer_ic_set_polarity(TRACE_TIM, TIM_IC2, TIM_IC_FALLING);
 
 	/* Trigger on Filtered Timer Input 1 (TI1FP1) */
-	timer_slave_set_trigger(TRACE_TIM, TIM_SMCR_TS_TI1FP1);
+	timer_slave_set_trigger(TRACE_TIM, TRACE_TRIG_IN);
 
 	/* Slave reset mode: reset counter on trigger */
 	timer_slave_set_mode(TRACE_TIM, TIM_SMCR_SMS_RM);

--- a/src/platforms/common/stm32/traceswo.c
+++ b/src/platforms/common/stm32/traceswo.c
@@ -81,6 +81,12 @@ void traceswo_init(uint32_t swo_chan_bitmask)
 
 	timer_enable_counter(TRACE_TIM);
 
+#if defined(STM32F4) || defined(STM32F0) || defined(STM32F3)
+	/* AF2: TIM3/TIM4/TIM5 */
+	gpio_mode_setup(TDO_PORT, GPIO_MODE_AF, GPIO_PUPD_NONE, TDO_PIN);
+	gpio_set_af(TDO_PORT, TRACE_TIM_PIN_AF, TDO_PIN);
+#endif
+
 	traceswo_setmask(swo_chan_bitmask);
 	decoding = (swo_chan_bitmask != 0);
 }

--- a/src/platforms/ctxlink/platform.h
+++ b/src/platforms/ctxlink/platform.h
@@ -173,10 +173,14 @@
 #define IRQ_PRI_USBUSART_DMA (2U << 4U)
 #define IRQ_PRI_TRACE        (0U << 4U)
 
+/* Use TIM3 Input 2 (from PC7/TDO) AF2, trigger on Rising Edge */
 #define TRACE_TIM          TIM3
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR(x)       tim3_isr(x)
+#define TRACE_IC_IN        TIM_IC_IN_TI2
+#define TRACE_TRIG_IN      TIM_SMCR_TS_TI1FP1
+#define TRACE_TIM_PIN_AF   GPIO_AF2
 
 #define SET_RUN_STATE(state)      \
 	{                             \

--- a/src/platforms/f072/platform.h
+++ b/src/platforms/f072/platform.h
@@ -132,6 +132,9 @@
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR          tim3_isr
+#define TRACE_IC_IN        TIM_IC_IN_TI1
+#define TRACE_TRIG_IN      TIM_SMCR_TS_TI1FP1
+#define TRACE_TIM_PIN_AF   GPIO_AF1
 
 #if ENABLE_DEBUG == 1
 extern bool debug_bmp;

--- a/src/platforms/f3/platform.h
+++ b/src/platforms/f3/platform.h
@@ -125,6 +125,9 @@
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR          tim3_isr
+#define TRACE_IC_IN        TIM_IC_IN_TI1
+#define TRACE_TRIG_IN      TIM_SMCR_TS_TI1FP1
+#define TRACE_TIM_PIN_AF   GPIO_AF2
 
 #if ENABLE_DEBUG == 1
 extern bool debug_bmp;

--- a/src/platforms/f4discovery/platform.h
+++ b/src/platforms/f4discovery/platform.h
@@ -130,6 +130,9 @@
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR(x)       tim3_isr(x)
+#define TRACE_IC_IN        TIM_IC_IN_TI1
+#define TRACE_TRIG_IN      TIM_SMCR_TS_TI1FP1
+#define TRACE_TIM_PIN_AF   GPIO_AF2
 
 #define SET_RUN_STATE(state)      \
 	{                             \

--- a/src/platforms/hydrabus/platform.h
+++ b/src/platforms/hydrabus/platform.h
@@ -124,10 +124,14 @@
 /* For STM32F4 DMA trigger source must be specified */
 #define USBUSART_DMA_TRG DMA_SxCR_CHSEL_4
 
+/* Use TIM3 Input 1 (from PC6), AF2, trigger on Rising Edge. FIXME: TDO is on PC2. */
 #define TRACE_TIM          TIM3
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR(x)       tim3_isr(x)
+#define TRACE_IC_IN        TIM_IC_IN_TI1
+#define TRACE_TRIG_IN      TIM_SMCR_TS_TI1FP1
+#define TRACE_TIM_PIN_AF   GPIO_AF2
 
 #define SET_RUN_STATE(state)      \
 	{                             \

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -27,6 +27,7 @@
 #include "timing.h"
 #include "timing_stm32.h"
 
+#define TRACESWO_PROTOCOL 1U /* 1 = Manchester, 2 = NRZ / async */
 #define PLATFORM_HAS_TRACESWO
 #define PLATFORM_HAS_POWER_SWITCH
 
@@ -288,10 +289,15 @@ extern int hwversion;
 #define USBUSART2_DMA_RX_IRQ    NVIC_DMA1_CHANNEL6_IRQ
 #define USBUSART2_DMA_RX_ISR(x) dma1_channel6_isr(x)
 
+#if TRACESWO_PROTOCOL == 1
+/* Use TIM3 Input 1 (from PA6/TDO) */
 #define TRACE_TIM          TIM3
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR(x)       tim3_isr(x)
+#define TRACE_IC_IN        TIM_IC_IN_TI1
+#define TRACE_TRIG_IN      TIM_SMCR_TS_TI1FP1
+#endif
 
 #define SET_RUN_STATE(state)   running_status = (state)
 #define SET_IDLE_STATE(state)  gpio_set_val(LED_PORT, LED_IDLE_RUN, state)

--- a/src/platforms/stlink/Makefile.inc
+++ b/src/platforms/stlink/Makefile.inc
@@ -33,7 +33,13 @@ endif
 ifeq ($(SWIM_NRST_AS_UART), 1)
 CFLAGS += -DSWIM_NRST_AS_UART=1
 else
+ifeq ($(TRACESWO_PROTOCOL), 1)
+SRC += traceswo.c
+CFLAGS += -DTRACESWO_PROTOCOL=1
+else
 SRC += traceswoasync.c
+CFLAGS += -DTRACESWO_PROTOCOL=2
+endif
 endif
 
 ifeq ($(BLUEPILL), 1)

--- a/src/platforms/stlink/meson.build
+++ b/src/platforms/stlink/meson.build
@@ -71,8 +71,11 @@ stlink_swim_nrst_as_uart = get_option('stlink_swim_nrst_as_uart')
 
 if probe == 'stlink' and stlink_swim_nrst_as_uart
 	probe_stlink_args += ['-DSWIM_NRST_AS_UART=1']
+	probe_stlink_dependencies += fixme_platform_stm32_traceswo
+	probe_stlink_args += ['-DTRACESWO_PROTOCOL=1']
 else
 	probe_stlink_dependencies += fixme_platform_stm32_traceswoasync
+	probe_stlink_args += ['-DTRACESWO_PROTOCOL=2']
 endif
 
 probe_host = declare_dependency(

--- a/src/platforms/stlink/platform.h
+++ b/src/platforms/stlink/platform.h
@@ -180,11 +180,11 @@ extern bool debug_bmp;
 #define SWO_UART_RX_PIN GPIO10
 
 /* This DMA channel is set by the USART in use */
-#define SWO_DMA_BUS    DMA1
-#define SWO_DMA_CLK    RCC_DMA1
-#define SWO_DMA_CHAN   DMA_CHANNEL5
-#define SWO_DMA_IRQ    NVIC_DMA1_CHANNEL5_IRQ
-#define SWO_DMA_ISR(x) dma1_channel5_isr(x)
+#define SWO_DMA_BUS     DMA1
+#define SWO_DMA_CLK     RCC_DMA1
+#define SWO_DMA_CHAN    DMA_CHANNEL5
+#define SWO_DMA_IRQ     NVIC_DMA1_CHANNEL5_IRQ
+#define SWO_DMA_ISR(x)  dma1_channel5_isr(x)
 
 extern uint16_t led_idle_run;
 #define LED_IDLE_RUN led_idle_run

--- a/src/platforms/swlink/Makefile.inc
+++ b/src/platforms/swlink/Makefile.inc
@@ -25,8 +25,15 @@ SRC +=          \
 	timing.c	\
 	timing_stm32.c	\
 	traceswodecode.c	\
-	traceswoasync.c	\
-	platform_common.c \
+	platform_common.c
+
+ifeq ($(TRACESWO_PROTOCOL), 1)
+SRC += traceswo.c
+CFLAGS += -DTRACESWO_PROTOCOL=1
+else
+SRC += traceswoasync.c
+CFLAGS += -DTRACESWO_PROTOCOL=2
+endif
 
 all:	blackmagic.bin blackmagic_dfu.bin blackmagic_dfu.hex
 

--- a/src/platforms/swlink/meson.build
+++ b/src/platforms/swlink/meson.build
@@ -42,6 +42,7 @@ probe_swlink_dfu_sources = files(
 
 probe_swlink_args = [
 	'-DDFU_SERIAL_LENGTH=9',
+	'-DTRACESWO_PROTOCOL=2',
 ]
 
 probe_swlink_common_link_args = [

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -140,11 +140,11 @@ extern bool debug_bmp;
 #define SWO_UART_RX_PIN GPIO3
 
 /* This DMA channel is set by the USART in use */
-#define SWO_DMA_BUS    DMA1
-#define SWO_DMA_CLK    RCC_DMA1
-#define SWO_DMA_CHAN   DMA_CHANNEL6
-#define SWO_DMA_IRQ    NVIC_DMA1_CHANNEL6_IRQ
-#define SWO_DMA_ISR(x) dma1_channel6_isr(x)
+#define SWO_DMA_BUS     DMA1
+#define SWO_DMA_CLK     RCC_DMA1
+#define SWO_DMA_CHAN    DMA_CHANNEL6
+#define SWO_DMA_IRQ     NVIC_DMA1_CHANNEL6_IRQ
+#define SWO_DMA_ISR(x)  dma1_channel6_isr(x)
 
 #define LED_PORT     GPIOC
 #define LED_IDLE_RUN GPIO15

--- a/src/platforms/swlink/platform.h
+++ b/src/platforms/swlink/platform.h
@@ -56,10 +56,6 @@ extern bool debug_bmp;
 #define LED_PORT_UART GPIOC
 #define LED_UART      GPIO14
 
-#define PLATFORM_HAS_TRACESWO 1
-#define NUM_TRACE_PACKETS     128U /* This is an 8K buffer */
-#define TRACESWO_PROTOCOL     2U   /* 1 = Manchester, 2 = NRZ / async */
-
 #define SWD_CR      GPIO_CRH(SWDIO_PORT)
 #define SWD_CR_MULT (1U << ((13U - 8U) << 2U))
 
@@ -100,6 +96,7 @@ extern bool debug_bmp;
 #define IRQ_PRI_USBUSART_DMA (2U << 4U)
 #define IRQ_PRI_USB_VBUS     (14U << 4U)
 #define IRQ_PRI_SWO_DMA      (0U << 4U)
+#define IRQ_PRI_TRACE        (0U << 4U)
 
 #define USBUSART               USART1
 #define USBUSART_CR1           USART1_CR1
@@ -121,12 +118,22 @@ extern bool debug_bmp;
 #define USBUSART_DMA_RX_IRQ    NVIC_DMA1_CHANNEL5_IRQ
 #define USBUSART_DMA_RX_ISR(x) dma1_channel5_isr(x)
 
+#define PLATFORM_HAS_TRACESWO 1
+#define NUM_TRACE_PACKETS     128U /* This is an 8K buffer */
+//#define TRACESWO_PROTOCOL     2U   /* 1 = Manchester, 2 = NRZ / async */
+
+#if TRACESWO_PROTOCOL == 1
+
+/* Use TIM2 Input 2 (from PB3/TDO with Remap) */
 #define TRACE_TIM          TIM2
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM2)
 #define TRACE_IRQ          NVIC_TIM2_IRQ
 #define TRACE_ISR(x)       tim2_isr(x)
 #define TRACE_IC_IN        TIM_IC_IN_TI2
-#define TRACE_TRIG_IN      TIM_SMCR_TS_IT1FP2
+#define TRACE_TRIG_IN      TIM_SMCR_TS_TI2FP2
+/* was TIM_SMCR_TS_IT1FP2 from 2010 API */
+
+#elif TRACESWO_PROTOCOL == 2
 
 /*
  * On F103, only USART1 is on AHB2 and can reach 4.5MBaud at 72 MHz.
@@ -145,6 +152,8 @@ extern bool debug_bmp;
 #define SWO_DMA_CHAN    DMA_CHANNEL6
 #define SWO_DMA_IRQ     NVIC_DMA1_CHANNEL6_IRQ
 #define SWO_DMA_ISR(x)  dma1_channel6_isr(x)
+
+#endif /* TRACESWO_PROTOCOL */
 
 #define LED_PORT     GPIOC
 #define LED_IDLE_RUN GPIO15


### PR DESCRIPTION
## Detailed description

* This is an existing/missing feature.
* There is an unconfirmed problem of Manchester capture not working on `native`, and a "feature request" to bring it back to swlink (on which it originally existed), stlink (this is new) and blackpill-f4 (neither mode worked due to various reasons).
* This PR solves that by restoring and copying some macros and introducing compile-time selection of traceswo protocol.

Changes from November 2023, so meson buildsystem parts are missing. I wonder how seamlessly it rebases this far forward.
Default capture modes are Manchester for `native` (and I'm not changing that), but Async/UART+DMA for `stlink` and `swlink`, which I tested to be somewhat working. Building with `TRACESWO_PROTOCOL=1` reverts the two latter platforms to TIM-based Manchester. The PR needs testing and minor cleanup.

Known benefits of Manchester mode capture are automatic data rate (up to a certain BMF-specific limit) useful for power-saving systems and otherwise dynamically changing clocks systems; smaller RAM buffer (as of now, because of slow data rate); less external wiring on `stlink BLUEPILL=1` (uses same TDO pin PA6, not PA10) and `blackpill-f4` (can use PB6, not just PB7). Drawbacks are, well, slower data rate, and 50% link efficiency (UART is 80% efficient and leverages DMA). I believe moving from TIM+IRQ to TIM+DMA and large buffers might boost this mode on par or faster than Uart, and still save users from matching baudrates (and holding Traceclk frequencies) without resorting to FPGA-based tools. No other MCU-based adapter I know of implements this.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)) *and should not affect it*
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

I would raise an issue of Manchester not working on blackpill-f4 (wrong pin and channel), but a) there may very well be existing one; b) uart/async is faster and I don't debug dynamically clocked chips.