### PR TITLE
Fix: avoid a NULL ptr dereference in HL-remote from !GV#

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -212,8 +212,10 @@ static bool cmd_jtag_scan(target_s *target, int argc, const char **argv)
 	(void)argc;
 	(void)argv;
 
-	if (platform_target_voltage())
-		gdb_outf("Target voltage: %s\n", platform_target_voltage());
+	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
+	const char *const target_voltage = platform_target_voltage();
+	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
+		gdb_outf("Target voltage: %s\n", target_voltage);
 
 	if (connect_assert_nrst)
 		platform_nrst_set_val(true); /* will be deasserted after attach */
@@ -254,8 +256,10 @@ bool cmd_swd_scan(target_s *target, int argc, const char **argv)
 	volatile uint32_t targetid = 0;
 	if (argc > 1)
 		targetid = strtoul(argv[1], NULL, 0);
-	if (platform_target_voltage())
-		gdb_outf("Target voltage: %s\n", platform_target_voltage());
+	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
+	const char *const target_voltage = platform_target_voltage();
+	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
+		gdb_outf("Target voltage: %s\n", target_voltage);
 
 	if (connect_assert_nrst)
 		platform_nrst_set_val(true); /* will be deasserted after attach */
@@ -296,8 +300,11 @@ bool cmd_auto_scan(target_s *t, int argc, const char **argv)
 	(void)argc;
 	(void)argv;
 
-	if (platform_target_voltage())
-		gdb_outf("Target voltage: %s\n", platform_target_voltage());
+	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
+	const char *const target_voltage = platform_target_voltage();
+	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
+		gdb_outf("Target voltage: %s\n", target_voltage);
+
 	if (connect_assert_nrst)
 		platform_nrst_set_val(true); /* will be deasserted after attach */
 

--- a/src/command.c
+++ b/src/command.c
@@ -212,10 +212,7 @@ static bool cmd_jtag_scan(target_s *target, int argc, const char **argv)
 	(void)argc;
 	(void)argv;
 
-	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
-	const char *const target_voltage = platform_target_voltage();
-	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
-		gdb_outf("Target voltage: %s\n", target_voltage);
+	gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
 	if (connect_assert_nrst)
 		platform_nrst_set_val(true); /* will be deasserted after attach */
@@ -256,10 +253,7 @@ bool cmd_swd_scan(target_s *target, int argc, const char **argv)
 	volatile uint32_t targetid = 0;
 	if (argc > 1)
 		targetid = strtoul(argv[1], NULL, 0);
-	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
-	const char *const target_voltage = platform_target_voltage();
-	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
-		gdb_outf("Target voltage: %s\n", target_voltage);
+	gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
 	if (connect_assert_nrst)
 		platform_nrst_set_val(true); /* will be deasserted after attach */
@@ -300,10 +294,7 @@ bool cmd_auto_scan(target_s *t, int argc, const char **argv)
 	(void)argc;
 	(void)argv;
 
-	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
-	const char *const target_voltage = platform_target_voltage();
-	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
-		gdb_outf("Target voltage: %s\n", target_voltage);
+	gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
 	if (connect_assert_nrst)
 		platform_nrst_set_val(true); /* will be deasserted after attach */

--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -54,6 +54,11 @@ void platform_delay(uint32_t ms);
 
 extern bool connect_assert_nrst;
 uint32_t platform_target_voltage_sense(void);
+/*
+ * Sample the voltage (Vref aka Vtgt) at which the target is presumably powered,
+ * then format as a string with static storage duration and return a pointer;
+ * or if platform ADC not implemented, then return the fixed string "Unknown".
+ */
 const char *platform_target_voltage(void);
 int platform_hwversion(void) BMD_CONST_FUNC;
 void platform_nrst_set_val(bool assert);

