### PR TITLE
Feature: AUX serial cleanup

### DIFF
--- a/src/platforms/common/stm32/swo.c
+++ b/src/platforms/common/stm32/swo.c
@@ -146,12 +146,11 @@ void swo_send_buffer(usbd_device *const dev, const uint8_t ep)
 		if (swo_itm_decoding) {
 			/* If we're in UART mode, hand as much as we can all at once */
 			if (swo_current_mode == swo_nrz_uart)
-				result = swo_itm_decode(dev, CDCACM_UART_ENDPOINT, swo_buffer + swo_buffer_read_index,
-					MIN(bytes_available, SWO_BUFFER_SIZE - swo_buffer_read_index));
+				result = swo_itm_decode(
+					swo_buffer + swo_buffer_read_index, MIN(bytes_available, SWO_BUFFER_SIZE - swo_buffer_read_index));
 			/* Otherwise, if we're in Manchester mode, manage the amount moved the same as we do USB */
 			else
-				result = swo_itm_decode(dev, CDCACM_UART_ENDPOINT, swo_buffer + swo_buffer_read_index,
-					MIN(bytes_available, SWO_ENDPOINT_SIZE));
+				result = swo_itm_decode(swo_buffer + swo_buffer_read_index, MIN(bytes_available, SWO_ENDPOINT_SIZE));
 		} else
 			/* Otherwise, queue the new data to the SWO data endpoint */
 			result = usbd_ep_write_packet(

--- a/src/platforms/common/stm32/swo_itm_decode.c
+++ b/src/platforms/common/stm32/swo_itm_decode.c
@@ -31,13 +31,8 @@ static uint32_t itm_decode_mask = 0;  /* bitmask of channels to print */
 static uint8_t itm_packet_length = 0; /* decoder state */
 static bool itm_decode_packet = false;
 
-uint16_t swo_itm_decode(usbd_device *usbd_dev, uint8_t ep, const uint8_t *data, uint16_t len)
+uint16_t swo_itm_decode(const uint8_t *data, uint16_t len)
 {
-	/* Check if we've got a valid USB device */
-	/* XXX: Can this ever actually be false?! */
-	if (usbd_dev == NULL)
-		return 0U;
-
 	/* Step through each byte in the SWO data buffer */
 	for (uint16_t idx = 0; idx < len; ++idx) {
 		/* If we're waiting for a new ITM packet, start decoding the new byte as a header */
@@ -63,7 +58,7 @@ uint16_t swo_itm_decode(usbd_device *usbd_dev, uint8_t ep, const uint8_t *data, 
 				if (itm_decoded_buffer_index == sizeof(itm_decoded_buffer)) {
 					/* However, if the link is not yet up, drop the packet data silently */
 					if (usb_get_config() && gdb_serial_get_dtr())
-						usbd_ep_write_packet(usbd_dev, ep, itm_decoded_buffer, itm_decoded_buffer_index);
+						debug_serial_send_stdout(itm_decoded_buffer, itm_decoded_buffer_index);
 					itm_decoded_buffer_index = 0U;
 				}
 			}

--- a/src/platforms/common/swo.h
+++ b/src/platforms/common/swo.h
@@ -55,7 +55,7 @@ void swo_send_buffer(usbd_device *dev, uint8_t ep);
 void swo_itm_decode_set_mask(uint32_t mask);
 
 /* Decode a new block of ITM data from SWO */
-uint16_t swo_itm_decode(usbd_device *usbd_dev, uint8_t ep, const uint8_t *data, uint16_t len);
+uint16_t swo_itm_decode(const uint8_t *data, uint16_t len);
 
 #endif /* !NO_LIBOPENCM3 */
 

--- a/src/platforms/common/tm4c/swo_uart.c
+++ b/src/platforms/common/tm4c/swo_uart.c
@@ -126,7 +126,7 @@ void trace_buf_push(void)
 	if (len > 64U)
 		len = 64;
 
-	if (usbd_ep_write_packet(usbdev, USB_REQ_TYPE_IN | SWO_ENDPOINT, (uint8_t *)&buf_rx[buf_rx_out], len) == len) {
+	if (usbd_ep_write_packet(usbdev, SWO_ENDPOINT, (uint8_t *)&buf_rx[buf_rx_out], len) == len) {
 		buf_rx_out += len;
 		buf_rx_out %= FIFO_SIZE;
 	}

--- a/src/platforms/common/usb_serial.c
+++ b/src/platforms/common/usb_serial.c
@@ -219,7 +219,8 @@ void usb_serial_set_config(usbd_device *dev, uint16_t value)
 	usbd_register_control_callback(dev, USB_REQ_TYPE_CLASS | USB_REQ_TYPE_INTERFACE,
 		USB_REQ_TYPE_TYPE | USB_REQ_TYPE_RECIPIENT, gdb_serial_control_request);
 
-	/* Notify the host that DCD is asserted.
+	/*
+	 * Notify the host that DCD is asserted.
 	 * Allows the use of /dev/tty* devices on *BSD/MacOS
 	 */
 	usb_serial_set_state(dev, GDB_IF_NO, CDCACM_GDB_NOTIF_ENDPOINT);
@@ -277,8 +278,7 @@ static void debug_serial_send_data(void)
 	debug_serial_send_complete = false;
 	aux_serial_update_receive_buffer_fullness();
 
-	/* Forcibly empty fifo if no USB endpoint.
-	 * If fifo empty, nothing further to do. */
+	/* Forcibly empty fifo if no USB endpoint. If fifo empty, nothing further to do. */
 	if (usb_get_config() != 1 ||
 		(aux_serial_receive_buffer_empty()
 #if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In the aftermath of the SWO fixup PR, we noticed some items around how the AUX serial interface is used that could do with some work. This PR is the culmination of that, delivering a small Flash size usage improvement and simplifying some of the code driving the SWO ITM decoder.

There are still improvements to be made for the AUX serial interface as if the host is not pulling data quickly enough right now, we will begin dropping packets of data even if buffers aren't full and waiting would solve it.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
