### PR TITLE
miscellaneus RTT fixes

### DIFF
--- a/src/include/rtt.h
+++ b/src/include/rtt.h
@@ -39,6 +39,7 @@ extern uint32_t rtt_num_up_chan;               // number of 'up' channels
 extern uint32_t rtt_num_down_chan;             // number of 'down' channels
 extern uint32_t rtt_min_poll_ms;               // min time between polls (ms)
 extern uint32_t rtt_max_poll_ms;               // max time between polls (ms)
+extern uint32_t rtt_poll_ms;                   // current amount of time between polls (ms)
 extern uint32_t rtt_max_poll_errs;             // max number of errors before disconnect
 extern bool rtt_flag_ram;                      // limit ram scanned by rtt to range rtt_ram_start .. rtt_ram_end
 extern uint32_t rtt_ram_start;                 // if rtt_flag_ram set, lower limit of ram scanned by rtt

--- a/src/rtt.c
+++ b/src/rtt.c
@@ -204,9 +204,9 @@ static void find_rtt(target_s *const cur_target)
 		else
 			rtt_cbaddr = memory_search(cur_target, rtt_ram_start, rtt_ram_end);
 	}
-	DEBUG_INFO("rtt: match at 0x%" PRIx32 "\r\n", rtt_cbaddr);
 
 	if (rtt_cbaddr) {
+		DEBUG_INFO("rtt: match at 0x%" PRIx32 "\n", rtt_cbaddr);
 		/* read number of rtt up and down channels from target */
 		uint32_t num_buf[2];
 		if (target_mem32_read(cur_target, num_buf, rtt_cbaddr + 16U, sizeof(num_buf)))

--- a/src/rtt.c
+++ b/src/rtt.c
@@ -220,12 +220,12 @@ static void find_rtt(target_s *const cur_target)
 
 		/* sanity checks */
 		if (rtt_num_up_chan > 255U || rtt_num_down_chan > 255U) {
-			gdb_out("rtt: bad cblock\r\n");
+			gdb_out("rtt: bad cblock\n");
 			rtt_enabled = false;
 			return;
 		}
 		if (rtt_num_up_chan == 0 && rtt_num_down_chan == 0) {
-			gdb_out("rtt: empty cblock\r\n");
+			gdb_out("rtt: empty cblock\n");
 			rtt_enabled = false;
 			return;
 		}

--- a/src/rtt.c
+++ b/src/rtt.c
@@ -45,7 +45,7 @@ rtt_channel_s rtt_channel[MAX_RTT_CHAN];
 uint32_t rtt_min_poll_ms = 8;   /* 8 ms */
 uint32_t rtt_max_poll_ms = 256; /* 0.256 s */
 uint32_t rtt_max_poll_errs = 10;
-static uint32_t poll_ms;
+uint32_t rtt_poll_ms;
 static uint32_t poll_errs;
 static uint32_t last_poll_ms;
 /* flags for data from host to target */
@@ -177,7 +177,7 @@ static uint32_t memory_search(target_s *const cur_target, const uint32_t ram_sta
 static void find_rtt(target_s *const cur_target)
 {
 	rtt_found = false;
-	poll_ms = rtt_max_poll_ms;
+	rtt_poll_ms = rtt_max_poll_ms;
 	poll_errs = 0;
 	last_poll_ms = 0;
 
@@ -388,7 +388,7 @@ void poll_rtt(target_s *const cur_target)
 	/* target present and rtt enabled */
 	uint32_t now = platform_time_ms();
 
-	if (last_poll_ms + poll_ms <= now || now < last_poll_ms) {
+	if (last_poll_ms + rtt_poll_ms <= now || now < last_poll_ms) {
 		if (!rtt_found)
 			/* check if target needs to be halted during memory access */
 			rtt_halt = target_mem_access_needs_halt(cur_target);
@@ -457,14 +457,14 @@ void poll_rtt(target_s *const cur_target)
 
 		/* rtt polling frequency goes up and down with rtt activity */
 		if (rtt_busy && !rtt_err)
-			poll_ms /= 2U;
+			rtt_poll_ms /= 2U;
 		else
-			poll_ms *= 2U;
+			rtt_poll_ms *= 2U;
 
-		if (poll_ms > rtt_max_poll_ms)
-			poll_ms = rtt_max_poll_ms;
-		else if (poll_ms < rtt_min_poll_ms)
-			poll_ms = rtt_min_poll_ms;
+		if (rtt_poll_ms > rtt_max_poll_ms)
+			rtt_poll_ms = rtt_max_poll_ms;
+		else if (rtt_poll_ms < rtt_min_poll_ms)
+			rtt_poll_ms = rtt_min_poll_ms;
 
 		if (rtt_err) {
 			gdb_out("rtt: err\r\n");


### PR DESCRIPTION
## Detailed description

This fixes an issue wherein RTT will report the following every 200 ms until it finds an RTT block:

```
rtt: match at 0x0
```

As part of this patch, remove a trailing `\r` that appears in several debug strings.

Finally, make `poll_ms` available globally as `rtt_poll_ms`. This will enable other projects to know when to poll RTT next.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do