### PR TITLE
Fix: `tdi_low_reset` crash

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -499,6 +499,8 @@ static bool cmd_tdi_low_reset(target_s *target, int argc, const char **argv)
 	(void)target;
 	(void)argc;
 	(void)argv;
+	if (!jtag_proc.jtagtap_next)
+		return false;
 	jtag_proc.jtagtap_next(true, false);
 	cmd_reset(NULL, 0, NULL);
 	return true;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address a crash that was reported by triggered_tux on Discord and via the issue tracker.

In this crash, if the user has not yet done a JTAG scan on their probe or run any JTAG remote protocol commands since boot prior to issuing `mon tdi_low_reset`, then the probe (or BMDA if done in BMDA) will crash due to trying to call a NULL pointer in the `jtag_proc` structure. To rectify this, we guard this call and make the command fail if the JTAG structure has not been initialised yet.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1979
