### PR TITLE
Feature: Cortex-M TrustZone support

### DIFF
--- a/src/target/adi.h
+++ b/src/target/adi.h
@@ -42,6 +42,9 @@ void adi_ap_component_probe(
 /* Helper for resuming all cores halted on an AP during probe */
 void adi_ap_resume_cores(adiv5_access_port_s *ap);
 
+/* Helper for setting up memory accesses */
+void adi_ap_mem_access_setup(adiv5_access_port_s *ap, target_addr64_t addr, align_e align);
+
 /*
  * Decode a designer code that's in the following form into BMD's internal designer code representation
  * Bits 10:7 - JEP-106 Continuation code

--- a/src/target/adi.h
+++ b/src/target/adi.h
@@ -42,8 +42,9 @@ void adi_ap_component_probe(
 /* Helper for resuming all cores halted on an AP during probe */
 void adi_ap_resume_cores(adiv5_access_port_s *ap);
 
-/* Helper for setting up memory accesses */
+/* Helpers for setting up memory accesses and banked accesses */
 void adi_ap_mem_access_setup(adiv5_access_port_s *ap, target_addr64_t addr, align_e align);
+void adi_ap_banked_access_setup(adiv5_access_port_s *base_ap);
 
 /*
  * Decode a designer code that's in the following form into BMD's internal designer code representation

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -246,7 +246,6 @@ const void *adiv5_pack_data(target_addr32_t dest, const void *src, uint32_t *dat
 void adiv5_mem_write(adiv5_access_port_s *ap, target_addr64_t dest, const void *src, size_t len);
 
 /* ADIv5 low-level logical operation functions for memory access */
-void adiv5_mem_access_setup(adiv5_access_port_s *ap, target_addr64_t addr, align_e align);
 void adiv5_mem_write_bytes(adiv5_access_port_s *ap, target_addr64_t dest, const void *src, size_t len, align_e align);
 void adiv5_mem_read_bytes(adiv5_access_port_s *ap, void *dest, target_addr64_t src, size_t len);
 /* ADIv5 logical operation functions for AP register I/O */

--- a/src/target/cortex.c
+++ b/src/target/cortex.c
@@ -114,9 +114,11 @@ void cortex_read_cpuid(target_s *const target)
 		break;
 	case CORTEX_M33:
 		target->core = "M33";
+		target->target_options |= CORTEXM_TOPT_FLAVOUR_V8M;
 		break;
 	case CORTEX_M23:
 		target->core = "M23";
+		target->target_options |= CORTEXM_TOPT_FLAVOUR_V8M;
 		break;
 	case CORTEX_M3:
 		target->core = "M3";
@@ -132,9 +134,11 @@ void cortex_read_cpuid(target_s *const target)
 		break;
 	case CORTEX_M0P:
 		target->core = "M0+";
+		target->target_options |= CORTEXM_TOPT_FLAVOUR_V6M;
 		break;
 	case CORTEX_M0:
 		target->core = "M0";
+		target->target_options |= CORTEXM_TOPT_FLAVOUR_V6M;
 		break;
 	default: {
 		const adiv5_access_port_s *const ap = cortex_ap(target);

--- a/src/target/cortex.c
+++ b/src/target/cortex.c
@@ -44,20 +44,20 @@
 
 #define CORTEX_CPUID 0xd00U
 
-adiv5_access_port_s *cortex_ap(target_s *t)
+adiv5_access_port_s *cortex_ap(target_s *const target)
 {
-	return ((cortex_priv_s *)t->priv)->ap;
+	return ((cortex_priv_s *)target->priv)->ap;
 }
 
-void cortex_priv_free(void *priv)
+void cortex_priv_free(void *const priv)
 {
 	adiv5_ap_unref(((cortex_priv_s *)priv)->ap);
 	free(priv);
 }
 
-bool cortex_check_error(target_s *t)
+bool cortex_check_error(target_s *const target)
 {
-	adiv5_access_port_s *ap = cortex_ap(t);
+	adiv5_access_port_s *const ap = cortex_ap(target);
 	return adiv5_dp_error(ap->dp) != 0;
 }
 
@@ -81,7 +81,7 @@ void cortex_dbg_write32(target_s *const target, const uint16_t dest, const uint3
 	adiv5_mem_write(ap, priv->base_addr + dest, &value, sizeof(value));
 }
 
-void cortex_read_cpuid(target_s *target)
+void cortex_read_cpuid(target_s *const target)
 {
 	/*
 	 * The CPUID register is defined in the ARMv6, ARMv7 and ARMv8 architectures

--- a/src/target/cortex.h
+++ b/src/target/cortex.h
@@ -75,10 +75,11 @@
 #define CORTEX_CPUID_REVISION_MASK 0x00f00000U
 #define CORTEX_CPUID_PATCH_MASK    0x0000000fU
 
-#define CORTEX_FLOAT_REG_COUNT     33U
-#define CORTEX_DOUBLE_REG_COUNT    17U
-#define CORTEXM_GENERAL_REG_COUNT  20U
-#define CORTEXAR_GENERAL_REG_COUNT 17U
+#define CORTEX_FLOAT_REG_COUNT      33U
+#define CORTEX_DOUBLE_REG_COUNT     17U
+#define CORTEXM_GENERAL_REG_COUNT   20U /* General purpose register count for Cortex-M cores */
+#define CORTEXM_TRUSTZONE_REG_COUNT 4U  /* TrustZone register count for Cortex-M cores */
+#define CORTEXAR_GENERAL_REG_COUNT  17U /* General purpose register count for Cortex-A/R cores */
 
 adiv5_access_port_s *cortex_ap(target_s *target);
 

--- a/src/target/cortex_internal.h
+++ b/src/target/cortex_internal.h
@@ -51,6 +51,14 @@
 #define CORTEX_MAX_BREAKPOINTS 8U
 #define CORTEX_MAX_WATCHPOINTS 8U
 
+/*
+ * Target options recognised by the Cortex-M architecture driver
+ * If neither of the flavour options are set, the core is assumed to be an ARMv7-M core
+ */
+#define CORTEXM_TOPT_FLAVOUR_V6M (1U << 1U) /* If set, target is an ARMv6-M core */
+#define CORTEXM_TOPT_FLAVOUR_V8M (1U << 2U) /* If set, target is an ARMv8-M core */
+#define CORTEXM_TOPT_TRUSTZONE   (1U << 3U) /* Whether a core implements the security model (TrustZone) */
+
 typedef struct cortex_priv {
 	/* AP from which this CPU hangs */
 	adiv5_access_port_s *ap;

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -43,6 +43,7 @@
 
 #include "general.h"
 #include "exception.h"
+#include "adi.h"
 #include "adiv5.h"
 #include "target.h"
 #include "target_internal.h"
@@ -412,7 +413,7 @@ static void cortexar_banked_dcc_mode(target_s *const target)
 	if (!(priv->base.ap->dp->quirks & ADIV5_AP_ACCESS_BANKED)) {
 		priv->base.ap->dp->quirks |= ADIV5_AP_ACCESS_BANKED;
 		/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
-		adiv5_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
+		adi_ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
 		/* Selecting AP bank 1 to finish switching into banked mode */
 		adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
 	}

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -414,8 +414,8 @@ static void cortexar_banked_dcc_mode(target_s *const target)
 		priv->base.ap->dp->quirks |= ADIV5_AP_ACCESS_BANKED;
 		/* Configure the AP to put {DBGDTR{TX,RX},DBGITR,DBGDCSR} in banked data registers window */
 		adi_ap_mem_access_setup(priv->base.ap, priv->base.base_addr + CORTEXAR_DBG_DTRTX, ALIGN_32BIT);
-		/* Selecting AP bank 1 to finish switching into banked mode */
-		adiv5_dp_write(priv->base.ap->dp, ADIV5_DP_SELECT, ((uint32_t)priv->base.ap->apsel << 24U) | 0x10U);
+		/* Now select AP bank 1 to finish switching into banked mode */
+		adi_ap_banked_access_setup(priv->base.ap);
 	}
 }
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -549,7 +549,6 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 				/* Go on and try to detect the target anyways */
 				break;
 			}
-			continue;
 		}
 	}
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1212,36 +1212,38 @@ static size_t cortexm_build_target_fpu_description(char *const buffer, const siz
  * function will return the amount of bytes that would be necessary to create this string.
  *
  * The string it creates is XML-equivalent to the following:
- * "<?xml version=\"1.0\"?>"
- * "<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
- * "<target>"
- * "  <architecture>arm</architecture>"
- * "  <feature name=\"org.gnu.gdb.arm.m-profile\">"
- * "    <reg name=\"r0\" bitsize=\"32\"/>"
- * "    <reg name=\"r1\" bitsize=\"32\"/>"
- * "    <reg name=\"r2\" bitsize=\"32\"/>"
- * "    <reg name=\"r3\" bitsize=\"32\"/>"
- * "    <reg name=\"r4\" bitsize=\"32\"/>"
- * "    <reg name=\"r5\" bitsize=\"32\"/>"
- * "    <reg name=\"r6\" bitsize=\"32\"/>"
- * "    <reg name=\"r7\" bitsize=\"32\"/>"
- * "    <reg name=\"r8\" bitsize=\"32\"/>"
- * "    <reg name=\"r9\" bitsize=\"32\"/>"
- * "    <reg name=\"r10\" bitsize=\"32\"/>"
- * "    <reg name=\"r11\" bitsize=\"32\"/>"
- * "    <reg name=\"r12\" bitsize=\"32\"/>"
- * "    <reg name=\"sp\" bitsize=\"32\" type=\"data_ptr\"/>"
- * "    <reg name=\"lr\" bitsize=\"32\" type=\"code_ptr\"/>"
- * "    <reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>"
- * "    <reg name=\"xpsr\" bitsize=\"32\"/>"
- * "    <reg name=\"msp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
- * "    <reg name=\"psp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
- * "    <reg name=\"primask\" bitsize=\"8\" save-restore=\"no\"/>"
- * "    <reg name=\"basepri\" bitsize=\"8\" save-restore=\"no\"/>"
- * "    <reg name=\"faultmask\" bitsize=\"8\" save-restore=\"no\"/>"
- * "    <reg name=\"control\" bitsize=\"8\" save-restore=\"no\"/>"
- * "  </feature>"
- * "</target>"
+ *  <?xml version=\"1.0\"?>
+ *  <!DOCTYPE target SYSTEM \"gdb-target.dtd\">
+ *  <target>
+ *      <architecture>arm</architecture>
+ *      <feature name="org.gnu.gdb.arm.m-profile">
+ *          <reg name="r0" bitsize="32"/>
+ *          <reg name="r1" bitsize="32"/>
+ *          <reg name="r2" bitsize="32"/>
+ *          <reg name="r3" bitsize="32"/>
+ *          <reg name="r4" bitsize="32"/>
+ *          <reg name="r5" bitsize="32"/>
+ *          <reg name="r6" bitsize="32"/>
+ *          <reg name="r7" bitsize="32"/>
+ *          <reg name="r8" bitsize="32"/>
+ *          <reg name="r9" bitsize="32"/>
+ *          <reg name="r10" bitsize="32"/>
+ *          <reg name="r11" bitsize="32"/>
+ *          <reg name="r12" bitsize="32"/>
+ *          <reg name="sp" bitsize="32" type="data_ptr"/>
+ *          <reg name="lr" bitsize="32" type="code_ptr"/>
+ *          <reg name="pc" bitsize="32" type="code_ptr"/>
+ *          <reg name="xpsr" bitsize="32" regnum="25"/>
+ *      </feature>
+ *      <feature name="org.gnu.gdb.arm.m-system">
+ *          <reg name="msp" bitsize="32" save-restore="no" type="data_ptr"/>
+ *          <reg name="psp" bitsize="32" save-restore="no" type="data_ptr"/>
+ *          <reg name="primask" bitsize="8" save-restore="no"/>
+ *          <reg name="basepri" bitsize="8" save-restore="no"/>
+ *          <reg name="faultmask" bitsize="8" save-restore="no"/>
+ *          <reg name="control" bitsize="8" save-restore="no"/>
+ *      </feature>
+ *  </target>
  */
 static size_t cortexm_build_target_description(
 	char *const buffer, const size_t max_length, const uint32_t target_options)

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -85,7 +85,7 @@ typedef struct cortexm_priv {
 } cortexm_priv_s;
 
 /* Register number tables */
-static const uint32_t regnum_cortex_m[CORTEXM_GENERAL_REG_COUNT] = {
+static const uint8_t regnum_cortex_m[CORTEXM_GENERAL_REG_COUNT] = {
 	0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U, 10U, 11U, 12U, 13U, 14U, 15U, /* r0-r15 */
 	0x10U,                                                                /* xpsr */
 	0x11U,                                                                /* msp */
@@ -93,12 +93,12 @@ static const uint32_t regnum_cortex_m[CORTEXM_GENERAL_REG_COUNT] = {
 	0x14U,                                                                /* special */
 };
 
-static const uint32_t regnum_cortex_m_trustzone[CORTEXM_TRUSTZONE_REG_COUNT] = {
+static const uint8_t regnum_cortex_m_trustzone[CORTEXM_TRUSTZONE_REG_COUNT] = {
 	0x18U, 0x19U, /* Non-secure msp + psp */
 	0x1aU, 0x1bU, /* Secure msp + psp */
 };
 
-static const uint32_t regnum_cortex_mf[CORTEX_FLOAT_REG_COUNT] = {
+static const uint8_t regnum_cortex_mf[CORTEX_FLOAT_REG_COUNT] = {
 	0x21U,                                                  /* fpscr */
 	0x40U, 0x41U, 0x42U, 0x43U, 0x44U, 0x45U, 0x46U, 0x47U, /* s0-s7 */
 	0x48U, 0x49U, 0x4aU, 0x4bU, 0x4cU, 0x4dU, 0x4eU, 0x4fU, /* s8-s15 */

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -29,6 +29,7 @@
 
 #include "general.h"
 #include "exception.h"
+#include "adi.h"
 #include "adiv5.h"
 #include "target.h"
 #include "target_internal.h"
@@ -581,7 +582,7 @@ static void cortexm_regs_read(target_s *const target, void *const data)
 		 * debug registers DHCSR, DCRSR, DCRDR and DEMCR respectively
 		 * and do so for 32-bit access
 		 */
-		adiv5_mem_access_setup(ap, CORTEXM_DHCSR, ALIGN_32BIT);
+		adi_ap_mem_access_setup(ap, CORTEXM_DHCSR, ALIGN_32BIT);
 		/* Configure the bank selection to the appropriate AP register bank */
 		adiv5_dp_write(ap->dp, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | 0x10U);
 
@@ -624,7 +625,7 @@ static void cortexm_regs_write(target_s *const target, const void *const data)
 		 * debug registers DHCSR, DCRSR, DCRDR and DEMCR respectively
 		 * and do so for 32-bit access
 		 */
-		adiv5_mem_access_setup(ap, CORTEXM_DHCSR, ALIGN_32BIT);
+		adi_ap_mem_access_setup(ap, CORTEXM_DHCSR, ALIGN_32BIT);
 		/* Configure the bank selection to the appropriate AP register bank */
 		adiv5_dp_write(ap->dp, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | 0x10U);
 

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -583,8 +583,7 @@ static void cortexm_regs_read(target_s *const target, void *const data)
 		 * and do so for 32-bit access
 		 */
 		adi_ap_mem_access_setup(ap, CORTEXM_DHCSR, ALIGN_32BIT);
-		/* Configure the bank selection to the appropriate AP register bank */
-		adiv5_dp_write(ap->dp, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | 0x10U);
+		adi_ap_banked_access_setup(ap);
 
 		/* Walk the regnum_cortex_m array, reading the registers it specifies */
 		for (size_t i = 0; i < CORTEXM_GENERAL_REG_COUNT; ++i) {
@@ -626,8 +625,7 @@ static void cortexm_regs_write(target_s *const target, const void *const data)
 		 * and do so for 32-bit access
 		 */
 		adi_ap_mem_access_setup(ap, CORTEXM_DHCSR, ALIGN_32BIT);
-		/* Configure the bank selection to the appropriate AP register bank */
-		adiv5_dp_write(ap->dp, ADIV5_DP_SELECT, ((uint32_t)ap->apsel << 24U) | 0x10U);
+		adi_ap_banked_access_setup(ap);
 
 		/* Walk the regnum_cortex_m array, writing the registers it specifies */
 		for (size_t i = 0; i < CORTEXM_GENERAL_REG_COUNT; ++i) {

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -184,218 +184,6 @@ static_assert(ARRAY_LENGTH(cortex_m_spr_bitsizes) == ARRAY_LENGTH(cortex_m_spr_n
 
 // clang-format on
 
-// Creates the target description XML string for a Cortex-M. Like snprintf(), this function
-// will write no more than max_len and returns the amount of bytes written. Or, if max_len is 0,
-// then this function will return the amount of bytes that _would_ be necessary to create this
-// string.
-//
-// This function is hand-optimized to decrease string duplication and thus code size, making it
-// unfortunately much less readable than the string literal it is equivalent to.
-//
-// The string it creates is XML-equivalent to the following:
-/*
-	"<?xml version=\"1.0\"?>"
-	"<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
-	"<target>"
-	"  <architecture>arm</architecture>"
-	"  <feature name=\"org.gnu.gdb.arm.m-profile\">"
-	"    <reg name=\"r0\" bitsize=\"32\"/>"
-	"    <reg name=\"r1\" bitsize=\"32\"/>"
-	"    <reg name=\"r2\" bitsize=\"32\"/>"
-	"    <reg name=\"r3\" bitsize=\"32\"/>"
-	"    <reg name=\"r4\" bitsize=\"32\"/>"
-	"    <reg name=\"r5\" bitsize=\"32\"/>"
-	"    <reg name=\"r6\" bitsize=\"32\"/>"
-	"    <reg name=\"r7\" bitsize=\"32\"/>"
-	"    <reg name=\"r8\" bitsize=\"32\"/>"
-	"    <reg name=\"r9\" bitsize=\"32\"/>"
-	"    <reg name=\"r10\" bitsize=\"32\"/>"
-	"    <reg name=\"r11\" bitsize=\"32\"/>"
-	"    <reg name=\"r12\" bitsize=\"32\"/>"
-	"    <reg name=\"sp\" bitsize=\"32\" type=\"data_ptr\"/>"
-	"    <reg name=\"lr\" bitsize=\"32\" type=\"code_ptr\"/>"
-	"    <reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>"
-	"    <reg name=\"xpsr\" bitsize=\"32\"/>"
-	"    <reg name=\"msp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
-	"    <reg name=\"psp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
-	"    <reg name=\"primask\" bitsize=\"8\" save-restore=\"no\"/>"
-	"    <reg name=\"basepri\" bitsize=\"8\" save-restore=\"no\"/>"
-	"    <reg name=\"faultmask\" bitsize=\"8\" save-restore=\"no\"/>"
-	"    <reg name=\"control\" bitsize=\"8\" save-restore=\"no\"/>"
-	"  </feature>"
-	"</target>"
-*/
-static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
-{
-	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
-	// these functions are given static input that should not be able to fail -- and if it does,
-	// then there's nothing we can do about it, so we'll repatedly cast this variable to a size_t
-	// when calculating printsz (see below).
-	int total = 0;
-
-	// We can't just repeatedly pass max_len to snprintf, because we keep changing the start
-	// of buffer (effectively changing its size), so we have to repeatedly compute the size
-	// passed to snprintf by subtracting the current total from max_len.
-	// ...Unless max_len is 0, in which case that subtraction will result in an (underflowed)
-	// negative number. So we also have to repatedly check if max_len is 0 before performing
-	// that subtraction.
-	size_t printsz = max_len;
-
-	// Start with the "preamble", which is generic across ARM targets,
-	// ...save for one word, so we'll have to do the preamble in halves.
-	total += snprintf(buffer, printsz, "%s target %sarm%s <feature name=\"org.gnu.gdb.arm.m-profile\">",
-		gdb_xml_preamble_first, gdb_xml_preamble_second, gdb_xml_preamble_third);
-
-	// Then the general purpose registers, which have names of r0 to r12,
-	// and all the same bitsize.
-	for (uint8_t i = 0; i <= 12; ++i) {
-		if (max_len != 0)
-			printsz = max_len - (size_t)total;
-
-		total += snprintf(buffer + total, printsz, "<reg name=\"r%u\" bitsize=\"32\"/>", i);
-	}
-
-	// Now for sp, lr, pc, xpsr, msp, psp, primask, basepri, faultmask, and control.
-	// These special purpose registers are a little more complicated.
-	// Some of them have different bitsizes, specified types, or specified save-restore values.
-	// We'll use the 'associative arrays' defined for those values.
-	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
-	for (size_t i = 0; i < ARRAY_LENGTH(cortex_m_spr_names); ++i) {
-		if (max_len != 0)
-			printsz = max_len - (size_t)total;
-
-		gdb_reg_type_e type = cortex_m_spr_types[i];
-		gdb_reg_save_restore_e save_restore = cortex_m_spr_save_restores[i];
-
-		total += snprintf(buffer + total, printsz, "<reg name=\"%s\" bitsize=\"%u\"%s%s/>", cortex_m_spr_names[i],
-			cortex_m_spr_bitsizes[i], gdb_reg_save_restore_strings[save_restore], gdb_reg_type_strings[type]);
-	}
-
-	if (max_len != 0)
-		printsz = max_len - (size_t)total;
-
-	total += snprintf(buffer + total, printsz, "</feature></target>");
-
-	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
-	// these functions are given static input that should not ever be able to fail -- and if it
-	// does, then there's nothing we can do about it, so we'll just discard the signedness
-	// of total when we return it.
-	return (size_t)total;
-}
-
-// Creates the target description XML string for a Cortex-MF. Like snprintf(), this function
-// will write no more than max_len and returns the amount of bytes written. Or, if max_len is 0,
-// then this function will return the amount of bytes that _would_ be necessary to create this
-// string.
-//
-// This function is hand-optimized to decrease string duplication and thus code size, making it
-// unfortunately much less readable than the string literal it is equivalent to.
-//
-// The string it creates is XML-equivalent to the following:
-/*
-	"<?xml version=\"1.0\"?>"
-	"<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
-	"<target>"
-	"  <architecture>arm</architecture>"
-	"  <feature name=\"org.gnu.gdb.arm.m-profile\">"
-	"    <reg name=\"r0\" bitsize=\"32\"/>"
-	"    <reg name=\"r1\" bitsize=\"32\"/>"
-	"    <reg name=\"r2\" bitsize=\"32\"/>"
-	"    <reg name=\"r3\" bitsize=\"32\"/>"
-	"    <reg name=\"r4\" bitsize=\"32\"/>"
-	"    <reg name=\"r5\" bitsize=\"32\"/>"
-	"    <reg name=\"r6\" bitsize=\"32\"/>"
-	"    <reg name=\"r7\" bitsize=\"32\"/>"
-	"    <reg name=\"r8\" bitsize=\"32\"/>"
-	"    <reg name=\"r9\" bitsize=\"32\"/>"
-	"    <reg name=\"r10\" bitsize=\"32\"/>"
-	"    <reg name=\"r11\" bitsize=\"32\"/>"
-	"    <reg name=\"r12\" bitsize=\"32\"/>"
-	"    <reg name=\"sp\" bitsize=\"32\" type=\"data_ptr\"/>"
-	"    <reg name=\"lr\" bitsize=\"32\" type=\"code_ptr\"/>"
-	"    <reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>"
-	"    <reg name=\"xpsr\" bitsize=\"32\"/>"
-	"    <reg name=\"msp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
-	"    <reg name=\"psp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
-	"    <reg name=\"primask\" bitsize=\"8\" save-restore=\"no\"/>"
-	"    <reg name=\"basepri\" bitsize=\"8\" save-restore=\"no\"/>"
-	"    <reg name=\"faultmask\" bitsize=\"8\" save-restore=\"no\"/>"
-	"    <reg name=\"control\" bitsize=\"8\" save-restore=\"no\"/>"
-	"  </feature>"
-	"  <feature name=\"org.gnu.gdb.arm.vfp\">"
-	"    <reg name=\"fpscr\" bitsize=\"32\"/>"
-	"    <reg name=\"d0\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d1\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d2\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d3\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d4\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d5\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d6\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d7\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d8\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d9\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d10\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d11\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d12\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d13\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d14\" bitsize=\"64\" type=\"float\"/>"
-	"    <reg name=\"d15\" bitsize=\"64\" type=\"float\"/>"
-	"  </feature>"
-	"</target>"
-*/
-static size_t create_tdesc_cortex_mf(char *buffer, size_t max_len)
-{
-	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
-	// these functions are given static input that should not be able to fail -- and if it does,
-	// then there's not really anything we can do about it, so we repatedly cast this variable
-	// to a size_t when calculating printsz (see below). Likewise, create_tdesc_cortex_m()
-	// has static inputs and shouldn't ever return a value large enough for casting it to a
-	// signed int to change its value, and if it does, then again there's something wrong that
-	// we can't really do anything about.
-
-	// The first part of the target description for the Cortex-MF is identical to the Cortex-M
-	// target description.
-	int total = (int)create_tdesc_cortex_m(buffer, max_len);
-
-	// We can't just repeatedly pass max_len to snprintf, because we keep changing the start
-	// of buffer (effectively changing its size), so we have to repeatedly compute the size
-	// passed to snprintf by subtracting the current total from max_len.
-	// ...Unless max_len is 0, in which case that subtraction will result in an (underflowed)
-	// negative number. So we also have to repatedly check if max_len is 0 before perofmring
-	// that subtraction.
-	size_t printsz = max_len;
-
-	if (max_len != 0) {
-		// Minor hack: subtract the target closing tag, since we have a bit more to add.
-		total -= strlen("</target>");
-
-		printsz = max_len - (size_t)total;
-	}
-
-	total += snprintf(buffer + total, printsz,
-		"<feature name=\"org.gnu.gdb.arm.vfp\">"
-		"<reg name=\"fpscr\" bitsize=\"32\"/>");
-
-	// After fpscr, the rest of the vfp registers follow a regular format: d0-d15, bitsize 64, type float.
-	for (uint8_t i = 0; i <= 15; ++i) {
-		if (max_len != 0)
-			printsz = max_len - (size_t)total;
-
-		total += snprintf(buffer + total, printsz, "<reg name=\"d%u\" bitsize=\"64\" type=\"float\"/>", i);
-	}
-
-	if (max_len != 0)
-		printsz = max_len - (size_t)total;
-
-	total += snprintf(buffer + total, printsz, "</feature></target>");
-
-	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
-	// these functions are given static input that should not ever be able to fail -- and if it
-	// does, then there's nothing we can do about it, so we'll just discard the signedness
-	// of total when we return it.
-	return (size_t)total;
-}
-
 static void cortexm_cache_clean(
 	target_s *const target, const target_addr32_t addr, const size_t len, const bool invalidate)
 {
@@ -432,21 +220,6 @@ static void cortexm_mem_write(target_s *target, target_addr64_t dest, const void
 {
 	cortexm_cache_clean(target, dest, len, true);
 	adiv5_mem_write(cortex_ap(target), dest, src, len);
-}
-
-const char *cortexm_regs_description(target_s *target)
-{
-	const bool is_cortexmf = target->target_options & CORTEXM_TOPT_FLAVOUR_V7MF;
-	const size_t description_length =
-		(is_cortexmf ? create_tdesc_cortex_mf(NULL, 0) : create_tdesc_cortex_m(NULL, 0)) + 1U;
-	char *const description = malloc(description_length);
-	if (description) {
-		if (is_cortexmf)
-			create_tdesc_cortex_mf(description, description_length);
-		else
-			create_tdesc_cortex_m(description, description_length);
-	}
-	return description;
 }
 
 bool cortexm_probe(adiv5_access_port_s *ap)
@@ -1375,4 +1148,231 @@ static bool cortexm_hostio_request(target_s *const target)
 	target_reg_write(target, 0, &result, sizeof(result));
 	/* Return if the request was in any way interrupted */
 	return target->tc->interrupted;
+}
+
+/*
+ * This function creates the target description XML string for a Cortex-M part.
+ * This is done this way to decrease string duplication adn thus code size, making it
+ * unfortunately much less readable than the string literal it is equvalent to.
+ *
+ * The backbone of this approach is snprintf() which will write no more than max_len bytes
+ * to the buffer and returns the amount of bytes written. Or, if max_len is 0, then this
+ * function will return the amount of bytes that would be necessary to create this string.
+ *
+ * The string it creates is XML-equivalent to the following:
+ * "<?xml version=\"1.0\"?>"
+ * "<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
+ * "<target>"
+ * "  <architecture>arm</architecture>"
+ * "  <feature name=\"org.gnu.gdb.arm.m-profile\">"
+ * "    <reg name=\"r0\" bitsize=\"32\"/>"
+ * "    <reg name=\"r1\" bitsize=\"32\"/>"
+ * "    <reg name=\"r2\" bitsize=\"32\"/>"
+ * "    <reg name=\"r3\" bitsize=\"32\"/>"
+ * "    <reg name=\"r4\" bitsize=\"32\"/>"
+ * "    <reg name=\"r5\" bitsize=\"32\"/>"
+ * "    <reg name=\"r6\" bitsize=\"32\"/>"
+ * "    <reg name=\"r7\" bitsize=\"32\"/>"
+ * "    <reg name=\"r8\" bitsize=\"32\"/>"
+ * "    <reg name=\"r9\" bitsize=\"32\"/>"
+ * "    <reg name=\"r10\" bitsize=\"32\"/>"
+ * "    <reg name=\"r11\" bitsize=\"32\"/>"
+ * "    <reg name=\"r12\" bitsize=\"32\"/>"
+ * "    <reg name=\"sp\" bitsize=\"32\" type=\"data_ptr\"/>"
+ * "    <reg name=\"lr\" bitsize=\"32\" type=\"code_ptr\"/>"
+ * "    <reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>"
+ * "    <reg name=\"xpsr\" bitsize=\"32\"/>"
+ * "    <reg name=\"msp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
+ * "    <reg name=\"psp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
+ * "    <reg name=\"primask\" bitsize=\"8\" save-restore=\"no\"/>"
+ * "    <reg name=\"basepri\" bitsize=\"8\" save-restore=\"no\"/>"
+ * "    <reg name=\"faultmask\" bitsize=\"8\" save-restore=\"no\"/>"
+ * "    <reg name=\"control\" bitsize=\"8\" save-restore=\"no\"/>"
+ * "  </feature>"
+ * "</target>"
+ */
+static size_t create_tdesc_cortex_m(char *buffer, size_t max_len)
+{
+	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
+	// these functions are given static input that should not be able to fail -- and if it does,
+	// then there's nothing we can do about it, so we'll repatedly cast this variable to a size_t
+	// when calculating printsz (see below).
+	int total = 0;
+
+	// We can't just repeatedly pass max_len to snprintf, because we keep changing the start
+	// of buffer (effectively changing its size), so we have to repeatedly compute the size
+	// passed to snprintf by subtracting the current total from max_len.
+	// ...Unless max_len is 0, in which case that subtraction will result in an (underflowed)
+	// negative number. So we also have to repatedly check if max_len is 0 before performing
+	// that subtraction.
+	size_t printsz = max_len;
+
+	// Start with the "preamble", which is generic across ARM targets,
+	// ...save for one word, so we'll have to do the preamble in halves.
+	total += snprintf(buffer, printsz, "%s target %sarm%s <feature name=\"org.gnu.gdb.arm.m-profile\">",
+		gdb_xml_preamble_first, gdb_xml_preamble_second, gdb_xml_preamble_third);
+
+	// Then the general purpose registers, which have names of r0 to r12,
+	// and all the same bitsize.
+	for (uint8_t i = 0; i <= 12; ++i) {
+		if (max_len != 0)
+			printsz = max_len - (size_t)total;
+
+		total += snprintf(buffer + total, printsz, "<reg name=\"r%u\" bitsize=\"32\"/>", i);
+	}
+
+	// Now for sp, lr, pc, xpsr, msp, psp, primask, basepri, faultmask, and control.
+	// These special purpose registers are a little more complicated.
+	// Some of them have different bitsizes, specified types, or specified save-restore values.
+	// We'll use the 'associative arrays' defined for those values.
+	// NOTE: unlike the other loops, this loop uses a size_t for its counter, as it's used to index into arrays.
+	for (size_t i = 0; i < ARRAY_LENGTH(cortex_m_spr_names); ++i) {
+		if (max_len != 0)
+			printsz = max_len - (size_t)total;
+
+		gdb_reg_type_e type = cortex_m_spr_types[i];
+		gdb_reg_save_restore_e save_restore = cortex_m_spr_save_restores[i];
+
+		total += snprintf(buffer + total, printsz, "<reg name=\"%s\" bitsize=\"%u\"%s%s/>", cortex_m_spr_names[i],
+			cortex_m_spr_bitsizes[i], gdb_reg_save_restore_strings[save_restore], gdb_reg_type_strings[type]);
+	}
+
+	if (max_len != 0)
+		printsz = max_len - (size_t)total;
+
+	total += snprintf(buffer + total, printsz, "</feature></target>");
+
+	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
+	// these functions are given static input that should not ever be able to fail -- and if it
+	// does, then there's nothing we can do about it, so we'll just discard the signedness
+	// of total when we return it.
+	return (size_t)total;
+}
+
+// Creates the target description XML string for a Cortex-MF. Like snprintf(), this function
+// will write no more than max_len and returns the amount of bytes written. Or, if max_len is 0,
+// then this function will return the amount of bytes that _would_ be necessary to create this
+// string.
+//
+// This function is hand-optimized to decrease string duplication and thus code size, making it
+// unfortunately much less readable than the string literal it is equivalent to.
+//
+// The string it creates is XML-equivalent to the following:
+/*
+	"<?xml version=\"1.0\"?>"
+	"<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
+	"<target>"
+	"  <architecture>arm</architecture>"
+	"  <feature name=\"org.gnu.gdb.arm.m-profile\">"
+	"    <reg name=\"r0\" bitsize=\"32\"/>"
+	"    <reg name=\"r1\" bitsize=\"32\"/>"
+	"    <reg name=\"r2\" bitsize=\"32\"/>"
+	"    <reg name=\"r3\" bitsize=\"32\"/>"
+	"    <reg name=\"r4\" bitsize=\"32\"/>"
+	"    <reg name=\"r5\" bitsize=\"32\"/>"
+	"    <reg name=\"r6\" bitsize=\"32\"/>"
+	"    <reg name=\"r7\" bitsize=\"32\"/>"
+	"    <reg name=\"r8\" bitsize=\"32\"/>"
+	"    <reg name=\"r9\" bitsize=\"32\"/>"
+	"    <reg name=\"r10\" bitsize=\"32\"/>"
+	"    <reg name=\"r11\" bitsize=\"32\"/>"
+	"    <reg name=\"r12\" bitsize=\"32\"/>"
+	"    <reg name=\"sp\" bitsize=\"32\" type=\"data_ptr\"/>"
+	"    <reg name=\"lr\" bitsize=\"32\" type=\"code_ptr\"/>"
+	"    <reg name=\"pc\" bitsize=\"32\" type=\"code_ptr\"/>"
+	"    <reg name=\"xpsr\" bitsize=\"32\"/>"
+	"    <reg name=\"msp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
+	"    <reg name=\"psp\" bitsize=\"32\" save-restore=\"no\" type=\"data_ptr\"/>"
+	"    <reg name=\"primask\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"basepri\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"faultmask\" bitsize=\"8\" save-restore=\"no\"/>"
+	"    <reg name=\"control\" bitsize=\"8\" save-restore=\"no\"/>"
+	"  </feature>"
+	"  <feature name=\"org.gnu.gdb.arm.vfp\">"
+	"    <reg name=\"fpscr\" bitsize=\"32\"/>"
+	"    <reg name=\"d0\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d1\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d2\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d3\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d4\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d5\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d6\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d7\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d8\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d9\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d10\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d11\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d12\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d13\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d14\" bitsize=\"64\" type=\"float\"/>"
+	"    <reg name=\"d15\" bitsize=\"64\" type=\"float\"/>"
+	"  </feature>"
+	"</target>"
+*/
+static size_t create_tdesc_cortex_mf(char *buffer, size_t max_len)
+{
+	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
+	// these functions are given static input that should not be able to fail -- and if it does,
+	// then there's not really anything we can do about it, so we repatedly cast this variable
+	// to a size_t when calculating printsz (see below). Likewise, create_tdesc_cortex_m()
+	// has static inputs and shouldn't ever return a value large enough for casting it to a
+	// signed int to change its value, and if it does, then again there's something wrong that
+	// we can't really do anything about.
+
+	// The first part of the target description for the Cortex-MF is identical to the Cortex-M
+	// target description.
+	int total = (int)create_tdesc_cortex_m(buffer, max_len);
+
+	// We can't just repeatedly pass max_len to snprintf, because we keep changing the start
+	// of buffer (effectively changing its size), so we have to repeatedly compute the size
+	// passed to snprintf by subtracting the current total from max_len.
+	// ...Unless max_len is 0, in which case that subtraction will result in an (underflowed)
+	// negative number. So we also have to repatedly check if max_len is 0 before perofmring
+	// that subtraction.
+	size_t printsz = max_len;
+
+	if (max_len != 0) {
+		// Minor hack: subtract the target closing tag, since we have a bit more to add.
+		total -= strlen("</target>");
+
+		printsz = max_len - (size_t)total;
+	}
+
+	total += snprintf(buffer + total, printsz,
+		"<feature name=\"org.gnu.gdb.arm.vfp\">"
+		"<reg name=\"fpscr\" bitsize=\"32\"/>");
+
+	// After fpscr, the rest of the vfp registers follow a regular format: d0-d15, bitsize 64, type float.
+	for (uint8_t i = 0; i <= 15; ++i) {
+		if (max_len != 0)
+			printsz = max_len - (size_t)total;
+
+		total += snprintf(buffer + total, printsz, "<reg name=\"d%u\" bitsize=\"64\" type=\"float\"/>", i);
+	}
+
+	if (max_len != 0)
+		printsz = max_len - (size_t)total;
+
+	total += snprintf(buffer + total, printsz, "</feature></target>");
+
+	// Minor hack: technically snprintf returns an int for possibility of error, but in this case
+	// these functions are given static input that should not ever be able to fail -- and if it
+	// does, then there's nothing we can do about it, so we'll just discard the signedness
+	// of total when we return it.
+	return (size_t)total;
+}
+
+static const char *cortexm_regs_description(target_s *target)
+{
+	const bool is_cortexmf = target->target_options & CORTEXM_TOPT_FLAVOUR_V7MF;
+	const size_t description_length =
+		(is_cortexmf ? create_tdesc_cortex_mf(NULL, 0) : create_tdesc_cortex_m(NULL, 0)) + 1U;
+	char *const description = malloc(description_length);
+	if (description) {
+		if (is_cortexmf)
+			create_tdesc_cortex_mf(description, description_length);
+		else
+			create_tdesc_cortex_m(description, description_length);
+	}
+	return description;
 }

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -54,6 +54,8 @@ const command_s cortexm_cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
+#define CORTEXM_DCRSR_REG_WRITE (1U << 16U)
+
 /* Target options recognised by the Cortex-M target */
 #define CORTEXM_TOPT_FLAVOUR_V6M (1U << 1U) /* if not set, target is assumed to be v7m */
 
@@ -630,13 +632,14 @@ static void cortexm_regs_write(target_s *const target, const void *const data)
 		/* Walk the regnum_cortex_m array, writing the registers it specifies */
 		for (size_t i = 0; i < CORTEXM_GENERAL_REG_COUNT; ++i) {
 			adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRDR), regs[i]);
-			adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRSR), 0x10000 | regnum_cortex_m[i]);
+			adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRSR), CORTEXM_DCRSR_REG_WRITE | regnum_cortex_m[i]);
 		}
+		/* If the device has a FPU, also walk the regnum_cortex_mf array */
 		if (target->target_options & CORTEXM_TOPT_FLAVOUR_V7MF) {
 			size_t offset = CORTEXM_GENERAL_REG_COUNT;
 			for (size_t i = 0; i < CORTEX_FLOAT_REG_COUNT; ++i) {
 				adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRDR), regs[offset + i]);
-				adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRSR), 0x10000 | regnum_cortex_mf[i]);
+				adiv5_dp_write(ap->dp, ADIV5_AP_DB(DB_DCRSR), CORTEXM_DCRSR_REG_WRITE | regnum_cortex_mf[i]);
 			}
 		}
 #if PC_HOSTED == 1

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -54,7 +54,7 @@ const command_s cortexm_cmd_list[] = {
 	{NULL, NULL, NULL},
 };
 
-/* target options recognised by the Cortex-M target */
+/* Target options recognised by the Cortex-M target */
 #define CORTEXM_TOPT_FLAVOUR_V6M (1U << 1U) /* if not set, target is assumed to be v7m */
 
 static const char *cortexm_target_description(target_s *target);
@@ -73,7 +73,7 @@ static int cortexm_breakwatch_set(target_s *target, breakwatch_s *breakwatch);
 static int cortexm_breakwatch_clear(target_s *target, breakwatch_s *breakwatch);
 static target_addr_t cortexm_check_watch(target_s *target);
 
-static bool cortexm_hostio_request(target_s *const target);
+static bool cortexm_hostio_request(target_s *target);
 
 typedef struct cortexm_priv {
 	cortex_priv_s base;

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1294,9 +1294,19 @@ static size_t cortexm_build_target_description(
 		gdb_reg_type_e type = cortex_m_spr_types[i];
 		gdb_reg_save_restore_e save_restore = cortex_m_spr_save_restores[i];
 
-		offset += (size_t)snprintf(buffer + offset, print_size, "<reg name=\"%s\" bitsize=\"%u\"%s%s/>",
+		/* xPSR (reg index 3) requires placement at register logical number 25 */
+		offset += (size_t)snprintf(buffer + offset, print_size, "<reg name=\"%s\" bitsize=\"%u\"%s%s%s/>",
 			cortex_m_spr_names[i], cortex_m_spr_bitsizes[i], gdb_reg_save_restore_strings[save_restore],
-			gdb_reg_type_strings[type]);
+			gdb_reg_type_strings[type], i == 3U ? " regnum=\"25\"" : "");
+
+		/* After the xPSR, we might need to generate one of either a system block or a secext block */
+		if (i == 3U) {
+			if (max_length != 0U)
+				print_size = max_length - offset;
+
+			offset +=
+				(size_t)snprintf(buffer + offset, print_size, "</feature><feature name=\"org.gnu.gdb.arm.m-system\">");
+		}
 	}
 
 	/* If the target has a FPU, include that */

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -56,9 +56,6 @@ const command_s cortexm_cmd_list[] = {
 
 #define CORTEXM_DCRSR_REG_WRITE (1U << 16U)
 
-/* Target options recognised by the Cortex-M target */
-#define CORTEXM_TOPT_FLAVOUR_V6M (1U << 1U) /* if not set, target is assumed to be v7m */
-
 static const char *cortexm_target_description(target_s *target);
 static void cortexm_regs_read(target_s *target, void *data);
 static void cortexm_regs_write(target_s *target, const void *data);
@@ -268,6 +265,11 @@ bool cortexm_probe(adiv5_access_port_s *ap)
 
 	target->attach = cortexm_attach;
 	target->detach = cortexm_detach;
+
+	/* Probe for the security extension if the core is not an ARMv6-M core */
+	if (!(target->target_options & CORTEXM_TOPT_FLAVOUR_V6M) &&
+		target_mem32_read32(target, CORTEXM_ID_PFR1) & CORTEXM_ID_PFR1_SECEXT_IMPL)
+		target->target_options |= CORTEXM_TOPT_TRUSTZONE;
 
 	/* Probe for FP extension. */
 	uint32_t cpacr = target_mem32_read32(target, CORTEXM_CPACR);

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -30,16 +30,17 @@ extern unsigned cortexm_wait_timeout;
 
 #define CORTEXM_SCS_BASE (CORTEXM_PPB_BASE + 0xe000U)
 
-#define CORTEXM_CPUID (CORTEXM_SCS_BASE + 0xd00U)
-#define CORTEXM_AIRCR (CORTEXM_SCS_BASE + 0xd0cU)
-#define CORTEXM_CFSR  (CORTEXM_SCS_BASE + 0xd28U)
-#define CORTEXM_HFSR  (CORTEXM_SCS_BASE + 0xd2cU)
-#define CORTEXM_DFSR  (CORTEXM_SCS_BASE + 0xd30U)
-#define CORTEXM_CPACR (CORTEXM_SCS_BASE + 0xd88U)
-#define CORTEXM_DHCSR (CORTEXM_SCS_BASE + 0xdf0U)
-#define CORTEXM_DCRSR (CORTEXM_SCS_BASE + 0xdf4U)
-#define CORTEXM_DCRDR (CORTEXM_SCS_BASE + 0xdf8U)
-#define CORTEXM_DEMCR (CORTEXM_SCS_BASE + 0xdfcU)
+#define CORTEXM_CPUID   (CORTEXM_SCS_BASE + 0xd00U)
+#define CORTEXM_AIRCR   (CORTEXM_SCS_BASE + 0xd0cU)
+#define CORTEXM_CFSR    (CORTEXM_SCS_BASE + 0xd28U)
+#define CORTEXM_HFSR    (CORTEXM_SCS_BASE + 0xd2cU)
+#define CORTEXM_DFSR    (CORTEXM_SCS_BASE + 0xd30U)
+#define CORTEXM_ID_PFR1 (CORTEXM_SCS_BASE + 0xd44U)
+#define CORTEXM_CPACR   (CORTEXM_SCS_BASE + 0xd88U)
+#define CORTEXM_DHCSR   (CORTEXM_SCS_BASE + 0xdf0U)
+#define CORTEXM_DCRSR   (CORTEXM_SCS_BASE + 0xdf4U)
+#define CORTEXM_DCRDR   (CORTEXM_SCS_BASE + 0xdf8U)
+#define CORTEXM_DEMCR   (CORTEXM_SCS_BASE + 0xdfcU)
 
 /* Cache identification */
 #define CORTEXM_CLIDR  (CORTEXM_SCS_BASE + 0xd78U)
@@ -92,6 +93,9 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_DFSR_DWTTRAP  (1U << 2U)
 #define CORTEXM_DFSR_BKPT     (1U << 1U)
 #define CORTEXM_DFSR_HALTED   (1U << 0U)
+
+/* Processor Feature Register 1 (ID_PFR1) */
+#define CORTEXM_ID_PFR1_SECEXT_IMPL (1U << 4U)
 
 /* Debug Halting Control and Status Register (DHCSR) */
 /* This key must be written to bits 31:16 for write to take effect */

--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -959,67 +959,67 @@ static const char *riscv_fpu_ext_string(const uint32_t extensions)
 }
 
 /*
- * Generate the fpu section of the description
- * fpu_size =32 single precision float
- * fpu_size =64 double precision float
- * The following are only generated for an F core (single precision HW float support):
- * <feature name="org.gnu.gdb.riscv.fpu">
- *			<reg name="ft0" bitsize="32"  regnum="33" />
- *			<reg name="ft1" bitsize="32"  regnum="34" />
- *			<reg name="ft2" bitsize="32"  regnum="35" />
- *			<reg name="ft3" bitsize="32"  regnum="36" />
- *			<reg name="ft4" bitsize="32"  regnum="37" />
- *			<reg name="ft5" bitsize="32"  regnum="38" />
- *			<reg name="ft6" bitsize="32"  regnum="39" />
- *			<reg name="ft7" bitsize="32"  regnum="40" />
- *			<reg name="fs0" bitsize="32"  regnum="41" />
- *			<reg name="fs1" bitsize="32"  regnum="42" />
- *			<reg name="fa0" bitsize="32"  regnum="43" />
- *			<reg name="fa1" bitsize="32"  regnum="44" />
- *			<reg name="fa2" bitsize="32"  regnum="45" />
- *			<reg name="fa3" bitsize="32"  regnum="46" />
- *			<reg name="fa4" bitsize="32"  regnum="47" />
- *			<reg name="fa5" bitsize="32"  regnum="48" />
- *			<reg name="fa6" bitsize="32"  regnum="49" />
- *			<reg name="fa7" bitsize="32"  regnum="50" />
- *			<reg name="fs2" bitsize="32"  regnum="51" />
- *			<reg name="fs3" bitsize="32"  regnum="52" />
- *			<reg name="fs4" bitsize="32"  regnum="53" />
- *			<reg name="fs5" bitsize="32"  regnum="54" />
- *			<reg name="fs6" bitsize="32"  regnum="55" />
- *			<reg name="fs7" bitsize="32"  regnum="56" />
- *			<reg name="fs8" bitsize="32"  regnum="57" />
- *			<reg name="fs9" bitsize="32"  regnum="58" />
- *			<reg name="fs10" bitsize="32"  regnum="59" />
- *			<reg name="fs11" bitsize="32"  regnum="60" />
- *			<reg name="ft8" bitsize="32"  regnum="61" />
- *			<reg name="ft9" bitsize="32"  regnum="62" />
- *			<reg name="ft10" bitsize="32"  regnum="63" />
- *			<reg name="ft11" bitsize="32"  regnum="64" />
- *			<reg name="fflags" bitsize="32" regnum="66"  save-restore="no"/>
- *			<reg name="frm" bitsize="32" regnum="67"  save-restore="no"/>
- *			<reg name="fcsr" bitsize="32" regnum="68"  save-restore="no"/>
- *</feature>
+ * Generate the FPU section of the description.
+ * fpu_size = 32 -> single precision float
+ * fpu_size = 64 -> double precision float
+ * The following XML-equivalent is only generated for an F core (single precision HW float support):
+ *  <feature name="org.gnu.gdb.riscv.fpu">
+ *      <reg name="ft0" bitsize="32" regnum="33" />
+ *      <reg name="ft1" bitsize="32" regnum="34" />
+ *      <reg name="ft2" bitsize="32" regnum="35" />
+ *      <reg name="ft3" bitsize="32" regnum="36" />
+ *      <reg name="ft4" bitsize="32" regnum="37" />
+ *      <reg name="ft5" bitsize="32" regnum="38" />
+ *      <reg name="ft6" bitsize="32" regnum="39" />
+ *      <reg name="ft7" bitsize="32" regnum="40" />
+ *      <reg name="fs0" bitsize="32" regnum="41" />
+ *      <reg name="fs1" bitsize="32" regnum="42" />
+ *      <reg name="fa0" bitsize="32" regnum="43" />
+ *      <reg name="fa1" bitsize="32" regnum="44" />
+ *      <reg name="fa2" bitsize="32" regnum="45" />
+ *      <reg name="fa3" bitsize="32" regnum="46" />
+ *      <reg name="fa4" bitsize="32" regnum="47" />
+ *      <reg name="fa5" bitsize="32" regnum="48" />
+ *      <reg name="fa6" bitsize="32" regnum="49" />
+ *      <reg name="fa7" bitsize="32" regnum="50" />
+ *      <reg name="fs2" bitsize="32" regnum="51" />
+ *      <reg name="fs3" bitsize="32" regnum="52" />
+ *      <reg name="fs4" bitsize="32" regnum="53" />
+ *      <reg name="fs5" bitsize="32" regnum="54" />
+ *      <reg name="fs6" bitsize="32" regnum="55" />
+ *      <reg name="fs7" bitsize="32" regnum="56" />
+ *      <reg name="fs8" bitsize="32" regnum="57" />
+ *      <reg name="fs9" bitsize="32" regnum="58" />
+ *      <reg name="fs10" bitsize="32" regnum="59" />
+ *      <reg name="fs11" bitsize="32" regnum="60" />
+ *      <reg name="ft8" bitsize="32" regnum="61" />
+ *      <reg name="ft9" bitsize="32" regnum="62" />
+ *      <reg name="ft10" bitsize="32" regnum="63" />
+ *      <reg name="ft11" bitsize="32" regnum="64" />
+ *      <reg name="fflags" bitsize="32" regnum="66" save-restore="no"/>
+ *      <reg name="frm" bitsize="32" regnum="67" save-restore="no"/>
+ *      <reg name="fcsr" bitsize="32" regnum="68" save-restore="no"/>
+ *  </feature>
  */
 static size_t riscv_build_target_fpu_description(char *const buffer, size_t max_length, size_t fpu_size)
 {
 	const size_t first_fpu_register = RV_FPU_GDB_OFFSET;             // see riscv_debug.h
 	const size_t first_fpu_control_register = RV_FPU_GDB_CSR_OFFSET; // see riscv_debug.h
-	size_t offset = 0;
+	size_t offset = 0U;
 	size_t print_size = max_length;
-	offset += snprintf(buffer + offset, print_size, "</feature><feature name=\"org.gnu.gdb.riscv.fpu\">");
+	offset += (size_t)snprintf(buffer + offset, print_size, "</feature><feature name=\"org.gnu.gdb.riscv.fpu\">");
 
-	for (size_t i = 0; i < ARRAY_LENGTH(riscv_fpu_regs); i++) {
-		if (max_length != 0)
-			print_size = max_length - (size_t)offset;
-		offset +=
-			snprintf(buffer + offset, print_size, "<reg name=\"f%s\" bitsize=\"%" PRIu32 "\"  regnum=\"%" PRIu32 "\"/>",
-				riscv_fpu_regs[i], (uint32_t)fpu_size, (uint32_t)(i + first_fpu_register));
+	for (size_t i = 0U; i < ARRAY_LENGTH(riscv_fpu_regs); ++i) {
+		if (max_length != 0U)
+			print_size = max_length - offset;
+		offset += (size_t)snprintf(buffer + offset, print_size,
+			"<reg name=\"f%s\" bitsize=\"%" PRIu32 "\"  regnum=\"%" PRIu32 "\"/>", riscv_fpu_regs[i],
+			(uint32_t)fpu_size, (uint32_t)(i + first_fpu_register));
 	}
-	for (size_t i = 0; i < ARRAY_LENGTH(riscv_fpu_ctrl_regs); i++) {
-		if (max_length != 0)
-			print_size = max_length - (size_t)offset;
-		offset += snprintf(buffer + offset, print_size,
+	for (size_t i = 0U; i < ARRAY_LENGTH(riscv_fpu_ctrl_regs); ++i) {
+		if (max_length != 0U)
+			print_size = max_length - offset;
+		offset += (size_t)snprintf(buffer + offset, print_size,
 			"<reg name=\"f%s\" bitsize=\"%" PRIu32 "\" regnum=\"%" PRIu32 "\" save-restore=\"no\"/>",
 			riscv_fpu_ctrl_regs[i], (uint32_t)fpu_size, (uint32_t)(i + first_fpu_control_register));
 	}

--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -1032,48 +1032,48 @@ static size_t riscv_build_target_fpu_description(char *const buffer, size_t max_
  * unfortunately much less readable than the string literal it is equivalent to.
  *
  * This string it creates is the XML-equivalent to the following:
- * "<?xml version=\"1.0\"?>"
- * "<!DOCTYPE target SYSTEM \"gdb-target.dtd\">"
- * "<target>"
- * "	<architecture>riscv:rv[address_width][exts]</architecture>"
- * "	<feature name=\"org.gnu.gdb.riscv.cpu\">"
- * "		<reg name=\"zero\" bitsize=\"[address_width]\" regnum=\"0\"/>"
- * "		<reg name=\"ra\" bitsize=\"[address_width]\" type=\"code_ptr\"/>"
- * "		<reg name=\"sp\" bitsize=\"[address_width]\" type=\"data_ptr\"/>"
- * "		<reg name=\"gp\" bitsize=\"[address_width]\" type=\"data_ptr\"/>"
- * "		<reg name=\"tp\" bitsize=\"[address_width]\" type=\"data_ptr\"/>"
- * "		<reg name=\"t0\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"t1\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"t2\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"fp\" bitsize=\"[address_width]\" type=\"data_ptr\"/>"
- * "		<reg name=\"s1\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"a0\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"a1\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"a2\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"a3\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"a4\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"a5\" bitsize=\"[address_width]\"/>"
+ *  <?xml version=\"1.0\"?>
+ *  <!DOCTYPE target SYSTEM \"gdb-target.dtd\">
+ *  <target>
+ *      <architecture>riscv:rv[address_width][exts]</architecture>
+ *      <feature name="org.gnu.gdb.riscv.cpu">
+ *          <reg name="zero" bitsize="[address_width]" regnum="0"/>
+ *          <reg name="ra" bitsize="[address_width]" type="code_ptr"/>
+ *          <reg name="sp" bitsize="[address_width]" type="data_ptr"/>
+ *          <reg name="gp" bitsize="[address_width]" type="data_ptr"/>
+ *          <reg name="tp" bitsize="[address_width]" type="data_ptr"/>
+ *          <reg name="t0" bitsize="[address_width]"/>
+ *          <reg name="t1" bitsize="[address_width]"/>
+ *          <reg name="t2" bitsize="[address_width]"/>
+ *          <reg name="fp" bitsize="[address_width]" type="data_ptr"/>
+ *          <reg name="s1" bitsize="[address_width]"/>
+ *          <reg name="a0" bitsize="[address_width]"/>
+ *          <reg name="a1" bitsize="[address_width]"/>
+ *          <reg name="a2" bitsize="[address_width]"/>
+ *          <reg name="a3" bitsize="[address_width]"/>
+ *          <reg name="a4" bitsize="[address_width]"/>
+ *          <reg name="a5" bitsize="[address_width]"/>
  * The following are only generated for an I core, not an E:
- * "		<reg name=\"a6\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"a7\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s2\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s3\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s4\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s5\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s6\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s7\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s8\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s9\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s10\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"s11\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"t3\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"t4\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"t5\" bitsize=\"[address_width]\"/>"
- * "		<reg name=\"t6\" bitsize=\"[address_width]\"/>"
+ *          <reg name="a6" bitsize="[address_width]"/>
+ *          <reg name="a7" bitsize="[address_width]"/>
+ *          <reg name="s2" bitsize="[address_width]"/>
+ *          <reg name="s3" bitsize="[address_width]"/>
+ *          <reg name="s4" bitsize="[address_width]"/>
+ *          <reg name="s5" bitsize="[address_width]"/>
+ *          <reg name="s6" bitsize="[address_width]"/>
+ *          <reg name="s7" bitsize="[address_width]"/>
+ *          <reg name="s8" bitsize="[address_width]"/>
+ *          <reg name="s9" bitsize="[address_width]"/>
+ *          <reg name="s10" bitsize="[address_width]"/>
+ *          <reg name="s11" bitsize="[address_width]"/>
+ *          <reg name="t3" bitsize="[address_width]"/>
+ *          <reg name="t4" bitsize="[address_width]"/>
+ *          <reg name="t5" bitsize="[address_width]"/>
+ *          <reg name="t6" bitsize="[address_width]"/>
  * Both are then continued with:
- * "		<reg name=\"pc\" bitsize=\"[address_width]\" type=\"code_ptr\"/>"
- * "	</feature>"
- * "</target>"
+ *          <reg name="pc" bitsize="[address_width]" type="code_ptr"/>
+ *      </feature>
+ *  </target>
  */
 static size_t riscv_build_target_description(
 	char *const buffer, size_t max_length, const uint8_t address_width, const uint32_t extensions)

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -50,6 +50,7 @@
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
+#include "adi.h"
 #include "cortexm.h"
 #ifdef ENABLE_RISCV
 #include "riscv_debug.h"
@@ -528,7 +529,7 @@ void mm32l0_mem_write_sized(adiv5_access_port_s *ap, target_addr64_t dest, const
 	/* Calculate how much each loop will increment the destination address by */
 	const uint8_t stride = 1U << align;
 	/* Set up the transfer */
-	adiv5_mem_access_setup(ap, dest, align);
+	adi_ap_mem_access_setup(ap, dest, align);
 	/* Now loop through the data and move it 1 stride at a time to the target */
 	for (; begin < end; begin += stride) {
 		/*


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we deal with some issues with core register I/O for ARM targets, and with TrustZone support between GDB and BMD for Cortex-M23 and Cortex-M33 targets. This is split into four main parts as described below.

The first part of this PR deals with some lints and code quality issues. The second deals with a residual ADIv6 support bug whereby because the register I/O code for both Cortex-M and Cortex-A/R support was directly writing the DP's SELECT register and presuming ADIv5, that was unintentionally deselecting the AP under ADIv6 and causing the reads and writes to go to an arbitrary point on the DP's debug resource bus.

The third part of this PR deals with some code organisation consistency problems, moving all the target.xml builder code for Cortex-M to the bottom of the file to match the Cortex-A/R and RISC-V support. This also sees corrections to the top of function comments and function nomenclature for the XML builders.

The fourth part implements support for GDB's secext block to read out the secure and non-secure stack pointers which are 4 new registers to handle. This involves generation of the XML for the feature block, handling the new registers in the mass read/write functions, and handling them in the individual read/write functions. Care must be taken, however, not to attempt reading the identity register on ARMv6-M cores as it's an invalid register there; and accessing the extra registers on ARMv7-M cores as their IDs are reserved values for DCRSR there.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #849
