### PR TITLE
Fix: s32k3xx: Remove the single assert 

### DIFF
--- a/src/target/s32k3xx.c
+++ b/src/target/s32k3xx.c
@@ -23,8 +23,6 @@
  * the XML memory map and Flash memory programming.
  */
 
-#include <assert.h>
-
 #include "command.h"
 #include "general.h"
 #include "target.h"
@@ -250,8 +248,6 @@ static bool s32k3xx_flash_erase(target_flash_s *const flash, target_addr_t addr,
 
 static bool s32k3xx_flash_write(target_flash_s *flash, target_addr_t dest, const void *src, size_t len)
 {
-	assert(len == flash->writesize);
-
 	const uint32_t *const s_data = src;
 	s32k3xx_flash_prepare(flash);
 	target_mem32_write32(flash->t, PFCPGM_PEADR_L, dest);


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is that the S32K3xx driver, introduced in #1652, references `assert()` which pulls `fiprintf()` and `_vfiprintf_r` again, resulting in extra 1.5 KiB of newlib stdio.
* This PR solves it by ~~replacing the assert with a logged runtime error.~~ IIUC target flash layer should call it with a `len=writesize`. Depending on review and API guarantees I can drop even that. Update: dropped.

I expect a significant size-diff from CI. This should restore the effect of my previous #1513.
Cannot test on hardware. CC @via.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues