### PR TITLE
Fix: CMSIS-DAP SWD data shift UB

### DIFF
--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -167,7 +167,7 @@ static bool dap_swd_seq_in_parity(uint32_t *const result, const size_t clock_cyc
 
 	uint32_t data = 0;
 	for (size_t offset = 0; offset < clock_cycles; offset += 8U)
-		data |= sequence.data[offset >> 3U] << offset;
+		data |= (uint32_t)sequence.data[offset >> 3U] << offset;
 	*result = data;
 	uint8_t parity = calculate_odd_parity(data);
 	return parity == (sequence.data[4] & 1U);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a UBSAN runtime notice in the SWD support for CMSIS-DAP adaptors. This is caused by an improper widening via integer promotion (which discards unsigned-ness during widening) of sequence data in `dap_swd_seq_in_parity()`. When this widening takes place and a shift right that would change the sign bit occurs, such as shifting 128 up 24 bits on a platform where `int` is 32-bit, this invokes undefined behaviour.

Before this PR, users would see a message such as `../src/platforms/hosted/dap_swd.c:170:39: runtime error: left shift of 255 by 24 places cannot be represented in type 'int'` from BMDA when built with UBSAN and this buggy behaviour triggers. After, no UBSAN errors are reported and SWD comms proceed normally.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
