### PR TITLE
stm32: fix formatting for DEBUG_TARGET on esp32

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -264,7 +264,8 @@ bool stm32h7_probe(target_s *target)
 	/* By now it's established that this is likely an H7, but check that it's not an MP15x_CM4 with an errata in AP part code */
 	const uint32_t idcode = target_mem32_read32(target, STM32H7_DBGMCU_IDCODE);
 	const uint16_t dev_id = idcode & STM32H7_DBGMCU_IDCODE_DEV_MASK;
-	DEBUG_TARGET("%s: looking at device ID 0x%03x at 0x%08" PRIx32 "\n", __func__, dev_id, STM32H7_DBGMCU_IDCODE);
+	DEBUG_TARGET(
+		"%s: looking at device ID 0x%03x at 0x%08" PRIu32 "\n", __func__, dev_id, (uint32_t)STM32H7_DBGMCU_IDCODE);
 	/* MP15x_CM4 errata: has a partno of 0x450. SoC DBGMCU says 0x500. */
 	if (dev_id != ID_STM32H72x && dev_id != ID_STM32H74x && dev_id != ID_STM32H7Bx)
 		return false;

--- a/src/target/stm32mp15.c
+++ b/src/target/stm32mp15.c
@@ -103,7 +103,8 @@ static bool stm32mp15_ident(target_s *const target, const bool cortexm)
 	/* By now it's established that this is likely an MP15x_CM4, but check that it's not an H74x */
 	const uint32_t idcode = target_mem32_read32(target, STM32MP15_DBGMCU_IDCODE);
 	const uint16_t dev_id = idcode & STM32MP15_DBGMCU_IDCODE_DEV_MASK;
-	DEBUG_TARGET("%s: looking at device ID 0x%03x at 0x%08" PRIx32 "\n", __func__, dev_id, STM32MP15_DBGMCU_IDCODE);
+	DEBUG_TARGET(
+		"%s: looking at device ID 0x%03x at 0x%08" PRIx32 "\n", __func__, dev_id, (uint32_t)STM32MP15_DBGMCU_IDCODE);
 	/* If this probe routine ever runs ahead of stm32h7_probe, skip the H74x. */
 	if (dev_id != ID_STM32MP15x)
 		return false;


### PR DESCRIPTION

## Detailed description

These functions incorrectly use formatting, resulting in build errors on ESP32. Use the correct formatting arguments to DEBUG_TARGET() to fix the build on those platforms.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
