### PR TITLE
Feature: CI overhaul

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -88,6 +88,27 @@ jobs:
         run: |
           meson setup build --cross-file cross-file/${{ matrix.probe }}.ini
           meson compile -C build
+          mkdir src/artefacts
+          mv build/blackmagic_*_firmware.{elf,bin} src/artefacts
+
+      # Package up the artefacts and upload them
+      - name: Archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: blackmagic_firmware-${{ matrix.probe }}
+          path: src/artefacts/*
+          if-no-files-found: error
+
+  package-firmware:
+    runs-on: ubuntu-latest
+    needs: build-firmware
+    steps:
+      - name: Merge firmware artefacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: blackmagic_firmware
+          pattern: blackmagic_firmware-*
+          delete-merged: true
 
   build-linux:
     # The type of runner that the job will run on

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -296,3 +296,67 @@ jobs:
           name: blackmagic_${{ matrix.os }}-${{ matrix.sys.abi }}-${{ matrix.sys.compiler }}
           path: src/artefacts/*
           if-no-files-found: error
+
+  build-macos:
+    # Name the job more appropriately so we can tell which Xcode/macOS version is in use
+    name: 'build-macos (${{ matrix.os.id }})'
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os.id }}
+
+    # Set the shell so run steps will execute inside the native environment
+    defaults:
+      run:
+        shell: bash
+
+    # We define a matrix of compilers and OS versions to build against so we can cover a variety of
+    # suitable compilation environments and early discover issues. The `build-and-upload`
+    # workflow contains an extended set.
+    strategy:
+      matrix:
+        os:
+          - {id: macos-12, name: '12'}
+          - {id: macos-13, name: '13'}
+      fail-fast: false
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Build a suitable runtime environment
+      - name: Runtime environment
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        # The GITHUB_WORKSPACE step here fixes https://github.com/actions/runner/issues/2058 which is an ongoing issue.
+        run: |
+          echo "GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+
+      # Install and setup a suitable Meson + Ninja
+      - name: Setup Meson + Ninja
+        run: |
+          brew install meson ninja
+
+      # Record the versions of all the tools used in the build
+      - name: Version tools
+        run: |
+          cc --version  || true
+          ld --version || true
+          meson --version
+          ninja --version
+
+      # Checkout the repository and branch to build under the default location
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Build the default BMDA configuration
+      - name: Build full BMDA
+        run: |
+          meson setup build
+          meson compile -C build
+          mkdir src/artefacts
+          mv build/blackmagic src/artefacts/blackmagic-bmda
+
+      # Package up the artefact and upload it
+      - name: Archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: blackmagic_macos-${{ matrix.os.name }}
+          path: src/artefacts/*
+          if-no-files-found: error

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -34,10 +34,6 @@ jobs:
           - 'gcc-11'
         arm-compiler:
           - '12.2.Rel1'
-        include:
-          - os: {id: ubuntu-20.04, name: focal}
-            compiler: gcc-9
-            arm-compiler: '10-2020-q4'
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -99,6 +99,15 @@ jobs:
           path: src/artefacts/*
           if-no-files-found: error
 
+      # Package and upload logs if the build fails so we can dissect why
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-firmware-${{ matrix.probe }}
+          path: ${{ github.workspace }}/build/meson-logs/*
+          retention-days: 5
+
   package-firmware:
     runs-on: ubuntu-latest
     needs: build-firmware
@@ -209,6 +218,15 @@ jobs:
           path: src/artefacts/*
           if-no-files-found: error
 
+      # Package and upload logs if the build fails so we can dissect why
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-linux-${{ matrix.os.id }}-${{ matrix.compiler }}
+          path: ${{ github.workspace }}/build/meson-logs/*
+          retention-days: 5
+
   build-windows-mingw:
     # Name the job more appropriately so we can tell which windows and which MinGW ABI is in use
     name: 'build-mingw (${{ matrix.os }}, ${{ matrix.sys.abi }})'
@@ -297,6 +315,15 @@ jobs:
           path: src/artefacts/*
           if-no-files-found: error
 
+      # Package and upload logs if the build fails so we can dissect why
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-${{ matrix.os }}-${{ matrix.sys.abi }}-${{ matrix.sys.compiler }}
+          path: ${{ github.workspace }}/build/meson-logs/*
+          retention-days: 5
+
   build-macos:
     # Name the job more appropriately so we can tell which Xcode/macOS version is in use
     name: 'build-macos (${{ matrix.os.id }})'
@@ -360,3 +387,12 @@ jobs:
           name: blackmagic_macos-${{ matrix.os.name }}
           path: src/artefacts/*
           if-no-files-found: error
+
+      # Package and upload logs if the build fails so we can dissect why
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-macos-${{ matrix.os.name }}
+          path: ${{ github.workspace }}/build/meson-logs/*
+          retention-days: 5

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -32,8 +32,6 @@ jobs:
           - 'clang-18' # Latest Clang compiler from the apt mirror
           - 'gcc-11' # Native GCC compiler for the CI image
           - 'gcc-13' # Latest GCC compiler from the toolchain PPA
-        arm-compiler:
-          - '12.2.Rel1'
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -58,6 +56,7 @@ jobs:
           sudo apt-get install $CC $CXX
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "BUILD_OPTS=" >> $GITHUB_ENV
         env:
           CC: ${{ matrix.compiler }}
       - name: Setup system Clang
@@ -73,44 +72,48 @@ jobs:
           CXX=${CC/#clang/clang++}
           echo "CC=$CC" >> $GITHUB_ENV
           echo "CXX=$CXX" >> $GITHUB_ENV
+          echo "BUILD_OPTS=-Dhidapi:b_lto=false -Dlibusb:b_lto=false" >> $GITHUB_ENV
         env:
           CC: ${{ matrix.compiler }}
         working-directory: ${{ runner.temp }}
 
       # Install the dependencies needed for a full BMDA build
-      - name: Install BMDA dependencies
-        run: sudo apt-get -y install libc6-dev-i386 libusb-dev libftdi1-dev libhidapi-dev
+      - name: Install dependencies
+        run: sudo apt-get -y install libudev-dev
 
-      # Setup and use a suitable ARM GCC for the firmware
-      - name: Setup ARM GCC
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
-        with:
-          release: ${{ matrix.arm-compiler }}
+      # Install and setup a suitable Meson + Ninja
+      - name: Setup Meson + Ninja
+        run: |
+          sudo python3 -m pip install --upgrade pip setuptools wheel
+          sudo python3 -m pip install meson ninja
+        working-directory: ${{ runner.temp }}
 
       # Record the versions of all the tools used in the build
       - name: Version tools
         shell: bash
         run: |
           $CC --version
-          arm-none-eabi-gcc --version
-          make --version
+          meson --version
+          ninja --version
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Build the firmware for all platform variants and full BMDA
-      - name: Build all platform variants firmware and Linux BMDA
+      # Build BMDA for Linux
+      - name: Build Linux BMDA
         run: |
-          make all_platforms
-          mv src/artifacts/blackmagic-{hosted,bmda}
+          meson setup build $BUILD_OPTS
+          meson compile -C build
+          mkdir src/artefacts
+          mv build/blackmagic src/artefacts/blackmagic-bmda
 
-      # Package up all the artefacts and upload them
-      - name: Archive firmware build artifacts as a zip
-        uses: actions/upload-artifact@v3
+      # Package up the artefact and upload it
+      - name: Archive
+        uses: actions/upload-artifact@v4
         with:
-          name: blackmagic-linux_${{ matrix.os.name }}-${{ matrix.compiler }}+arm-${{ matrix.arm-compiler }}
-          path: src/artifacts/*
+          name: blackmagic_linux-${{ matrix.os.id }}-${{ matrix.compiler }}
+          path: src/artefacts/*
           if-no-files-found: error
 
   build-windows-mingw:

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -17,6 +17,78 @@ concurrency:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a job for each supported OS in the form `build-<os>`
+  build-firmware:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os.id }}
+
+    # We define a matrix of compilers and OS versions to build against so we can cover a variety of
+    # suitable compilation environments and early discover issues
+    strategy:
+      matrix:
+        os:
+          - {id: ubuntu-22.04, name: jammy}
+        compiler:
+          - '12.2.Rel1'
+        probe:
+          - '96b_carbon'
+          - 'bluepill'
+          - 'ctxlink'
+          - 'f072'
+          - 'f3'
+          - 'f4discovery'
+          - 'hydrabus'
+          - 'launchpad-icdi'
+          - 'native'
+          - 'stlink'
+          - 'stlinkv3'
+          - 'swlink'
+      fail-fast: false
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Build a suitable runtime environment
+      - name: Runtime environment
+        shell: bash
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        # The GITHUB_WORKSPACE step here fixes https://github.com/actions/runner/issues/2058 which is an ongoing issue.
+        run: |
+          echo "$GITHUB_WORKSPACE=`pwd`" >> $GITHUB_ENV
+
+      # Setup and use a suitable ARM GCC for the firmware
+      - name: Setup ARM GCC
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: ${{ matrix.compiler }}
+
+      # Install and setup a suitable Meson + Ninja
+      - name: Setup Meson + Ninja
+        run: |
+          sudo python3 -m pip install --upgrade pip setuptools wheel
+          sudo python3 -m pip install meson ninja
+        working-directory: ${{ runner.temp }}
+
+      # Record the versions of all the tools used in the build
+      - name: Version tools
+        shell: bash
+        run: |
+          cc --version
+          arm-none-eabi-gcc --version
+          meson --version
+          ninja --version
+
+      # Checkout the repository and branch to build under the default location
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # Build the firmware for all platform variants (currently available)
+      - name: Build
+        run: |
+          meson setup build --cross-file cross-file/${{ matrix.probe }}.ini
+          meson compile -C build
+
   build-linux:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os.id }}

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -26,12 +26,12 @@ jobs:
     strategy:
       matrix:
         os:
-          - {id: ubuntu-20.04, name: focal}
+          - {id: ubuntu-22.04, name: jammy}
         compiler:
-          - 'clang-9'
-          - 'clang-15'
-          - 'gcc-9'
-          - 'gcc-11'
+          - 'clang-13' # Native Clang compiler for the CI image
+          - 'clang-18' # Latest Clang compiler from the apt mirror
+          - 'gcc-11' # Native GCC compiler for the CI image
+          - 'gcc-13' # Latest GCC compiler from the toolchain PPA
         arm-compiler:
           - '12.2.Rel1'
       fail-fast: false

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -225,12 +225,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
         sys:
-          - {abi: mingw64, env: x86_64, compiler: gcc}
           - {abi: ucrt64, env: ucrt-x86_64, compiler: gcc}
-          - {abi: clang64, env: clang-x86_64, compiler: clang}
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -242,8 +239,9 @@ jobs:
           msystem: ${{matrix.sys.abi}}
           update: true
           path-type: inherit
-          install: >-
-            mingw-w64-${{matrix.sys.env}}-toolchain
+          pacboy: >-
+            toolchain:p
+            meson:p
 
       # Build a suitable runtime environment
       - name: Runtime environment
@@ -271,43 +269,30 @@ jobs:
         env:
           CC: ${{ matrix.sys.compiler }}
 
-      # Install the dependencies needed for a full BMDA build
-      - name: Install BMDA dependencies
-        run: |
-          pacman --noconfirm -S mingw-w64-${{matrix.sys.env}}-libusb mingw-w64-${{matrix.sys.env}}-libftdi \
-            mingw-w64-${{matrix.sys.env}}-hidapi
-
-      # Setup and use a suitable ARM GCC for the firmware
-      - name: Setup ARM GCC
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
-        with:
-          release: '12.2.Rel1'
-
       # Record the versions of all the tools used in the build
       - name: Version tools
-        shell: bash
         run: |
           $CC --version
-          arm-none-eabi-gcc --version
-          make --version
+          meson --version
+          ninja --version
 
       # Checkout the repository and branch to build under the default location
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Build the firmware for all platform variants and full BMDA
-      - name: Build all platform variants firmware and Windows BMDA
+      # Build the default BMDA configuration
+      - name: Build full BMDA
         run: |
-          make all_platforms
-          make -C src clean
-          make PROBE_HOST=hosted HOSTED_BMP_ONLY=0
-          mv src/artifacts/blackmagic-{hosted,bmda-bmp-only}.exe
-          mv src/blackmagic.exe src/artifacts/blackmagic-bmda-full.exe
+          meson setup build
+          meson compile -C build
+          mkdir src/artefacts
+          mv build/blackmagic.exe src/artefacts/blackmagic-bmda.exe
+          mv build/ftd2xx.dll src/artefacts
 
       # Package up all the artefacts and upload them
-      - name: Archive firmware build artifacts as a zip
-        uses: actions/upload-artifact@v3
+      - name: Archive firmware build artefacts as a zip
+        uses: actions/upload-artifact@v4
         with:
-          name: blackmagic-windows_${{ matrix.os }}-${{ matrix.sys.abi }}-${{ matrix.sys.compiler }}
-          path: src/artifacts/*
+          name: blackmagic_${{ matrix.os }}-${{ matrix.sys.abi }}-${{ matrix.sys.compiler }}
+          path: src/artefacts/*
           if-no-files-found: error

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -379,7 +379,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - macos-11
+          - macos-12
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -226,8 +226,8 @@ jobs:
           msystem: ${{matrix.sys.abi}}
           update: true
           path-type: inherit
-          install: >-
-            mingw-w64-${{matrix.sys.env}}-toolchain
+          pacboy: >-
+            toolchain:p
 
       # Build a suitable runtime environment
       - name: Runtime environment

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -437,7 +437,8 @@ jobs:
         compiler:
           - gcc@11
           - gcc@12
-          - gcc@13 # Don't use 'gcc', the symlink is versioned -- see below
+          - gcc@13
+          - gcc@14 # Don't use 'gcc', the symlink is versioned -- see below
         exclude:
           # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114007
           # Fix was backported to GCC 13, but there's no release available yet

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -27,10 +27,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - {id: ubuntu-20.04, name: focal}
+          - {id: ubuntu-22.04, name: jammy}
         compiler:
-          - 'clang-15'
-          - 'gcc-11'
+          - 'clang-18'
+          - 'gcc-13'
         arm-compiler:
           - '12.2.Rel1'
       fail-fast: false
@@ -296,7 +296,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - {id: ubuntu-20.04, name: focal}
+          - {id: ubuntu-22.04, name: jammy}
         arm-compiler:
           - '12.2.Rel1'
         probe:
@@ -345,6 +345,7 @@ jobs:
       # Record the versions of all the tools used in the build
       - name: Version tools
         run: |
+          cc --version
           arm-none-eabi-gcc --version
           meson --version
           ninja --version
@@ -503,7 +504,7 @@ jobs:
           meson compile -C build
 
   size-diff:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       # Setup and use a suitable ARM GCC for the firmware

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -151,7 +151,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-2019
           - windows-2022
       fail-fast: false
 
@@ -276,8 +275,7 @@ jobs:
       # Install the dependencies needed for a full BMDA build
       - name: Install BMDA dependencies
         run: |
-          pacman --noconfirm -S mingw-w64-${{matrix.sys.env}}-libusb mingw-w64-${{matrix.sys.env}}-libftdi \
-            mingw-w64-${{matrix.sys.env}}-hidapi
+          pacman --noconfirm -S mingw-w64-${{matrix.sys.env}}-libusb mingw-w64-${{matrix.sys.env}}-hidapi
 
       # And build that full binary
       - name: Build full BMDA

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -212,6 +212,7 @@ jobs:
         os:
           - windows-2022
         sys:
+          - {abi: mingw64, env: x86_64, compiler: gcc}
           - {abi: ucrt64, env: ucrt-x86_64, compiler: gcc}
           - {abi: clang64, env: clang-x86_64, compiler: clang}
       fail-fast: false

--- a/src/platforms/hosted/meson.build
+++ b/src/platforms/hosted/meson.build
@@ -170,6 +170,7 @@ if build_machine.system() == 'linux'
 		fallback: ['hidapi', 'hidapi_hidraw_dep'],
 		native: is_cross_build,
 		default_options: [
+			'c_std=gnu99',
 			'default_library=static',
 			'install_targets=false',
 			'with_libusb=false',
@@ -185,6 +186,7 @@ else
 		fallback: 'hidapi',
 		native: is_cross_build,
 		default_options: [
+			'c_std=c99',
 			'default_library=static',
 			'install_targets=false',
 			'build_native=true',


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR overhauls both the PR CI workflow and the build-and-upload workflow.

The PR workflow changes are relatively minimal - bumps to OS releases used, compilers targeted and dropping ones that have either already been removed from GHA's runners set, or will be soon.

The build-and-upload workflow rewrite is very comprehensive and encompases completely rewriting the flows to use Meson only (Makefile builds are already tested by the PR CI), and to work smarter rather than harder with the firmware builds. Additionally, this introduces macOS builds of BMDA, makes the Linux Windows builds stand-alone, and cleans up which Windows builds get done as the volume and combinations were a bit ridiculous.

Overall, the resulting flows should be faster, less duplicated, and produce more meaningful results for users wishing to consume the builds from the build-and-upload flow.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
