### PR TITLE
Fix `blackpill-f4` requiring a reset after exiting ST MaskROM

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -72,6 +72,12 @@ void platform_init(void)
 		scb_reset_core();
 	}
 #endif
+
+	/* Unmap ST MaskROM and map back Internal Flash */
+	rcc_periph_clock_enable(RCC_SYSCFG);
+	if ((SYSCFG_MEMRM & 3U) == 1U)
+		SYSCFG_MEMRM &= ~3U;
+
 	rcc_clock_setup_pll(&rcc_hse_25mhz_3v3[PLATFORM_CLOCK_FREQ]);
 
 	/* Set up DM/DP pins. PA9/PA10 are not routed to USB-C. */

--- a/src/platforms/common/blackpill-f4/usbdfu.c
+++ b/src/platforms/common/blackpill-f4/usbdfu.c
@@ -23,6 +23,7 @@
 #include <libopencm3/cm3/scb.h>
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/syscfg.h>
 #include <libopencm3/usb/dwc/otg_fs.h>
 
 #include "usbdfu.h"
@@ -53,6 +54,11 @@ int main(void)
 		magic[1] = 0;
 	} else
 		dfu_jump_app_if_valid();
+
+	/* Unmap ST MaskROM and map back Internal Flash */
+	rcc_periph_clock_enable(RCC_SYSCFG);
+	if ((SYSCFG_MEMRM & 3U) == 1U)
+		SYSCFG_MEMRM &= ~3U;
 
 	rcc_clock_setup_pll(&rcc_hse_25mhz_3v3[PLATFORM_CLOCK_FREQ]);
 


### PR DESCRIPTION
## Detailed description

* This is an old feature ported between platforms.
* The existing problem is `blackpill-f411ce` and likely other variants hanging in either BMF or BMD bootloader upon exiting ST MaskROM USB DFU -- mitigated by pressing reset button (after the initial flashing of BMD bootloader, or after `dfu-util -s :leave` for project bootloader-less builds.
* This PR finally solves it by copying the register pokes for restoring STM32F4 memory remap.

Armed with inception debugging, knowledge of adjacent platforms, and dfu-util on Linux amd64 I dived into this once more and noticed something weird. After ST MaskROM USB DFU (located at 0x1fff_0000) performs a leave into application (located at 0x0800_0000), it keeps itself remapped to 0. If BMD bootloader is present, it then updates SCB->VTOR to 0x0000_4000 and jumps to BMF at +16KiB. Finally, this enables interrupts and ends up in MaskROM again because that's what the vector table essentially is at this point.

There are at least two solutions to this. I opted for restoring SYSCFG->MEMRMP bits. Other platforms which have no ST remap functionality, at least always manually update their SCB->VTOR value to point to their vector tables in flash. I can do this on Cortex-M4. *Note that it's impossible on F072-IF which has a Cortex-M0, so remap has to be used.*

Another note is that I tried linking the entire BMF not into 0x0800_0000, but into 0x0, and it runs okay assuming remap is valid. The refman states this may increase performance by replacing S-bus fetch with I-Code bus and D-Code bus fetch in <0x2000_0000. I assume it's only useful for Boot from SRAM to reduce S-bus contention and/or Load-Store Unit utilization -- both MaskROM and Internal Flash fall into I-Code addressable executable region. SRAM fetch does not affect ART or Flash prefetch.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] ~~It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))~~
* [x] ~~It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))~~
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Certainly could fix something. I consider this port much more ready for release now.