### PR TITLE
Feature: Add support for Arterytek MCU AT32F405, F402

### DIFF
--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -1,8 +1,8 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
- * Written by ALTracer <tolstov_den@mail.ru>
+ * Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+ * Written by ALTracer <11005378+ALTracer@users.noreply.github.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -376,8 +376,10 @@ bool at32f43x_probe(target_s *target)
 	const uint16_t part_id = idcode & AT32F4x_IDCODE_PART_MASK;
 	// ... and highest byte of UID
 	const uint8_t project_id = target_mem32_read8(target, AT32F4x_PROJECT_ID);
+	const uint32_t debug_ser_id = target_mem32_read32(target, AT32F43x_DBGMCU_SER_ID);
 
-	DEBUG_TARGET("%s: idcode = %08" PRIx32 ", project_id = %02x\n", __func__, idcode, project_id);
+	DEBUG_TARGET("%s: idcode = %08" PRIx32 ", project_id = %02x, debug_ser_id = %08" PRIx32 "\n", __func__, idcode,
+		project_id, debug_ser_id);
 
 	/* 0x0e: F437 (has EMAC), 0x0d: F435 (no EMAC). 4K/2K describe sector sizes, not total flash capacity. */
 	if ((series == AT32F43_SERIES_4K || series == AT32F43_SERIES_2K) && (project_id == 0x0dU || project_id == 0x0eU))

--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -25,6 +25,8 @@
  * References:
  * AT32F435/437 Series Reference Manual
  *   https://www.arterychip.com/download/RM/RM_AT32F435_437_EN_V2.04.pdf
+ * AT32F402/405 Series Reference Manual
+ *   https://www.arterychip.com/download/RM/RM_AT32F402_405_EN_V2.01.pdf
  */
 
 #include "general.h"
@@ -89,6 +91,9 @@ static bool at32f43_mass_erase(target_s *target);
 #define AT32F43x_2K_OB_COUNT 256U
 #define AT32F43x_4K_OB_COUNT 2048U
 
+#define AT32F405_USD_BASE 0x1ffff800U
+#define AT32F405_OB_COUNT 256U
+
 /*
  * refman: DEBUG has 5 registers, of which CTRL, APB1_PAUSE, APB2_PAUSE are
  * "asynchronously reset by POR Reset (not reset by system reset). It can be written by the debugger under reset."
@@ -114,6 +119,8 @@ static bool at32f43_mass_erase(target_s *target);
 #define AT32F4x_IDCODE_PART_MASK   0x00000fffU
 #define AT32F43_SERIES_4K          0x70084000U
 #define AT32F43_SERIES_2K          0x70083000U
+#define AT32F405_SERIES_256KB      0x70053000U
+#define AT32F405_SERIES_128KB      0x70042000U
 #define AT32F4x_PROJECT_ID         0x1ffff7f3U
 #define AT32F4x_FLASHSIZE          0x1ffff7e0U
 
@@ -292,6 +299,37 @@ static bool at32f43_detect(target_s *target, const uint16_t part_id)
 	return true;
 }
 
+/* Identify AT32F405 Mainstream devices */
+static bool at32f405_detect(target_s *target, const uint32_t series)
+{
+	/*
+	 * AT32F405/F402 always contain 1 bank with 128 sectors
+	 * Flash (C): 256 KiB, 2 KiB per sector, 0x7005_3000
+	 * Flash (B): 128 KiB, 1 KiB per sector, 0x7004_2000
+	 */
+	const uint16_t flash_size = target_mem32_read16(target, AT32F4x_FLASHSIZE);
+	const uint16_t sector_size = series == AT32F405_SERIES_128KB ? 1024U : 2048U;
+	at32f43_add_flash(target, 0x08000000, flash_size, sector_size, 0, AT32F43x_FLASH_BANK1_REG_OFFSET);
+
+	/*
+	 * Either 96 or 102 KiB of SRAM, depending on USD bit 7 nRAM_PRT_CHK:
+	 * when first 48 KiB are protected by odd parity, last 6 KiB are reserved for this purpose
+	 */
+	target_add_ram32(target, 0x20000000, 102U * 1024U);
+	target->driver = "AT32F405";
+	target->mass_erase = at32f43_mass_erase;
+
+	/* 512 byte User System Data area at 0x1fff_f800 (different USD_BASE, no EOPB0) */
+	//target_add_commands(target, at32f43_cmd_list, target->driver);
+
+	/* Same registers and freeze bits in DBGMCU as F437 */
+	target->attach = at32f43_attach;
+	target->detach = at32f43_detach;
+	at32f43_configure_dbgmcu(target);
+
+	return true;
+}
+
 /* Identify any Arterytek devices with Cortex-M4 and FPEC at 0x4002_3c00 */
 bool at32f43x_probe(target_s *target)
 {
@@ -311,6 +349,10 @@ bool at32f43x_probe(target_s *target)
 	/* 0x0e: F437 (has EMAC), 0x0d: F435 (no EMAC). 4K/2K describe sector sizes, not total flash capacity. */
 	if ((series == AT32F43_SERIES_4K || series == AT32F43_SERIES_2K) && (project_id == 0x0dU || project_id == 0x0eU))
 		return at32f43_detect(target, part_id);
+	/* 0x13: F405 (has USB HS), 0x14: F402 (no USB HS) */
+	if ((series == AT32F405_SERIES_256KB || series == AT32F405_SERIES_128KB) &&
+		(project_id == 0x13U || project_id == 0x14U))
+		return at32f405_detect(target, series);
 
 	return false;
 }


### PR DESCRIPTION
## Detailed description

* This could be described as a new feature (new target support in existing driver)
* The existing problem is AT32F405 not identified by BMD but likely supported via AT32F435 API.
* This PR solves it by adding required match code in `at32f43_probe`.

I do not have any chips accessible for that target and cannot test live, only read refmans. FPEC is at 0x40023C00, which is promising. USD and DBGMCU support not considered yet.
The generic F_SIZE method was used to not carry yet another table of Part IDs.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
