### PR TITLE
ARM:Add Jtag to Dormant sequence in case the target has both jtag and swd

### DIFF
--- a/src/target/adiv5_internal.h
+++ b/src/target/adiv5_internal.h
@@ -44,6 +44,11 @@
 #define ADIV5_SWD_TO_JTAG_SELECT_SEQUENCE 0xe73cU /* 16 bits, LSB (MSB: 0x3ce7) */
 #define ADIV5_JTAG_TO_SWD_SELECT_SEQUENCE 0xe79eU /* 16 bits, LSB (MSB: 0x79e7) */
 
+/* ADIv5 JTAG to dormant sequence */
+#define ADIV5_JTAG_TO_DORMANT_SEQUENCE0 0x1fU       /* 5 bits */
+#define ADIV5_JTAG_TO_DORMANT_SEQUENCE1 0x33bbbbbaU /* 31 bits, LSB  (MSB : 0x2eeeeee6) */
+#define ADIV5_JTAG_TO_DORMANT_SEQUENCE2 0xffU       /* 8 bits  */
+
 /*
  * ADIv5 Selection Alert sequence
  * This sequence is sent MSB first and can be represented as either:

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -75,11 +75,19 @@ static void dormant_to_swd_sequence(void)
 	 * §5.3.4 Switching out of Dormant state
 	 */
 
-	DEBUG_INFO("Switching out of dormant state into SWD\n");
-
 	/* Send at least 8 SWCLKTCK cycles with SWDIOTMS HIGH */
 	swd_line_reset_sequence(false);
+
+	/* 
+	 * If the target is both JTAG and SWD with JTAG as default, switch JTAG->DS first. 
+	 * See B5.3.2
+	 */
+	DEBUG_INFO("Switching from JTAG do dormant\n");
+	swd_proc.seq_out(ADIV5_JTAG_TO_DORMANT_SEQUENCE0, 5U);
+	swd_proc.seq_out(ADIV5_JTAG_TO_DORMANT_SEQUENCE1, 31U);
+	swd_proc.seq_out(ADIV5_JTAG_TO_DORMANT_SEQUENCE2, 8U);
 	/* Send the 128-bit Selection Alert sequence on SWDIOTMS */
+	DEBUG_INFO("Switching out of dormant state into SWD\n");
 	swd_proc.seq_out(ADIV5_SELECTION_ALERT_SEQUENCE_0, 32U);
 	swd_proc.seq_out(ADIV5_SELECTION_ALERT_SEQUENCE_1, 32U);
 	swd_proc.seq_out(ADIV5_SELECTION_ALERT_SEQUENCE_2, 32U);


### PR DESCRIPTION
## Detailed description
* The current Dormant to SWD code manages correctly the case where SWD is default/the only interface
* If the chip has both SWD & Jtag and default is Jtag, it lacks the Jtag->dormant sequence and does not work
* The proposed patch adds that sequence

For what i could see, it still works with RP2040 and older Arm chips i have (STM32F1/GD32F3)
Tested on a chip with both Jtag & SWD/Default jtag + Debug Protocol v3, it works with the change, doesnt without

NB: Not completely sure the 8 trailer '1' bits are really needed, it works fine with, was there in the demo code

## Your checklist for this pull request

* [X ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ X] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ x] I've tested it to the best of my ability
* [ x] My commit messages provide a useful short description of what the commits do

## Closing issues


