### PR TITLE
Fix: Use unbuffered stdout on Windows

### DIFF
--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -114,6 +114,10 @@ void platform_init(int argc, char **argv)
 {
 #if defined(_WIN32) || defined(__CYGWIN__)
 	SetConsoleOutputCP(CP_UTF8);
+	if (setvbuf(stdout, NULL, _IONBF, 0) < 0) {
+		int err = errno;
+		fprintf(stderr, "%s: %s returns %s\n", __func__, "setvbuf()", strerror(err));
+	}
 #endif
 	cl_init(&cl_opts, argc, argv);
 	atexit(exit_function);


### PR DESCRIPTION
## Detailed description

* Not a feature.
* The existing problem is BMDA on Windows defaulting to 4 KiB block buffering on stdout. Users don't see output progress (which is line-buffered on Linux) until enough text appears, or BMDA exits.
* This PR switches stdout to unbuffered mode for WIN32 and Cygwin.

Initially I tried _IOLBF, but it returns some error from libc internals.
I don't feel like dealing with placing strategic fflush(stdout) calls in BMDA to massage it into printing info interactively.
Tested on Msys2 ucrt64 to remove delays between activity and printed output. Also tested in Qt Creator Debug to corrupt (mix) Program output significantly.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] ~~It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))~~ and should not affect it
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Not self-opening one.