### PR TITLE
Feature: Add support for APB2/APB3 configuration

### DIFF
--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -386,6 +386,9 @@ bool adi_configure_ap(adiv5_access_port_s *const ap)
 		ap->csw |= ADIV5_AP_CSW_DBGSWENABLE;
 
 		switch (ap_type) {
+		case ADIV5_AP_IDR_TYPE_APB2_3:
+			/* We have no prot modes on APB2 and APB3 */
+			break;
 		case ADIV5_AP_IDR_TYPE_AXI3_4:
 			/* XXX: Handle AXI4 w/ ACE-Lite which makes Mode and Type do ~things~™ (§E1.3.1, pg237) */
 			/* Clear any existing prot modes and disable memory tagging */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Add missing APB2 and APB3 case in `adi_configure_ap`.

This was tested against a [Solitude AML-S905D3-CC](https://libre.computer/products/aml-s905d3-cc/).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
