### PR TITLE
Fix GH CI size-diff by switching from make to meson

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -512,11 +512,22 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: head
 
+      # Install and setup a suitable Meson + Ninja
+      - name: Setup Meson + Ninja
+        run: |
+          sudo python3 -m pip install --upgrade pip setuptools wheel
+          sudo python3 -m pip install meson ninja
+        working-directory: ${{ runner.temp }}
+
       - name: Build base
-        run: make -C base > base/build.log
+        run: |
+          meson setup base/build-native base --cross-file base/cross-file/native.ini
+          meson compile -C base/build-native bin > base/build.log
 
       - name: Build head
-        run: make -C head > head/build.log
+        run: |
+          meson setup head/build-native head --cross-file head/cross-file/native.ini
+          meson compile -C head/build-native bin > head/build.log
 
       - name: Diff
         run: head/scripts/diff_size.py base/build.log head/build.log


### PR DESCRIPTION
## Detailed description

* No new features.
* CI size-diff is failing because it relies on effectively `make PROBE_HOST=native` which has been overflowing flash for some time.
* This PR solves it by switching to building via meson, which since #1964 should fit (and is controlled more easily).

I wish there was a way to also report size-diff for 256-512 KiB probes with every driver compiled (and every applicable log statement compiled), but let's unblock the existing workflow first.
Tested on own fork by manulally triggering CI. Caveat: I asked for `meson compile -C build-native bin` the firmware bin alias, so it runs faster (omits BMDA), but still downloads hidapi/libusb/ftdi submodules for some reason. Network-isolated containers should not access internet past "install bdepends" and "fetch sources" stage (Gentoo ebuild FEATURE=network-sandbox).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues