### PR TITLE
Fix: BMDA version command output

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -188,9 +188,8 @@ bool cmd_version(target_s *t, int argc, const char **argv)
 #if PC_HOSTED == 1
 	char ident[256];
 	gdb_ident(ident, sizeof(ident));
-	DEBUG_WARN("%s\n", ident);
-	DEBUG_WARN("Copyright (C) 2010-2023 Black Magic Debug Project\n");
-	DEBUG_WARN("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\n");
+	gdb_out("Black Magic Debug App " FIRMWARE_VERSION "\n");
+	gdb_outf("Using a %s\n", ident);
 #else
 #ifndef PLATFORM_IDENT_DYNAMIC
 	gdb_out(BOARD_IDENT);
@@ -198,9 +197,9 @@ bool cmd_version(target_s *t, int argc, const char **argv)
 	gdb_outf(BOARD_IDENT, platform_ident());
 #endif
 	gdb_outf(", Hardware Version %d\n", platform_hwversion());
-	gdb_out("Copyright (C) 2010-2023 Black Magic Debug Project\n");
-	gdb_out("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\n");
 #endif
+	gdb_out("Copyright (C) 2010-2024 Black Magic Debug Project\n");
+	gdb_out("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\n");
 
 	return true;
 }

--- a/src/command.c
+++ b/src/command.c
@@ -51,34 +51,34 @@
 #include "usb.h"
 #endif
 
-static bool cmd_version(target_s *t, int argc, const char **argv);
-static bool cmd_help(target_s *t, int argc, const char **argv);
+static bool cmd_version(target_s *target, int argc, const char **argv);
+static bool cmd_help(target_s *target, int argc, const char **argv);
 
 static bool cmd_jtag_scan(target_s *target, int argc, const char **argv);
 static bool cmd_swd_scan(target_s *target, int argc, const char **argv);
-static bool cmd_auto_scan(target_s *t, int argc, const char **argv);
-static bool cmd_frequency(target_s *t, int argc, const char **argv);
-static bool cmd_targets(target_s *t, int argc, const char **argv);
-static bool cmd_morse(target_s *t, int argc, const char **argv);
-static bool cmd_halt_timeout(target_s *t, int argc, const char **argv);
-static bool cmd_connect_reset(target_s *t, int argc, const char **argv);
-static bool cmd_reset(target_s *t, int argc, const char **argv);
-static bool cmd_tdi_low_reset(target_s *t, int argc, const char **argv);
+static bool cmd_auto_scan(target_s *target, int argc, const char **argv);
+static bool cmd_frequency(target_s *target, int argc, const char **argv);
+static bool cmd_targets(target_s *target, int argc, const char **argv);
+static bool cmd_morse(target_s *target, int argc, const char **argv);
+static bool cmd_halt_timeout(target_s *target, int argc, const char **argv);
+static bool cmd_connect_reset(target_s *target, int argc, const char **argv);
+static bool cmd_reset(target_s *target, int argc, const char **argv);
+static bool cmd_tdi_low_reset(target_s *target, int argc, const char **argv);
 #ifdef PLATFORM_HAS_POWER_SWITCH
-static bool cmd_target_power(target_s *t, int argc, const char **argv);
+static bool cmd_target_power(target_s *target, int argc, const char **argv);
 #endif
 #ifdef PLATFORM_HAS_TRACESWO
-static bool cmd_swo(target_s *t, int argc, const char **argv);
+static bool cmd_swo(target_s *target, int argc, const char **argv);
 #endif
-static bool cmd_heapinfo(target_s *t, int argc, const char **argv);
+static bool cmd_heapinfo(target_s *target, int argc, const char **argv);
 #ifdef ENABLE_RTT
-static bool cmd_rtt(target_s *t, int argc, const char **argv);
+static bool cmd_rtt(target_s *target, int argc, const char **argv);
 #endif
 #if defined(PLATFORM_HAS_DEBUG) && PC_HOSTED == 0
-static bool cmd_debug_bmp(target_s *t, int argc, const char **argv);
+static bool cmd_debug_bmp(target_s *target, int argc, const char **argv);
 #endif
 #if PC_HOSTED == 1
