### PR TITLE
Feature: RISC-V Debug remote protocol acceleration

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -112,3 +112,9 @@ option(
 	type: 'feature',
 	value: 'auto'
 )
+option(
+	'enable_riscv_accel',
+	type: 'boolean',
+	value: false,
+	description: 'Enable firmware-side protocol acceleration of RISC-V Debug'
+)

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,7 @@ ENABLE_ARTERY ?= 0
 ENABLE_CH579 ?= 0
 ENABLE_PUYA ?= 0
 ENABLE_XILINX ?= 0
+ENABLE_RISCV_ACCEL ?= 0
 
 SYS = $(shell $(CC) -dumpmachine)
 
@@ -120,24 +121,28 @@ SRC +=     \
 endif
 
 ifeq ($(ENABLE_CORTEXAR), 1)
-CFLAGS += -DENABLE_CORTEXAR
+CFLAGS += -DENABLE_CORTEXAR=1
 SRC +=           \
 	cortexar.c   \
 	renesas_rz.c
 
 ifeq ($(ENABLE_XILINX), 1)
-CFLAGS += -DENABLE_XILINX
+CFLAGS += -DENABLE_XILINX=1
 SRC +=         \
 	zynq7000.c
 endif
 endif
 
 ifeq ($(ENABLE_RISCV), 1)
-CFLAGS += -DENABLE_RISCV
+CFLAGS += -DENABLE_RISCV=1
 SRC +=               \
 	riscv32.c        \
 	riscv64.c        \
 	riscv_debug.c    \
+	riscv_jtag_dtm.c
+else ifeq ($(ENABLE_RISCV_ACCEL), 1)
+CFLAGS == -DENABLE_RISCV_ACCEL=1
+SRC +=               \
 	riscv_jtag_dtm.c
 endif
 

--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -130,7 +130,7 @@ SRC += timing.c cli.c utils.c probe_info.c debug.c
 SRC += protocol_v0.c protocol_v0_swd.c protocol_v0_jtag.c protocol_v0_adiv5.c
 SRC += protocol_v1.c protocol_v1_adiv5.c protocol_v2.c
 SRC += protocol_v3.c protocol_v3_adiv5.c
-SRC += protocol_v4.c protocol_v4_adiv5.c
+SRC += protocol_v4.c protocol_v4_adiv5.c protocol_v4_riscv.c
 SRC += bmp_remote.c
 ifneq ($(HOSTED_BMP_ONLY), 1)
     ifeq ($(OS), Windows_NT)

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -211,6 +211,11 @@ void remote_adiv5_dp_init(adiv5_debug_port_s *const dp)
 	remote_funcs.adiv5_init(dp);
 }
 
+void remote_riscv_jtag_dtm_init(riscv_dmi_s *dmi)
+{
+	(void)dmi;
+}
+
 void remote_add_jtag_dev(uint32_t dev_index, const jtag_dev_s *jtag_dev)
 {
 	if (remote_funcs.add_jtag_dev)

--- a/src/platforms/hosted/bmp_remote.c
+++ b/src/platforms/hosted/bmp_remote.c
@@ -208,12 +208,14 @@ bool remote_swd_init(void)
 
 void remote_adiv5_dp_init(adiv5_debug_port_s *const dp)
 {
-	remote_funcs.adiv5_init(dp);
+	if (remote_funcs.adiv5_init)
+		remote_funcs.adiv5_init(dp);
 }
 
 void remote_riscv_jtag_dtm_init(riscv_dmi_s *dmi)
 {
-	(void)dmi;
+	if (remote_funcs.riscv_jtag_init)
+		remote_funcs.riscv_jtag_init(dmi);
 }
 
 void remote_add_jtag_dev(uint32_t dev_index, const jtag_dev_s *jtag_dev)

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -37,6 +37,7 @@ typedef struct bmp_remote_protocol {
 	bool (*swd_init)(void);
 	bool (*jtag_init)(void);
 	bool (*adiv5_init)(adiv5_debug_port_s *dp);
+	bool (*riscv_jtag_init)(riscv_dmi_s *dmi);
 	void (*add_jtag_dev)(uint32_t dev_index, const jtag_dev_s *jtag_dev);
 	uint32_t (*get_comms_frequency)(void);
 	bool (*set_comms_frequency)(uint32_t freq);

--- a/src/platforms/hosted/bmp_remote.h
+++ b/src/platforms/hosted/bmp_remote.h
@@ -27,6 +27,7 @@
 #include "jtagtap.h"
 #include "jtag_devs.h"
 #include "adiv5.h"
+#include "riscv_debug.h"
 #include "target.h"
 #include "target_internal.h"
 
@@ -60,6 +61,7 @@ uint32_t remote_max_frequency_get(void);
 void remote_target_clk_output_enable(bool enable);
 
 void remote_adiv5_dp_init(adiv5_debug_port_s *dp);
+void remote_riscv_jtag_dtm_init(riscv_dmi_s *dmi);
 void remote_add_jtag_dev(uint32_t dev_index, const jtag_dev_s *jtag_dev);
 
 uint64_t remote_decode_response(const char *response, size_t digits);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -34,6 +34,7 @@
 #include "target.h"
 #include "target_internal.h"
 #include "adiv5.h"
+#include "riscv_debug.h"
 #include "timing.h"
 #include "cli.h"
 #include "gdb_if.h"
@@ -313,7 +314,7 @@ void bmda_adiv5_dp_init(adiv5_debug_port_s *const dp)
 	switch (bmda_probe_info.type) {
 	case PROBE_TYPE_BMP:
 		if (cl_opts.opt_no_hl) {
-			DEBUG_WARN("Not using HL commands\n");
+			DEBUG_WARN("Not using ADIv5 acceleration commands\n");
 			break;
 		}
 		remote_adiv5_dp_init(dp);
@@ -350,6 +351,22 @@ void bmda_jtag_dp_init(adiv5_debug_port_s *dp)
 #else
 	(void)dp;
 #endif
+}
+
+void bmda_riscv_jtag_dtm_init(riscv_dmi_s *const dmi)
+{
+	switch (bmda_probe_info.type) {
+	case PROBE_TYPE_BMP:
+		if (cl_opts.opt_no_hl) {
+			DEBUG_WARN("Not using RISC-V Debug acceleration commands\n");
+			break;
+		}
+		remote_riscv_jtag_dtm_init(dmi);
+		break;
+
+	default:
+		break;
+	}
 }
 
 char *bmda_adaptor_ident(void)

--- a/src/platforms/hosted/remote/meson.build
+++ b/src/platforms/hosted/remote/meson.build
@@ -40,4 +40,5 @@ bmda_sources += files(
 	'protocol_v3_adiv5.c',
 	'protocol_v4.c',
 	'protocol_v4_adiv5.c',
+	'protocol_v4_riscv.c',
 )

--- a/src/platforms/hosted/remote/protocol_v3_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v3_adiv5.c
@@ -79,7 +79,6 @@ bool remote_v3_adiv5_check_error(
 uint32_t remote_v3_adiv5_raw_access(
 	adiv5_debug_port_s *const dp, const uint8_t rnw, const uint16_t addr, const uint32_t request_value)
 {
-	(void)dp;
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	/* Create the request and send it to the remote */
 	ssize_t length =
@@ -101,7 +100,6 @@ uint32_t remote_v3_adiv5_raw_access(
 
 uint32_t remote_v3_adiv5_dp_read(adiv5_debug_port_s *const dp, const uint16_t addr)
 {
-	(void)dp;
 	char buffer[REMOTE_MAX_MSG_SIZE];
 	/* Create the request and send it to the remote */
 	ssize_t length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_DP_READ_STR, dp->dev_index, addr);

--- a/src/platforms/hosted/remote/protocol_v4.c
+++ b/src/platforms/hosted/remote/protocol_v4.c
@@ -105,6 +105,18 @@ bool remote_v4_adiv5_init(adiv5_debug_port_s *const dp)
 
 bool remote_v4_riscv_jtag_init(riscv_dmi_s *const dmi)
 {
+	/* Format the RISC-V JTAG DTM init request into a new buffer and send it to the probe */
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	ssize_t length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_RISCV_INIT_STR, REMOTE_RISCV_JTAG);
+	platform_buffer_write(buffer, length);
+
+	/* Read back the answer and check for errors */
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1 || buffer[0U] != REMOTE_RESP_OK) {
+		DEBUG_ERROR("%s failed, error %s\n", __func__, length ? buffer + 1 : "with communication");
+		return false;
+	}
+
 	dmi->read = remote_v4_riscv_jtag_dmi_read;
 	dmi->write = remote_v4_riscv_jtag_dmi_write;
 	return true;

--- a/src/platforms/hosted/remote/protocol_v4.c
+++ b/src/platforms/hosted/remote/protocol_v4.c
@@ -42,6 +42,7 @@
 #include "protocol_v4.h"
 #include "protocol_v4_defs.h"
 #include "protocol_v4_adiv5.h"
+#include "protocol_v4_riscv.h"
 
 bool remote_v4_init(void)
 {
@@ -104,6 +105,7 @@ bool remote_v4_adiv5_init(adiv5_debug_port_s *const dp)
 
 bool remote_v4_riscv_jtag_init(riscv_dmi_s *const dmi)
 {
-	(void)dmi;
+	dmi->read = remote_v4_riscv_jtag_dmi_read;
+	dmi->write = remote_v4_riscv_jtag_dmi_write;
 	return true;
 }

--- a/src/platforms/hosted/remote/protocol_v4.h
+++ b/src/platforms/hosted/remote/protocol_v4.h
@@ -36,9 +36,11 @@
 
 #include <stdbool.h>
 #include "adiv5.h"
+#include "riscv_debug.h"
 
 bool remote_v4_init(void);
 
 bool remote_v4_adiv5_init(adiv5_debug_port_s *dp);
+bool remote_v4_riscv_jtag_init(riscv_dmi_s *dmi);
 
 #endif /*PLATFORMS_HOSTED_REMOTE_PROTOCOL_V4_H*/

--- a/src/platforms/hosted/remote/protocol_v4_defs.h
+++ b/src/platforms/hosted/remote/protocol_v4_defs.h
@@ -88,8 +88,18 @@
 /* This version of the protocol introduces an optional RISC-V acceleration protocol */
 #define REMOTE_RISCV_PACKET    'R'
 #define REMOTE_RISCV_PROTOCOLS 'P'
+#define REMOTE_RISCV_DMI_READ  'd'
+#define REMOTE_RISCV_DMI_WRITE 'D'
 
-#define REMOTE_RISCV_PROTOCOL '%', 'c'
+/* Supported RISC-V DTM protocols */
+#define REMOTE_RISCV_JTAG 'J'
+
+#define REMOTE_RISCV_PROTOCOL    '%', 'c'
+#define REMOTE_RISCV_DEV_INDEX   REMOTE_UINT8
+#define REMOTE_RISCV_IDLE_CYCLES REMOTE_UINT8
+#define REMOTE_RISCV_ADDR_WIDTH  REMOTE_UINT8
+#define REMOTE_RISCV_ADDR32      REMOTE_UINT32
+#define REMOTE_RISCV_DATA        REMOTE_UINT32
 
 /* RISC-V remote protocol messages */
 #define REMOTE_RISCV_PROTOCOLS_STR                                             \
@@ -102,9 +112,18 @@
 	{                                                                                      \
 		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_INIT, REMOTE_RISCV_PROTOCOL, REMOTE_EOM, 0 \
 	}
-
-/* Supported RISC-V DTM protocols (for init command) */
-#define REMOTE_RISCV_JTAG 'J'
+#define REMOTE_RISCV_DMI_READ_STR                                                                                 \
+	(char[])                                                                                                      \
+	{                                                                                                             \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_RISCV_DMI_READ, REMOTE_RISCV_DEV_INDEX, REMOTE_RISCV_IDLE_CYCLES, \
+			REMOTE_RISCV_ADDR_WIDTH, REMOTE_RISCV_ADDR32, REMOTE_EOM, 0                                           \
+	}
+#define REMOTE_RISCV_DMI_WRITE_STR                                                                                 \
+	(char[])                                                                                                       \
+	{                                                                                                              \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_RISCV_DMI_WRITE, REMOTE_RISCV_DEV_INDEX, REMOTE_RISCV_IDLE_CYCLES, \
+			REMOTE_RISCV_ADDR_WIDTH, REMOTE_RISCV_ADDR32, REMOTE_RISCV_DATA, REMOTE_EOM, 0                         \
+	}
 
 /* Remote protocol enabled RISC-V protocols bit values */
 #define REMOTE_RISCV_PROTOCOL_JTAG (1U << 0U)

--- a/src/platforms/hosted/remote/protocol_v4_defs.h
+++ b/src/platforms/hosted/remote/protocol_v4_defs.h
@@ -85,4 +85,28 @@
  */
 #define REMOTE_ADIV5_MEM_WRITE_LENGTH 42U
 
+/* This version of the protocol introduces an optional RISC-V acceleration protocol */
+#define REMOTE_RISCV_PACKET    'R'
+#define REMOTE_RISCV_PROTOCOLS 'P'
+
+#define REMOTE_RISCV_PROTOCOL '%', 'c'
+
+/* RISC-V remote protocol messages */
+#define REMOTE_RISCV_PROTOCOLS_STR                                             \
+	(char[])                                                                   \
+	{                                                                          \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_RISCV_PROTOCOLS, REMOTE_EOM, 0 \
+	}
+#define REMOTE_RISCV_INIT_STR                                                              \
+	(char[])                                                                               \
+	{                                                                                      \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_INIT, REMOTE_RISCV_PROTOCOL, REMOTE_EOM, 0 \
+	}
+
+/* Supported RISC-V DTM protocols (for init command) */
+#define REMOTE_RISCV_JTAG 'J'
+
+/* Remote protocol enabled RISC-V protocols bit values */
+#define REMOTE_RISCV_PROTOCOL_JTAG (1U << 0U)
+
 #endif /*PLATFORMS_HOSTED_REMOTE_PROTOCOL_V4_DEFS_H*/

--- a/src/platforms/hosted/remote/protocol_v4_riscv.c
+++ b/src/platforms/hosted/remote/protocol_v4_riscv.c
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include "bmp_remote.h"
+#include "protocol_v4_defs.h"
+#include "protocol_v4_riscv.h"
+#include "hex_utils.h"
+#include "exception.h"
+
+bool remote_v4_riscv_check_error(
+	const char *const func, riscv_dmi_s *const dmi, const char *const buffer, const ssize_t length)
+{
+	/* Check the response length for error codes */
+	if (length < 1) {
+		DEBUG_ERROR("%s comms error: %zd\n", func, length);
+		return false;
+	}
+	/* Now check if the remote is returning an error */
+	if (buffer[0U] == REMOTE_RESP_ERR) {
+		const uint64_t response_code = remote_decode_response(buffer + 1, (size_t)length - 1U);
+		const uint8_t error = response_code & 0xffU;
+		/* If the error part of the response code indicates a fault, store the fault value */
+		if (error == REMOTE_ERROR_FAULT)
+			dmi->fault = response_code >> 8U;
+		/* If the error part indicates an exception had occurred, make that happen here too */
+		else if (error == REMOTE_ERROR_EXCEPTION)
+			raise_exception(response_code >> 8U, "Remote protocol exception");
+		/* Otherwise it's an unexpected error */
+		else
+			DEBUG_ERROR("%s: Unexpected error %u\n", func, error);
+	} /* Check if the remote is reporting a parameter error*/
+	else if (buffer[0U] == REMOTE_RESP_PARERR)
+		DEBUG_ERROR("%s: !BUG! Firmware reported a parameter error\n", func);
+	/* Check if the firmware is reporting some other kind of error */
+	else if (buffer[0U] != REMOTE_RESP_OK)
+		DEBUG_ERROR("%s: Firmware reported unexpected error: %c\n", func, buffer[0]);
+	/* Return whether the remote indicated the request was successful */
+	return buffer[0U] == REMOTE_RESP_OK;
+}
+
+bool remote_v4_riscv_jtag_dmi_read(riscv_dmi_s *const dmi, const uint32_t address, uint32_t *const value)
+{
+	/* Format the read request into a new buffer and send it to the probe */
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	ssize_t length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_RISCV_DMI_READ_STR, dmi->dev_index, dmi->idle_cycles,
+		dmi->address_width, address);
+	platform_buffer_write(buffer, length);
+
+	/* Read back the answer and check for errors */
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (!remote_v4_riscv_check_error(__func__, dmi, buffer, length))
+		return false;
+
+	/* Log the probe-level request and its response having decoded it from the buffer */
+	unhexify(value, buffer + 1U, 4U);
+	DEBUG_PROBE("%s: %08" PRIx32 " -> %08" PRIx32 "\n", __func__, address, *value);
+	return true;
+}
+
+bool remote_v4_riscv_jtag_dmi_write(riscv_dmi_s *const dmi, const uint32_t address, const uint32_t value)
+{
+	/* Format the write request into a new buffer and send it to the probe */
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	ssize_t length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_RISCV_DMI_WRITE_STR, dmi->dev_index, dmi->idle_cycles,
+		dmi->address_width, address, value);
+	platform_buffer_write(buffer, length);
+
+	/* Read back the answer and check for errors */
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (!remote_v4_riscv_check_error(__func__, dmi, buffer, length))
+		return false;
+	/* Log the probe-level request now it's succeeded */
+	DEBUG_PROBE("%s: %08" PRIx32 " <- %08" PRIx32 "\n", __func__, address, value);
+	return true;
+}

--- a/src/platforms/hosted/remote/protocol_v4_riscv.h
+++ b/src/platforms/hosted/remote/protocol_v4_riscv.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2024 1BitSquared <info@1bitsquared.com>
+ * Written by Rachel Mant <git@dragonmux.network>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef PLATFORMS_HOSTED_REMOTE_PROTOCOL_V4_RISCV_H
+#define PLATFORMS_HOSTED_REMOTE_PROTOCOL_V4_RISCV_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include "riscv_debug.h"
+
+bool remote_v4_riscv_jtag_dmi_read(riscv_dmi_s *dmi, uint32_t address, uint32_t *value);
+bool remote_v4_riscv_jtag_dmi_write(riscv_dmi_s *dmi, uint32_t address, uint32_t value);
+
+#endif /*PLATFORMS_HOSTED_REMOTE_PROTOCOL_V4_RISCV_H*/

--- a/src/remote.h
+++ b/src/remote.h
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2019  Black Sphere Technologies Ltd.
  * Written by Dave Marples <dave@marples.net>
- * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2022-2024 1BitSquared <info@1bitsquared.com>
  * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -252,7 +252,7 @@
 #define REMOTE_ACCEL_CORTEX_AR (1U << 1U)
 #define REMOTE_ACCEL_RISCV     (1U << 2U)
 
-/* ADIv5 protocol elements */
+/* ADIv5 accleration protocol elements */
 #define REMOTE_ADIV5_PACKET     'A'
 #define REMOTE_DP_READ          'd'
 #define REMOTE_AP_READ          'a'
@@ -316,6 +316,27 @@
  * 16 for the address and 8 for the count and one trailer gives 42U
  */
 #define REMOTE_ADIV5_MEM_WRITE_LENGTH 42U
+
+/* RISC-V acceleration protocol elements */
+#define REMOTE_RISCV_PACKET    'R'
+#define REMOTE_RISCV_PROTOCOLS 'P'
+
+#define REMOTE_RISCV_PROTOCOLS_STR                                             \
+	(char[])                                                                   \
+	{                                                                          \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_RISCV_PROTOCOLS, REMOTE_EOM, 0 \
+	}
+#define REMOTE_RISCV_INIT_STR                                                 \
+	(char[])                                                                  \
+	{                                                                         \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_INIT, '%', 'c', REMOTE_EOM, 0 \
+	}
+
+/* Supported RISC-V DTM protocols (for init command) */
+#define REMOTE_RISCV_JTAG 'J'
+
+/* Remote protocol enabled RISC-V protocols bit values */
+#define REMOTE_RISCV_PROTOCOL_JTAG (1U << 0U)
 
 /* SPI protocol elements */
 #define REMOTE_SPI_PACKET      's'

--- a/src/remote.h
+++ b/src/remote.h
@@ -320,20 +320,41 @@
 /* RISC-V acceleration protocol elements */
 #define REMOTE_RISCV_PACKET    'R'
 #define REMOTE_RISCV_PROTOCOLS 'P'
+#define REMOTE_RISCV_DMI_READ  'd'
+#define REMOTE_RISCV_DMI_WRITE 'D'
+
+#define REMOTE_RISCV_PROTOCOL    '%', 'c'
+#define REMOTE_RISCV_DEV_INDEX   REMOTE_UINT8
+#define REMOTE_RISCV_IDLE_CYCLES REMOTE_UINT8
+#define REMOTE_RISCV_ADDR_WIDTH  REMOTE_UINT8
+#define REMOTE_RISCV_ADDR32      REMOTE_UINT32
+#define REMOTE_RISCV_DATA        REMOTE_UINT32
+
+/* Supported RISC-V DTM protocols */
+#define REMOTE_RISCV_JTAG 'J'
 
 #define REMOTE_RISCV_PROTOCOLS_STR                                             \
 	(char[])                                                                   \
 	{                                                                          \
 		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_RISCV_PROTOCOLS, REMOTE_EOM, 0 \
 	}
-#define REMOTE_RISCV_INIT_STR                                                 \
-	(char[])                                                                  \
-	{                                                                         \
-		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_INIT, '%', 'c', REMOTE_EOM, 0 \
+#define REMOTE_RISCV_INIT_STR                                                              \
+	(char[])                                                                               \
+	{                                                                                      \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_INIT, REMOTE_RISCV_PROTOCOL, REMOTE_EOM, 0 \
 	}
-
-/* Supported RISC-V DTM protocols (for init command) */
-#define REMOTE_RISCV_JTAG 'J'
+#define REMOTE_RISCV_DMI_READ_STR                                                                                 \
+	(char[])                                                                                                      \
+	{                                                                                                             \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_RISCV_DMI_READ, REMOTE_RISCV_DEV_INDEX, REMOTE_RISCV_IDLE_CYCLES, \
+			REMOTE_RISCV_ADDR_WIDTH, REMOTE_RISCV_ADDR32, REMOTE_EOM, 0                                           \
+	}
+#define REMOTE_RISCV_DMI_WRITE_STR                                                                                 \
+	(char[])                                                                                                       \
+	{                                                                                                              \
+		REMOTE_SOM, REMOTE_RISCV_PACKET, REMOTE_RISCV_DMI_WRITE, REMOTE_RISCV_DEV_INDEX, REMOTE_RISCV_IDLE_CYCLES, \
+			REMOTE_RISCV_ADDR_WIDTH, REMOTE_RISCV_ADDR32, REMOTE_RISCV_DATA, REMOTE_EOM, 0                         \
+	}
 
 /* Remote protocol enabled RISC-V protocols bit values */
 #define REMOTE_RISCV_PROTOCOL_JTAG (1U << 0U)

--- a/src/target/meson.build
+++ b/src/target/meson.build
@@ -1,7 +1,8 @@
 # This file is part of the Black Magic Debug project.
 #
-# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
 # Written by Rafael Silva <perigoso@riseup.net>
+# Modified by Rachel Mant <git@dragonmux.network>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -130,12 +131,18 @@ target_cortexm = declare_dependency(
 	dependencies: target_cortex,
 )
 
+riscv_jtag_dtm = declare_dependency(
+	sources: files(
+		'riscv_jtag_dtm.c',
+	),
+)
+
 target_riscv = declare_dependency(
 	sources: files(
 		'riscv_debug.c',
-		'riscv_jtag_dtm.c',
 	),
 	compile_args: ['-DENABLE_RISCV=1'],
+	dependencies: riscv_jtag_dtm,
 )
 
 target_riscv32 = declare_dependency(
@@ -287,6 +294,14 @@ if is_firmware_build
 	foreach target : enabled_targets
 		enabled_target_deps += get_variable(f'target_@target@')
 	endforeach
+
+	# Check if we should enable the RISC-V Debug remote protocol acceleration and do so if required
+	if get_option('enable_riscv_accel')
+		enabled_target_deps += declare_dependency(
+			compile_args: ['-DENABLE_RISCV_ACCEL=1'],
+			dependencies: riscv_jtag_dtm,
+		)
+	endif
 
 	# BMD target dependency
 	bmd_targets = declare_dependency(

--- a/src/target/riscv_debug.h
+++ b/src/target/riscv_debug.h
@@ -222,7 +222,9 @@ typedef struct riscv_hart {
 #define RV_FPU_GDB_CSR_OFFSET 66
 
 /* JTAG DTM function declarations */
+#ifdef ENABLE_RISCV
 void riscv_jtag_dtm_handler(uint8_t dev_index);
+#endif
 bool riscv_jtag_dmi_read(riscv_dmi_s *dmi, uint32_t address, uint32_t *value);
 bool riscv_jtag_dmi_write(riscv_dmi_s *dmi, uint32_t address, uint32_t value);
 

--- a/src/target/riscv_debug.h
+++ b/src/target/riscv_debug.h
@@ -221,7 +221,11 @@ typedef struct riscv_hart {
 #define RV_FPU_GDB_OFFSET     33
 #define RV_FPU_GDB_CSR_OFFSET 66
 
+/* JTAG DTM function declarations */
 void riscv_jtag_dtm_handler(uint8_t dev_index);
+bool riscv_jtag_dmi_read(riscv_dmi_s *dmi, uint32_t address, uint32_t *value);
+bool riscv_jtag_dmi_write(riscv_dmi_s *dmi, uint32_t address, uint32_t value);
+
 void riscv_dmi_init(riscv_dmi_s *dmi);
 riscv_hart_s *riscv_hart_struct(target_s *target);
 

--- a/src/target/riscv_debug.h
+++ b/src/target/riscv_debug.h
@@ -225,6 +225,11 @@ void riscv_jtag_dtm_handler(uint8_t dev_index);
 void riscv_dmi_init(riscv_dmi_s *dmi);
 riscv_hart_s *riscv_hart_struct(target_s *target);
 
+#if PC_HOSTED == 1
+/* BMDA interposition functions for DP setup */
+void bmda_riscv_jtag_dtm_init(riscv_dmi_s *dmi);
+#endif
+
 bool riscv_dm_read(riscv_dm_s *dbg_module, uint8_t address, uint32_t *value);
 bool riscv_dm_write(riscv_dm_s *dbg_module, uint8_t address, uint32_t value);
 bool riscv_command_wait_complete(riscv_hart_s *hart);

--- a/src/target/riscv_jtag_dtm.c
+++ b/src/target/riscv_jtag_dtm.c
@@ -107,6 +107,9 @@ static void riscv_jtag_dtm_init(riscv_dmi_s *const dmi)
 	dmi->prepare = riscv_jtag_prepare;
 	dmi->read = riscv_jtag_dmi_read;
 	dmi->write = riscv_jtag_dmi_write;
+#if PC_HOSTED == 1
+	bmda_riscv_jtag_dtm_init(dmi);
+#endif
 
 	riscv_dmi_init(dmi);
 }

--- a/src/target/riscv_jtag_dtm.c
+++ b/src/target/riscv_jtag_dtm.c
@@ -60,8 +60,6 @@
 
 static void riscv_jtag_dtm_init(riscv_dmi_s *dmi);
 static uint32_t riscv_shift_dtmcs(const riscv_dmi_s *dmi, uint32_t control);
-static bool riscv_jtag_dmi_read(riscv_dmi_s *dmi, uint32_t address, uint32_t *value);
-static bool riscv_jtag_dmi_write(riscv_dmi_s *dmi, uint32_t address, uint32_t value);
 static riscv_debug_version_e riscv_dtmcs_version(uint32_t dtmcs);
 
 static void riscv_jtag_prepare(target_s *target);
@@ -182,7 +180,7 @@ static bool riscv_dmi_transfer(riscv_dmi_s *const dmi, const uint8_t operation, 
 	return status == RV_DMI_SUCCESS;
 }
 
-static bool riscv_jtag_dmi_read(riscv_dmi_s *const dmi, const uint32_t address, uint32_t *const value)
+bool riscv_jtag_dmi_read(riscv_dmi_s *const dmi, const uint32_t address, uint32_t *const value)
 {
 	bool result = true;
 	do {
@@ -198,7 +196,7 @@ static bool riscv_jtag_dmi_read(riscv_dmi_s *const dmi, const uint32_t address, 
 	return result;
 }
 
-static bool riscv_jtag_dmi_write(riscv_dmi_s *const dmi, const uint32_t address, const uint32_t value)
+bool riscv_jtag_dmi_write(riscv_dmi_s *const dmi, const uint32_t address, const uint32_t value)
 {
 	bool result = true;
 	do {

--- a/src/target/riscv_jtag_dtm.c
+++ b/src/target/riscv_jtag_dtm.c
@@ -119,7 +119,7 @@ static uint32_t riscv_shift_dtmcs(const riscv_dmi_s *const dmi, const uint32_t c
 {
 	jtag_dev_write_ir(dmi->dev_index, IR_DTMCS);
 	uint32_t status = 0;
-	jtag_dev_shift_dr(dmi->dev_index, (uint8_t *)&status, (const uint8_t *)&control, 32);
+	jtag_dev_shift_dr(dmi->dev_index, (uint8_t *)&status, (const uint8_t *)&control, 32U);
 	return status;
 }
 
@@ -137,12 +137,12 @@ static uint8_t riscv_shift_dmi(riscv_dmi_s *const dmi, const uint8_t operation, 
 	jtag_proc.jtagtap_tdi_seq(false, ones, device->dr_prescan);
 	/* Shift out the 2 bits for the operation, and get the status bits for the previous back */
 	uint8_t status = 0;
-	jtag_proc.jtagtap_tdi_tdo_seq(&status, false, &operation, 2);
+	jtag_proc.jtagtap_tdi_tdo_seq(&status, false, &operation, 2U);
 	/* Then the data component */
 	if (data_out)
-		jtag_proc.jtagtap_tdi_tdo_seq((uint8_t *)data_out, false, (const uint8_t *)&data_in, 32);
+		jtag_proc.jtagtap_tdi_tdo_seq((uint8_t *)data_out, false, (const uint8_t *)&data_in, 32U);
 	else
-		jtag_proc.jtagtap_tdi_seq(false, (const uint8_t *)&data_in, 32);
+		jtag_proc.jtagtap_tdi_seq(false, (const uint8_t *)&data_in, 32U);
 	/* And finally the address component */
 	jtag_proc.jtagtap_tdi_seq(!device->dr_postscan, (const uint8_t *)&address, dmi->address_width);
 	jtag_proc.jtagtap_tdi_seq(true, ones, device->dr_postscan);
@@ -163,7 +163,7 @@ static bool riscv_dmi_transfer(riscv_dmi_s *const dmi, const uint8_t operation, 
 	if (status == RV_DMI_TOO_SOON) {
 		/*
 		 * If we got RV_DMI_TOO_SOON and we're under 8 idle cycles, increase the number
-		 * of idle cycles used to compensate and have the outer code re-run the transnfers
+		 * of idle cycles used to compensate and have the outer code re-run the transfers
 		 */
 		if (dmi->idle_cycles < 8)
 			++dmi->idle_cycles;
@@ -187,10 +187,10 @@ bool riscv_jtag_dmi_read(riscv_dmi_s *const dmi, const uint32_t address, uint32_
 	bool result = true;
 	do {
 		/* Setup the location to read from */
-		result = riscv_dmi_transfer(dmi, RV_DMI_READ, address, 0, NULL);
+		result = riscv_dmi_transfer(dmi, RV_DMI_READ, address, 0U, NULL);
 		if (result)
 			/* If that worked, read back the value and check the operation status */
-			result = riscv_dmi_transfer(dmi, RV_DMI_NOOP, 0, 0, value);
+			result = riscv_dmi_transfer(dmi, RV_DMI_NOOP, 0U, 0U, value);
 	} while (dmi->fault == RV_DMI_TOO_SOON);
 
 	if (!result)
@@ -206,7 +206,7 @@ bool riscv_jtag_dmi_write(riscv_dmi_s *const dmi, const uint32_t address, const 
 		result = riscv_dmi_transfer(dmi, RV_DMI_WRITE, address, value, NULL);
 		if (result)
 			/* If that worked, read back the operation status to ensure the write actually worked */
-			result = riscv_dmi_transfer(dmi, RV_DMI_NOOP, 0, 0, NULL);
+			result = riscv_dmi_transfer(dmi, RV_DMI_NOOP, 0U, 0U, NULL);
 	} while (dmi->fault == RV_DMI_TOO_SOON);
 
 	if (!result)

--- a/src/target/riscv_jtag_dtm.c
+++ b/src/target/riscv_jtag_dtm.c
@@ -58,6 +58,7 @@
 #define RV_DMI_FAILURE  2U
 #define RV_DMI_TOO_SOON 3U
 
+#ifdef ENABLE_RISCV
 static void riscv_jtag_dtm_init(riscv_dmi_s *dmi);
 static uint32_t riscv_shift_dtmcs(const riscv_dmi_s *dmi, uint32_t control);
 static riscv_debug_version_e riscv_dtmcs_version(uint32_t dtmcs);
@@ -111,9 +112,10 @@ static void riscv_jtag_dtm_init(riscv_dmi_s *const dmi)
 
 	riscv_dmi_init(dmi);
 }
+#endif
 
 /* Shift (read + write) the Debug Transport Module Control/Status (DTMCS) register */
-uint32_t riscv_shift_dtmcs(const riscv_dmi_s *const dmi, const uint32_t control)
+static uint32_t riscv_shift_dtmcs(const riscv_dmi_s *const dmi, const uint32_t control)
 {
 	jtag_dev_write_ir(dmi->dev_index, IR_DTMCS);
 	uint32_t status = 0;
@@ -212,6 +214,7 @@ bool riscv_jtag_dmi_write(riscv_dmi_s *const dmi, const uint32_t address, const 
 	return result;
 }
 
+#ifdef ENABLE_RISCV
 static riscv_debug_version_e riscv_dtmcs_version(const uint32_t dtmcs)
 {
 	uint8_t version = dtmcs & RV_STATUS_VERSION_MASK;
@@ -235,3 +238,4 @@ static void riscv_jtag_prepare(target_s *const target)
 	/* We put the TAP into bypass at the end of the JTAG handler, so put it back into DMI */
 	jtag_dev_write_ir(hart->dbg_module->dmi_bus->dev_index, IR_DMI);
 }
+#endif


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we implement acceleration of the RISC-V Debug protocol when using BMDA with the BMD remote protocol with a probe. This dramatically improves the speed of RISC-V communications, bringing the 3s discovery time for the GD32VF103 down to just under 0.5s.

This acceleration makes use of the protocol v4 framework for optional accelerations, allowing it to be introduced in an entirely backwards and forwards compatible way. It is gated behind a new Meson compilation option (`enable_riscv_accel`) so the Flash usage it causes is fully opt-in.

Additionally, this PR introduces RISC-V specific acceleration expansion, allowing other protocols for the DTM to be implemented later without bumping the protocol version, due to the supported RISC-V DTM protocols being enumerated in the same manner as acceleration protocols are.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
