### PR TITLE
ctxlink: Fix bootloader related readme and optimize code

### DIFF
--- a/src/platforms/ctxlink/README.md
+++ b/src/platforms/ctxlink/README.md
@@ -23,9 +23,7 @@ After build:
 1) `apt install dfu-util`
 2) Force ctxLink into system bootloader mode by holding down the Mode switch while
    pressing reset. Release reset followed by Mode. System bootloader should appear.
-3) `dfu-util -a 0 --dfuse-address 0x08000000 -D blackmagic_ctxlink_firmware.bin`
-
-To exit from DFU mode press and release Reset on ctxLink.
+3) `dfu-util -a 0 --dfuse-address 0x08000000:leave -D blackmagic_ctxlink_firmware.bin`
 
 ## 10 pin male from pins
 


### PR DESCRIPTION
This PR refactors the request for the STM32F401 to enter the system bootloader, based upon input from @ALTracer. The platform readme is also updated to request dfu-util leaves boot loader mode and enters the ctxlink firmware upon flash completion.

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

