### PR TITLE
fix/ctxlink/platform

### DIFF
--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -333,6 +333,7 @@ bool platform_nrst_get_val(void)
 const char *platform_target_voltage(void)
 {
 	static char target[64] = {0};
+	memset(target, 0, sizeof(target));
 	uint32_t val = platform_target_voltage_sense();
 	target[0] = '0' + val / 1000U;
 	target[1] = '.';


### PR DESCRIPTION
This PR addresses a crash when reporting the battery voltage in the response to the "mon swd" command. The buffer being used was not initailized before each use and multiple reports were being concatinated.

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