--- a/src/platforms/96b_carbon/platform.c
+++ b/src/platforms/96b_carbon/platform.c
@@ -89,7 +89,7 @@ bool platform_nrst_get_val(void)
 
 const char *platform_target_voltage(void)
 {
-	return "ABSENT!";
+	return "Unknown";
 }
 
 void platform_request_boot(void)

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -138,7 +138,7 @@ bool platform_nrst_get_val(void)
 
 const char *platform_target_voltage(void)
 {
-	return NULL;
+	return "Unknown";
 }
 
 /*

--- a/src/platforms/f072/platform.c
+++ b/src/platforms/f072/platform.c
@@ -106,7 +106,7 @@ bool platform_nrst_get_val(void)
 
 const char *platform_target_voltage(void)
 {
-	return "ABSENT!";
+	return "Unknown";
 }
 
 #pragma GCC diagnostic push

--- a/src/platforms/f3/platform.c
+++ b/src/platforms/f3/platform.c
@@ -114,7 +114,7 @@ bool platform_nrst_get_val(void)
 
 const char *platform_target_voltage(void)
 {
-	return "ABSENT!";
+	return "Unknown";
 }
 
 #pragma GCC diagnostic push

--- a/src/platforms/f4discovery/platform.c
+++ b/src/platforms/f4discovery/platform.c
@@ -117,7 +117,7 @@ bool platform_nrst_get_val(void)
 
 const char *platform_target_voltage(void)
 {
-	return NULL;
+	return "Unknown";
 }
 
 #pragma GCC diagnostic push

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -480,10 +480,7 @@ int cl_execute(bmda_cli_options_s *opt)
 	platform_nrst_set_val(opt->opt_connect_under_reset);
 	if (opt->opt_mode == BMP_MODE_TEST)
 		DEBUG_INFO("Running in Test Mode\n");
-	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
-	const char *const target_voltage = platform_target_voltage();
-	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
-		DEBUG_INFO("Target voltage: %s\n", target_voltage);
+	DEBUG_INFO("Target voltage: %s\n", platform_target_voltage());
 
 	if (!scan_for_targets(opt)) {
 		DEBUG_ERROR("No target found\n");

--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -480,7 +480,10 @@ int cl_execute(bmda_cli_options_s *opt)
 	platform_nrst_set_val(opt->opt_connect_under_reset);
 	if (opt->opt_mode == BMP_MODE_TEST)
 		DEBUG_INFO("Running in Test Mode\n");
-	DEBUG_INFO("Target voltage: %s Volt\n", platform_target_voltage());
+	/* Call the sampling function only once, check for NULL, check for unimplemented and suppress the output */
+	const char *const target_voltage = platform_target_voltage();
+	if (target_voltage && strcmp(target_voltage, "Unknown") != 0)
+		DEBUG_INFO("Target voltage: %s\n", target_voltage);
 
 	if (!scan_for_targets(opt)) {
 		DEBUG_ERROR("No target found\n");

--- a/src/platforms/hosted/ftdi_bmp.c
+++ b/src/platforms/hosted/ftdi_bmp.c
@@ -823,7 +823,7 @@ const char *ftdi_target_voltage(void)
 			return "Present";
 		return "Absent";
 	}
-	return NULL;
+	return "Unknown";
 }
 
 static uint16_t divisor;

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -399,7 +399,7 @@ const char *platform_target_voltage(void)
 #endif
 
 	default:
-		return NULL;
+		return "Unknown";
 	}
 }
 

--- a/src/platforms/hydrabus/platform.c
+++ b/src/platforms/hydrabus/platform.c
@@ -89,7 +89,7 @@ bool platform_nrst_get_val(void)
 
 const char *platform_target_voltage(void)
 {
-	return NULL;
+	return "Unknown";
 }
 
 void platform_request_boot(void)

--- a/src/platforms/launchpad-icdi/platform.c
+++ b/src/platforms/launchpad-icdi/platform.c
@@ -120,7 +120,7 @@ void platform_delay(uint32_t ms)
 
 const char *platform_target_voltage(void)
 {
-	return NULL;
+	return "Unknown";
 }
 
 void read_serial_number(void)

