### PR TITLE
Feature: AT32F435/437 Option Bytes support

### DIFF
--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -420,9 +420,14 @@ static bool at32f43_option_write_erased(target_s *const target, const size_t off
 
 	const uint32_t addr = AT32F43x_USD_BASE + (offset * 2U);
 	DEBUG_TARGET("%s: 0x%08" PRIX32 " <- 0x%04X\n", __func__, addr, value);
+	const uint32_t time_start = platform_time_ms();
 	target_mem32_write16(target, addr, value);
 
 	const bool result = at32f43_flash_busy_wait(target, 0, NULL);
+	const uint32_t time_end = platform_time_ms();
+	const uint32_t time_spent = time_end - time_start;
+	if (time_spent > 20U)
+		DEBUG_TARGET("%s: took %" PRIu32 " ms\n", __func__, time_spent);
 	if (result || offset != 0U)
 		return result;
 

--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -304,6 +304,8 @@ static bool at32f43_flash_erase(target_flash_s *target_flash, target_addr_t addr
 	}
 
 	at32f43_flash_clear_eop(target, bank_reg_offset);
+	DEBUG_TARGET("%s: 0x%08" PRIX32 "+%" PRIu32 " reg_base 0x%08" PRIX32 "\n", __func__, addr, (uint32_t)len,
+		bank_reg_offset + AT32F43x_FLASH_REG_BASE);
 
 	/* Prepare for page/sector erase */
 	target_mem32_write32(target, AT32F43x_FLASH_CTRL + bank_reg_offset, AT32F43x_FLASH_CTRL_SECERS);
@@ -325,6 +327,8 @@ static bool at32f43_flash_write(target_flash_s *target_flash, target_addr_t dest
 	const align_e psize = ALIGN_32BIT;
 
 	at32f43_flash_clear_eop(target, bank_reg_offset);
+	DEBUG_TARGET("%s: 0x%08" PRIX32 "+%" PRIu32 " reg_base 0x%08" PRIX32 "\n", __func__, dest, (uint32_t)len,
+		bank_reg_offset + AT32F43x_FLASH_REG_BASE);
 
 	/* Write to bank corresponding to flash region */
 	target_mem32_write32(target, AT32F43x_FLASH_CTRL + bank_reg_offset, AT32F43x_FLASH_CTRL_FPRGM);

--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -394,6 +394,7 @@ static bool at32f43_option_erase(target_s *target)
 {
 	/* bank_reg_offset is 0, option bytes belong to first bank */
 	at32f43_flash_clear_eop(target, 0);
+	DEBUG_TARGET("%s\n", __func__);
 
 	/* Wipe User System Data */
 	target_mem32_write32(target, AT32F43x_FLASH_CTRL, AT32F43x_FLASH_CTRL_USDERS | AT32F43x_FLASH_CTRL_USDULKS);
@@ -414,6 +415,7 @@ static bool at32f43_option_write_erased(target_s *const target, const size_t off
 	target_mem32_write32(target, AT32F43x_FLASH_CTRL, AT32F43x_FLASH_CTRL_USDPRGM | AT32F43x_FLASH_CTRL_USDULKS);
 
 	const uint32_t addr = AT32F43x_USD_BASE + (offset * 2U);
+	DEBUG_TARGET("%s: 0x%08" PRIX32 " <- 0x%04X\n", __func__, addr, value);
 	target_mem32_write16(target, addr, value);
 
 	const bool result = at32f43_flash_busy_wait(target, 0, NULL);


### PR DESCRIPTION
## Detailed description

* This is technically a new feature in a driver I contributed.
* The existing problem is at32f43x.c not supporting option bytes, which are required for e.g. RDP1 and EOPB0 modification.
* This PR solves it by porting driver code from stm32f1.c and adapting where necessary.

ArteryTek MCU AT32F435, F437 chips contain 512 byte User System Data regions (in SKUs with 2048 byte flash page size), or 4096 byte (for 4096-byte page size), that is 256 and 2048 halfwords [byte-invbyte]. The first 8 are very similar to STM32F1 in function, like 0x5AA5 for RDP1, but during testing via BMDA I encountered some functional differences. Also it's too long to overwrite all of them (and print), so some shortcuts were taken. Compared to #1803 my intent is to get this merged, because I don't have to tread carefully over legacy & widely-used stm32f1.c code. We needed to touch Userdata0-Userdata1 bytes, and on first pass the writes sticked, so I consider this somewhat working.

Remaining issue: I easily managed to escalate from unprotected to RDP1, but couldn't degrade back to unprotected, BMDA kept giving write errors. This needs to be investigated and resolved for soft-unbricking of targets. Observation: under RDP1 neither Flash & USD nor Unique ID is readable by debugger, which poses a problem for efficient identification (just PID+UID+F_SIZE).

If this gets blocked by `native` flash utilization, then I might have to do something about part_id jumptables, but the question about detecting RDP1-locked parts remains. If I can refactor this driver to take both `0x40023c00` and `0x40022000` FLASH_REG_BASE, then it could support __all__ AT32F4 parts in a generic fashion (which also helps containing those jumptables and dropping one vendor-specific driver from Meson/Makefiles config, disentangling from other stm32f1 targets).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Not self-opening one, but there could be a checklist for features (sLib, EPP/WRP, encryption etc.)