### PR TITLE
Fix: AT32F435/437: Correct typos in WFI/WDT handling

### DIFF
--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -96,8 +96,8 @@ static bool at32f43_mass_erase(target_s *target);
  */
 #define AT32F43x_DBGMCU_BASE       0xe0042000U
 #define AT32F43x_DBGMCU_IDCODE     (AT32F43x_DBGMCU_BASE + 0x00U)
-#define AT32F43x_DBGMCU_CTRL       (AT32F43x_DBGMCU_BASE + 0x40U)
-#define AT32F43x_DBGMCU_APB1_PAUSE (AT32F43x_DBGMCU_BASE + 0x80U)
+#define AT32F43x_DBGMCU_CTRL       (AT32F43x_DBGMCU_BASE + 0x04U)
+#define AT32F43x_DBGMCU_APB1_PAUSE (AT32F43x_DBGMCU_BASE + 0x08U)
 #define AT32F43x_DBGMCU_APB2_PAUSE (AT32F43x_DBGMCU_BASE + 0x0cU)
 #define AT32F43x_DBGMCU_SER_ID     (AT32F43x_DBGMCU_BASE + 0x20U)
 
@@ -164,7 +164,7 @@ static void at32f43_configure_dbgmcu(target_s *target)
 	const uint32_t dbgmcu_apb1_pause_mask = AT32F43x_DBGMCU_APB1_PAUSE_WWDT | AT32F43x_DBGMCU_APB1_PAUSE_WDT;
 	const uint32_t dbgmcu_apb1_pause = target_mem32_read32(target, AT32F43x_DBGMCU_APB1_PAUSE);
 	if ((dbgmcu_apb1_pause & dbgmcu_apb1_pause_mask) != dbgmcu_apb1_pause_mask)
-		target_mem32_write32(target, AT32F43x_DBGMCU_APB1_PAUSE, dbgmcu_apb1_pause & dbgmcu_apb1_pause_mask);
+		target_mem32_write32(target, AT32F43x_DBGMCU_APB1_PAUSE, dbgmcu_apb1_pause | dbgmcu_apb1_pause_mask);
 }
 
 static bool at32f43_attach(target_s *target)


### PR DESCRIPTION
## Detailed description

* This is a follow-up to #1869 (merged recently) which is supposed to deal with WFI/sleep and WDT/reset on AT32F437.
* This PR corrects a couple typos in that.

This, edited, version of that is tested on AT-START-F437 using its AT-Link EZ CMSIS-DAP firmware, affected by #1925 as well.
Now BMDA actually writes into correct DBGMCU offsets and hence works better than AT32IDE's version of OpenOCD (in which Tcl scripts still write 0x307 into CTRL, neglecting APB1_PAUSE), allowing me to halt, step, and reflash a chip with nWDT_ATO_EN option bit unset in SSB.
Not appending extra log instrumentation which I used to confirm that the reads and writes are happening in the order I expect them to.
Sorry for introducing typos in the process of responding to review of PR1869, that codestyle was more novel to me. To be honest I did test the unreviewed version then.
CI will fail with linker errors, I won't do anything about it in light of driver selection rebalance to happen soon. This driver is already disabled for smaller probes.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
No issue heard of yet.