### PR TITLE
Fix: Read CPUID when the core is powered

### DIFF
--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -746,6 +746,9 @@ static bool cortexar_ensure_core_powered(target_s *const target)
 	if (status & CORTEXAR_DBG_PRSR_DOUBLE_LOCK)
 		return false;
 
+	/* Read CPUID now that the core is powered and there is no OS double lock */
+	cortex_read_cpuid(target);
+
 	/*
 	 * Finally, check for the normal OS Lock and clear it if it's set prior to halting the core.
 	 * Trying to do this after target_halt_request() does not function over JTAG and triggers
@@ -805,7 +808,6 @@ static target_s *cortexar_probe(
 	if (reason == TARGET_HALT_FAULT || reason == TARGET_HALT_ERROR)
 		return false;
 
-	cortex_read_cpuid(target);
 	/* The format of the debug identification register is described in DDI0406C §C11.11.15 pg2217 */
 	const uint32_t debug_id = cortex_dbg_read32(target, CORTEXAR_DBG_IDR);
 	/* Reserve the last available breakpoint for our use to implement single-stepping */

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -795,7 +795,8 @@ static target_s *cortexar_probe(
 	target->halt_resume = cortexar_halt_resume;
 
 	/* Ensure the core is powered up and we can talk to it */
-	cortexar_ensure_core_powered(target);
+	if (cortexar_ensure_core_powered(target))
+		return false;
 
 	/* Try to halt the target core */
 	target_halt_request(target);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As per A-profile TRM, MIDR_EL1 access when not powered or in double lock is implementation defined.

Instead of reading the value after the halt request, let's do it right after the core is powered up and not in double lock.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
