### PR TITLE
Fix: Guard the CH579 driver in Makefile builds for parity with meson (opt-in)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,7 @@ VPATH += $(PLATFORM_DIR) target
 ENABLE_DEBUG ?= 0
 ENABLE_CORTEXAR ?= 0
 ENABLE_RISCV ?= 0
+ENABLE_CH579 ?= 0
 ENABLE_PUYA ?= 0
 ENABLE_XILINX ?= 0
 
@@ -42,7 +43,6 @@ SRC =              \
 	cortex.c       \
 	cortexm.c      \
 	crc32.c        \
-	ch579.c        \
 	efm32.c        \
 	exception.c    \
 	gdb_if.c       \
@@ -104,6 +104,11 @@ endif
 ifeq ($(ENABLE_PUYA), 1)
 SRC +=     \
 	puya.c
+endif
+
+ifeq ($(ENABLE_CH579), 1)
+SRC +=     \
+	ch579.c
 endif
 
 ifeq ($(ENABLE_CORTEXAR), 1)

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -9,6 +9,7 @@ CFLAGS +=-I ./target
 ENABLE_CORTEXAR := 1
 ENABLE_RISCV := 1
 # Target enables
+ENABLE_CH579 := 1
 ENABLE_PUYA := 1
 ENABLE_XILINX := 1
 


### PR DESCRIPTION
## Detailed description

* Not a feature.
* The existing problem is CI failures for Makefile builds of `native` firmware, including size-diff workflows.
* The PR solves (postpones) it by disabling building of CH579 driver by default in Makefiles, just like meson does.

This is a follow-up to #1788. Inspired by 8be1fcf5. CC @ArcaneNibble and maybe jediminer543.
I may similarly gate my at32f43x driver which will grow after adding OB support, so please merge before 1852 not after.
I'm not sure how would CI check disabled drivers in firmware builds later, but the clues are in >=256 KiB platforms, and meson_options.txt + cross-files ini.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
