### PR TITLE
Fix CDC-ACM on STLINK/V3

### DIFF
--- a/src/platforms/common/aux_serial.c
+++ b/src/platforms/common/aux_serial.c
@@ -40,14 +40,14 @@ static uint32_t aux_serial_active_baud_rate;
 
 static char aux_serial_receive_buffer[AUX_UART_BUFFER_SIZE];
 /* Fifo in pointer, writes assumed to be atomic, should be only incremented within RX ISR */
-static uint8_t aux_serial_receive_write_index = 0;
+static uint16_t aux_serial_receive_write_index = 0;
 /* Fifo out pointer, writes assumed to be atomic, should be only incremented outside RX ISR */
-static uint8_t aux_serial_receive_read_index = 0;
+static uint16_t aux_serial_receive_read_index = 0;
 
 #if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
 static char aux_serial_transmit_buffer[2U][AUX_UART_BUFFER_SIZE];
-static uint8_t aux_serial_transmit_buffer_index = 0;
-static uint8_t aux_serial_transmit_buffer_consumed = 0;
+static uint16_t aux_serial_transmit_buffer_index = 0;
+static uint16_t aux_serial_transmit_buffer_consumed = 0;
 static bool aux_serial_transmit_complete = true;
 
 static volatile uint8_t aux_serial_led_state = 0;

--- a/src/platforms/common/aux_serial.h
+++ b/src/platforms/common/aux_serial.h
@@ -27,11 +27,14 @@
 
 #if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
 /* XXX: Does the st_usbfs_v2_usb_driver work on F3 with 128 byte buffers? */
-#if defined(STM32F1) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7)
+#if defined(STM32F1) || defined(STM32F3) || defined(STM32F4)
 #define USART_DMA_BUF_SHIFT 7U
 #elif defined(STM32F0)
 /* The st_usbfs_v2_usb_driver only works with up to 64-byte buffers on the F0 parts */
 #define USART_DMA_BUF_SHIFT 6U
+#elif defined(STM32F7)
+/* HS bulk packets are 512 bytes, use 2x that */
+#define USART_DMA_BUF_SHIFT 10U
 #endif
 
 #define USART_DMA_BUF_SIZE   (1U << USART_DMA_BUF_SHIFT)

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -195,8 +195,12 @@ void usb_serial_set_config(usbd_device *dev, uint16_t value)
 #endif
 
 	/* Serial interface */
-	usbd_ep_setup(
-		dev, CDCACM_UART_ENDPOINT, USB_ENDPOINT_ATTR_BULK, CDCACM_PACKET_SIZE / 2U, debug_serial_receive_callback);
+#if defined(USB_HS)
+	const uint16_t uart_epout_size = CDCACM_PACKET_SIZE;
+#else
+	const uint16_t uart_epout_size = CDCACM_PACKET_SIZE / 2U;
+#endif
+	usbd_ep_setup(dev, CDCACM_UART_ENDPOINT, USB_ENDPOINT_ATTR_BULK, uart_epout_size, debug_serial_receive_callback);
 	usbd_ep_setup(dev, CDCACM_UART_ENDPOINT | USB_REQ_TYPE_IN, USB_ENDPOINT_ATTR_BULK, CDCACM_PACKET_SIZE,
 		debug_serial_send_callback);
 #if defined(STM32F4) && CDCACM_UART_NOTIF_ENDPOINT >= 4


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is Virtual COM port terribly broken on `stlinkv3` platform Blackmagic Debug firmware, whereas it works fine on original proprietary firmware.
* This PR solves it by bumping aux_serial.c buffer sizes to 2x512 for USB HS STM32F723, index type widths, and correcting USB Out endpoint size.

Tested on ST-LINK/V3E by performing a cbrake/linux-serial-test in external loopback mode at 12 Mbaud (Hclk DIV18 gives a round number, and I need OVER8 to go 432M/24=18M) with 1'200'000 chars/s reported in both directions and Wireshark usbmon displaying Bulk packets up to 511 bytes long.
May need independent testing both on FSDev STM32F1 and OTGFS STM32F4 (so an swlink and a blackpill-f4), but the code is macro-gated. I expect slightly better codegen and faster 32-bit ALU-native ops where 8-bit indices were previously used.

## Miscellaneous
* The CDC-ACM Out EP kludge looks ugly to me, but that has to deal with PMA utilization limitation of FSDev (512 bytes?), and I can't walk the private config with descriptors from usb_serial.c -- otherwise that patch becomes
```c
#include "usb_private.h"
const uint16_t uart_epout_size = usbdev->config.interface[UART_IF_NO+1].altsetting.endpoint.wMaxPacketSize;
```
* Initially I suspected some Cortex-M7 D-cache coherency problem, and went to set up the unused MPU with Shareable Non-cacheable region on SRAM2 for 16 KiB and moved said buffers via attribute section there (with an altered linkerscript), but actually DMA2 can reach default DTCM via Cortex-M7 AHBS port, so this ended up being unnecessary. You can still do this to reduce AHB contention between CM7 S-bus, DMA2 and AHB SRAM during high-baudrate VCP and TraceSWO UART stream activity, but assuming they are no faster than 18 Mbaud each, and AHB runs at 216 MHz, I think it's not a significant enough problem.
* CM7 has no cacheability and no waitstates over ITCM & DTCM, so any cache coherency is dealt with automatically. ART requires we link to 0x00220000 not 0x08020000 for ITCM Flash fetch, otherwise only I-cache works for AXI Flash fetch. I tried it and measured no perf benefit.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] ~~It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))~~
* [x] ~~It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))~~
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
