### PR TITLE
Feature: tri-state SWDIO, SWCLK on unbuffered platforms

### DIFF
--- a/src/platforms/stlinkv3/platform.c
+++ b/src/platforms/stlinkv3/platform.c
@@ -188,20 +188,20 @@ void platform_init(void)
 	gpio_set(NRST_PORT, NRST_PIN);
 
 	gpio_mode_setup(TMS_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TMS_PIN);
-	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TMS_PIN);
+	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TMS_PIN);
 	gpio_mode_setup(SWDIO_IN_PORT, GPIO_MODE_INPUT, GPIO_PUPD_PULLUP, SWDIO_IN_PIN);
 
 	/* Configure TDI pin. */
 	gpio_mode_setup(TDI_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TDI_PIN);
-	gpio_set_output_options(TDI_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TDI_PIN);
+	gpio_set_output_options(TDI_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TDI_PIN);
 
 	/* Drive the tck/swck pin low. */
 	gpio_mode_setup(TCK_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TCK_PIN);
-	gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TCK_PIN);
+	gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TCK_PIN);
 
 	/* Drive direction switch pin. */
 	gpio_mode_setup(TMS_DRIVE_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TMS_DRIVE_PIN);
-	gpio_set_output_options(TMS_DRIVE_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TMS_DRIVE_PIN);
+	gpio_set_output_options(TMS_DRIVE_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TMS_DRIVE_PIN);
 	gpio_set(TMS_DRIVE_PORT, TMS_DRIVE_PIN);
 
 	gpio_mode_setup(PWR_EN_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, PWR_EN_PIN);
@@ -260,7 +260,7 @@ void platform_target_clk_output_enable(bool enable)
 	/* Regardless of swdptap.c, tri-state TCK and TMS */
 	if (enable) {
 		gpio_mode_setup(TCK_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TCK_PIN);
-		gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TCK_PIN);
+		gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TCK_PIN);
 		SWDIO_MODE_DRIVE();
 	} else {
 		gpio_mode_setup(TCK_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, TCK_PIN);

--- a/src/platforms/stlinkv3/platform.c
+++ b/src/platforms/stlinkv3/platform.c
@@ -257,7 +257,15 @@ void platform_init(void)
 
 void platform_target_clk_output_enable(bool enable)
 {
-	(void)enable;
+	/* Regardless of swdptap.c, tri-state TCK and TMS */
+	if (enable) {
+		gpio_mode_setup(TCK_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TCK_PIN);
+		gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TCK_PIN);
+		SWDIO_MODE_DRIVE();
+	} else {
+		gpio_mode_setup(TCK_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, TCK_PIN);
+		SWDIO_MODE_FLOAT();
+	}
 }
 
 bool platform_spi_init(const spi_bus_e bus)

--- a/src/platforms/stlinkv3/platform.h
+++ b/src/platforms/stlinkv3/platform.h
@@ -90,7 +90,7 @@ extern bool debug_bmp;
 
 #define TMS_SET_MODE()                                                    \
 	gpio_mode_setup(TMS_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TMS_PIN); \
-	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TMS_PIN);
+	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TMS_PIN);
 
 #define SWDIO_MODE_FLOAT()                         \
 	do {                                           \
@@ -170,7 +170,7 @@ extern const struct _usbd_driver stm32f723_usb_driver;
 	do {                                                                                                   \
 		rcc_periph_clock_enable(USBUSART_PORT_CLKEN);                                                      \
 		gpio_mode_setup(USBUSART_PORT, GPIO_MODE_AF, GPIO_PUPD_PULLUP, USBUSART_TX_PIN | USBUSART_RX_PIN); \
-		gpio_set_output_options(USBUSART_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, USBUSART_TX_PIN);          \
+		gpio_set_output_options(USBUSART_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, USBUSART_TX_PIN);         \
 		gpio_set_af(USBUSART_PORT, USBUSART_PIN_AF, USBUSART_TX_PIN | USBUSART_RX_PIN);                    \
 	} while (0)
 


### PR DESCRIPTION
## Detailed description

* This feature is a principle from `native` #1192 applied to other platforms.
* The existing problem is unbuffered BMP-compatibles hogging SWDIO/SWCLK lines in push-pull output modes, rendering other debuggers unusable when connected in parallel for extended diagnostics (this includes onboard debuggers).
* This PR solves that by switching GPIOs from push-pull output into input mode on the same function call that `native` uses.

Tested on stlink/v3e of Nucleo-144 to give up the lines and allow using another external debugger. If SWDIO_MODE_DRIVE/SWDIO_MODE_FLOAT of swdptap.c and TMS_SET_MODE of jtagtap.c macros worked correctly, then I'd only need to touch the TCK gpio, but it was not enough. It may have to do with the sequence of swd writes (BMP is expected to write the next command and can't know it should idle).

The bonus change increases the slowest 2MHz slew rate on f723 to at least 25 MHz, because I've seen it bitbang faster than 10 MHz, and the waveform is degraded. Also CFLAGS="-Og" slow the swdptap.c routines down compared to "-Os" of other platforms, I'd like to update that as well (considering most stlinkv3's are in RDP2 anyways).

The same patch should be adapted and applied to blackpills and swlink, likely others (f072, f3, f4discovery, etc.)
I can't assume what pull-ups or pull-downs will be present on target's SWJ-DP (SW-DP), e.g. STM32 uses a TCK pull-down but RP2040 uses pull-ups on both TCK and TMS. So I just float the (normally driven) pins.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware)) *and should not affect it*
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)) *and should not affect it*
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1868 point 3.