-static bool cmd_shutdown_bmda(target_s *t, int argc, const char **argv);
+static bool cmd_shutdown_bmda(target_s *target, int argc, const char **argv);
 #endif
 
 #ifdef _MSC_VER
@@ -138,7 +138,7 @@ bool debug_bmp;
 #endif
 unsigned cortexm_wait_timeout = 2000; /* Timeout to wait for Cortex to react on halt command. */
 
-int command_process(target_s *const t, char *const cmd_buffer)
+int command_process(target_s *const target, char *const cmd_buffer)
 {
 	/* Initial estimate for argc */
 	size_t argc = 1;
@@ -165,24 +165,24 @@ int command_process(target_s *const t, char *const cmd_buffer)
 		 * So 'mon ver' will match 'monitor version'
 		 */
 		if ((argc == 0) || !strncmp(argv[0], cmd->cmd, strlen(argv[0])))
-			return !cmd->handler(t, argc, argv);
+			return !cmd->handler(target, argc, argv);
 	}
 
 #ifdef PLATFORM_HAS_CUSTOM_COMMANDS
 	for (const command_s *cmd = platform_cmd_list; cmd->cmd; ++cmd) {
 		if (!strncmp(argv[0], cmd->cmd, strlen(argv[0])))
-			return !cmd->handler(t, argc, argv);
+			return !cmd->handler(target, argc, argv);
 	}
 #endif
 
-	if (!t)
+	if (!target)
 		return -1;
-	return target_command(t, argc, argv);
+	return target_command(target, argc, argv);
 }
 
-bool cmd_version(target_s *t, int argc, const char **argv)
+bool cmd_version(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	(void)argc;
 	(void)argv;
 #if PC_HOSTED == 1
@@ -204,12 +204,12 @@ bool cmd_version(target_s *t, int argc, const char **argv)
 	return true;
 }
 
-bool cmd_help(target_s *t, int argc, const char **argv)
+bool cmd_help(target_s *target, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
 
-	if (!t || t->tc->destroy_callback) {
+	if (!target || target->tc->destroy_callback) {
 		gdb_out("General commands:\n");
 		for (const command_s *cmd = cmd_list; cmd->cmd; cmd++)
 			gdb_outf("\t%s -- %s\n", cmd->cmd, cmd->help);
@@ -218,11 +218,11 @@ bool cmd_help(target_s *t, int argc, const char **argv)
 		for (const command_s *cmd = platform_cmd_list; cmd->cmd; ++cmd)
 			gdb_outf("\t%s -- %s\n", cmd->cmd, cmd->help);
 #endif
-		if (!t)
+		if (!target)
 			return true;
 	}
 
-	target_command_help(t);
+	target_command_help(target);
 	return true;
 }
 
@@ -308,9 +308,9 @@ bool cmd_swd_scan(target_s *target, int argc, const char **argv)
 	return true;
 }
 
-bool cmd_auto_scan(target_s *t, int argc, const char **argv)
+bool cmd_auto_scan(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	(void)argc;
 	(void)argv;
 
@@ -360,9 +360,9 @@ bool cmd_auto_scan(target_s *t, int argc, const char **argv)
 	return true;
 }
 
-bool cmd_frequency(target_s *t, int argc, const char **argv)
+bool cmd_frequency(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	if (argc == 2) {
 		char *multiplier = NULL;
 		uint32_t frequency = strtoul(argv[1], &multiplier, 10);
@@ -415,9 +415,9 @@ bool cmd_targets(target_s *target, int argc, const char **argv)
 	return true;
 }
 
-bool cmd_morse(target_s *t, int argc, const char **argv)
+bool cmd_morse(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	(void)argc;
 	(void)argv;
 	if (morse_msg) {
@@ -442,9 +442,9 @@ bool parse_enable_or_disable(const char *value, bool *out)
 	return true;
 }
 
-static bool cmd_connect_reset(target_s *t, int argc, const char **argv)
+static bool cmd_connect_reset(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	bool print_status = false;
 	if (argc == 1)
 		print_status = true;
@@ -460,18 +460,18 @@ static bool cmd_connect_reset(target_s *t, int argc, const char **argv)
 	return true;
 }
 
-static bool cmd_halt_timeout(target_s *t, int argc, const char **argv)
+static bool cmd_halt_timeout(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	if (argc > 1)
 		cortexm_wait_timeout = strtoul(argv[1], NULL, 0);
 	gdb_outf("Cortex-M timeout to wait for device halts: %u\n", cortexm_wait_timeout);
 	return true;
 }
 
-static bool cmd_reset(target_s *t, int argc, const char **argv)
+static bool cmd_reset(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	uint32_t pulse_len_ms = 0;
 	if (argc > 1)
 		pulse_len_ms = strtoul(argv[1], NULL, 0);
@@ -482,9 +482,9 @@ static bool cmd_reset(target_s *t, int argc, const char **argv)
 	return true;
 }
 
-static bool cmd_tdi_low_reset(target_s *t, int argc, const char **argv)
+static bool cmd_tdi_low_reset(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	(void)argc;
 	(void)argv;
 	jtag_proc.jtagtap_next(true, false);
@@ -493,9 +493,9 @@ static bool cmd_tdi_low_reset(target_s *t, int argc, const char **argv)
 }
 
 #ifdef PLATFORM_HAS_POWER_SWITCH
-static bool cmd_target_power(target_s *t, int argc, const char **argv)
+static bool cmd_target_power(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	if (argc == 1)
 		gdb_outf("Target Power: %s\n", platform_target_get_power() ? "enabled" : "disabled");
 	else if (argc == 2) {
@@ -523,9 +523,8 @@ static const char *on_or_off(const bool value)
 	return value ? "on" : "off";
 }
 
-static bool cmd_rtt(target_s *t, int argc, const char **argv)
+static bool cmd_rtt(target_s *target, int argc, const char **argv)
 {
-	(void)t;
 	const size_t command_len = argc > 1 ? strlen(argv[1]) : 0;
 	if (argc == 1 || (argc == 2 && strncmp(argv[1], "enabled", command_len) == 0)) {
 		rtt_enabled = true;
@@ -540,7 +539,7 @@ static bool cmd_rtt(target_s *t, int argc, const char **argv)
 			gdb_out("off");
 		else
 			gdb_outf("\"%s\"", rtt_ident);
-		gdb_outf(" halt: %s", on_or_off(target_mem_access_needs_halt(t)));
+		gdb_outf(" halt: %s", on_or_off(target_mem_access_needs_halt(target)));
 		gdb_out(" channels: ");
 		if (rtt_auto_channel)
 			gdb_out("auto ");
@@ -688,9 +687,9 @@ static bool cmd_swo_disable(void)
 	return true;
 }
 
-static bool cmd_swo(target_s *t, int argc, const char **argv)
+static bool cmd_swo(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	bool enable_swo = false;
 	if (argc >= 2 && !parse_enable_or_disable(argv[1], &enable_swo)) {
 		gdb_out("Usage: traceswo <enable|disable> [2000000] [decode [0 1 3 31]]\n");
@@ -704,9 +703,9 @@ static bool cmd_swo(target_s *t, int argc, const char **argv)
 #endif
 
 #if defined(PLATFORM_HAS_DEBUG) && PC_HOSTED == 0
-static bool cmd_debug_bmp(target_s *t, int argc, const char **argv)
+static bool cmd_debug_bmp(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	if (argc == 2 && !parse_enable_or_disable(argv[1], &debug_bmp))
 		return false;
 	if (argc > 2) {
@@ -720,9 +719,9 @@ static bool cmd_debug_bmp(target_s *t, int argc, const char **argv)
 #endif
 
 #if PC_HOSTED == 1
-static bool cmd_shutdown_bmda(target_s *t, int argc, const char **argv)
+static bool cmd_shutdown_bmda(target_s *target, int argc, const char **argv)
 {
-	(void)t;
+	(void)target;
 	(void)argc;
 	(void)argv;
 	shutdown_bmda = true;
@@ -738,9 +737,9 @@ static bool cmd_shutdown_bmda(target_s *t, int argc, const char **argv)
  * - If the target system crashes, increase heap or stack
  * See newlib/libc/sys/arm/crt0.S "Issue Angel SWI to read stack info"
  */
-static bool cmd_heapinfo(target_s *t, int argc, const char **argv)
+static bool cmd_heapinfo(target_s *target, int argc, const char **argv)
 {
-	if (t == NULL)
+	if (target == NULL)
 		gdb_out("not attached\n");
 	else if (argc == 5) {
 		target_addr_t heap_base = strtoul(argv[1], NULL, 16);
@@ -750,7 +749,7 @@ static bool cmd_heapinfo(target_s *t, int argc, const char **argv)
 		gdb_outf("heap_base: %08" PRIx32 " heap_limit: %08" PRIx32 " stack_base: %08" PRIx32 " stack_limit: "
 				 "%08" PRIx32 "\n",
 			heap_base, heap_limit, stack_base, stack_limit);
-		target_set_heapinfo(t, heap_base, heap_limit, stack_base, stack_limit);
+		target_set_heapinfo(target, heap_base, heap_limit, stack_base, stack_limit);
 	} else
 		gdb_outf("%s\n", "Set semihosting heapinfo: HEAP_BASE HEAP_LIMIT STACK_BASE STACK_LIMIT");
 	return true;

--- a/src/command.c
+++ b/src/command.c
@@ -252,6 +252,8 @@ static bool cmd_jtag_scan(target_s *target, int argc, const char **argv)
 	case EXCEPTION_ERROR:
 		gdb_outf("Exception: %s\n", exception_frame.msg);
 		break;
+	default:
+		break;
 	}
 
 	if (!scan_result) {
@@ -292,6 +294,8 @@ bool cmd_swd_scan(target_s *target, int argc, const char **argv)
 		break;
 	case EXCEPTION_ERROR:
 		gdb_outf("Exception: %s\n", exception_frame.msg);
+		break;
+	default:
 		break;
 	}
 
@@ -345,6 +349,8 @@ bool cmd_auto_scan(target_s *target, int argc, const char **argv)
 	case EXCEPTION_ERROR:
 		gdb_outf("Exception: %s\n", exception_frame.msg);
 		break;
+	default:
+		break;
 	}
 
 	if (!scan_result) {
@@ -376,6 +382,8 @@ bool cmd_frequency(target_s *target, int argc, const char **argv)
 			break;
 		case 'M':
 			frequency *= 1000U * 1000U;
+			break;
+		default:
 			break;
 		}
 		platform_max_frequency_set(frequency);

--- a/src/command.c
+++ b/src/command.c
@@ -186,10 +186,8 @@ bool cmd_version(target_s *target, int argc, const char **argv)
 	(void)argc;
 	(void)argv;
 #if PC_HOSTED == 1
-	char ident[256];
-	gdb_ident(ident, sizeof(ident));
 	gdb_out("Black Magic Debug App " FIRMWARE_VERSION "\n");
-	gdb_outf("Using a %s\n", ident);
+	bmda_display_probe();
 #else
 #ifndef PLATFORM_IDENT_DYNAMIC
 	gdb_out(BOARD_IDENT);

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -69,9 +69,9 @@ static uint32_t max_frequency = 4000000U;
 
 static bmda_cli_options_s cl_opts;
 
-void gdb_ident(char *p, int count)
+void bmda_display_probe(void)
 {
-	snprintf(p, count, "%s (%s), %s", bmda_probe_info.manufacturer, bmda_probe_info.product, bmda_probe_info.version);
+	gdb_outf("Using a %s (%s), %s\n", bmda_probe_info.product, bmda_probe_info.manufacturer, bmda_probe_info.version);
 }
 
 static void exit_function(void)

--- a/src/platforms/hosted/platform.h
+++ b/src/platforms/hosted/platform.h
@@ -87,7 +87,7 @@ typedef enum probe_type {
 	PROBE_TYPE_GPIOD,
 } probe_type_e;
 
-void gdb_ident(char *p, int count);
+void bmda_display_probe(void);
 
 #ifdef ENABLE_GPIOD
 #include "bmda_gpiod_platform.h"


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address where the output of `monitor version` in GDB was being put under BMDA and what exactly was being reported.

This brings BMDA closer to being consistent with the other platforms, reducing user surprise, and making the output of `mon ver` more helpful when users are facing issues by providing which BMDA version and probe they're using precicely.

We have taken the opportunity to update the copyright string in the process.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
