### PR TITLE
Fix: Fixed platform_cmd_list extern declaration in command.c

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -126,7 +126,7 @@ const command_s cmd_list[] = {
 };
 
 #ifdef PLATFORM_HAS_CUSTOM_COMMANDS
-extern const command_s *platform_cmd_list;
+extern const command_s platform_cmd_list[];
 #endif
 
 bool connect_assert_nrst;


### PR DESCRIPTION
## Detailed description

Fix: Fixed platform_cmd_list extern declaration in command.c that causes hardfault.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues