### PR TITLE
hosted: #include "general.h" before system headers

### DIFF
--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -18,6 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "general.h"
+#include "remote.h"
+#include "bmp_hosted.h"
+#include "utils.h"
+#include "cortexm.h"
+
 #include <sys/stat.h>
 #include <sys/select.h>
 #include <dirent.h>
@@ -31,12 +37,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
-
-#include "general.h"
-#include "remote.h"
-#include "bmp_hosted.h"
-#include "utils.h"
-#include "cortexm.h"
 
 #define READ_BUFFER_LENGTH 4096U
 


### PR DESCRIPTION
## Detailed description

This is required to set `__USE_XOPEN2K` which is required to have access to `getaddrinfo`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do