### PR TITLE
Fix: Broken CMSIS-DAP SWD sequence

### DIFF
--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -67,6 +67,7 @@ typedef enum dap_led_type {
 
 #define DAP_QUIRK_NO_JTAG_MUTLI_TAP          (1U << 0U)
 #define DAP_QUIRK_BAD_SWD_NO_RESP_DATA_PHASE (1U << 1U)
+#define DAP_QUIRK_BROKEN_SWD_SEQUENCE        (1U << 2U)
 
 extern uint8_t dap_caps;
 extern dap_cap_e dap_mode;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we correct an issue pointed out by both @litui on the MCULink adaptors, and by @asumagic on debugprobe firmware running on a RPi Pico. When using the logic from ARM for handling these transactions, they come out wrong (1 bit shifted due to all the in sequences capturing data one cycle too early).

We adjust for this with a new quirk flag when we detect this bugged behaviour during DP IDR readout, and post-processing the results with a corrective loop.

Tested working with both adaptors, allowing the debugprobe firmware to work flawlessly with BMD and the MCULink firmware to get a lot further with the MCXC041 before hitting a different issue (FAULT response handling during memory accesses setup). This latter issue will be dealt with in a separate PR.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
