### PR TITLE
target: stm32h7: print hex instead of decimal

### DIFF
--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -265,7 +265,7 @@ bool stm32h7_probe(target_s *target)
 	const uint32_t idcode = target_mem32_read32(target, STM32H7_DBGMCU_IDCODE);
 	const uint16_t dev_id = idcode & STM32H7_DBGMCU_IDCODE_DEV_MASK;
 	DEBUG_TARGET(
-		"%s: looking at device ID 0x%03x at 0x%08" PRIu32 "\n", __func__, dev_id, (uint32_t)STM32H7_DBGMCU_IDCODE);
+		"%s: looking at device ID 0x%03x at 0x%08" PRIx32 "\n", __func__, dev_id, (uint32_t)STM32H7_DBGMCU_IDCODE);
 	/* MP15x_CM4 errata: has a partno of 0x450. SoC DBGMCU says 0x500. */
 	if (dev_id != ID_STM32H72x && dev_id != ID_STM32H74x && dev_id != ID_STM32H7Bx)
 		return false;


### PR DESCRIPTION
## Detailed description

Use PRIx32 rather than PRId32 in the formatting string.

Unfortunately the wrong string was included in f1aec5f786ab2decfe577f880adeb29fc667cd57.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do