### PR TITLE
Feature: Improved native platform `hwversion` handling

### DIFF
--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -33,12 +33,16 @@
 #if PC_HOSTED == 1
 void platform_init(int argc, char **argv);
 void platform_pace_poll(void);
+
+#define BMD_CONST_FUNC
 #else
 void platform_init(void);
 
 inline void platform_pace_poll(void)
 {
 }
+
+#define BMD_CONST_FUNC __attribute__((const))
 #endif
 
 typedef struct platform_timeout platform_timeout_s;
@@ -51,7 +55,7 @@ void platform_delay(uint32_t ms);
 extern bool connect_assert_nrst;
 uint32_t platform_target_voltage_sense(void);
 const char *platform_target_voltage(void);
-int platform_hwversion(void);
+int platform_hwversion(void) BMD_CONST_FUNC;
 void platform_nrst_set_val(bool assert);
 bool platform_nrst_get_val(void);
 bool platform_target_get_power(void);

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -60,6 +60,8 @@ static void setup_vbus_irq(void);
  */
 #define BMP_HWVERSION_BYTE FLASH_OPTION_BYTE_2
 
+int hwversion = -1;
+
 /*
  * Pins PB[7:5] are used to detect hardware revision.
  * User option byte Data1 is used starting with hardware revision 4.
@@ -82,7 +84,6 @@ static void setup_vbus_irq(void);
  */
 int platform_hwversion(void)
 {
-	static int hwversion = -1;
 	uint16_t hwversion_pins = GPIO7 | GPIO6 | GPIO5;
 	uint16_t unused_pins = hwversion_pins ^ 0xffffU;
 

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -38,11 +38,12 @@ extern bool debug_bmp;
 #define PLATFORM_IDENT   ""
 #define UPD_IFACE_STRING "@Internal Flash   /0x08000000/8*001Kg"
 
+extern int hwversion;
 /*
  * Hardware version switcher helper - when the hardware
  * version is smaller than ver it outputs opt1, otherwise opt2
  */
-#define HW_SWITCH(ver, opt1, opt2) (platform_hwversion() < (ver) ? (opt1) : (opt2))
+#define HW_SWITCH(ver, opt1, opt2) (hwversion < (ver) ? (opt1) : (opt2))
 
 /*
  * Important pin mappings for native implementation:

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -1091,7 +1091,7 @@ void adiv5_dp_init(adiv5_debug_port_s *const dp)
 		DEBUG_INFO("TARGETID 0x%08" PRIx32 " designer 0x%x partno 0x%x\n", targetid, dp->target_designer_code,
 			dp->target_partno);
 
-		dp->targetsel = dp->dev_index << ADIV5_DP_TARGETSEL_TINSTANCE_OFFSET |
+		dp->targetsel = ((uint32_t)dp->dev_index << ADIV5_DP_TARGETSEL_TINSTANCE_OFFSET) |
 			(targetid & (ADIV5_DP_TARGETID_TDESIGNER_MASK | ADIV5_DP_TARGETID_TPARTNO_MASK)) | 1U;
 	}
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we refactor the `hwversion` handling a bit using ALTracer's suggestions as a basis, saving close to 300 bytes of Flash and modestly improving the speed of the bitbanging routines due to them having to deal with a little less code on the hot path for every pin change.

Tested with the RP2040 due to it being one of the more expensive targets to enumerate and rewrite the Flash on, so giving one of the better benchmarks for this change.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
