### PR TITLE
Fix: imxrt: Cortex-M4 core detection for RT1176

### DIFF
--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -50,10 +50,34 @@
 #define IMXRT_SRC_BOOT_MODE1 (IMXRT_SRC_BASE + 0x004U)
 #define IMXRT_SRC_BOOT_MODE2 (IMXRT_SRC_BASE + 0x01cU)
 
-#define IMXRT_OCRAM1_BASE  UINT32_C(0x20280000)
-#define IMXRT_OCRAM1_SIZE  0x00080000U
-#define IMXRT_OCRAM2_BASE  UINT32_C(0x20200000)
-#define IMXRT_OCRAM2_SIZE  0x00080000U
+#define IMXRT_OCRAM1_BASE UINT32_C(0x20280000)
+#define IMXRT_OCRAM1_SIZE 0x00080000U
+#define IMXRT_OCRAM2_BASE UINT32_C(0x20200000)
+#define IMXRT_OCRAM2_SIZE 0x00080000U
+
+#define IMXRT117x_PART_ID 0x88c6U
+
+#define IMXRT117x_ITCM_BASE       0x00000000U /* FlexRAM */
+#define IMXRT117x_ITCM_SIZE       0x00080000U
+#define IMXRT117x_DTCM_BASE       0x20000000U /* FlexRAM */
+#define IMXRT117x_DTCM_SIZE       0x00080000U
+#define IMXRT117x_CODE_TCM_BASE   0x1ffe0000U
+#define IMXRT117x_CODE_TCM_SIZE   0x00020000U
+#define IMXRT117x_SYS_TCM_BASE    0x20000000U
+#define IMXRT117x_SYS_TCM_SIZE    0x00020000U
+#define IMXRT117x_OCRAM_M4_BASE   0x20200000U /* Only available when M4 is powered up */
+#define IMXRT117x_OCRAM_M4_SIZE   0x00040000U
+#define IMXRT117x_OCRAM1_BASE     0x20240000U
+#define IMXRT117x_OCRAM1_SIZE     0x00080000U
+#define IMXRT117x_OCRAM2_BASE     0x202c0000U
+#define IMXRT117x_OCRAM2_SIZE     0x00080000U
+#define IMXRT117x_OCRAM1_ECC_BASE 0x20340000U
+#define IMXRT117x_OCRAM1_ECC_SIZE 0x00010000U
+#define IMXRT117x_OCRAM2_ECC_BASE 0x20350000U
+#define IMXRT117x_OCRAM2_ECC_SIZE 0x00010000U
+#define IMXRT117x_OCRAM_M7_BASE   0x20360000U
+#define IMXRT117x_OCRAM_M7_SIZE   0x000a0000U
+
 #define IMXRT_FLEXSPI_BASE UINT32_C(0x60000000)
 
 #define IMXRT_MPU_BASE UINT32_C(0xe000ed90)
@@ -244,8 +268,28 @@ bool imxrt_probe(target_s *const target)
 	}
 
 	/* Build the RAM map for the part */