--- a/src/platforms/native/platform.c
+++ b/src/platforms/native/platform.c
@@ -406,7 +406,7 @@ uint32_t platform_target_voltage_sense(void)
 const char *platform_target_voltage(void)
 {
 	if (hwversion == 0)
-		return gpio_get(GPIOB, GPIO0) ? "OK" : "ABSENT!";
+		return gpio_get(GPIOB, GPIO0) ? "Present" : "Absent";
 
 	static char ret[] = "0.0V";
 	uint32_t val = platform_target_voltage_sense();

--- a/src/platforms/swlink/platform.c
+++ b/src/platforms/swlink/platform.c
@@ -172,7 +172,7 @@ const char *platform_target_voltage(void)
 		ret[2] = '0' + value % 10U;
 		return ret;
 	}
-	return NULL;
+	return "Unknown";
 }
 
 void set_idle_state(int state)


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is Read of NULL in remote.c on platforms which implement a stub for `platform_target_voltage()` as returning a NULL char*.
* This PR offers three possible solutions to this problem, two of them behind `#if 0` because of bigger flash impact.

Before deploying a development build of BMF to stlinkv3e in RDP2 (so no inception debug) I tested my MPU setup idea on my trusty blackpill-f411ce. As I was tapping into the newfound power that is a working MPU on Cortex-M, I also felt like adding (to region 6 "uncaching" top 16 KiB out of 128 KiB of F411CE SRAM) a region 7 to catch any accesses to address 0, that is, NULL dereferences as a known UB in C. Even though libopencm3 doesn't help much, I have already had written the helper functions and tested them elsewhere, so appending two lines of register pokes was trivial.

Imagine my surprise when my mem_manage_handler triggered a reboot (as coded) not during GDB operation, but on attempting a BMDA scan/read. Adding a swlink-bluepillplus (with a cheesy 4-pin cable) revealed this (now that the debugger is present, my handler executes a coded breakpoint instead) beautiful stack backtrace:

```c
(gdb) bt
#0  mem_manage_handler () at ../src/platforms/common/blackpill-f4/blackpill-f4.c:334
#1  <signal handler called>
#2  0x080209c6 in strlen ()
#3  0x08006128 in remote_respond_string (str=0x0, response_code=75 'K') at ../src/remote.c:97
#4  0x0800660a in remote_packet_process_general (packet_len=<optimized out>, packet=0x20001198 <pbuf> "GV") at ../src/remote.c:306
#5  remote_packet_process (packet=packet@entry=0x20001198 <pbuf> "GV", packet_length=packet_length@entry=2) at ../src/remote.c:604
#6  0x08005a64 in consume_remote_packet (packet=packet@entry=0x20001198 <pbuf> "GV", size=size@entry=1024) at ../src/gdb_packet.c:91
#7  0x08005ae4 in gdb_getpacket (packet=packet@entry=0x20001198 <pbuf> "GV", size=size@entry=1024) at ../src/gdb_packet.c:147
#8  0x08005f7c in bmp_poll_loop () at ../src/main.c:65
#9  main () at ../src/main.c:84
```
This was working fine with MPU disabled -- because at 0x0 on STM32 we have the 0x08000000 Internal Flash mapped, and it starts with 0x20001000 for Initial_MSP value of +4KiB, that is bytes 0x00, 0x10, 0x00, 0x20. Or, earlier, some bigger address (actual end of SRAM) divisible by 256, so that it starts with 0x00. `strlen(NULL)` encounters a null-terminator and returns a 0 length.

1. Robust solution: in remote_packet_process_general(), catch the NULL returned by platform and turn it into a fixed string, kinda like feeding it to %s on some libc's, e.g. "(null)"
2. Thin solution: in remote_respond_string(), catch the NULL passed from anywhere in HL-remote stack, skip the strlen & loop and just respond with EOM. A branch-if-zero should be really cheap.
3. Proper solution: fix all the platforms to return something else. Some platforms return "ABSENT!". However, this needs cooperation with command.c

There are multiple calls of this function in command.c which print nothing or print said fixed string verbatim, or print a decimal-formatted platform ADC voltage.
```c
	if (platform_target_voltage())
		gdb_outf("Target voltage: %s\n", platform_target_voltage());
```
I tried to return an empty string consisting of a null-terminator, and this no longer passes a NULL pointer around, but also prints this:
`Target voltage:  Volt`
So whatever fixed string response we choose to use, both callsites need a way to detect it (strcmp?) and suppress the print.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)) *and should not affect it*
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
