### PR TITLE
Fix: BMDA BMP-only probe discovery for Windows

### DIFF
--- a/src/include/general.h
+++ b/src/include/general.h
@@ -34,20 +34,20 @@
 #endif // _MSC_VER <= 1932
 #endif
 
-#if !defined(BMD_IS_STDC) && !defined(BMD_MSVC_PRE_172)
+#if !defined(BMD_IS_STDC) && defined(BMD_MSVC_PRE_172)
 #error "Black Magic Debug must be built in a standards compliant C mode"
 #endif
 
 #ifndef _GNU_SOURCE
-// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 #define _GNU_SOURCE
 #endif
 #ifndef _DEFAULT_SOURCE
-// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 #define _DEFAULT_SOURCE
 #endif
 #if !defined(__USE_MINGW_ANSI_STDIO)
-// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 #define __USE_MINGW_ANSI_STDIO 1
 #endif
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -31,7 +31,7 @@
 #include <sys/types.h>
 
 #if defined(_MSC_VER)
-#include <BaseTsd.h>
+#include <basetsd.h>
 typedef SSIZE_T ssize_t;
 typedef int32_t mode_t;
 #endif /* _MSC_VER */

--- a/src/platforms/hosted/bmp_hosted.h
+++ b/src/platforms/hosted/bmp_hosted.h
@@ -96,7 +96,7 @@ typedef struct timeval timeval_s;
 
 extern bmda_probe_s bmda_probe_info;
 void bmp_ident(bmda_probe_s *info);
-int find_debuggers(bmda_cli_options_s *cl_opts, bmda_probe_s *info);
+bool find_debuggers(bmda_cli_options_s *cl_opts, bmda_probe_s *info);
 void libusb_exit_function(bmda_probe_s *info);
 
 #if HOSTED_BMP_ONLY == 1

--- a/src/platforms/hosted/bmp_serial.c
+++ b/src/platforms/hosted/bmp_serial.c
@@ -172,7 +172,8 @@ static const probe_info_s *scan_for_devices(void)
 	return probe_info_correct_order(probe_list);
 }
 #else
-/* Old ID: Black_Sphere_Technologies_Black_Magic_Probe_BFE4D6EC-if00
+/*
+ * Old ID: Black_Sphere_Technologies_Black_Magic_Probe_BFE4D6EC-if00
  * Recent: Black_Sphere_Technologies_Black_Magic_Probe_v1.7.1-212-g212292ab_7BAE7AB8-if00
  * usb-Black_Sphere_Technologies_Black_Magic_Probe__SWLINK__v1.7.1-155-gf55ad67b-dirty_DECB8811-if00
  */
@@ -294,7 +295,7 @@ static probe_info_s *parse_device_node(const char *name, probe_info_s *probe_lis
 	}
 
 	if (!version || !type) {
-		DEBUG_ERROR("Failed to construct version of type string");
+		DEBUG_ERROR("Failed to construct version or type string");
 		free(serial);
 		free(version);
 		free(type);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -129,7 +129,7 @@ void platform_init(int argc, char **argv)
 		bmda_probe_info.type = PROBE_TYPE_BMP;
 	else if (cl_opts.opt_gpio_map)
 		bmda_probe_info.type = PROBE_TYPE_GPIOD;
-	else if (find_debuggers(&cl_opts, &bmda_probe_info))
+	else if (!find_debuggers(&cl_opts, &bmda_probe_info))
 		exit(1);
 
 	if (cl_opts.opt_list_only)

--- a/src/platforms/hosted/serial_win.c
+++ b/src/platforms/hosted/serial_win.c
@@ -1,7 +1,11 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2020  Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
+ * Copyright (C) 2020 Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Copyright (C) 2022-2024 1BitSquared <info@1bitsquared.com>
+ *
+ * Written by Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +26,7 @@
 #include "platform.h"
 #include "remote.h"
 #include "cli.h"
+#include "utils.h"
 
 #include <assert.h>
 #include <string.h>
@@ -31,25 +36,6 @@
 
 #define NT_DEV_SUFFIX     "\\\\.\\"
 #define NT_DEV_SUFFIX_LEN ARRAY_LENGTH(NT_DEV_SUFFIX)
-
-static char *format_string(const char *format, ...) DEBUG_FORMAT_ATTR;
-
-static char *format_string(const char *format, ...)
-{
-	va_list args;
-	va_start(args, format);
-	const int len = vsnprintf(NULL, 0, format, args);
-	va_end(args);
-	if (len <= 0)
-		return NULL;
-	char *const ret = (char *)malloc(len + 1);
-	if (!ret)
-		return NULL;
-	va_start(args, format);
-	vsprintf(ret, format, args);
-	va_end(args);
-	return ret;
-}
 
 #define READ_BUFFER_LENGTH 4096U
 

--- a/src/platforms/hosted/utils.c
+++ b/src/platforms/hosted/utils.c
@@ -1,11 +1,13 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2020 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
- * Base on code:
- * Copyright (C) 2011  Black Sphere Technologies Ltd.
- * Written by Gareth McMullin <gareth@blacksphere.co.nz>
- * and others.
+ * Copyright (C) 2011 Black Sphere Technologies Ltd.
+ * Copyright (C) 2020 Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Copyright (C) 2022-2024 1BitSquared <info@1bitsquared.com>
+ *
+ * Originally written by Gareth McMullin <gareth@blacksphere.co.nz> and others.
+ * Modified by Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +28,7 @@
 #include "general.h"
 
 #include <string.h>
+#include <stdio.h>
 
 #include "timeofday.h"
 #include "timing.h"
@@ -45,6 +48,23 @@ uint32_t platform_time_ms(void)
 	timeval_s tv;
 	gettimeofday(&tv, NULL);
 	return (tv.tv_sec * 1000U) + (tv.tv_usec / 1000U);
+}
+
+char *format_string(const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	const int len = vsnprintf(NULL, 0, format, args);
+	va_end(args);
+	if (len <= 0)
+		return NULL;
+	char *const ret = (char *)malloc(len + 1);
+	if (!ret)
+		return NULL;
+	va_start(args, format);
+	vsprintf(ret, format, args);
+	va_end(args);
+	return ret;
 }
 
 bool begins_with(const char *const str, const size_t str_length, const char *const value)

--- a/src/platforms/hosted/utils.h
+++ b/src/platforms/hosted/utils.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2022 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2022-2024 1BitSquared <info@1bitsquared.com>
  * Written by Rachel Mant <git@dragonmux.network>
  * All rights reserved.
  *
@@ -36,6 +36,8 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+
+char *format_string(const char *format, ...) DEBUG_FORMAT_ATTR;
 
 bool begins_with(const char *str, size_t str_length, const char *value);
 bool ends_with(const char *str, size_t str_length, const char *value);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the recent CI breakage for BMP-only BMDA builds on Windows. This was caused by the compiler becoming stricter and so detecting and erring on some buffer overflow issues in the Windows-specific probe discovery code for BMP-only BMDA.

This PR addresses it by rewriting that code using the probe_info_s structure to store probes, and with considerably more error handling and proper buffer management to discover available devices on the user's system.

This could still do with some de-duplication between serial_win.c and bmp_serial.c, however it works (tested with both a native BMP and a Black Pill made into a BMP) and unifies the output with BMP-only BMDA on Linux by using the same `find_debuggers()` with different logic plugged in for probe discovery and building a probe_info_s list.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
