### PR TITLE
Fix stlinkv3 platform bits

### DIFF
--- a/src/platforms/stlinkv3/README.md
+++ b/src/platforms/stlinkv3/README.md
@@ -28,6 +28,17 @@ The ST firmware checks the Romtable and only allows access to STM32 devices. In
 some situations, Romtable access may also fail on STM32 device and so a debugger
 warm plug will fail. Cold plug should work with any STM32 device.
 
+## Performance
+Stock firmware has three settings: High-performance (192M), Standard frequency (96M), Low-consumption (48M).
+SWD up to 24000 kHz, JTAG up to 21333 kHz (SPI), SWO up to 16 Mbaud, VCP 732-16000000 baud.
+Suffix 7 devices are rated for -40..+125 deg C but at 200 MHz frequency maximum.
+Other mentioned limits from DS11853 are 144M, 168M, 180M for scales 3-2-1 and overdrive on/off.
+
+This firmware always runs at 216 MHz (suffix 6). AHB clock = 216M, APB1 = 54M, APB2 = 108M.
+USART1, USART6 on APB2 (108M Pclk), others (including UART5) on APB1.
+SWO capture is implemented as UART5 Rx DMA. 3375k (4500k with OVER8) is the limit.
+13.5 Mbaud (18M with OVER8) could be derived from Sysclk, 216/N where N>=16 (OVER8: 2*216/N where 24<=N<=31).
+
 ## Building.
 
 As simple as

--- a/src/platforms/stlinkv3/platform.c
+++ b/src/platforms/stlinkv3/platform.c
@@ -230,6 +230,19 @@ void platform_init(void)
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_PIN);
 	gpio_set_output_options(LED_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, LED_PIN);
 
+	/* Switch SWO UART clocksource from Pclk (54M) to Hclk (216M) */
+	const uint8_t uart5_clksel = RCC_DCKCFGR2_UARTxSEL_SYSCLK;
+	uint32_t regval = RCC_DCKCFGR2;
+	regval &= ~(RCC_DCKCFGR2_UARTxSEL_MASK << RCC_DCKCFGR2_UART5SEL_SHIFT);
+	regval |= (uart5_clksel & RCC_DCKCFGR2_UARTxSEL_MASK) << RCC_DCKCFGR2_UART5SEL_SHIFT;
+	RCC_DCKCFGR2 = regval;
+	/* Switch USB UART clocksource from Pclk (108M) to Hclk (216M) */
+	const uint8_t usart6_clksel = RCC_DCKCFGR2_UARTxSEL_SYSCLK;
+	regval = RCC_DCKCFGR2;
+	regval &= ~(RCC_DCKCFGR2_UARTxSEL_MASK << RCC_DCKCFGR2_USART6SEL_SHIFT);
+	regval |= (usart6_clksel & RCC_DCKCFGR2_UARTxSEL_MASK) << RCC_DCKCFGR2_USART6SEL_SHIFT;
+	RCC_DCKCFGR2 = regval;
+
 	/* Relocate interrupt vector table here */
 	SCB_VTOR = (uintptr_t)&vector_table;
 

--- a/src/platforms/stlinkv3/platform.c
+++ b/src/platforms/stlinkv3/platform.c
@@ -171,6 +171,7 @@ void platform_init(void)
 	rcc_periph_clock_enable(RCC_GPIOH);
 	rcc_periph_clock_enable(RCC_GPIOF);
 	rcc_periph_clock_enable(RCC_GPIOG);
+	rcc_periph_clock_enable(RCC_CRC);
 
 	/* Initialize ADC. */
 	gpio_mode_setup(GPIOA, GPIO_MODE_ANALOG, GPIO_PUPD_NONE, GPIO0);


### PR DESCRIPTION
## Detailed description

* There is a small new feature.
* Existing problems are `(gdb) compare-sections` potentially not working on STLINK/V3, and SWO capture baudrate too low.
* This PR solves these by enabling RCC_CRC and switching UART5 clocksource from APB1 Pclk to Sysclk.

Also I add a couple paragraphs of documentation to platform README.md with info from ST manuals and libopencm3.
Testing on stlinkv3 required prior to merge.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware)) *and does not affect it*
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)) *and does not affect it*
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None reported.