### PR TITLE
Remove DFU from ctxlink platform

### DIFF
--- a/src/platforms/ctxlink/Makefile.inc
+++ b/src/platforms/ctxlink/Makefile.inc
@@ -1,28 +1,18 @@
 CROSS_COMPILE ?= arm-none-eabi-
-BMP_BOOTLOADER ?=
 CC = $(CROSS_COMPILE)gcc
 OBJCOPY = $(CROSS_COMPILE)objcopy
 
 CFLAGS += -Istm32/include -mcpu=cortex-m4 -mthumb \
 	-mfloat-abi=hard -mfpu=fpv4-sp-d16 \
-	-DSTM32F4 -DCTX_LINK -I../deps/libopencm3/include \
+	-DSTM32F4 -DCTX_LINK -DDFU_SERIAL_LENGTH=13 -I../deps/libopencm3/include \
 	-Iplatforms/common/stm32
 
-LDFLAGS_BOOT = -lopencm3_stm32f4 \
+LDFLAGS = -lopencm3_stm32f4 \
 	-Tctxlink.ld -nostartfiles -lc -lnosys \
 	-Lplatforms/ctxlink \
 	-Wl,-Map=mapfile -mthumb -mcpu=cortex-m4 -Wl,-gc-sections \
 	-mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 	-L../deps/libopencm3/lib
-
-ifeq ($(BMP_BOOTLOADER), 1)
-$(info  Load address 0x08004000 for BMPBootloader)
-LDFLAGS = $(LDFLAGS_BOOT) -Wl,-Ttext=0x8004000
-CFLAGS += -DDFU_SERIAL_LENGTH=9
-else
-LDFLAGS = $(LDFLAGS_BOOT)
-CFLAGS += -DDFU_SERIAL_LENGTH=13
-endif
 
 VPATH += platforms/common/stm32
 
@@ -41,14 +31,7 @@ SRC += traceswoasync.c
 CFLAGS += -DTRACESWO_PROTOCOL=2
 endif
 
-ifneq ($(BMP_BOOTLOADER), 1)
 all:	blackmagic.bin
-else
-all:	blackmagic.bin  blackmagic_dfu.bin blackmagic_dfu.hex
-blackmagic_dfu.elf: usbdfu.o dfucore.o dfu_f4.o serialno.o
-	@echo "  LD      $@"
-	$(Q)$(CC) $^ -o $@ $(LDFLAGS_BOOT)
-endif
 
 host_clean:
 	-$(Q)$(RM) blackmagic.bin

--- a/src/platforms/ctxlink/meson.build
+++ b/src/platforms/ctxlink/meson.build
@@ -32,12 +32,8 @@ probe_ctxlink_includes = include_directories('.')
 
 probe_ctxlink_sources = files('platform.c')
 
-bmd_bootloader = get_option('bmd_bootloader')
-
-probe_ctxlink_dfu_serial_length = bmd_bootloader ? '9' : '13'
-
 probe_ctxlink_args = [
-	f'-DDFU_SERIAL_LENGTH=@probe_ctxlink_dfu_serial_length@',
+	'-DDFU_SERIAL_LENGTH=13',
 ]
 
 trace_protocol = get_option('trace_protocol')
@@ -57,9 +53,6 @@ probe_ctxlink_commonn_link_args = [
 ]
 
 probe_ctxlink_link_args = []
-if bmd_bootloader
-	probe_ctxlink_link_args += ['-Wl,-Ttext=0x8004000']
-endif
 
 probe_host = declare_dependency(
 	include_directories: probe_ctxlink_includes,
@@ -73,7 +66,7 @@ summary(
 	{
 		'Name': 'ctxLink',
 		'Platform': 'STM32F4',
-		'Bootloader': bmd_bootloader ? 'Black Magic Debug Bootloader' : 'OEM ST Bootloader',
+		'Bootloader': 'OEM ST Bootloader',
 	},
 	section: 'Probe',
 )


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

ctxLink uses the ST built-in bootloader and does not need the BMD DFU bootloader.

This PR removes the builkd settings for the DFU bootloader from both the makefile and meson build file.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None.