### PR TITLE
Fix: increase semihosting F-packet detection robustness

### DIFF
--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -183,9 +183,10 @@ static int32_t semihosting_get_gdb_response(target_controller_s *const tc)
 		/* If this was an escape packet (or gdb_if reports link closed), fail the call */
 		if (size == 1U && packet_buffer[0] == '\x04')
 			return -1;
+		/* If this was an F-reply packet, we're done. Check before clobbering buffer with m-reply. */
+		const bool done = packet_buffer[0] == 'F';
 		const int32_t result = gdb_main_loop(tc, packet_buffer, GDB_PACKET_BUFFER_SIZE, size, true);
-		/* If this was an F-packet, we're done */
-		if (packet_buffer[0] == 'F')
+		if (done)
 			return result;
 	}
 }


### PR DESCRIPTION
## Detailed description

* This is a fix, not a new feature.
* The existing problem is BMD core code detecting GDB F-reply packets too loosely (contributed in #1686).
* This PR solves it by moving the F-reply check up.

Thanks to @TechnoMancer for the idea of capturing `gdb_getpacket()` results before `gdb_main_loop()` potentially clobbers the single in-BMD `gdb_packet_buffer[]` with `gdb_putpacket()` via m-reply. Such as write syscalls with payload beginning with negative numbers, bytes 0xF0..0xFF.

Tested on `blackpill-f411ce` with extra diagnostic logging enabled, against `gd32f303cc` bluepill-plus running Koen's SemihostingTest.ino I modified to do extra writes of negative int32_t numbers (like -3). Logs from GDB and BMP on request.

v1.10 branch is also affected, but some reorganisation has happened on current `main`, so that is not deemed worth backporting (or using for semihosting).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1845.