### PR TITLE
Fix: Unify help messages for Unique ID with STM32

### DIFF
--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -58,7 +58,7 @@ static bool efm32_cmd_efm_info(target_s *t, int argc, const char **argv);
 static bool efm32_cmd_bootloader(target_s *t, int argc, const char **argv);
 
 const command_s efm32_cmd_list[] = {
-	{"serial", efm32_cmd_serial, "Prints unique number"},
+	{"serial", efm32_cmd_serial, "Print unique device ID"},
 	{"efm_info", efm32_cmd_efm_info, "Prints information about the device"},
 	{"bootloader", efm32_cmd_bootloader, "Bootloader status in CLW0"},
 	{NULL, NULL, NULL},

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -54,7 +54,7 @@ const command_s nrf51_read_cmd_list[] = {
 	{"help", nrf51_cmd_read_help, "Display help for read commands"},
 	{"hwid", nrf51_cmd_read_hwid, "Read hardware identification number"},
 	{"fwid", nrf51_cmd_read_fwid, "Read pre-loaded firmware ID"},
-	{"deviceid", nrf51_cmd_read_deviceid, "Read unique device ID"},
+	{"deviceid", nrf51_cmd_read_deviceid, "Print unique device ID"},
 	{"deviceaddr", nrf51_cmd_read_deviceaddr, "Read device address"},
 	{"deviceinfo", nrf51_cmd_read_deviceinfo, "Read device information"},
 	{NULL, NULL, NULL},

--- a/src/target/renesas_ra.c
+++ b/src/target/renesas_ra.c
@@ -284,7 +284,7 @@ typedef enum {
 static bool renesas_uid(target_s *t, int argc, const char **argv);
 
 const command_s renesas_cmd_list[] = {
-	{"uid", renesas_uid, "Prints unique id"},
+	{"uid", renesas_uid, "Print unique device ID"},
 	{NULL, NULL, NULL},
 };
 


### PR DESCRIPTION
## Detailed description

* Not a new feature, but rather a minor fix for size optimization.
* The existing problem is four distinct variants of the same idea of a message in UID commands or equivalents in target drivers for EFM32, nRF51, Renesas RA.
* This PR replaces the help messages to match the STM32 one, shrinking all builds by ~60 bytes thanks to linker relaxation.

I can't exactly test it live, due to no devices, but `strings -n12 blackmagic.bin | grep "unique"` no longer matches four entries, and the binary is smaller.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues