### PR TITLE
Fix: Support libgpiod in Makefiles

### DIFF
--- a/src/platforms/hosted/Makefile.inc
+++ b/src/platforms/hosted/Makefile.inc
@@ -123,6 +123,17 @@ ifneq ($(HOSTED_BMP_ONLY), 1)
     LDFLAGS += $(shell pkg-config --libs $(HIDAPILIB))
 endif
 
+ifeq ($(ENABLE_GPIOD), 1)
+    SRC += bmda_gpiod.c
+    SRC += platforms/common/jtagtap.c platforms/common/swdptap.c
+    ifneq ($(shell pkg-config --exists libgpiod; echo $$?), 0)
+        $(error Please install libgpiod dependency or drop ENABLE_GPIOD=1)
+    endif
+    CFLAGS += $(shell pkg-config --cflags libgpiod)
+    LDFLAGS += $(shell pkg-config --libs libgpiod)
+    CFLAGS += -DENABLE_GPIOD=1
+endif
+
 VPATH += platforms/hosted/remote
 
 SRC += platform.c

--- a/src/platforms/hosted/bmda_gpiod.c
+++ b/src/platforms/hosted/bmda_gpiod.c
@@ -147,7 +147,7 @@ static bool bmda_gpiod_parse_gpio(const char *name, char *gpio)
 	DEBUG_INFO("gpiochip: %s offset: %u\n", gpio, gpio_off);
 	struct gpiod_line *line = gpiod_line_get(gpio, gpio_off);
 	if (!line) {
-		DEBUG_ERROR("Couldn't get GPIO: %s:%u errno: %d\n", gpio, gpio_off, errno);
+		DEBUG_ERROR("Couldn't get GPIO %s:%u, error %d: %s\n", gpio, gpio_off, errno, strerror(errno));
 		return false;
 	}
 
@@ -186,7 +186,7 @@ static bool bmda_gpiod_parse_gpio(const char *name, char *gpio)
 	return true;
 
 out_fail_close:
-	DEBUG_ERROR("Requesting gpio failed errno: %d", errno);
+	DEBUG_ERROR("Requesting gpio failed, error %d: %s", errno, strerror(errno));
 	gpiod_chip_close(gpiod_line_get_chip(line));
 	return false;
 }


### PR DESCRIPTION
## Detailed description

* This feature is not new.
* The existing problem is it's impossible to build BMDA with libgpiod backend when Meson doesn't work, i.e. via Makefile buildsystem.
* This PR enables said support by adding required sources, macros, and pkg-config flags.

Tested in March of 2024 to work on STM32MP157 in OpenSTLinux userspace.
I also thought to expand the reason message for when gpiod_get_line() fails to claim a pin. `strerror()` is already used elsewhere in this codebase (in hosted).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] ~~It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))~~ and should not affect it
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