-	target_add_ram32(target, IMXRT_OCRAM1_BASE, IMXRT_OCRAM1_SIZE);
-	target_add_ram32(target, IMXRT_OCRAM2_BASE, IMXRT_OCRAM2_SIZE);
+	const uint16_t cpuid_partno = target->cpuid & CORTEX_CPUID_PARTNO_MASK;
+	if (target->part_id == IMXRT117x_PART_ID) {
+		/* Mapping depends on which core we're looking at */
+		if (cpuid_partno == CORTEX_M4) {
+			target_add_ram32(target, IMXRT117x_CODE_TCM_BASE, IMXRT117x_CODE_TCM_SIZE);
+			target_add_ram32(target, IMXRT117x_SYS_TCM_BASE, IMXRT117x_SYS_TCM_SIZE);
+		} else { /* CORTEX_M7 */
+			target_add_ram32(target, IMXRT117x_ITCM_BASE, IMXRT117x_ITCM_SIZE);
+			target_add_ram32(target, IMXRT117x_DTCM_BASE, IMXRT117x_DTCM_SIZE);
+		}
+		target_add_ram32(target, IMXRT117x_OCRAM_M4_BASE, IMXRT117x_OCRAM_M4_SIZE);
+		target_add_ram32(target, IMXRT117x_OCRAM1_BASE, IMXRT117x_OCRAM1_SIZE);
+		target_add_ram32(target, IMXRT117x_OCRAM2_BASE, IMXRT117x_OCRAM2_SIZE);
+		target_add_ram32(target, IMXRT117x_OCRAM1_ECC_BASE, IMXRT117x_OCRAM1_ECC_SIZE);
+		target_add_ram32(target, IMXRT117x_OCRAM2_ECC_BASE, IMXRT117x_OCRAM2_ECC_SIZE);
+		target_add_ram32(target, IMXRT117x_OCRAM_M7_BASE, IMXRT117x_OCRAM_M7_SIZE);
+
+	} else {
+		/* Generic RAM mapping - probably not accurate to all IMXRT devices */
+		target_add_ram32(target, IMXRT_OCRAM1_BASE, IMXRT_OCRAM1_SIZE);
+		target_add_ram32(target, IMXRT_OCRAM2_BASE, IMXRT_OCRAM2_SIZE);
+	}
 
 	if (priv->boot_source == BOOT_FLEX_SPI) {
 		/* Try to detect the Flash that should be attached */
@@ -286,7 +330,12 @@ static bool imxrt_ident_device(target_s *const target)
 	if (cpuid_partno == CORTEX_M33)
 		rom_location = IMXRTx00_ROM_FINGERPRINT_ADDR;
 	else if (cpuid_partno == CORTEX_M7) {
-		if (target->part_id == 0x88c6U)
+		if (target->part_id == IMXRT117x_PART_ID)
+			rom_location = IMXRT11xx_ROM_FINGERPRINT_ADDR;
+		else
+			rom_location = IMXRT10xx_ROM_FINGERPRINT_ADDR;
+	} else if (cpuid_partno == CORTEX_M4) {
+		if (target->part_id == IMXRT117x_PART_ID)
 			rom_location = IMXRT11xx_ROM_FINGERPRINT_ADDR;
 		else
 			rom_location = IMXRT10xx_ROM_FINGERPRINT_ADDR;

--- a/src/target/imxrt.c
+++ b/src/target/imxrt.c
@@ -57,14 +57,6 @@
 
 #define IMXRT117x_PART_ID 0x88c6U
 
-#define IMXRT117x_ITCM_BASE       0x00000000U /* FlexRAM */
-#define IMXRT117x_ITCM_SIZE       0x00080000U
-#define IMXRT117x_DTCM_BASE       0x20000000U /* FlexRAM */
-#define IMXRT117x_DTCM_SIZE       0x00080000U
-#define IMXRT117x_CODE_TCM_BASE   0x1ffe0000U
-#define IMXRT117x_CODE_TCM_SIZE   0x00020000U
-#define IMXRT117x_SYS_TCM_BASE    0x20000000U
-#define IMXRT117x_SYS_TCM_SIZE    0x00020000U
 #define IMXRT117x_OCRAM_M4_BASE   0x20200000U /* Only available when M4 is powered up */
 #define IMXRT117x_OCRAM_M4_SIZE   0x00040000U
 #define IMXRT117x_OCRAM1_BASE     0x20240000U
@@ -268,16 +260,7 @@ bool imxrt_probe(target_s *const target)
 	}
 
 	/* Build the RAM map for the part */
-	const uint16_t cpuid_partno = target->cpuid & CORTEX_CPUID_PARTNO_MASK;
 	if (target->part_id == IMXRT117x_PART_ID) {
-		/* Mapping depends on which core we're looking at */
-		if (cpuid_partno == CORTEX_M4) {
-			target_add_ram32(target, IMXRT117x_CODE_TCM_BASE, IMXRT117x_CODE_TCM_SIZE);
-			target_add_ram32(target, IMXRT117x_SYS_TCM_BASE, IMXRT117x_SYS_TCM_SIZE);
-		} else { /* CORTEX_M7 */
-			target_add_ram32(target, IMXRT117x_ITCM_BASE, IMXRT117x_ITCM_SIZE);
-			target_add_ram32(target, IMXRT117x_DTCM_BASE, IMXRT117x_DTCM_SIZE);
-		}
 		target_add_ram32(target, IMXRT117x_OCRAM_M4_BASE, IMXRT117x_OCRAM_M4_SIZE);
 		target_add_ram32(target, IMXRT117x_OCRAM1_BASE, IMXRT117x_OCRAM1_SIZE);
 		target_add_ram32(target, IMXRT117x_OCRAM2_BASE, IMXRT117x_OCRAM2_SIZE);
@@ -329,12 +312,7 @@ static bool imxrt_ident_device(target_s *const target)
 	const uint16_t cpuid_partno = target->cpuid & CORTEX_CPUID_PARTNO_MASK;
 	if (cpuid_partno == CORTEX_M33)
 		rom_location = IMXRTx00_ROM_FINGERPRINT_ADDR;
-	else if (cpuid_partno == CORTEX_M7) {
-		if (target->part_id == IMXRT117x_PART_ID)
-			rom_location = IMXRT11xx_ROM_FINGERPRINT_ADDR;
-		else
-			rom_location = IMXRT10xx_ROM_FINGERPRINT_ADDR;
-	} else if (cpuid_partno == CORTEX_M4) {
+	else if (cpuid_partno == CORTEX_M4 || cpuid_partno == CORTEX_M7) {
 		if (target->part_id == IMXRT117x_PART_ID)
 			rom_location = IMXRT11xx_ROM_FINGERPRINT_ADDR;
 		else


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

* The i.MX RT1176 includes both an M7 and M4 core but only the M7 was being detected by BMP / BMDA. This fix enables detection of the M4 core (a separate AP entry) under the same target part_id as the M7.
* The generic RAM mapping provided in imxrt.c for all i.MXRT devices was inaccurate for the RT117x and did not distinguish between the memory available to the M7 core vs. the M4 core. This fix maps the RAM based on the target->part_id and core and includes a fairly comprehensive mapping for the RT117x.
* Flash detection logic did not require changing (both cores map the FlexSPI controller at the same location).
* The i.MX RT117x supports register-configurable SDRAM and SRAM but the addresses for this are not fixed and the same controller can be used for flash memory as well. These ranges have been excluded from this fix.
* The [i.MX RT1170 Processor Reference Manual rev 2](https://www.nxp.com/webapp/Download?colCode=IMXRT1170RM) (sign-in required) was used as reference.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
