### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ src/ftd2xx.dll
 scripts/swolisten
 
 .direnv/
+
+/deps/*
+!/deps/*.wrap
+!/deps/libopencm3


### PR DESCRIPTION
## Detailed description
Update the project gitignore to properly respect the meson `deps` folder and the appropriate wrap files/libopencm3. This is basically just Dragonmux's patch from Discord, but since I was poking at other stuff anyway, I figured that I would throw together a pull request for it.

## Your checklist for this pull request

* [X] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [X] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [X] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [X] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do