### PR TITLE
Feature: Switch `blackpill-f4` to traceswoasync.c driver

### DIFF
--- a/src/platforms/common/blackpill-f4/Makefile.inc
+++ b/src/platforms/common/blackpill-f4/Makefile.inc
@@ -58,7 +58,7 @@ VPATH +=                          \
 SRC +=               \
 	blackpill-f4.c   \
 	traceswodecode.c \
-	traceswo.c       \
+	traceswoasync.c  \
 	serialno.c       \
 	timing.c         \
 	timing_stm32.c

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -20,6 +20,11 @@
 
 /* This file provides the platform specific declarations for the blackpill-f4 implementation. */
 
+/* References: ST doc
+ * RM0383 Rev 3, 2015: https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf
+ * DS10314 Rev 7, 2017: https://www.st.com/resource/en/datasheet/stm32f411ce.pdf
+ */
+
 #ifndef PLATFORMS_COMMON_BLACKPILL_F4_H
 #define PLATFORMS_COMMON_BLACKPILL_F4_H
 
@@ -205,8 +210,10 @@ extern bool debug_bmp;
 #define USBUSART_DMA_TRG DMA_SxCR_CHSEL_4
 
 /*
- * To use USART1 as USBUSART, DMA2 is selected from https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf, page 170, table 28.
+ * To use USART1 as USBUSART, DMA2 is selected from RM0383, page 170, table 28.
  * This table defines USART1_TX as stream 7, channel 4, and USART1_RX as stream 5, channel 4.
+ * Because USART1 is on APB2 with max Pclk of 100 MHz,
+ * reachable baudrates are up to 12.5M with OVER8 or 6.25M with default OVER16 (per DS10314, page 31, table 6)
  */
 #define USBUSART1                USART1
 #define USBUSART1_CR1            USART1_CR1
@@ -227,8 +234,10 @@ extern bool debug_bmp;
 #define USBUSART1_DMA_RX_ISRx(x) dma2_stream5_isr(x)
 
 /*
- * To use USART2 as USBUSART, DMA1 is selected from https://www.st.com/resource/en/reference_manual/dm00119316-stm32f411xc-e-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf, page 170, table 27.
+ * To use USART2 as USBUSART, DMA1 is selected from RM0383, page 170, table 27.
  * This table defines USART2_TX as stream 6, channel 4, and USART2_RX as stream 5, channel 4.
+ * Because USART2 is on APB1 with max Pclk of 50 MHz,
+ * reachable baudrates are up to 6.25M with OVER8 or 3.125M with default OVER16 (per DS10314, page 31, table 6)
  */
 #define USBUSART2                USART2
 #define USBUSART2_CR1            USART2_CR1

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -33,6 +33,8 @@
 #include "timing_stm32.h"
 
 #define PLATFORM_HAS_TRACESWO
+#define NUM_TRACE_PACKETS 256U /* 16K buffer */
+#define TRACESWO_PROTOCOL 1U   /* 1 = RZ/Manchester, 2 = NRZ/async/uart */
 
 #if ENABLE_DEBUG == 1
 #define PLATFORM_HAS_DEBUG
@@ -281,11 +283,28 @@ extern bool debug_bmp;
 #define IRQ_PRI_USBUSART     (2U << 4U)
 #define IRQ_PRI_USBUSART_DMA (2U << 4U)
 #define IRQ_PRI_TRACE        (0U << 4U)
+#define IRQ_PRI_SWO_DMA      (0U << 4U)
 
 #define TRACE_TIM          TIM3
 #define TRACE_TIM_CLK_EN() rcc_periph_clock_enable(RCC_TIM3)
 #define TRACE_IRQ          NVIC_TIM3_IRQ
 #define TRACE_ISR(x)       tim3_isr(x)
+
+/* On F411 use USART1_RX mapped on PB7 for async capture */
+#define SWO_UART        USBUSART1
+#define SWO_UART_CLK    USBUSART1_CLK
+#define SWO_UART_DR     USBUSART1_DR
+#define SWO_UART_PORT   GPIOB
+#define SWO_UART_RX_PIN GPIO7
+#define SWO_UART_PIN_AF GPIO_AF7
+
+/* Bind to the same DMA Rx channel */
+#define SWO_DMA_BUS    USBUSART1_DMA_BUS
+#define SWO_DMA_CLK    USBUSART1_DMA_CLK
+#define SWO_DMA_CHAN   USBUSART1_DMA_RX_CHAN
+#define SWO_DMA_IRQ    USBUSART1_DMA_RX_IRQ
+#define SWO_DMA_ISR(x) USBUSART1_DMA_RX_ISRx(x)
+#define SWO_DMA_TRG    DMA_SxCR_CHSEL_4
 
 #define SET_RUN_STATE(state)      \
 	{                             \

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -34,7 +34,7 @@
 
 #define PLATFORM_HAS_TRACESWO
 #define NUM_TRACE_PACKETS 256U /* 16K buffer */
-#define TRACESWO_PROTOCOL 1U   /* 1 = RZ/Manchester, 2 = NRZ/async/uart */
+#define TRACESWO_PROTOCOL 2U   /* 1 = RZ/Manchester, 2 = NRZ/async/uart */
 
 #if ENABLE_DEBUG == 1
 #define PLATFORM_HAS_DEBUG

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -79,7 +79,7 @@ probe_host = declare_dependency(
 	sources: probe_blackpill_sources,
 	compile_args: probe_blackpill_args,
 	link_args: probe_blackpill_common_link_args + probe_blackpill_link_args,
-	dependencies: [platform_common, platform_stm32f4, fixme_platform_stm32_traceswo],
+	dependencies: [platform_common, platform_stm32f4, fixme_platform_stm32_traceswoasync],
 )
 
 probe_bootloader = declare_dependency(


### PR DESCRIPTION
## Detailed description

* The feature is technically not new.
* The existing problem is traceswo.c driver (TIM) not working / incompatible with blackpill-f4 platforms.
* This PR solves it by switching altogether to the patched traceswoasync.c driver (UART).

It's based on the branch patching traceswoasync.c, so when that's merged I'll replay/rebase it away and diff becomes smaller.
If other F4 platforms require a similar switch procedure, please provide the macros like here, required to leverage the driver.
Buffer size could be smaller, I haven't found a good rule of thumb for it.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] ~~It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))~~ and should not affect it
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues