### PR TITLE
target_flash: Prevent NULL dereference when detached from targets

### DIFF
--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -300,7 +300,7 @@ bool target_flash_write(target_s *target, target_addr_t dest, const void *src, s
 
 bool target_flash_complete(target_s *target)
 {
-	if (!target->flash_mode)
+	if (!target || !target->flash_mode)
 		return false;
 
 	bool result = true; /* Catch false returns with &= */


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is BMDA crashing upon vFlashWrite packet received with no target.
* This PR solves it by adding a nullptr check.

Discovered during compatibility testing with Segger emStudio V7. When BMD has detached from last target (or never attached to a target), the `target` pointer is set to NULL. This function does not check for this and will try to dereference the `flash_mode` field.
https://github.com/blackmagic-debug/blackmagic/blob/992f8714ffff647ae87d2a63aa5be21d0fa4864b/src/target/target_flash.c#L301-L304
Invokable via the `else` branch in `exec_v_flash_write()` here
https://github.com/blackmagic-debug/blackmagic/blob/992f8714ffff647ae87d2a63aa5be21d0fa4864b/src/gdb_main.c#L794-L799
Normally GDB will fail on vFlashErase, but SES is special. I also couldn't figure out how to make it `attach 1`, so it kinda issues qXfer and vFlashWrite commands in detached state. This works with OpenOCD and st-util because they always attach and implement simple remote -- BMD implements extended-remote.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues