### PR TITLE
Support connecting to BMP devices via TCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ scripts/swolisten
 
 /deps/*
 !/deps/*.wrap
-!/deps/libopencm3


### PR DESCRIPTION
## Detailed description

TCP connections can behave similarly to sockets on all supported platforms. This patch allows for specifying "address:port" on Linux, Windows, and Mac for connecting to a remote device.

Currently this has been tested with Farpatch, however future versions could allow inception debugging wherein low-level commands are forwarded from BMDA to the target, which could even be a second instance of BMDA.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do