### PR TITLE
Fix cross-compiling BMDA for 32-bit Windows

### DIFF
--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -35,8 +35,12 @@
 typedef SOCKET socket_t;
 #define PRI_SOCKET "zu"
 #ifndef __CYGWIN__
+#ifdef _WIN64
 typedef signed long long ssize_t;
-#endif
+#else
+typedef signed int ssize_t;
+#endif /* _WIN64 */
+#endif /* __CYGWIN__ */
 #else
 #include <sys/socket.h>
 #include <netdb.h>

--- a/src/platforms/hosted/remote/protocol_v0_jtag.c
+++ b/src/platforms/hosted/remote/protocol_v0_jtag.c
@@ -76,7 +76,7 @@ void remote_v0_jtag_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t
 	/* Loop through the data to send/receive and handle it in chunks of up to 32 bits */
 	for (size_t cycle = 0; cycle < clock_cycles; cycle += 32U) {
 		/* Calculate how many bits need to be in this chunk, capped at 32 */
-		const size_t chunk_length = MIN(clock_cycles - cycle, 32U);
+		const uint8_t chunk_length = MIN(clock_cycles - cycle, 32U);
 		/* If the result would complete the transaction, check if TMS needs to be high at the end */
 		const char packet_type =
 			cycle + chunk_length == clock_cycles && final_tms ? REMOTE_TDITDO_TMS : REMOTE_TDITDO_NOTMS;
@@ -93,7 +93,7 @@ void remote_v0_jtag_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t
 		 * This uses its own copy of the REMOTE_JTAG_TDIDO_STR to correct for how
 		 * formatting a uint32_t is platform-specific.
 		 */
-		int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "!J%c%02zx%" PRIx32 "%c", packet_type, chunk_length,
+		int length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, "!J%c%02x%" PRIx32 "%c", packet_type, chunk_length,
 			packet_data_in, REMOTE_EOM);
 		platform_buffer_write(buffer, length);
 


### PR DESCRIPTION
## Detailed description

* There are no new features, just porting.
* The existing problem is the BMDA part of the project being *almost* buildable via cross-compilation for Windows, except there are a couple minor errors, even on Windows-hosted MSYS2 MINGW32.
* This PR corrects a Makefile and gdb_if.c, trying to not affect much else.

Tested to succeed up to linking on Gentoo crossdev i686-w64-mingw32-gcc-13 (x86_64- as well) and Ubuntu 22.04 LTS i686-w64-mingw32-gcc-10 (x86_64, too), also MSYS2 MINGW32 (previously only UCRT64 worked, and probably MINGW64). I don't know how this affects MacOS or FreeBSD or anything other I'm not able to test on -- relying on CI.

I am not claiming to *provide* further support for 32-bit desktop operating systems, the world is moving on to 64-bit; but the changes required seem minor enough to not have negative impact on the rest. Point in case, armhf (armv7-a) SBCs can also run BMDA, and they are 32-bit Linux userspace environments, so I see no point in outright refusing 32-bit support. BMF *only* targets armv6-m/armv7-m/armv7e-m which are all 32-bit in nature, but it's different enough from `hosted`.

Also note, Windows XP is incompatible with `HOSTED_BMP_ONLY=1` bmp_serial.c in SetupDiGetPropertyW-related code. And I have not been successful in running any `HOSTED_BMP_ONLY=0` executable binary under it, produced by either old Cygwin 2 or modern MSYS2 runtime-3.5 (msys2-xp perhaps?)

If review finds contradictions in this patchset, I'll agree to drop some first and/or third commit as long as there's a way to still build BMDA for affected OS.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware)) *and should not affect it*
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues