### PR TITLE
ctxlink/platform: Fix plarform_target_voltage_return

### DIFF
--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -213,7 +213,7 @@ bool platform_nrst_get_val(void)
 
 const char *platform_target_voltage(void)
 {
-	return NULL;
+	return "Unknown";
 }
 
 #pragma GCC diagnostic push


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a change made in other platforms to remove the usage of "NULL" value returns. When these changes were made, ctxLink was not updated. 

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

None