### PR TITLE
Feature: Add platform-specific commands support

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -125,6 +125,10 @@ const command_s cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
+#ifdef PLATFORM_HAS_CUSTOM_COMMANDS
+extern const command_s platform_cmd_list[];
+#endif
+
 bool connect_assert_nrst;
 #if defined(PLATFORM_HAS_DEBUG) && PC_HOSTED == 0
 bool debug_bmp;
@@ -160,6 +164,13 @@ int command_process(target_s *const t, char *const cmd_buffer)
 		if ((argc == 0) || !strncmp(argv[0], cmd->cmd, strlen(argv[0])))
 			return !cmd->handler(t, argc, argv);
 	}
+
+#ifdef PLATFORM_HAS_CUSTOM_COMMANDS
+	for (const command_s *cmd = platform_cmd_list; cmd->cmd; ++cmd) {
+		if ((argc == 0) || !strncmp(argv[0], cmd->cmd, strlen(argv[0])))
+			return !cmd->handler(t, argc, argv);
+	}
+#endif
 
 	if (!t)
 		return -1;
@@ -198,6 +209,10 @@ bool cmd_help(target_s *t, int argc, const char **argv)
 		gdb_out("General commands:\n");
 		for (const command_s *cmd = cmd_list; cmd->cmd; cmd++)
 			gdb_outf("\t%s -- %s\n", cmd->cmd, cmd->help);
+#ifdef PLATFORM_HAS_CUSTOM_COMMANDS
+		for (const command_s *cmd = platform_cmd_list; cmd->cmd; ++cmd)
+			gdb_outf("\t%s -- %s\n", cmd->cmd, cmd->help);
+#endif
 		if (!t)
 			return true;
 	}

--- a/src/command.c
+++ b/src/command.c
@@ -126,7 +126,7 @@ const command_s cmd_list[] = {
 };
 
 #ifdef PLATFORM_HAS_CUSTOM_COMMANDS
-extern const command_s platform_cmd_list[];
+extern const command_s *platform_cmd_list;
 #endif
 
 bool connect_assert_nrst;
@@ -167,7 +167,7 @@ int command_process(target_s *const t, char *const cmd_buffer)
 
 #ifdef PLATFORM_HAS_CUSTOM_COMMANDS
 	for (const command_s *cmd = platform_cmd_list; cmd->cmd; ++cmd) {
-		if ((argc == 0) || !strncmp(argv[0], cmd->cmd, strlen(argv[0])))
+		if (!strncmp(argv[0], cmd->cmd, strlen(argv[0])))
 			return !cmd->handler(t, argc, argv);
 	}
 #endif


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

I'm currently porting this project to my custom platform and at one point I needed to add a custom command for my platform.
My port uses this project as a submodule, so I thought it would be great to be able to add platform-specific commands without patching command.c file.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues