### PR TITLE
Fix: Update meson targets in cross-files for bigger platforms

### DIFF
--- a/cross-file/96b_carbon.ini
+++ b/cross-file/96b_carbon.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = '96b_carbon'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = false

--- a/cross-file/blackpill-f401cc.ini
+++ b/cross-file/blackpill-f401cc.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'blackpill-f401cc'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = true

--- a/cross-file/blackpill-f401ce.ini
+++ b/cross-file/blackpill-f401ce.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'blackpill-f401ce'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = true

--- a/cross-file/blackpill-f411ce.ini
+++ b/cross-file/blackpill-f411ce.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'blackpill-f411ce'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = true

--- a/cross-file/f3.ini
+++ b/cross-file/f3.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'f3'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = false

--- a/cross-file/f4discovery.ini
+++ b/cross-file/f4discovery.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'f4discovery'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = false

--- a/cross-file/hydrabus.ini
+++ b/cross-file/hydrabus.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'hydrabus'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = false

--- a/cross-file/launchpad-icdi.ini
+++ b/cross-file/launchpad-icdi.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'launchpad-icdi'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = false

--- a/cross-file/stlinkv3.ini
+++ b/cross-file/stlinkv3.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'stlinkv3'
-targets = 'cortexar,cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti,xilinx'
+targets = 'cortexar,cortexm,riscv32,riscv64,at32f4,ch579,efm,hc32,lpc,nrf,nxp,puya,renesas,rp,sam,stm,ti,xilinx'
 rtt_support = true
 bmd_bootloader = false


### PR DESCRIPTION
## Detailed description

* No new feature.
* The existing problem is big adapters missing three relatively new, gated, target drivers, so users don't get them by default, and CI doesn't check whether that code compiles in firmware builds.
* This PR solves it by updating target lists in cross-files.

Follow-up to #1858, 1857 etc. Keep in mind F103CB platforms still need custom -Dtarget= options to change the built set.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues