### PR TITLE
Fix gdb idling too much on DWC

### DIFF
--- a/src/platforms/common/stm32/gdb_if.c
+++ b/src/platforms/common/stm32/gdb_if.c
@@ -90,6 +90,8 @@ static void gdb_if_update_buf(void)
 #else
 	cm_disable_interrupts();
 	__asm__ volatile("isb");
+	/* count_new will become 0 by the time of decision to WFI, so save a copy at entry */
+	const uint32_t count_new_saved = count_new;
 	if (count_new) {
 		memcpy(buffer_out, double_buffer_out, count_new);
 		count_out = count_new;
@@ -99,7 +101,8 @@ static void gdb_if_update_buf(void)
 	}
 	cm_enable_interrupts();
 	__asm__ volatile("isb");
-	if (!count_new)
+	/* Wait for Host OUT packets (count_new is 0 by now, so use the copy saved at entry) */
+	if (!count_new_saved)
 		__WFI();
 #endif
 	if (!count_out)


### PR DESCRIPTION
* Not a new feature.
* The existing problem is 2x reduced performance in `bmpflash read -b int file.bin`, `blackmagic -r file.bin` BMDA memory dumping, and less obvious in other actions, on `blackpill-f4` (and possibly `stlinkv3` F723, `f4discovery` F407).
* This PR solves it by correcting the check in USB interrupt callback code which controls WFI entry.

Follow-up to #1689. Because I added the check on `if(count_new == 0) __WFI();` but by the time of check `count_new` was either zeroed by previous lines of code, or already zero at callback entry, this added an extra sleep, reducing how often USB packets could be fetched from Host OUT endpoint. What I should've done instead is save the `count_new` value at entry and use that to dispatch the WFI. Now this works as I expect it to. Despite that, `0.26% gdb_set_noackmode`. Do with that what you will.

Tested on `blackpill-f411ce` to restore onboard w25q64 read data rate from 123-129 back to 230-257 KiB/s. Monitored with orbtop to sleep 10% of PC samples during the readout. It still sleeps 99% on `gdb_if` port closed, and on `ttyBmpGdb` open but no activity (pre-PR1689 it would not sleep with this port open at all). `ttyBmpTarg` state has no effect on the sleep, Aux UART is IRQ+DMA driven, as is Trace capture (Host IN-only), if only on max packet rate (because of extra Naks).
I think stm32f1 platforms are not affected by both of these changes (thanks to preprocessing macros).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1689.