### PR TITLE
Feature: Calculate and report real USART baudrate

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -605,12 +605,10 @@ static bool cmd_rtt(target_s *t, int argc, const char **argv)
 #ifdef PLATFORM_HAS_TRACESWO
 static bool cmd_traceswo_enable(int argc, const char **argv)
 {
-#if TRACESWO_PROTOCOL == 2
-	uint32_t baudrate = SWO_DEFAULT_BAUD;
-#endif
 	uint32_t swo_channelmask = 0; /* swo decoding off */
 	uint8_t decode_arg = 1;
 #if TRACESWO_PROTOCOL == 2
+	uint32_t baudrate = SWO_DEFAULT_BAUD;
 	/* argument: optional baud rate for async mode */
 	if (argc > 1 && argv[1][0] >= '0' && argv[1][0] <= '9') {
 		baudrate = strtoul(argv[1], NULL, 0);
@@ -634,7 +632,10 @@ static bool cmd_traceswo_enable(int argc, const char **argv)
 	}
 
 #if TRACESWO_PROTOCOL == 2
-	gdb_outf("Baudrate: %lu ", baudrate);
+	traceswo_init(baudrate, swo_channelmask);
+	gdb_outf("Baudrate: %lu ", traceswo_get_baudrate());
+#else
+	traceswo_init(swo_channelmask);
 #endif
 	gdb_outf("Channel mask: ");
 	for (size_t i = 0; i < 32U; ++i) {
@@ -642,12 +643,6 @@ static bool cmd_traceswo_enable(int argc, const char **argv)
 		gdb_outf("%" PRIu32, bit);
 	}
 	gdb_outf("\n");
-
-#if TRACESWO_PROTOCOL == 2
-	traceswo_init(baudrate, swo_channelmask);
-#else
-	traceswo_init(swo_channelmask);
-#endif
 
 	gdb_outf("Trace enabled for BMP serial %s, USB EP %u\n", serial_no, TRACE_ENDPOINT);
 	return true;

--- a/src/platforms/common/aux_serial.c
+++ b/src/platforms/common/aux_serial.c
@@ -36,8 +36,6 @@
 #include "usb_serial.h"
 #include "aux_serial.h"
 
-static uint32_t aux_serial_active_baud_rate;
-
 static char aux_serial_receive_buffer[AUX_UART_BUFFER_SIZE];
 /* Fifo in pointer, writes assumed to be atomic, should be only incremented within RX ISR */
 static uint16_t aux_serial_receive_write_index = 0;
@@ -80,6 +78,7 @@ static char aux_serial_transmit_buffer[AUX_UART_BUFFER_SIZE];
 
 #define usart_enable(uart)                 uart_enable(uart)
 #define usart_disable(uart)                uart_disable(uart)
+#define usart_get_baudrate(uart)           uart_get_baudrate(uart)
 #define usart_set_baudrate(uart, baud)     uart_set_baudrate(uart, baud)
 #define usart_get_databits(uart)           uart_get_databits(uart)
 #define usart_get_stopbits(uart)           uart_get_stopbits(uart)
@@ -87,12 +86,6 @@ static char aux_serial_transmit_buffer[AUX_UART_BUFFER_SIZE];
 #define usart_get_parity(uart)             uart_get_parity(uart)
 #define usart_set_parity(uart, parity)     uart_set_parity(uart, parity)
 #endif
-
-static void aux_serial_set_baudrate(const uint32_t baud_rate)
-{
-	usart_set_baudrate(USBUSART, baud_rate);
-	aux_serial_active_baud_rate = baud_rate;
-}
 
 #if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
 void aux_serial_init(void)
@@ -103,7 +96,7 @@ void aux_serial_init(void)
 
 	/* Setup UART parameters */
 	UART_PIN_SETUP();
-	aux_serial_set_baudrate(38400);
+	usart_set_baudrate(USBUSART, 38400);
 	usart_set_databits(USBUSART, 8);
 	usart_set_stopbits(USBUSART, USART_STOPBITS_1);
 	usart_set_mode(USBUSART, USART_MODE_TX_RX);
@@ -195,7 +188,7 @@ void aux_serial_init(void)
 
 	/* Setup UART parameters. */
 	uart_clock_from_sysclk(USBUART);
-	aux_serial_set_baudrate(38400);
+	uart_set_baudrate(USBUART, 38400);
 	uart_set_databits(USBUART, 8);
 	uart_set_stopbits(USBUART, 1);
 	uart_set_parity(USBUART, UART_PARITY_NONE);
@@ -225,7 +218,7 @@ void aux_serial_set_encoding(const usb_cdc_line_coding_s *const coding)
 	/* Some devices require that the usart is disabled before
 	 * changing the usart registers. */
 	usart_disable(USBUSART);
-	aux_serial_set_baudrate(coding->dwDTERate);
+	usart_set_baudrate(USBUSART, coding->dwDTERate);
 
 #if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
 	if (coding->bParityType != USB_CDC_NO_PARITY)
@@ -267,7 +260,7 @@ void aux_serial_set_encoding(const usb_cdc_line_coding_s *const coding)
 
 void aux_serial_get_encoding(usb_cdc_line_coding_s *const coding)
 {
-	coding->dwDTERate = aux_serial_active_baud_rate;
+	coding->dwDTERate = usart_get_baudrate(USBUSART);
 
 	switch (usart_get_stopbits(USBUSART)) {
 	case USART_STOPBITS_1:

--- a/src/platforms/common/stm32/traceswoasync.c
+++ b/src/platforms/common/stm32/traceswoasync.c
@@ -91,6 +91,11 @@ void trace_buf_drain(usbd_device *dev, uint8_t ep)
 	atomic_flag_clear_explicit(&reentry_flag, memory_order_relaxed);
 }
 
+uint32_t traceswo_get_baudrate(void)
+{
+	return usart_get_baudrate(SWO_UART);
+}
+
 void traceswo_setspeed(uint32_t baudrate)
 {
 	dma_disable_channel(SWO_DMA_BUS, SWO_DMA_CHAN);

--- a/src/platforms/common/stm32/traceswoasync_f723.c
+++ b/src/platforms/common/stm32/traceswoasync_f723.c
@@ -75,6 +75,11 @@ void trace_buf_drain(usbd_device *dev, uint8_t ep)
 	atomic_flag_clear_explicit(&reentry_flag, memory_order_relaxed);
 }
 
+uint32_t traceswo_get_baudrate(void)
+{
+	return usart_get_baudrate(SWO_UART);
+}
+
 void traceswo_setspeed(uint32_t baudrate)
 {
 	dma_disable_stream(SWO_DMA_BUS, SWO_DMA_STREAM);

--- a/src/platforms/common/tm4c/traceswo.c
+++ b/src/platforms/common/tm4c/traceswo.c
@@ -76,7 +76,7 @@ void traceswo_init(void)
 	nvic_enable_irq(TRACEUART_IRQ);
 
 	/* Un-stall USB endpoint */
-	usbd_ep_stall_set(usbdev, 0x85, 0);
+	usbd_ep_stall_set(usbdev, USB_REQ_TYPE_IN | TRACE_ENDPOINT, 0);
 
 	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO3);
 }
@@ -111,7 +111,7 @@ void trace_buf_push(void)
 	if (len > 64U)
 		len = 64;
 
-	if (usbd_ep_write_packet(usbdev, 0x85, (uint8_t *)&buf_rx[buf_rx_out], len) == len) {
+	if (usbd_ep_write_packet(usbdev, USB_REQ_TYPE_IN | TRACE_ENDPOINT, (uint8_t *)&buf_rx[buf_rx_out], len) == len) {
 		buf_rx_out += len;
 		buf_rx_out %= FIFO_SIZE;
 	}

--- a/src/platforms/common/tm4c/traceswo.c
+++ b/src/platforms/common/tm4c/traceswo.c
@@ -87,6 +87,11 @@ void traceswo_baud(unsigned int baud)
 	uart_set_databits(TRACEUART, 8);
 }
 
+uint32_t traceswo_get_baudrate(void)
+{
+	return uart_get_baudrate(TRACEUART);
+}
+
 #define FIFO_SIZE 256U
 
 /* RX Fifo buffer */

--- a/src/platforms/common/traceswo.h
+++ b/src/platforms/common/traceswo.h
@@ -28,6 +28,7 @@
 #define SWO_DEFAULT_BAUD 2250000U
 void traceswo_init(uint32_t baudrate, uint32_t swo_chan_bitmask);
 void traceswo_deinit(void);
+uint32_t traceswo_get_baudrate(void);
 #else
 void traceswo_init(uint32_t swo_chan_bitmask);
 #endif


### PR DESCRIPTION
## Detailed description

* This is a small new feature.
* The existing problem is BMP platforms parroting back whatever baudrate you set it to. The discrepancy gets significant at high baudrates, close to Pclk DIV16, effectively ruining communications to other boards +-5% (especially TraceSWO Async which is tuned by an integer(!) divisor off TraceClk).
* This PR makes TI ICDI and STM32 platforms recompute real baudrate by reading back the programmed USART BRR divisors. It's a function missing from libopencm3 API, but to upstream this there OVER8 support would be required.

As I was compile-testing this, I also noticed some stray hardcoded 0x85 endpoints in ICDI and replaced them with new compile-time macros.
Runtime tested on `blackpill-f411ce`, `swlink`-bluepillplus, stlinkv3-minie (f723). I needed this for better TraceSWO Async UART diagnostics, to ensure TraceClk/SWO_PR is close enough to Pclk/BRR. I don't know how to visibly test how this positively affects aux_serial behaviour, I didn't see a difference in minicom, ckermit, tio. Only tio can reach non-standard baudrates because it uses a different API to set them (kinda like orbtrace serialFeeder), minicom can't (it uses B2000000 macros etc.)
Minor problem with this is I don't like that neither BMF nor libopencm3 has guardrails limiting BRR to 16 or more, so I could "set" and "read back" a baudrate equal to Pclk, which does not work.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)) *and should not affect it*
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
