### PR TITLE
Fix: Opt out of libgcc unwinder pulled by >=newlib-4.3.0

### DIFF
--- a/src/platforms/common/syscalls.c
+++ b/src/platforms/common/syscalls.c
@@ -186,3 +186,16 @@ __attribute__((used)) void *_sbrk(const ptrdiff_t alloc_size)
 	heap_current += alloc_size;
 	return result;
 }
+
+/* ARM EABI Personality functions for newlib-4.3.0 */
+__attribute__((weak)) void __aeabi_unwind_cpp_pr0()
+{
+}
+
+__attribute__((weak)) void __aeabi_unwind_cpp_pr1()
+{
+}
+
+__attribute__((weak)) void __aeabi_unwind_cpp_pr2()
+{
+}


### PR DESCRIPTION
## Detailed description

* This is not really a feature.
* The existing problem is that `arm-none-eabi-` toolchains based on newlib-4.3.0 and newer, pull about 4 KiB of ARM EABI unwinder stuff and fail to link BMF for native.
* This PR solves it by making the explicit choice to not use the libgcc unwinder, via overriding one of (weak?) Personality functions.

Blackmagic Debug Firmware is a unique C project in that it's not C++ and does not use ARM EABI unwinder for C++ exceptions, but it still uses setjmp/longjmp for hand-rolled custom exceptions.
In newlib-4.3.0 a change to setjmp.S was merged which marks the assembly setjmp implementation for ARMv7-M (THUMB2) as `.fnstart/.fnend` but not `.cantunwind`. This was described as necessary for ARMv8-M PAC/BTI features; however all affected in-tree BMF platforms are ARMv7-M. So for all builds involving setjmp usage on Cortex-M3, either GNU linker ld.bfd or assembler (or compiler?) will attempt to add 3600-4200 bytes total of libgcc-unwind functions and `.ARM.extab, .ARM.exidx` binary sections (which `blackmagic.ld` linkerscript does not `/DISCARD/`).
Important note: `f072` platform is not affected, because it's ARMv6-M, THUMB1, and gets a different/simpler setjmp.S implementation, which was never marked for unwinding. Other firmware projects not calling `setjmp()` on armv7-m may not have to pay this cost as well.

Affected toolchains should be 12.3.Rel1 (20230728), 13.2.Rel1 (20231030), 13.3.Rel1 (20240704), and I build-tested on the latter. 12.2.MPACBTI-Rel1, I guess. Not affected are 12.2.Rel1 (20221205) and older, e.g. 11, 10, but then it goes downhill for probably jumptable size optimization reasons. Also build-tested on the xPack versions 12.2.1-1.3 & 13.2.1-1.1.

I chose to do it this way because it's not obvious to me what function references these three Personality functions, and the other approach would be to fork and carry a patched version of setjmp.S macro assembly source, with `.cantunwind` directive inserted, (search for Klipper issue); but that would involve nontrivial buildsystem changes and related maintenance chores. FWIW the Linux kernel, the FreeBSD kernel and red-rocket-computing/backtrace (three other projects targeting baremetal armv7-m in C) just redefine all three functions to do absolutely nothing. I may drop the abort call here, too. I have not runtime-tested this yet (e.g. set a hw breakpoint during inception debug and use normally or run a HITL testbench).
If the project ever wants to reintroduce usage of this and leverage it somehow, via `CFLAGS += -funwind-tables` and calls of _Unwind_Backtrace, then I recommend revisiting this. With this patch I got multiple definition linker errors for the new non-weak function, because it used to not be weak in newlib-4.2.0 (is it now?). CI will show whether that `__attribute__((weak))` is required or not for gcc-10, gcc-12.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] ~~It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))~~ and should not affect it
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes build/link failures for f103-based platforms when 2023+ Arm GNU toolchains are used.