### PR TITLE
Fix: `target_list_free()` exception handling

### DIFF
--- a/src/include/exception.h
+++ b/src/include/exception.h
@@ -31,7 +31,7 @@
  * }
  * CATCH () {
  *    case EXCEPTION_TIMEOUT:
- *        printf("timeout: %s\n", e.msg);
+ *        printf("timeout: %s\n", exception_frame.msg);
  * }
  *
  * Limitations:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the lack of exception handling in `target_list_free()` which results in some very funky behaviour including crashes from double-free() and some other badness.

In the advent that the function is called and thinks it needs to detach from a target, but that target has gone away, `target->detach()` will throw. If left unhandled in this function, the `target_list` state becomes invalid/stale and in an unpredictable state, leading to all the bad things that happen. So, we envelop this section of the function in a `TRY()`-`CATCH()` so we can discard the exception and continue clean-up, giving a consistent and valid final state on the function returning.

Tested working on the STM32H503.

Test protocol is to scan and attach, then either disconnect the debug umbilical, or cut power to the target, and try to `detach`/`kill`. If running BMDA, a message such as
```
Exception caught while detaching from target: Remote protocol exception
TARGET LOST.
```
should be seen, but everything otherwise remains up and working.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
