### PR TITLE
Fix: remote protocol fault handling

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -380,6 +380,7 @@ static void remote_packet_process_adiv5(const char *const packet, const size_t p
 
 	/* Set up the DP and a fake AP structure to perform the access with */
 	remote_dp.dev_index = hex_string_to_num(2, packet + 2);
+	remote_dp.fault = 0U;
 	adiv5_access_port_s remote_ap;
 	remote_ap.apsel = hex_string_to_num(2, packet + 4);
 	remote_ap.dp = &remote_dp;

--- a/src/target/adiv5_jtag.c
+++ b/src/target/adiv5_jtag.c
@@ -96,17 +96,17 @@ uint32_t adiv5_jtag_clear_error(adiv5_debug_port_s *dp, const bool protocol_reco
 	return adiv5_dp_low_access(dp, ADIV5_LOW_WRITE, ADIV5_DP_CTRLSTAT, status) & 0x32U;
 }
 
-uint32_t adiv5_jtag_raw_access(adiv5_debug_port_s *dp, uint8_t RnW, uint16_t addr, uint32_t value)
+uint32_t adiv5_jtag_raw_access(adiv5_debug_port_s *dp, uint8_t rnw, uint16_t addr, uint32_t value)
 {
-	const bool APnDP = addr & ADIV5_APnDP;
+	const bool is_ap = addr & ADIV5_APnDP;
 	addr &= 0xffU;
 
-	const uint64_t request = ((uint64_t)value << 3U) | ((addr >> 1U) & 0x06U) | (RnW ? 1U : 0U);
+	const uint64_t request = ((uint64_t)value << 3U) | ((addr >> 1U) & 0x06U) | (rnw ? 1U : 0U);
 
 	uint32_t result;
 	uint8_t ack;
 
-	jtag_dev_write_ir(dp->dev_index, APnDP ? IR_APACC : IR_DPACC);
+	jtag_dev_write_ir(dp->dev_index, is_ap ? IR_APACC : IR_DPACC);
 
 	platform_timeout_s timeout;
 	platform_timeout_set(&timeout, 250);

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -31,17 +31,17 @@
 #include "target.h"
 #include "target_internal.h"
 
-uint8_t make_packet_request(uint8_t RnW, uint16_t addr)
+uint8_t make_packet_request(uint8_t rnw, uint16_t addr)
 {
-	bool APnDP = addr & ADIV5_APnDP;
+	bool is_ap = addr & ADIV5_APnDP;
 
 	addr &= 0xffU;
 
 	uint8_t request = 0x81U; /* Park and Startbit */
 
-	if (APnDP)
+	if (is_ap)
 		request ^= 0x22U;
-	if (RnW)
+	if (rnw)
 		request ^= 0x24U;
 
 	addr &= 0xcU;
@@ -375,12 +375,12 @@ uint32_t adiv5_swd_clear_error(adiv5_debug_port_s *const dp, const bool protocol
 	return err;
 }
 
-uint32_t adiv5_swd_raw_access(adiv5_debug_port_s *dp, const uint8_t RnW, const uint16_t addr, const uint32_t value)
+uint32_t adiv5_swd_raw_access(adiv5_debug_port_s *dp, const uint8_t rnw, const uint16_t addr, const uint32_t value)
 {
 	if ((addr & ADIV5_APnDP) && dp->fault)
 		return 0;
 
-	const uint8_t request = make_packet_request(RnW, addr);
+	const uint8_t request = make_packet_request(rnw, addr);
 	uint32_t response = 0;
 	uint8_t ack = SWDP_ACK_WAIT;
 	platform_timeout_s timeout;
@@ -422,7 +422,7 @@ uint32_t adiv5_swd_raw_access(adiv5_debug_port_s *dp, const uint8_t RnW, const u
 		raise_exception(EXCEPTION_ERROR, "SWD invalid ACK");
 	}
 
-	if (RnW) {
+	if (rnw) {
 		if (swd_proc.seq_in_parity(&response, 32U)) { /* Give up on parity error */
 			dp->fault = 1U;
 			DEBUG_ERROR("SWD access resulted in parity error\n");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses some issues with fault handling in the remote protocol that were identified as part of a set of issues @Xobs reported earlier in the year.

The first of two major issues that were occuring are that if a fault happens in the ADIv5 acceleration interface on the probe, setting remote_dp.fault non-zero, that would become a permanent error and lock the stack out of correctly handling further communication. This is addressed by making sure the fault status gets reset during request setup processing on the probe.

The second is that some errors, such as no-response, were not being properly propergated back up to BMDA. This has been addressed by a fix to `adiv5_dp_recoverable_access()` which solves a long standing issue with how it would (fail to) deal with a still-faulting access, and to the v3 and v4 protocol response handling to turn no-response faults back into exceptions to propagate properly. This aligns the BMDA remote protocol implementation more closely to the native firmware behaviour the architecture code is expecting.

Part of the reason to address these issues is what happens when target power is removed part way through discovery, or between discovery and attach, or even between attach and detach. In these cases, several extremely bad things would happen and the only fix would be to power cycle the probe and restart BMDA.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
