### PR TITLE
Feature-bootloader led mapping blackpill on carrier or standalone

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,6 +108,12 @@ option(
 	description: 'Alternative pinout for probe (only applicable to blackpill-f4*)'
 )
 option(
+	'on_carrier_board',
+	type: 'boolean',
+	value: false,
+	description: 'Maps some LEDs to use those on carrier board (only applicable to blackpill-f4*)'
+)
+option(
 	'enable_gpiod',
 	type: 'feature',
 	value: 'auto'

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -333,4 +333,22 @@ extern bool debug_bmp;
 		gpio_set_val(LED_PORT, LED_ERROR, state); \
 	}
 
+#ifdef ON_CARRIER_BOARD
+/*
+ * When the Blackpill is mounted on a carrier board with a full set of LEDs,
+ * a separate BOOTLOADER LED is available.
+ */
+#define LED_BOOT_LED      LED_BOOTLOADER
+#define BOOT_STATE_INVERT false
+#else
+#define LED_BOOT_LED      LED_IDLE_RUN
+#define BOOT_STATE_INVERT true
+#endif /* ON_CARRIER_BOARD */
+// gpio_set_val(LED_PORT, LED_BOOT_LED, BOOT_STATE_INVERT ? !(state) : (state));
+
+#define SET_BOOTLOADER_STATE(state)                                                   \
+	{                                                                                 \
+		gpio_set_val(LED_PORT, LED_BOOT_LED, BOOT_STATE_INVERT ? !(state) : (state)); \
+	}
+
 #endif /* PLATFORMS_COMMON_BLACKPILL_F4_H */

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -47,6 +47,8 @@ probe_blackpill_dfu_sources = files('usbdfu.c')
 
 bmd_bootloader = get_option('bmd_bootloader')
 
+on_carrier_board = get_option('on_carrier_board')
+
 probe_blackpill_dfu_serial_length = '13'
 probe_blackpill_load_address = bmd_bootloader ? '0x08004000' : '0x08000000'
 
@@ -59,6 +61,10 @@ probe_blackpill_args = [
 blackpill_alternative_pinout = get_option('alternative_pinout')
 if blackpill_alternative_pinout != '0'
 	probe_blackpill_args += [f'-DALTERNATIVE_PINOUT=@blackpill_alternative_pinout@']
+endif
+
+if on_carrier_board
+	probe_blackpill_args += ['-DON_CARRIER_BOARD']
 endif
 
 if bmd_bootloader

--- a/src/platforms/common/blackpill-f4/usbdfu.c
+++ b/src/platforms/common/blackpill-f4/usbdfu.c
@@ -65,8 +65,12 @@ int main(void)
 	/* Assert blue LED as indicator we are in the bootloader */
 	rcc_periph_clock_enable(RCC_GPIOC);
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_BOOTLOADER | LED_IDLE_RUN);
+#ifdef ON_CARRIER_BOARD
+	gpio_set(LED_PORT, LED_IDLE_RUN);
+	gpio_clear(LED_PORT, LED_BOOTLOADER);
+#else
 	gpio_clear(LED_PORT, LED_BOOTLOADER | LED_IDLE_RUN);
-
+#endif
 	/* Run heartbeat on blue LED */
 	sys_tick_init();
 

--- a/src/platforms/common/blackpill-f4/usbdfu.c
+++ b/src/platforms/common/blackpill-f4/usbdfu.c
@@ -121,12 +121,12 @@ void sys_tick_handler(void)
 	case 0U:
 		/* Reload downcounter and disable LED */
 		count = 10U;
-		SET_IDLE_STATE(false);
+		SET_BOOTLOADER_STATE(false);
 		break;
 	case 1U:
 		count--;
 		/* Enable LED for 1/10th of cycle */
-		SET_IDLE_STATE(true);
+		SET_BOOTLOADER_STATE(true);
 		break;
 	default:
 		count--;

--- a/src/platforms/common/blackpill-f4/usbdfu.c
+++ b/src/platforms/common/blackpill-f4/usbdfu.c
@@ -94,7 +94,7 @@ void dfu_event(void)
 	/* Ask systick to pause blinking for 1 second */
 	dfu_activity_counter = 10U;
 	/* Toggle-blink it ourself */
-	SET_IDLE_STATE(idle_state);
+	SET_BOOTLOADER_STATE(idle_state);
 	idle_state = !idle_state;
 }
 


### PR DESCRIPTION
The LED used to indicate the bootloader is active
is selected according to whether the bootloader
was built for Blackpill-F4 on carrier or standalone.

The option set using Meson:

meson setup --reconfigure -Don_carrier_board=true

This option only applies to the BMD bootloader for Blackpill-F4, that opiton should also be set:

meson setup --reconfigure -Dbmd_bootloader=true

<!-- Filling this template is mandatory -->

This PR updates the build system to provide a conditional compilation  option to build the Blackpill-F4 bootloader so that the bootloader LED is driven correctly when the Blackpill is on a carrier or standalone.
## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [ ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

None
