### PR TITLE
meson: add C++ compiler entry to the default cross files

### DIFF
--- a/cross-file/96b_carbon.ini
+++ b/cross-file/96b_carbon.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/blackpill-f401cc.ini
+++ b/cross-file/blackpill-f401cc.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/blackpill-f401ce.ini
+++ b/cross-file/blackpill-f401ce.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/blackpill-f411ce.ini
+++ b/cross-file/blackpill-f411ce.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/bluepill.ini
+++ b/cross-file/bluepill.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/f072.ini
+++ b/cross-file/f072.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/f3.ini
+++ b/cross-file/f3.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/f4discovery.ini
+++ b/cross-file/f4discovery.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/hydrabus.ini
+++ b/cross-file/hydrabus.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/launchpad-icdi.ini
+++ b/cross-file/launchpad-icdi.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/native.ini
+++ b/cross-file/native.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/stlink.ini
+++ b/cross-file/stlink.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/stlinkv3.ini
+++ b/cross-file/stlinkv3.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'

--- a/cross-file/swlink.ini
+++ b/cross-file/swlink.ini
@@ -2,6 +2,7 @@
 
 [binaries]
 c = 'arm-none-eabi-gcc'
+cpp = 'arm-none-eabi-g++'
 ld = 'arm-none-eabi-gcc'
 ar = 'arm-none-eabi-ar'
 nm = 'arm-none-eabi-nm'


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This will enable building libftdi's C++ component with the correct compiler, avoiding the defaulting to C++03 on macOS,
once https://github.com/blackmagic-debug/libftdi/pull/2 and https://github.com/blackmagic-debug/libusb/pull/3 are merged.

cc @dragonmux 

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [X] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
