### PR TITLE
Fix meson BMPBootloader on blackpill-f4

### DIFF
--- a/src/platforms/common/blackpill-f4/Makefile.inc
+++ b/src/platforms/common/blackpill-f4/Makefile.inc
@@ -1,5 +1,5 @@
 CROSS_COMPILE ?= arm-none-eabi-
-BMP_BOOTLOADER ?=
+BMD_BOOTLOADER ?=
 CC = $(CROSS_COMPILE)gcc
 OBJCOPY = $(CROSS_COMPILE)objcopy
 
@@ -29,10 +29,10 @@ LDFLAGS_BOOT :=                     \
 	-mfpu=fpv4-sp-d16               \
 	-L../deps/libopencm3/lib
 
-ifeq ($(BMP_BOOTLOADER), 1)
+ifeq ($(BMD_BOOTLOADER), 1)
 $(info  Load address 0x08004000 for BMPBootloader)
 LDFLAGS = $(LDFLAGS_BOOT) -Wl,-Ttext=0x8004000
-CFLAGS += -DAPP_START=0x08004000 -DBMP_BOOTLOADER
+CFLAGS += -DAPP_START=0x08004000 -DBMD_BOOTLOADER
 else
 LDFLAGS = $(LDFLAGS_BOOT)
 endif
@@ -63,7 +63,7 @@ SRC +=               \
 	timing.c         \
 	timing_stm32.c
 
-ifneq ($(BMP_BOOTLOADER), 1)
+ifneq ($(BMD_BOOTLOADER), 1)
 all:	blackmagic.bin
 else
 all:	blackmagic.bin  blackmagic_dfu.bin blackmagic_dfu.hex

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -51,7 +51,7 @@ void platform_init(void)
 	rcc_periph_clock_enable(RCC_GPIOB);
 	rcc_periph_clock_enable(RCC_CRC);
 
-#ifndef BMP_BOOTLOADER
+#ifndef BMD_BOOTLOADER
 	/* Blackpill board has a floating button on PA0. Pull it up and use as active-low. */
 	gpio_mode_setup(USER_BUTTON_KEY_PORT, GPIO_MODE_INPUT, GPIO_PUPD_PULLUP, USER_BUTTON_KEY_PIN);
 

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -61,7 +61,7 @@ if blackpill_alternative_pinout != '0'
 endif
 
 if bmd_bootloader
-	probe_blackpill_args += ['-DBMP_BOOTLOADER']
+	probe_blackpill_args += ['-DBMD_BOOTLOADER']
 endif
 
 probe_blackpill_common_link_args = [

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -47,7 +47,7 @@ probe_blackpill_dfu_sources = files('usbdfu.c')
 
 bmd_bootloader = get_option('bmd_bootloader')
 
-probe_blackpill_dfu_serial_length = bmd_bootloader ? '9' : '13'
+probe_blackpill_dfu_serial_length = '13'
 probe_blackpill_load_address = bmd_bootloader ? '0x08004000' : '0x08000000'
 
 probe_blackpill_args = [
@@ -61,7 +61,7 @@ if blackpill_alternative_pinout != '0'
 endif
 
 if bmd_bootloader
-	probe_blackpill_args += ['-DBMD_BOOTLOADER']
+	probe_blackpill_args += ['-DBMP_BOOTLOADER']
 endif
 
 probe_blackpill_common_link_args = [


### PR DESCRIPTION
* Not a feature, this was available via Makefiles for some time.
* The existing problems are meson always building ST MaskROM-jumping firmware, and mismatching serial number lengths.
* This PR solves these problems by updating settings in meson.build for this family of platforms.

Attention blackpill-F4x1Cx users, a recent PR has effectively moved the .noinit boot magic variable flag location (above the 4 KiB of stack), and you may need to rebuild and reflash BMPBootloader (via BOOT0 method, i.e. ST MaskROM USB DFU or USART) so that it matches latest Blackmagic Debug Firmware.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware)) *and does not affect it*
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)) *and does not affect it*
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Not self-opening an issue for this.