### PR TITLE
rtt: support channels other than 0

### DIFF
--- a/src/include/rtt_if.h
+++ b/src/include/rtt_if.h
@@ -65,11 +65,11 @@ int rtt_if_init(void);
 /* hosted teardown */
 int rtt_if_exit(void);
 
-/* target to host: write len bytes from the buffer starting at buf. return number bytes written */
-uint32_t rtt_write(const char *buf, uint32_t len);
-/* host to target: read one character, non-blocking. return character, -1 if no character */
-int32_t rtt_getchar(void);
-/* host to target: true if no characters available for reading */
-bool rtt_nodata(void);
+/* target to host: write len bytes from the buffer on the channel starting at buf. return number bytes written */
+uint32_t rtt_write(const uint32_t channel, const char *buf, uint32_t len);
+/* host to target: read one character from the channel, non-blocking. return character, -1 if no character */
+int32_t rtt_getchar(const uint32_t channel);
+/* host to target: true if no characters available for reading in the selected channel */
+bool rtt_nodata(const uint32_t channel);
 
 #endif /* INCLUDE_RTT_IF_H */

--- a/src/platforms/common/stm32/rtt_if.c
+++ b/src/platforms/common/stm32/rtt_if.c
@@ -93,9 +93,10 @@ void rtt_serial_receive_callback(usbd_device *dev, uint8_t ep)
 }
 
 /* rtt host to target: read one character */
-int32_t rtt_getchar()
+int32_t rtt_getchar(const uint32_t channel)
 {
 	int retval;
+	(void)channel;
 
 	if (recv_head == recv_tail)
 		return -1;
@@ -110,14 +111,20 @@ int32_t rtt_getchar()
 }
 
 /* rtt host to target: true if no characters available for reading */
-bool rtt_nodata()
+bool rtt_nodata(const uint32_t channel)
 {
+	/* only support reading from down channel 0 */
+	if (channel != 0U)
+		return true;
 	return recv_head == recv_tail;
 }
 
 /* rtt target to host: write string */
-uint32_t rtt_write(const char *buf, uint32_t len)
+uint32_t rtt_write(const uint32_t channel, const char *buf, uint32_t len)
 {
+	/* only support writing to up channel 0 */
+	if (channel != 0U)
+		return len;
 	if (len != 0 && usbdev && usb_get_config() && gdb_serial_get_dtr()) {
 		for (uint32_t p = 0; p < len; p += CDCACM_PACKET_SIZE) {
 			uint32_t plen = MIN(CDCACM_PACKET_SIZE, len - p);

--- a/src/platforms/hosted/rtt_if.c
+++ b/src/platforms/hosted/rtt_if.c
@@ -71,8 +71,11 @@ int rtt_if_exit()
 
 /* write buffer to terminal */
 
-uint32_t rtt_write(const char *buf, uint32_t len)
+uint32_t rtt_write(const uint32_t channel, const char *buf, uint32_t len)
 {
+	/* only support writing to up channel 0 */
+	if (channel != 0U)
+		return len;
 	int unused = write(1, buf, len);
 	(void)unused;
 	return len;
@@ -80,10 +83,11 @@ uint32_t rtt_write(const char *buf, uint32_t len)
 
 /* read character from terminal */
 
-int32_t rtt_getchar()
+int32_t rtt_getchar(const uint32_t channel)
 {
 	char ch;
 	int len;
+	(void)channel;
 	len = read(0, &ch, 1);
 	if (len == 1)
 		return ch;
@@ -92,8 +96,9 @@ int32_t rtt_getchar()
 
 /* true if no characters available */
 
-bool rtt_nodata()
+bool rtt_nodata(const uint32_t channel)
 {
+	(void)channel;
 	return false;
 }
 
@@ -113,23 +118,28 @@ int rtt_if_exit()
 
 /* write buffer to terminal */
 
-uint32_t rtt_write(const char *buf, uint32_t len)
+uint32_t rtt_write(const uint32_t channel, const char *buf, uint32_t len)
 {
+	/* only support writing to up channel 0 */
+	if (channel != 0U)
+		return len;
 	write(1, buf, len);
 	return len;
 }
 
 /* read character from terminal */
 
-int32_t rtt_getchar()
+int32_t rtt_getchar(const uint32_t channel)
 {
+	(void)channel;
 	return -1;
 }
 
 /* true if no characters available */
 
-bool rtt_nodata()
+bool rtt_nodata(const uint32_t channel)
 {
+	(void)channel;
 	return false;
 }
 

--- a/src/platforms/launchpad-icdi/rtt_if.c
+++ b/src/platforms/launchpad-icdi/rtt_if.c
@@ -93,9 +93,10 @@ void rtt_serial_receive_callback(usbd_device *dev, uint8_t ep)
 }
 
 /* rtt host to target: read one character */
-int32_t rtt_getchar()
+int32_t rtt_getchar(const uint32_t channel)
 {
 	int retval;
+	(void)channel;
 
 	if (recv_head == recv_tail)
 		return -1;
@@ -110,14 +111,20 @@ int32_t rtt_getchar()
 }
 
 /* rtt host to target: true if no characters available for reading */
-bool rtt_nodata()
+bool rtt_nodata(const uint32_t channel)
 {
+	/* only support reading from down channel 0 */
+	if (channel != 0U)
+		return true;
 	return recv_head == recv_tail;
 }
 
 /* rtt target to host: write string */
-uint32_t rtt_write(const char *buf, uint32_t len)
+uint32_t rtt_write(const uint32_t channel, const char *buf, uint32_t len)
 {
+	/* only support writing to up channel 0 */
+	if (channel != 0U)
+		return len;
 	if (len != 0 && usbdev && usb_get_config() && gdb_serial_get_dtr()) {
 		for (uint32_t p = 0; p < len; p += CDCACM_PACKET_SIZE) {
 			uint32_t plen = MIN(CDCACM_PACKET_SIZE, len - p);


### PR DESCRIPTION
Add support for targets that use channels other than 0. Currently these channels are all ignored, which can prevent confusion, however furure work may be done to connect other channels to e.g. different USB endpoints.

## Detailed description

RTT supports the concept of multiple channels. Usually, up channel 0 is stdout and down channel 0 is stdin, however it supports more than just those two.

Add an argument to the RTT interface to indicate which channel is being addressed, and ignore it if the channel is not channel 0.

This enables platforms to take special actions for channels other than channel 0.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do