### PR TITLE
Fix: Enable parallel make workers on GH Actions CI

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -97,7 +97,7 @@ jobs:
 
       # Build the firmware for all platform variants and BMDA in BMP-only mode
       - name: Build all platform variants firmware and BMP only BMDA
-        run: make all_platforms HOSTED_BMP_ONLY=1
+        run: make all_platforms HOSTED_BMP_ONLY=1 -j$(nproc) -Otarget
 
       - name: Clean
         run: make clean
@@ -105,23 +105,23 @@ jobs:
       # Build all the firmware variants that have more than 128kiB of Flash, with RTT enabled
       - name: Build firmware with RTT
         run: |
-          make PROBE_HOST=96b_carbon ENABLE_RTT=1
+          make PROBE_HOST=96b_carbon ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=blackpill-f401cc ENABLE_RTT=1
+          make PROBE_HOST=blackpill-f401cc ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=blackpill-f401ce ENABLE_RTT=1
+          make PROBE_HOST=blackpill-f401ce ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=blackpill-f411ce ENABLE_RTT=1
+          make PROBE_HOST=blackpill-f411ce ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=f3 ENABLE_RTT=1
+          make PROBE_HOST=f3 ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=f4discovery ENABLE_RTT=1
+          make PROBE_HOST=f4discovery ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=hydrabus ENABLE_RTT=1
+          make PROBE_HOST=hydrabus ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=launchpad-icdi ENABLE_RTT=1
+          make PROBE_HOST=launchpad-icdi ENABLE_RTT=1 -j$(nproc) -Otarget
           make -C src clean
-          make PROBE_HOST=stlinkv3 ENABLE_RTT=1
+          make PROBE_HOST=stlinkv3 ENABLE_RTT=1 -j$(nproc) -Otarget
 
       - name: Clean
         run: make clean
@@ -132,7 +132,7 @@ jobs:
 
       # And build that full binary
       - name: Build full BMDA binary
-        run: make PROBE_HOST=hosted HOSTED_BMP_ONLY=0
+        run: make PROBE_HOST=hosted HOSTED_BMP_ONLY=0 -j$(nproc) -Otarget
 
   build-windows-msvc:
     # Name the job more appropriately so we can tell which VS version is in use


### PR DESCRIPTION
## Detailed description

* This can sound as a minor new feature.
* The existing problem is suboptimal utilisation of Free runners, which are 4-core, and hence longer build times (4 minutes) for Makefile workflows.
* This PR solves it by reintroducing -j option and nproc applet (coreutils). Not touching Windows/mingw or MacOS.

Tested on GH CI Free in fork by manually triggering a workflow from branch, the speedup is there (2m20s).

There was a known problem with log clobbering, where multiple `make` jobserver workers attempt to pass compiler errors up simultaneously. Make 4.3 now supports `--output-sync` option, and I used `-Otarget` here to make it buffer and sync output up to one build target (object). https://www.gnu.org/software/make/manual/html_node/Parallel-Output.html Did not test this yet, I'd need to see (or introduce) errors in multiple sources of one probe platform for this.

I would also like to apply -k, --keep to both make and meson/ninja, so that they attempt to compile everything and gather up all diagnostics, and not simply fail early on first build error -- this project is relatively small in terms of build time.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues