### PR TITLE
Fix: STM32L4/L5/U5/G4/WL/WB family identification

### DIFF
--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -470,7 +470,7 @@ static stm32l4_device_info_s const stm32l4_device_info[] = {
 	{
 		.device_id = ID_STM32WB35,
 		.family = STM32L4_FAMILY_WBxx,
-		.designator = "STM32WBxx",
+		.designator = "STM32WB35/55",
 		.sram1 = 192U,
 		.sram2 = 64U,
 		.flags = 2U,


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address some issues in stm32l4.c with part identification - while the logic that was present was probably alright for SWD, it absolutely does not work for JTAG due to an encoding difference between SWD-DPv2's TARGETID register and the AP ROM table PIDR's part number value. Additionally, it turns out the logic was sketchy when it comes to the second core on dual core parts.

To address these two issues, we fully overhaul the identification system for these parts and update all of the part IDs used. Tested confirmed working with a couple of different STM32WL parts and a STM32G4. Detailed cross-checking with the TRMs performed for everything.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
