### PR TITLE
Fix: renesas_rz: autodetect RAM size based on RAM reads

### DIFF
--- a/src/target/renesas_rz.c
+++ b/src/target/renesas_rz.c
@@ -73,7 +73,7 @@
  * except for pnrs stored in 'FIXED_PNR1', where the code is stored in reverse order (but the last 3 bytes are still 0x20 aka ' ')
  */
 
-/* Base address for the RZ-series, including mirror */
+/* Base address for the OCRAM regions, including their mirrors (including RETRAM) */
 #define RENESAS_OCRAM_BASE        0x20000000U
 #define RENESAS_OCRAM_MIRROR_BASE 0x60000000U
 
@@ -191,7 +191,7 @@ bool renesas_rz_probe(target_s *const target)
 		renesas_rz_add_flash(target);
 
 	/* Determine RAM size by attempting to read in 512MB increments */
-	uint32_t ram_size = renesas_rz_ram_size(target);
+	const uint32_t ram_size = renesas_rz_ram_size(target);
 	target_add_ram32(target, RENESAS_OCRAM_BASE, ram_size);
 	target_add_ram32(target, RENESAS_OCRAM_MIRROR_BASE, ram_size);
 	return true;
@@ -216,9 +216,9 @@ static const char *renesas_rz_part_name(const uint32_t part_id)
  */
 static uint32_t renesas_rz_ram_size(target_s *target)
 {
-	uint32_t result = 0;
 	for (uint32_t addr = RENESAS_OCRAM_BASE; addr < RENESAS_OCRAM_BASE + RENESAS_OCRAM_MAX_SIZE;
 		 addr += RENESAS_OCRAM_SCAN_INCREMENT) {
+		uint32_t result;
 		/* Read ahead by one scan increment and if there's an error, return the current size. */
 		if (target_mem32_read(target, &result, addr + RENESAS_OCRAM_SCAN_INCREMENT - 8U, sizeof(result)))
 			return addr - RENESAS_OCRAM_BASE;

--- a/src/target/renesas_rz.c
+++ b/src/target/renesas_rz.c
@@ -77,6 +77,7 @@
 #define RENESAS_OCRAM_BASE        0x20000000U
 #define RENESAS_OCRAM_MIRROR_BASE 0x60000000U
 #define RENESAS_OCRAM_SIZE        0x00200000U
+#define RENESAS_OCRAM_SIZE_A1L    0x00300000U
 /* Base address and max size for the SPI Flash XIP region */
 #define RENESAS_SPI_FLASH_BASE 0x18000000U
 #define RENESAS_SPI_FLASH_SIZE 0x04000000U
@@ -139,6 +140,7 @@
 #define ID_RZ_A1 0x012U
 
 static const char *renesas_rz_part_name(uint32_t part_id);
+static uint32_t renesas_rz_ram_size(const uint32_t part_id);
 static bool renesas_rz_flash_prepare(target_s *target);
 static bool renesas_rz_flash_resume(target_s *target);
 static void renesas_rz_spi_read(target_s *target, uint16_t command, target_addr_t address, void *buffer, size_t length);
@@ -183,8 +185,8 @@ bool renesas_rz_probe(target_s *const target)
 	if (boot_mode == RENESAS_BSCAN_BOOT_MODE_SPI)
 		renesas_rz_add_flash(target);
 
-	target_add_ram32(target, RENESAS_OCRAM_BASE, RENESAS_OCRAM_SIZE);
-	target_add_ram32(target, RENESAS_OCRAM_MIRROR_BASE, RENESAS_OCRAM_SIZE);
+	target_add_ram32(target, RENESAS_OCRAM_BASE, renesas_rz_ram_size(part_id));
+	target_add_ram32(target, RENESAS_OCRAM_MIRROR_BASE, renesas_rz_ram_size(part_id));
 	return true;
 }
 
@@ -200,6 +202,17 @@ static const char *renesas_rz_part_name(const uint32_t part_id)
 		return "RZ/A1";
 	}
 	return "Unknown";
+}
+
+static uint32_t renesas_rz_ram_size(const uint32_t part_id)
+{
+	switch (part_id) {
+	case RENESAS_BSCAN_BSID_RZ_A1L:
+		return RENESAS_OCRAM_SIZE_A1L;
+	case RENESAS_BSCAN_BSID_RZ_A1LU:
+		return RENESAS_OCRAM_SIZE_A1L;
+	}
+	return RENESAS_OCRAM_SIZE;
 }
 
 static bool renesas_rz_flash_prepare(target_s *const target)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

* Previously, RAM was statically set to size 0x200000U but the RZ/A1L and RZ/A1LU have an additional 1MB of RAM. This code adds a function to determine RAM size ~~for a given part_id~~ based on auto-detection (there may be other examples of this in the RZ series).
* Code currently iterates through RZ-series RAM at probe time at 512kB intervals and sets the RAM size to the maximum error-free read position. If that fails, it sets RAM to the maximum known for the RZ series (at present, 10MB).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
