### PR TITLE
Feature: added "Platform commands:" message in cmd_help

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -210,6 +210,7 @@ bool cmd_help(target_s *t, int argc, const char **argv)
 		for (const command_s *cmd = cmd_list; cmd->cmd; cmd++)
 			gdb_outf("\t%s -- %s\n", cmd->cmd, cmd->help);
 #ifdef PLATFORM_HAS_CUSTOM_COMMANDS
+		gdb_out("Platform commands:\n");
 		for (const command_s *cmd = platform_cmd_list; cmd->cmd; ++cmd)
 			gdb_outf("\t%s -- %s\n", cmd->cmd, cmd->help);
 #endif


### PR DESCRIPTION
# Detailed description

In this PR https://github.com/blackmagic-debug/blackmagic/pull/1881 I forgot to add "Platform commands:" message in cmd_help to highlight plaftorm-specific commands, so this PR adds this.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
