### PR TITLE
Feature: allow dynamic PLATFORM_IDENT

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -180,8 +180,6 @@ int command_process(target_s *const t, char *const cmd_buffer)
 	return target_command(t, argc, argv);
 }
 
-#define BOARD_IDENT "Black Magic Probe " PLATFORM_IDENT "" FIRMWARE_VERSION
-
 bool cmd_version(target_s *t, int argc, const char **argv)
 {
 	(void)t;
@@ -194,7 +192,11 @@ bool cmd_version(target_s *t, int argc, const char **argv)
 	DEBUG_WARN("Copyright (C) 2010-2023 Black Magic Debug Project\n");
 	DEBUG_WARN("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\n");
 #else
+#ifndef PLATFORM_IDENT_DYNAMIC
 	gdb_out(BOARD_IDENT);
+#else
+	gdb_outf(BOARD_IDENT, platform_ident());
+#endif
 	gdb_outf(", Hardware Version %d\n", platform_hwversion());
 	gdb_out("Copyright (C) 2010-2023 Black Magic Debug Project\n");
 	gdb_out("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\n");

--- a/src/include/general.h
+++ b/src/include/general.h
@@ -184,4 +184,10 @@ static inline int vasprintf(char **strp, const char *const fmt, va_list ap)
 
 #endif /* _MSC_VER */
 
+#ifndef PLATFORM_IDENT_DYNAMIC
+#define BOARD_IDENT "Black Magic Probe " PLATFORM_IDENT "" FIRMWARE_VERSION
+#else
+#define BOARD_IDENT "Black Magic Probe (%s) " FIRMWARE_VERSION
+#endif
+
 #endif /* INCLUDE_GENERAL_H */

--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -79,4 +79,8 @@ bool platform_spi_chip_select(uint8_t device_select);
 uint8_t platform_spi_xfer(spi_bus_e bus, uint8_t value);
 #endif
 
+#ifdef PLATFORM_IDENT_DYNAMIC
+const char *platform_ident(void);
+#endif
+
 #endif /* INCLUDE_PLATFORM_SUPPORT_H */

--- a/src/platforms/common/usb_descriptors.h
+++ b/src/platforms/common/usb_descriptors.h
@@ -32,8 +32,6 @@
 #include "version.h"
 #include "usb_types.h"
 
-#define BOARD_IDENT "Black Magic Probe " PLATFORM_IDENT FIRMWARE_VERSION
-
 /* Top-level device descriptor */
 static const usb_device_descriptor_s dev_desc = {
 	.bLength = USB_DT_DEVICE_SIZE,
@@ -416,6 +414,10 @@ static const usb_config_descriptor_s config = {
 
 	.interface = ifaces,
 };
+
+#ifdef PLATFORM_IDENT_DYNAMIC
+#error "Dynamic platform identification not supported by the in-tree USB descriptors at this time"
+#endif
 
 static const char *const usb_strings[] = {
 	"Black Magic Debug",

--- a/src/remote.c
+++ b/src/remote.c
@@ -305,7 +305,12 @@ static void remote_packet_process_general(char *packet, const size_t packet_len)
 #if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 		debug_bmp = true;
 #endif
+#ifndef PLATFORM_IDENT_DYNAMIC
 		remote_respond_string(REMOTE_RESP_OK, BOARD_IDENT);
+#else
+		snprintf(packet, GDB_PACKET_BUFFER_SIZE, BOARD_IDENT, platform_ident());
+		remote_respond_string(REMOTE_RESP_OK, packet);
+#endif
 		break;
 	case REMOTE_TARGET_CLK_OE:
 		platform_target_clk_output_enable(packet[2] != '0');

--- a/src/remote.c
+++ b/src/remote.c
@@ -255,7 +255,7 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 	}
 }
 
-#if !defined(BOARD_IDENT) && defined(BOARD_IDENT)
+#if !defined(PLATFORM_IDENT)
 #define PLATFORM_IDENT BOARD_IDENT
 #endif
 

--- a/src/remote.c
+++ b/src/remote.c
@@ -255,10 +255,6 @@ static void remote_packet_process_jtag(const char *const packet, const size_t pa
 	}
 }
 
-#if !defined(PLATFORM_IDENT)
-#define PLATFORM_IDENT BOARD_IDENT
-#endif
-
 static void remote_packet_process_general(char *packet, const size_t packet_len)
 {
 	(void)packet_len;
@@ -309,7 +305,7 @@ static void remote_packet_process_general(char *packet, const size_t packet_len)
 #if ENABLE_DEBUG == 1 && defined(PLATFORM_HAS_DEBUG)
 		debug_bmp = true;
 #endif
-		remote_respond_string(REMOTE_RESP_OK, PLATFORM_IDENT "" FIRMWARE_VERSION);
+		remote_respond_string(REMOTE_RESP_OK, BOARD_IDENT);
 		break;
 	case REMOTE_TARGET_CLK_OE:
 		platform_target_clk_output_enable(packet[2] != '0');


### PR DESCRIPTION
## Detailed description

The feature to modify PLATFORM_IDENT in runtime has been added. To enable this, `PLATFORM_IDENT_DYNAMIC` should be defined, and the `platform_ident` function must be implemented to return `PLATFORM_IDENT`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
