### PR TITLE
cortexm: allow updating demcr from outside

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -227,6 +227,24 @@ static void cortexm_mem_write(target_s *target, target_addr64_t dest, const void
 	adiv5_mem_write(cortex_ap(target), dest, src, len);
 }
 
+bool target_is_cortexm(const target_s *target)
+{
+	return target == NULL && target->regs_description == cortexm_target_description;
+}
+
+uint32_t cortexm_demcr_read(const target_s *target)
+{
+	const cortexm_priv_s *priv = (const cortexm_priv_s *)target->priv;
+	return priv->demcr;
+}
+
+void cortexm_demcr_write(target_s *target, uint32_t demcr)
+{
+	cortexm_priv_s *priv = (cortexm_priv_s *)target->priv;
+	priv->demcr = demcr;
+	target_mem32_write32(target, CORTEXM_DEMCR, demcr);
+}
+
 bool cortexm_probe(adiv5_access_port_s *ap)
 {
 	target_s *target = target_new();

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -175,5 +175,8 @@ void cortexm_detach(target_s *target);
 void cortexm_halt_resume(target_s *target, bool step);
 bool cortexm_run_stub(target_s *target, uint32_t loadaddr, uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3);
 int cortexm_mem_write_aligned(target_s *target, target_addr_t dest, const void *src, size_t len, align_e align);
+uint32_t cortexm_demcr_read(const target_s *target);
+void cortexm_demcr_write(target_s *target, uint32_t demcr);
+bool target_is_cortexm(const target_s *target);
 
 #endif /* TARGET_CORTEXM_H */


### PR DESCRIPTION
Allow outside accessors to update the demcr. This is useful for updating the exceptions to catch for handling things like devices that go into powersave.

<!-- Filling this template is mandatory -->

## Detailed description

Certain targets need to fail safe rather than failing into a debugger. An example of this is a heater, where it is preferable to have the target reboot when it has a hardfault.

Another example is an STM32F4 device that powers itself off. When catching reset vectors, it'll break into GDB every time the system is powered on, which may not be desirable.

Add functions to be able to peek into these values, as well as update them from outside of `cortexm.c`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
