### PR TITLE
Add TraceSWO UART protocol to platform

### DIFF
--- a/src/platforms/ctxlink/Makefile.inc
+++ b/src/platforms/ctxlink/Makefile.inc
@@ -29,10 +29,17 @@ VPATH += platforms/common/stm32
 SRC +=               \
 	platform.c \
 	traceswodecode.c \
-	traceswo.c	\
 	serialno.c	\
 	timing.c	\
 	timing_stm32.c
+
+ifeq ($(TRACESWO_PROTOCOL), 1)
+SRC += traceswo.c
+CFLAGS += -DTRACESWO_PROTOCOL=1
+else
+SRC += traceswoasync.c
+CFLAGS += -DTRACESWO_PROTOCOL=2
+endif
 
 ifneq ($(BMP_BOOTLOADER), 1)
 all:	blackmagic.bin

--- a/src/platforms/ctxlink/meson.build
+++ b/src/platforms/ctxlink/meson.build
@@ -40,6 +40,17 @@ probe_ctxlink_args = [
 	f'-DDFU_SERIAL_LENGTH=@probe_ctxlink_dfu_serial_length@',
 ]
 
+trace_protocol = get_option('trace_protocol')
+if trace_protocol == '3'
+	trace_protocol = '2'
+endif
+probe_ctxlink_args += [f'-DTRACESWO_PROTOCOL=@trace_protocol@']
+if trace_protocol == '1'
+	probe_ctxlink_dependencies = fixme_platform_stm32_traceswo
+else
+	probe_ctxlink_dependencies = fixme_platform_stm32_traceswoasync
+endif
+
 probe_ctxlink_commonn_link_args = [
 	'-L@0@'.format(meson.current_source_dir()),
 	'-T@0@'.format('ctxlink.ld'),
@@ -55,7 +66,7 @@ probe_host = declare_dependency(
 	sources: probe_ctxlink_sources,
 	compile_args: probe_ctxlink_args,
 	link_args: probe_ctxlink_commonn_link_args + probe_ctxlink_link_args,
-	dependencies: [platform_common, platform_stm32f4, fixme_platform_stm32_traceswo],
+	dependencies: [platform_common, platform_stm32f4, probe_ctxlink_dependencies],
 )
 
 summary(

--- a/src/platforms/ctxlink/platform.h
+++ b/src/platforms/ctxlink/platform.h
@@ -108,8 +108,8 @@
 /*
  * To use USART1 as USBUSART, DMA2 is selected from RM0368, page 170, table 29.
  * This table defines USART1_TX as stream 7, channel 4, and USART1_RX as stream 2, channel 4.
- * Because USART1 is on APB2 with max Pclk of 100 MHz,
- * reachable baudrates are up to 12.5M with OVER8 or 6.25M with default OVER16 (per DS10314, page 31, table 6)
+ * Because USART1 is on APB2 with max Pclk of 84 MHz,
+ * reachable baudrates are up to 10.5M with OVER8 or 5.25M with default OVER16 (per DocID025644 Rev3, page 30, table 6)
  */
 #define USBUSART               USART1
 #define USBUSART_CR1           USART1_CR1


### PR DESCRIPTION
Note: The UART protocol is tested, however, the Manchester
protocol is not tested, in fact, the defines still
need adjusting to match the ctxlink hardware.

## Detailed description

This PR implements UART TraceSWO protocol for ctxLink. Having SWO trace over USB is a new feature of ctxLink and is possible because of the new implementation of USB endpoint usage now present in BMF.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
Lack of trace SWO over USB in ctxLink