### PR TITLE
Allow reopening CMSIS-DAP v2 adapters in v1 mode

### DIFF
--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -245,6 +245,7 @@ static const getopt_option_s long_options[] = {
 #ifdef ENABLE_GPIOD
 	{"gpiod", required_argument, NULL, 'g'},
 #endif
+	{"allow-fallback", no_argument, NULL, 'k'},
 	{NULL, 0, NULL, 0},
 };
 
@@ -264,7 +265,7 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 	opt->opt_mode = BMP_MODE_DEBUG;
 	while (true) {
 		const int option =
-			getopt_long(argc, argv, "eEFhHv:Od:f:s:I:c:Cln:m:M:wVtTa:S:jApP:rR::" GPIOD_ARG_STR, long_options, NULL);
+			getopt_long(argc, argv, "eEFhHv:Od:f:s:I:c:Cln:m:M:wVtTa:S:jApP:rR::k" GPIOD_ARG_STR, long_options, NULL);
 		if (option == -1)
 			break;
 
@@ -421,6 +422,9 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 			if (optarg)
 				opt->opt_gpio_map = optarg;
 #endif
+		case 'k':
+			opt->opt_cmsisdap_allow_fallback = true;
+			break;
 		}
 	}
 	if (optind && argv[optind]) {

--- a/src/platforms/hosted/cli.h
+++ b/src/platforms/hosted/cli.h
@@ -68,6 +68,7 @@ typedef struct bmda_cli_options {
 	uint32_t opt_max_frequency;
 	size_t opt_flash_size;
 	char *opt_gpio_map;
+	bool opt_cmsisdap_allow_fallback;
 } bmda_cli_options_s;
 
 void cl_init(bmda_cli_options_s *opt, int argc, char **argv);

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -271,12 +271,18 @@ bool dap_init(bool allow_fallback)
 		type = CMSIS_TYPE_HID;
 
 	/* Windows hosts may not have the winusb driver associated with v2, handle that by degrading to v1 */
-	if (type == CMSIS_TYPE_BULK) {
-		if (!dap_init_bulk()) {
+	if (type == CMSIS_TYPE_BULK && !dap_init_bulk()) {
+		if (allow_fallback) {
 			DEBUG_WARN("Could not setup a CMSIS-DAP v2 device in Bulk mode (no drivers?), retrying HID mode\n");
 			type = CMSIS_TYPE_HID;
+		} else {
+			DEBUG_ERROR("Could not setup a CMSIS-DAP device over Bulk interface, failing. Hint: pass %s to retry "
+						"HID interface\n",
+				"--allow-fallback");
+			return false;
 		}
 	}
+
 	if (type == CMSIS_TYPE_HID) {
 		if (!dap_init_hid())
 			return false;

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -262,7 +262,7 @@ static bool dap_init_bulk(void)
 }
 
 /* LPC845 Breakout Board Rev. 0 reports an invalid response with > 65 bytes */
-bool dap_init(void)
+bool dap_init(bool allow_fallback)
 {
 	/* Initialise the adaptor via a suitable protocol */
 	if (bmda_probe_info.in_ep && bmda_probe_info.out_ep)

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -24,7 +24,7 @@
 #include "adiv5.h"
 #include "cli.h"
 
-bool dap_init(void);
+bool dap_init(bool allow_fallback);
 void dap_exit_function(void);
 void dap_adiv5_dp_init(adiv5_debug_port_s *dp);
 void dap_adiv6_dp_init(adiv5_debug_port_s *dp);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -150,7 +150,7 @@ void platform_init(int argc, char **argv)
 		break;
 
 	case PROBE_TYPE_CMSIS_DAP:
-		if (!dap_init())
+		if (!dap_init(cl_opts.opt_cmsisdap_allow_fallback))
 			exit(1);
 		break;
 


### PR DESCRIPTION
## Detailed description

* This sounds like a small new compatibilty feature.
* The existing problem is BMDA unusable on Windows with adapters implementing CMSIS-DAP v2 (Bulk) and v1 (HID) transports when no drivers are installed on them (WinUSB, libwdi, Zadig etc.)
* This PR solves it by attempting to open the adapter again (on a failed v2 call) via v1 API.

Tested on Windows Msys2 ucrt64 to allow working with RP2040 running free-dap again. Could test against other impls. I understand FS HID is worse performance than FS Bulk, but some users may have no admin rights to keep installing/associating drivers. So much for Plug&Play.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] ~~It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))~~ and should not affect it
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
