### PR TITLE
Fix mis-identification of STM32MP15x_CM4 as STM32H74x_CM4

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -565,6 +565,8 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 	if (conn_reset)
 		target_mem32_write32(target, CORTEXM_DEMCR, 0);
 
+	DEBUG_TARGET("%s: Examining Part ID 0x%04x, AP Part ID: 0x%04x\n", __func__, target->part_id, ap->partno);
+
 	switch (target->designer_code) {
 	case JEP106_MANUFACTURER_FREESCALE:
 		PROBE(imxrt_probe);

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -260,6 +260,15 @@ bool stm32h7_probe(target_s *target)
 	/* Use the partno from the AP always to handle the difference between JTAG and SWD */
 	if (ap->partno != ID_STM32H72x && ap->partno != ID_STM32H74x && ap->partno != ID_STM32H7Bx)
 		return false;
+
+	/* By now it's established that this is likely an H7, but check that it's not an MP15x_CM4 with an errata in AP part code */
+	const uint32_t idcode = target_mem32_read32(target, DBGMCU_IDCODE);
+	const uint16_t dev_id = idcode & STM32H7_DBGMCU_IDCODE_DEV_MASK;
+	DEBUG_TARGET("%s: looking at device ID 0x%03x at 0x%08" PRIx32 "\n", __func__, dev_id, DBGMCU_IDCODE);
+	/* MP15x_CM4 errata: has a partno of 0x450. SoC DBGMCU says 0x500. */
+	if (dev_id != ID_STM32H72x && dev_id != ID_STM32H74x && dev_id != ID_STM32H7Bx)
+		return false;
+
 	target->part_id = ap->partno;
 
 	/* Save private storage */

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -277,6 +277,12 @@ bool stm32h7_probe(target_s *target)
 		write_be4((uint8_t *)priv_storage->name, 5U, target_mem32_read32(target, STM32H7_CHIP_IDENT));
 		priv_storage->name[9] = '\0';
 		break;
+	case ID_STM32H74x:
+		memcpy(priv_storage->name + 5U, "H74x", 5U); /* H742/H743/H753/H750 */
+		break;
+	case ID_STM32H7Bx:
+		memcpy(priv_storage->name + 5U, "H7Bx", 5U); /* H7A3/H7B3/H7B0 */
+		break;
 	default:
 		memcpy(priv_storage->name + 5U, "H7", 3U);
 		break;

--- a/src/target/stm32mp15.c
+++ b/src/target/stm32mp15.c
@@ -91,6 +91,15 @@ static bool stm32mp15_ident(target_s *const target, const bool cortexm)
 		if (!cortexm || ap->partno != ID_STM32MP15x_ERRATA)
 			return false;
 	}
+
+	/* By now it's established that this is likely an MP15x_CM4, but check that it's not an H74x */
+	const uint32_t idcode = target_mem32_read32(target, DBGMCU_IDCODE);
+	const uint16_t dev_id = idcode & STM32MP15_DBGMCU_IDCODE_DEV_MASK;
+	DEBUG_TARGET("%s: looking at device ID 0x%03x at 0x%08" PRIx32 "\n", __func__, dev_id, DBGMCU_IDCODE);
+	/* If this probe routine ever runs ahead of stm32h7_probe, skip the H74x. */
+	if (dev_id != ID_STM32MP15x)
+		return false;
+
 	/*
 	 * We now know the part is either a Cortex-M core with the errata code, or matched the main ID code.
 	 * Copy the correct (AP) part number over to the target structure to handle the difference between


### PR DESCRIPTION
## Detailed description

* There are minor features here, I think.
* The existing problem is `STM32MP15 M4` wrongly identified by BMD as `STM32H7 M4` since 0f226232 of #1819.
* This PR solves it by adding gated code to read the DBGMCU_IDC value as mandated by ST for silicon identification.

First thing I tried is simply reordering the probe calls, and sure enough, that made the two chips light up as `STM32MP15 M4` again but also `STM32MP15 M7` which is unheard of. Then I added the H74x, H7Bx short literals to H7 driver to see slightly more detail in reported target list -- those don't have the H723-like string in their Engineering bytes.
Then the logging of three variants of IDs. By staring at them long enough I figured we only need to read DBGMCU in the dubious case of seeing 0x450.
Tested on STM32MP157C and Nucleo-H743ZI2 to detect each properly and not upset the Cortex-M AHB-AP. Tested on MiniH7B0 to not even try to read IDC because it's 0x480, not 0x450. Similarly, I believe H72x detection should not regress.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues