### PR TITLE
Fix diagnostic logs on CDC-ACM of STLINK/V3

### DIFF
--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -82,8 +82,8 @@ static bool debug_serial_send_complete = true;
 void initialise_monitor_handles(void);
 
 static char debug_serial_debug_buffer[AUX_UART_BUFFER_SIZE];
-static uint8_t debug_serial_debug_write_index;
-static uint8_t debug_serial_debug_read_index;
+static uint16_t debug_serial_debug_write_index;
+static uint16_t debug_serial_debug_read_index;
 #endif
 
 static usbd_request_return_codes_e gdb_serial_control_request(usbd_device *dev, usb_setup_data_s *req, uint8_t **buf,


### PR DESCRIPTION
## Detailed description

* Not a feature.
* The existing problem is the opt-in ENABLE_DEBUG logs misbehaving on stlinkv3 platform due to 8-bit ringbuffer indices overflowing from 512-byte HS Bulk packets.
* This PR solves it by increasing index width to 16-bit. Follow-up to #1865.

Tested on STLINK/V3E. I often use optional advanced diagnostic logging in-probe (sacrificing some targets on size-restricted platforms), but on this one under ST bootloader something hung/misbehaved (RDP2 forbids DebugMon?), so I applied my usual hack of skipping the `initialize_monitor_handles()` call in usb_serial.c and not linking with `-lrdimon`. This time I was greeted with working, but malformed, logs, which seemed somewhat faster than all the FS probes.
Sure enough, I haven't noticed the other two `uint8_t` gated by macros in a different TU. Consider this a follow-up/hotfix to that. I hope this time no .bss growth is observed on CI size-diff, because it's disabled by default. If there will be any other HS probes, I think this architecturally unblocks them to freely use 512-byte packets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] ~~It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))~~ and should not affect it
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues