### PR TITLE
Fix: macOS CI deprecation

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -341,8 +341,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - {id: macos-12, name: '12'}
           - {id: macos-13, name: '13'}
+          - {id: macos-14, name: '14'}
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -378,8 +378,9 @@ jobs:
     strategy:
       matrix:
         os:
+          - macos-13
+          - macos-14
           - macos-latest
-          - macos-12
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -433,8 +434,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
           - macos-13
+          - macos-14
         compiler:
           - gcc@11
           - gcc@12

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -441,18 +441,6 @@ jobs:
           - gcc@12
           - gcc@13
           - gcc@14 # Don't use 'gcc', the symlink is versioned -- see below
-        exclude:
-          # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114007
-          # Fix was backported to GCC 13, but there's no release available yet
-          # Changing the SDK is not viable either, because GCC hotpatches
-          # some includes at build time based on the sysroot
-          # defined when configured:
-          #    In file included from /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/Availability.h:166,
-          #    from /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdlib.h:61,
-          #    from ../src/include/general.h:62,
-          #    from ../src/command.c:28:
-          #    /opt/homebrew/Cellar/gcc@11/11.4.0/lib/gcc/11/gcc/aarch64-apple-darwin23/11/include-fixed/AvailabilityInternal.h:162:10: fatal error: AvailabilityInternalLegacy.h: No such file or directory
-          - os: macos-latest
       fail-fast: false
 
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the upcoming macOS 12 GHA deprecation and switch-off scheduled for the 3rd of December this year. This moves CI entirely to macOS 13 and 14 (latest), with 15 currently in beta.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
