### PR TITLE
meson: Disabled some of the default targets to make the code fit again.

### DIFF
--- a/cross-file/f072.ini
+++ b/cross-file/f072.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'f072'
-targets = 'cortexm,riscv32,riscv64,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
+targets = 'cortexm,riscv32,riscv64,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
 rtt_support = false
 bmd_bootloader = false

--- a/cross-file/native.ini
+++ b/cross-file/native.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'native'
-targets = 'cortexm,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
+targets = 'cortexm,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
 rtt_support = false
 bmd_bootloader = true

--- a/cross-file/stlink.ini
+++ b/cross-file/stlink.ini
@@ -19,7 +19,7 @@ endian = 'little'
 
 [project options]
 probe = 'stlink'
-targets = 'cortexm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
+targets = 'cortexm,lpc,nrf,nxp,renesas,sam,stm,ti'
 rtt_support = false
 stlink_swim_nrst_as_uart = false
 bmd_bootloader = false


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Due to space constraints we have to disable some of the targets enabled on certain host hardware. Users can mix and match what targets they need supported if they rebuild their firmware.

We will need to have a more comprehensive automatic build system for different sets of target support and allow for easier firmware swapping to make the use of BlackMagic with an ever growing set of supported targets. But for the moment the only choice we have is to disable some stuff so that the firmware targets are building again.

This PR disables the following:
* f072 host: efm, hc32 targets
* stlink host: hc32, rp targets
* native host: efm, hc32

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
