### PR TITLE
Fix: STM32L4 DBGMCU handling

### DIFF
--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -575,7 +575,7 @@ static uint32_t stm32l4_main_sram_length(const target_s *const target)
 	return (device->sram1 + device->sram2 + device->sram3) * 1024U;
 }
 
-static bool stm32l4_configure_dbgmcu(target_s *const target, const stm32l4_device_info_s *device)
+static bool stm32l4_configure_dbgmcu(target_s *const target, const stm32l4_device_info_s *const device)
 {
 	/* If we're in the probe phase */
 	if (target->target_storage == NULL) {
@@ -603,7 +603,7 @@ static bool stm32l4_configure_dbgmcu(target_s *const target, const stm32l4_devic
 	 * Now we have a stable debug environment, make sure the WDTs can't bonk the processor out from under us,
 	 * then Reconfigure the config register to prevent WFI/WFE from cutting debug access
 	 */
-	if (device->family == STM32L4_FAMILY_L55x || device->family == STM32L4_FAMILY_U5xx) {
+	if (priv->device->family == STM32L4_FAMILY_L55x || priv->device->family == STM32L4_FAMILY_U5xx) {
 		target_mem32_write32(
 			target, STM32L5_DBGMCU_APB1FREEZE1, STM32L4_DBGMCU_APB1FREEZE1_IWDG | STM32L4_DBGMCU_APB1FREEZE1_WWDG);
 		target_mem32_write32(target, STM32L5_DBGMCU_CONFIG,


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we fix an issue with the new DBGMCU handling for the STM32L4-like parts. In the original PR for this, #1882, we accidentally mishandled the device family checks when going to configure the DBGMCU, using the parameter version of `device` rather than the `priv` structure version. This results in a NULL dereference and a crash on attach.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1787, closing the final item in the issue.
