### PR TITLE
Fix: STM32 UID decoder: avoid displaying non-printable bytes

### DIFF
--- a/src/target/stm32_common.c
+++ b/src/target/stm32_common.c
@@ -51,6 +51,11 @@ bool stm32_uid(target_s *const target, const target_addr_t uid_base)
 	uid.wafer_ycoord = read_le2(uid_bytes, 2);
 	uid.wafer_number = uid_bytes[4];
 	memcpy(uid.lot_number, &uid_bytes[5], 7);
+	/* Avoid decoding as non-printable characters */
+	for (size_t j = 5U; j < 12U; j++) {
+		if (uid_bytes[j] < 0x20U || uid_bytes[j] >= 0x7fU)
+			return true;
+	}
 
 	tc_printf(target, "Wafer coords X=%u, Y=%u, number %u; Lot number %.7s\n", uid.wafer_xcoord, uid.wafer_ycoord,
 		uid.wafer_number, uid.lot_number);


### PR DESCRIPTION
## Detailed description

* It's a fix to a new-ish feature.
* The existing problem is STM32 UID decoder sending whatever bytes to GDB remote monitor output, potentially resulting in control characters messing up display in terminal emulators.
* This PR solves that by conditionally skipping the "decoded" print, leaving just the hex print.

In testing I noticed that some of ST parts have a different UID encoding. For example, stm32f1.c driver supports STM32F072, and those have what I expect, and decode appropriately; but older designs, including STM32F103, and their followers, like GD32F103, AT32F403A, can have arbitrary non-printable bytes, then BMD interprets them as a null-terminated string and sends as an O-packet. I have had my gnome-terminal corrupted multiple times due to that, and I was running gdb in a byobu-tmux window/panel. The mitigation is `(gdb) !reset` or whatever tput reset sequence to restore xterm mode.

For now, let's check the would-be Lot string and skip the printout if it includes control bytes 0-31 (32/0x20 "space" is legal and exists in F072) or 127-255 (0x7F is DEL). Actually I only have seen uppercase ASCII/Latin-1 letters 0x41-0x5A and digits 0x30-0x39 (and space 0x20) in validly encoded UIDs. The proper fix would be to have two versions of decoder function, or to pass a flag inhibiting the printout, unset at target driver callsite per part family or ID; but also it may cost more adapter flash space. Also, I'd like to get extra docs or intuit the encoding for early variant parts and add a different printout for it, but I have come across no such information.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Not self-reporting one, and the feature is fairly new to get any early testing feedback.