### PR TITLE
Correct USB UART DMA configuration

### DIFF
--- a/src/platforms/ctxlink/platform.h
+++ b/src/platforms/ctxlink/platform.h
@@ -114,14 +114,14 @@
 #define USBUSART_TX_PIN        GPIO6
 #define USBUSART_RX_PIN        GPIO7
 #define USBUSART_ISR(x)        usart1_isr(x)
-#define USBUSART_DMA_BUS       DMA1
-#define USBUSART_DMA_CLK       RCC_DMA1
-#define USBUSART_DMA_TX_CHAN   DMA_STREAM3
-#define USBUSART_DMA_TX_IRQ    NVIC_DMA1_STREAM3_IRQ
-#define USBUSART_DMA_TX_ISR(x) dma1_stream3_isr(x)
-#define USBUSART_DMA_RX_CHAN   DMA_STREAM1
-#define USBUSART_DMA_RX_IRQ    NVIC_DMA1_STREAM1_IRQ
-#define USBUSART_DMA_RX_ISR(x) dma1_stream1_isr(x)
+#define USBUSART_DMA_BUS       DMA2
+#define USBUSART_DMA_CLK       RCC_DMA2
+#define USBUSART_DMA_TX_CHAN   DMA_STREAM7
+#define USBUSART_DMA_TX_IRQ    NVIC_DMA2_STREAM7_IRQ
+#define USBUSART_DMA_TX_ISR(x) dma2_stream7_isr(x)
+#define USBUSART_DMA_RX_CHAN   DMA_STREAM2
+#define USBUSART_DMA_RX_IRQ    NVIC_DMA2_STREAM2_IRQ
+#define USBUSART_DMA_RX_ISR(x) dma2_stream2_isr(x)
 /* For STM32F4 DMA trigger source must be specified */
 #define USBUSART_DMA_TRG DMA_SxCR_CHSEL_4
 


### PR DESCRIPTION
This PR addresses the failure of the ctxLink USB UART to either send or receive data from the dewvice under test.

The DMA configuration used by ctxLink was based upon the F4Disco platform (STM32F407) and several things needed to be corrected before the ctxLink (STM32F411) USB UART worked.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
