### PR TITLE
Fix: Ensure F-packet replies from gdb are reliably detected

### DIFF
--- a/src/target/semihosting.c
+++ b/src/target/semihosting.c
@@ -183,9 +183,13 @@ static int32_t semihosting_get_gdb_response(target_controller_s *const tc)
 		/* If this was an escape packet (or gdb_if reports link closed), fail the call */
 		if (size == 1U && packet_buffer[0] == '\x04')
 			return -1;
+		/* 
+		 * If this was an F-packet, we are done waiting.
+		 * Check before gdb_main_loop as it may clobber the packet buffer.
+		 */
+		const bool done = packet_buffer[0] == 'F';
 		const int32_t result = gdb_main_loop(tc, packet_buffer, GDB_PACKET_BUFFER_SIZE, size, true);
-		/* If this was an F-packet, we're done */
-		if (packet_buffer[0] == 'F')
+		if (done)
 			return result;
 	}
 }


### PR DESCRIPTION
## Detailed description

* This fixes an issue.
* The origin of the issue was the change contributed in #1686 which added the loop in semihosting_get_gdb_response.
* The check for an F-packet reply was too late as gdb_main_loop may have already clobbered the packet by the time this is checked.

Collaborative inspection of debug logs from #1845 and provided by others pointed to inconsistent behaviour dealing with remote file i/o completion, which was narrowed down to the F-packet reply check being done after the packet had been processed and the packet buffer possibly clobbered.

This is corrected by checking if the received packet is an F-packet first then processing it and using the result of the check to exit the loop after the processing.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1845.
