### PR TITLE
remote: provide correct 3-byte buffer to `hexify()`

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -48,7 +48,7 @@ static void remote_packet_process_adiv6(const char *packet, size_t packet_len);
 /* hex-ify and send a buffer of data */
 static void remote_send_buf(const void *const buffer, const size_t len)
 {
-	char hex[2] = {0};
+	char hex[3] = {0};
 	const uint8_t *const data = (const uint8_t *)buffer;
 	for (size_t offset = 0; offset < len; ++offset) {
 		hexify(hex, data + offset, 1U);


### PR DESCRIPTION
## Detailed description

When sending data to the remote client, data is hex-encoded. However, an additional byte needs to be allocated in the buffer so as to allow space for the NULL byte.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do