### PR TITLE
Fix `hosted/cli.c`, minor implicit fallthrough

### DIFF
--- a/src/platforms/hosted/cli.c
+++ b/src/platforms/hosted/cli.c
@@ -421,6 +421,7 @@ void cl_init(bmda_cli_options_s *opt, int argc, char **argv)
 		case 'g':
 			if (optarg)
 				opt->opt_gpio_map = optarg;
+			break;
 #endif
 		case 'k':
 			opt->opt_cmsisdap_allow_fallback = true;


### PR DESCRIPTION
## Detailed description

* Not a feature
* Since #1871 when libgpiod-dev is installed on build host, a warning is emitted.
* This PR solves it by terminating both cases with a `break`.

CMSIS-DAP and GPIOD backends are runtime mutually exclusive, so it was not critical, but also nobody picked it up, so I'll clean it up myself.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware)) and should not affect it
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues