### PR TITLE
Meson_build_option_for_trace_protocol_selection

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,6 +108,13 @@ option(
 	description: 'Alternative pinout for probe (only applicable to blackpill-f4*)'
 )
 option(
+	'trace_protocol',
+	type: 'combo',
+	choices: ['1','2', '3'],
+	value: '2',
+	description: 'Select the Trace SWO protocol, 1 == Manchester, 2 == UART, 3 == platform'
+)
+option(
 	'on_carrier_board',
 	type: 'boolean',
 	value: false,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -111,7 +111,7 @@ option(
 	'trace_protocol',
 	type: 'combo',
 	choices: ['1','2', '3'],
-	value: '2',
+	value: '3',
 	description: 'Select the Trace SWO protocol, 1 == Manchester, 2 == UART, 3 == platform'
 )
 option(

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -55,7 +55,6 @@ probe_blackpill_load_address = bmd_bootloader ? '0x08004000' : '0x08000000'
 probe_blackpill_args = [
 	f'-DDFU_SERIAL_LENGTH=@probe_blackpill_dfu_serial_length@',
 	f'-DAPP_START=@probe_blackpill_load_address@',
-	'-DTRACESWO_PROTOCOL=2',
 ]
 
 blackpill_alternative_pinout = get_option('alternative_pinout')
@@ -65,6 +64,17 @@ endif
 
 if on_carrier_board
 	probe_blackpill_args += ['-DON_CARRIER_BOARD']
+endif
+
+trace_protocol = get_option('trace_protocol')
+if trace_protocol == '3'
+	trace_protocol = '2'
+endif
+probe_blackpill_args += [f'-DTRACESWO_PROTOCOL=@trace_protocol@']
+if trace_protocol == '1'
+	probe_blackpill_dependencies = fixme_platform_stm32_traceswo
+else
+	probe_blackpill_dependencies = fixme_platform_stm32_traceswoasync
 endif
 
 if bmd_bootloader
@@ -86,7 +96,7 @@ probe_host = declare_dependency(
 	sources: probe_blackpill_sources,
 	compile_args: probe_blackpill_args,
 	link_args: probe_blackpill_common_link_args + probe_blackpill_link_args,
-	dependencies: [platform_common, platform_stm32f4, fixme_platform_stm32_traceswoasync],
+	dependencies: [platform_common, platform_stm32f4, probe_blackpill_dependencies],
 )
 
 probe_bootloader = declare_dependency(

--- a/src/platforms/native/Makefile.inc
+++ b/src/platforms/native/Makefile.inc
@@ -4,7 +4,7 @@ OBJCOPY = $(CROSS_COMPILE)objcopy
 
 CFLAGS += -Istm32/include -mcpu=cortex-m3 -mthumb \
 	-DSTM32F1 -DBLACKMAGIC -I../deps/libopencm3/include \
-	-Iplatforms/common/stm32 -DDFU_SERIAL_LENGTH=9
+	-Iplatforms/common/stm32 -DDFU_SERIAL_LENGTH=9 -DTRACESWO_PROTOCOL=1
 
 LDFLAGS_BOOT := $(LDFLAGS) -lopencm3_stm32f1 -Lplatforms/native \
 	-Tnative.ld --specs=nano.specs -nostartfiles -lc \

--- a/src/platforms/native/meson.build
+++ b/src/platforms/native/meson.build
@@ -40,8 +40,8 @@ probe_native_args = [
 ]
 
 trace_protocol = get_option('trace_protocol')
-if trace_protocol == '1'
-	probe_native_args += [f'-DTRACESWO_PROTOCOL=@trace_protocol@']
+if trace_protocol in ['1', '3']
+	probe_native_args += [f'-DTRACESWO_PROTOCOL=1']
 	probe_native_dependencies = fixme_platform_stm32_traceswo
 else
 	error('Unsupported SWO mode requested')

--- a/src/platforms/native/meson.build
+++ b/src/platforms/native/meson.build
@@ -41,7 +41,7 @@ probe_native_args = [
 
 trace_protocol = get_option('trace_protocol')
 if trace_protocol == '1'
-probe_native_args += [f'-DTRACESWO_PROTOCOL=@trace_protocol@']
+	probe_native_args += [f'-DTRACESWO_PROTOCOL=@trace_protocol@']
 	probe_native_dependencies = fixme_platform_stm32_traceswo
 else
 	error('Unsupported SWO mode requested')

--- a/src/platforms/native/meson.build
+++ b/src/platforms/native/meson.build
@@ -39,6 +39,14 @@ probe_native_args = [
 	'-DBLACKMAGIC',
 ]
 
+trace_protocol = get_option('trace_protocol')
+if trace_protocol == '1'
+probe_native_args += [f'-DTRACESWO_PROTOCOL=@trace_protocol@']
+	probe_native_dependencies = fixme_platform_stm32_traceswo
+else
+	error('Unsupported SWO mode requested')
+endif
+
 probe_native_common_link_args = [
 	'-L@0@'.format(meson.current_source_dir()),
 	'-T@0@'.format('native.ld'),
@@ -53,7 +61,7 @@ probe_host = declare_dependency(
 	sources: probe_native_sources,
 	compile_args: probe_native_args,
 	link_args: probe_native_common_link_args + probe_native_link_args,
-	dependencies: [platform_common, platform_stm32f1, fixme_platform_stm32_traceswo],
+	dependencies: [platform_common, platform_stm32f1, probe_native_dependencies],
 )
 
 probe_bootloader = declare_dependency(

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -27,7 +27,6 @@
 #include "timing.h"
 #include "timing_stm32.h"
 
-#define TRACESWO_PROTOCOL 1U /* 1 = Manchester, 2 = NRZ / async */
 #define PLATFORM_HAS_TRACESWO
 #define PLATFORM_HAS_POWER_SWITCH
 

--- a/src/platforms/stlink/meson.build
+++ b/src/platforms/stlink/meson.build
@@ -70,6 +70,9 @@ probe_stlink_dependencies = [platform_common, platform_stm32f1]
 stlink_swim_nrst_as_uart = get_option('stlink_swim_nrst_as_uart')
 
 trace_protocol = get_option('trace_protocol')
+if trace_protocol == '3'
+	trace_protocol = '2'
+endif
 if probe == 'stlink' and stlink_swim_nrst_as_uart
 	probe_stlink_args += ['-DSWIM_NRST_AS_UART=1']
 	probe_stlink_dependencies += fixme_platform_stm32_traceswo

--- a/src/platforms/stlink/meson.build
+++ b/src/platforms/stlink/meson.build
@@ -69,13 +69,19 @@ probe_stlink_dependencies = [platform_common, platform_stm32f1]
 
 stlink_swim_nrst_as_uart = get_option('stlink_swim_nrst_as_uart')
 
+trace_protocol = get_option('trace_protocol')
 if probe == 'stlink' and stlink_swim_nrst_as_uart
 	probe_stlink_args += ['-DSWIM_NRST_AS_UART=1']
 	probe_stlink_dependencies += fixme_platform_stm32_traceswo
 	probe_stlink_args += ['-DTRACESWO_PROTOCOL=1']
-else
+elif trace_protocol == '1'
+	probe_stlink_dependencies += fixme_platform_stm32_traceswo
+	probe_stlink_args += ['-DTRACESWO_PROTOCOL=1']
+elif trace_protocol == '2'
 	probe_stlink_dependencies += fixme_platform_stm32_traceswoasync
 	probe_stlink_args += ['-DTRACESWO_PROTOCOL=2']
+else
+	error('Unsupported SWO mode requested')
 endif
 
 probe_host = declare_dependency(

--- a/src/platforms/stlinkv3/Makefile.inc
+++ b/src/platforms/stlinkv3/Makefile.inc
@@ -5,7 +5,7 @@ OBJCOPY = $(CROSS_COMPILE)objcopy
 OPT_FLAGS = -Og -g
 CFLAGS += -mcpu=cortex-m7 -mthumb -mfpu=fpv5-sp-d16 -mfloat-abi=hard \
 	-DSTM32F7 -DDFU_SERIAL_LENGTH=25 -I../deps/libopencm3/include \
-	-I platforms/common/stm32
+	-I platforms/common/stm32 -DTRACESWO_PROTOCOL=2
 LDFLAGS_BOOT := $(LDFLAGS) -mfpu=fpv5-sp-d16 -mfloat-abi=hard \
 	--specs=nano.specs -lopencm3_stm32f7 -Lplatforms/stlinkv3 \
 	-Tstlinkv3.ld -nostartfiles -lc \

--- a/src/platforms/stlinkv3/meson.build
+++ b/src/platforms/stlinkv3/meson.build
@@ -59,6 +59,9 @@ probe_stlinkv3_link_args = [
 ]
 
 trace_protocol = get_option('trace_protocol')
+if trace_protocol == '3'
+	trace_protocol = '2'
+endif
 if trace_protocol == '2'
 	probe_stlinkv3_dependencies = fixme_platform_stm32f7_traceswoasync
 	probe_stlinkv3_args += ['-DTRACESWO_PROTOCOL=2']

--- a/src/platforms/stlinkv3/meson.build
+++ b/src/platforms/stlinkv3/meson.build
@@ -58,6 +58,14 @@ probe_stlinkv3_link_args = [
 	f'-Wl,-Ttext=@probe_stlinkv3_load_address@',
 ]
 
+trace_protocol = get_option('trace_protocol')
+if trace_protocol == '2'
+	probe_stlinkv3_dependencies = fixme_platform_stm32f7_traceswoasync
+	probe_stlinkv3_args += ['-DTRACESWO_PROTOCOL=2']
+else
+	error('Unsupported SWO protocol requested')
+endif
+
 probe_host = declare_dependency(
 	include_directories: probe_stlinkv3_includes,
 	sources: probe_stlinkv3_sources,

--- a/src/platforms/stlinkv3/platform.h
+++ b/src/platforms/stlinkv3/platform.h
@@ -81,7 +81,6 @@ extern bool debug_bmp;
 
 #define PLATFORM_HAS_TRACESWO 1
 #define NUM_TRACE_PACKETS     (16)
-#define TRACESWO_PROTOCOL     2 /* 1 = Manchester, 2 = NRZ / async */
 
 #define SWDIO_MODE_REG      GPIO_MODER(TMS_PORT)
 #define SWDIO_MODE_REG_MULT (1 << (9 << 1))

--- a/src/platforms/swlink/meson.build
+++ b/src/platforms/swlink/meson.build
@@ -42,7 +42,6 @@ probe_swlink_dfu_sources = files(
 
 probe_swlink_args = [
 	'-DDFU_SERIAL_LENGTH=9',
-	'-DTRACESWO_PROTOCOL=2',
 ]
 
 probe_swlink_common_link_args = [
@@ -53,6 +52,13 @@ probe_swlink_common_link_args = [
 probe_swlink_link_args = [
 	'-Wl,-Ttext=0x8002000',
 ]
+
+trace_protocol = get_option('trace_protocol')
+if trace_protocol == '2'
+	probe_swlink_args += '-DTRACESWO_PROTOCOL=2'
+else
+	error('Unsupported SWO protocol requested')
+endif
 
 probe_host = declare_dependency(
 	include_directories: probe_swlink_includes,

--- a/src/platforms/swlink/meson.build
+++ b/src/platforms/swlink/meson.build
@@ -54,6 +54,9 @@ probe_swlink_link_args = [
 ]
 
 trace_protocol = get_option('trace_protocol')
+if trace_protocol == '3'
+	trace_protocol = '2'
+endif
 if trace_protocol == '2'
 	probe_swlink_args += '-DTRACESWO_PROTOCOL=2'
 else


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR introduces a new meson build option, "trace_protocol."

This option is used to select the protocol used by a platform for trace SWO.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Platforms will need testing to verify the changes made.