### PR TITLE
Feature: Update libopencm3

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 Checks: 'bugprone-*,cert-*,clang-analyzer-*,misc-*,modernize-*,portability-*,performance-*,readability-*,-readability-magic-numbers,-readability-braces-around-statements,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-modernize-macro-to-enum,-bugprone-easily-swappable-parameters,-misc-include-cleaner'
 FormatStyle: 'none'
 HeaderFilterRegex: '(src|upgrade)/.+'
-AnalyzeTemporaryDtors: false
+#AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:   cert-dcl16-c.NewSuffixes
     value: 'L;LL;UL;ULL'

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
 	"recommendations": [
-		"ms-vscode.cpptools",
-		"notskm.clang-tidy"
+		"ms-vscode.cpptools"
 	]
 }

--- a/src/platforms/stlinkv3/usb_f723.c
+++ b/src/platforms/stlinkv3/usb_f723.c
@@ -188,7 +188,7 @@ static void stm32f723_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type
 		OTG_HS_DIEPCTL0 |= OTG_DIEPCTL0_SNAK;
 
 		/* Configure OUT part. */
-		usbd_dev->doeptsiz[0] = OTG_DIEPSIZ0_STUPCNT_1 | OTG_DIEPSIZ0_PKTCNT | (max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
+		usbd_dev->doeptsiz[0] = OTG_DOEPSIZ0_STUPCNT_1 | OTG_DIEPSIZ0_PKTCNT | (max_size & OTG_DIEPSIZ0_XFRSIZ_MASK);
 		OTG_HS_DOEPTSIZ(0) = usbd_dev->doeptsiz[0];
 		OTG_HS_DOEPCTL(0) |= OTG_DOEPCTL0_EPENA | OTG_DIEPCTL0_SNAK;
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we update libopencm3 to pull in patches for a variety of things, including and most notably Stoyan Shopov's libopencm3/libopencm3#1259 which fixes libopencm3/libopencm3#1241.

We have taken the opportunity to do a little non-code repository maintenance too. This cleans up the clang-tidy configuration situation to help keep it working.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
