### PR TITLE
Fix: Old firmware BMP identification via libusb

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -142,6 +142,12 @@ void bmp_read_product_version(libusb_device_descriptor_s *device_descriptor, lib
 	(void)manufacturer;
 	*product = get_device_descriptor_string(handle, device_descriptor->iProduct);
 
+	/* Check if the product name does not contain a version string */
+	if (strcmp(*product, "Black Magic Probe") == 0) {
+		*version = strdup("Unknown");
+		return;
+	}
+
 	char *start_of_version = strrchr(*product, ' ');
 	if (start_of_version == NULL) {
 		*version = NULL;

--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -80,6 +80,23 @@ static const debugger_device_s debugger_devices[] = {
 	{0, 0, PROBE_TYPE_NONE, NULL, ""},
 };
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+static char *strndup(const char *const src, const size_t size)
+{
+	/* Determine how many bytes to copy to the new string, including the NULL terminator */
+	const size_t length = MIN(size, strlen(src)) + 1U;
+	/* Try to allocate storage for the new string */
+	char *result = malloc(length);
+	if (!result)
+		return NULL;
+	/* Now we have storage, copy the bytes over */
+	memcpy(result, src, length - 1U);
+	/* And finally terminate the string to return */
+	result[length - 1U] = '\0';
+	return result;
+}
+#endif
+
 const debugger_device_s *get_debugger_device_from_vid_pid(const uint16_t probe_vid, const uint16_t probe_pid)
 {
 	/* Iterate over the list excluding the last entry (PROBE_TYPE_NONE) */

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -30,7 +30,8 @@
  * * EFR32BG13P532F512GM32 (EFR Blue Gecko)
  */
 
-/* Refer to the family reference manuals:
+/*
+ * Refer to the family reference manuals:
  *
  * Also refer to AN0062 "Programming Internal Flash Over the Serial Wire Debug Interface"
  * http://www.silabs.com/Support%20Documents/TechnicalDocs/an0062.pdf
@@ -98,7 +99,7 @@ const command_s efm32_cmd_list[] = {
 /* Flash Information Area                                                      */
 /* -------------------------------------------------------------------------- */
 
-#define EFM32_INFO      0x0fe00000U
+#define EFM32_INFO      UINT32_C(0x0fe00000)
 #define EFM32_USER_DATA (EFM32_INFO + 0x0000U)
 #define EFM32_LOCK_BITS (EFM32_INFO + 0x4000U)
 #define EFM32_V1_DI     (EFM32_INFO + 0x8000U)
@@ -766,11 +767,11 @@ static bool efm32_cmd_efm_info(target_s *t, int argc, const char **argv)
 
 	switch (di_version) {
 	case 1:
-		tc_printf(t, "DI version 1 (silabs remix?) base 0x%08" PRIx16 "\n\n", EFM32_V1_DI);
+		tc_printf(t, "DI version 1 (silabs remix?) base 0x%08" PRIx32 "\n\n", EFM32_V1_DI);
 		break;
 
 	case 2:
-		tc_printf(t, "DI version 2 (energy micro remix?) base 0x%08" PRIx16 "\n\n", EFM32_V2_DI);
+		tc_printf(t, "DI version 2 (energy micro remix?) base 0x%08" PRIx32 "\n\n", EFM32_V2_DI);
 		break;
 
 	default:

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -765,16 +765,16 @@ static bool stm32lx_cmd_option(target_s *const target, const int argc, const cha
 	const size_t read_protection = stm32lx_prot_level(options);
 	if (stm32lx_is_stm32l1(target)) {
 		tc_printf(target,
-			"OPTR: 0x%08" PRIx32 ", RDPRT %" PRIu32 ", SPRMD %u, BOR %" PRIu32 " , WDG_SW %u"
+			"OPTR: 0x%08" PRIx32 ", RDPRT %" PRIu32 ", SPRMD %u, BOR %" PRIu32 ", WDG_SW %u"
 			", nRST_STP %u, nRST_STBY %u, nBFB2 %u\n",
-			options, (uint32_t)read_protection, (options & STM32L1_FLASH_OPTR_SPRMOD) ? 1 : 0,
+			options, (uint32_t)read_protection, (options & STM32L1_FLASH_OPTR_SPRMOD) ? 1U : 0U,
 			(options >> STM32L1_FLASH_OPTR_BOR_LEV_SHIFT) & STM32L1_FLASH_OPTR_BOR_LEV_MASK,
-			(options & STM32Lx_FLASH_OPTR_WDG_SW) ? 1 : 0, (options & STM32L1_FLASH_OPTR_nRST_STOP) ? 1 : 0,
-			(options & STM32L1_FLASH_OPTR_nRST_STDBY) ? 1 : 0, (options & STM32L1_FLASH_OPTR_nBFB2) ? 1 : 0);
+			(options & STM32Lx_FLASH_OPTR_WDG_SW) ? 1U : 0U, (options & STM32L1_FLASH_OPTR_nRST_STOP) ? 1U : 0U,
+			(options & STM32L1_FLASH_OPTR_nRST_STDBY) ? 1U : 0U, (options & STM32L1_FLASH_OPTR_nBFB2) ? 1U : 0U);
 	} else {
-		tc_printf(target, "OPTR: 0x%08" PRIx32 ", RDPROT %" PRIu32 ", WPRMOD %" PRIu16 ", WDG_SW %u, BOOT1 %u\n",
-			options, (uint32_t)read_protection, (options & STM32L0_FLASH_OPTR_WPRMOD) ? 1 : 0,
-			(options & STM32Lx_FLASH_OPTR_WDG_SW) ? 1 : 0, (options & STM32L0_FLASH_OPTR_BOOT1) ? 1 : 0);
+		tc_printf(target, "OPTR: 0x%08" PRIx32 ", RDPROT %" PRIu32 ", WPRMOD %u, WDG_SW %u, BOOT1 %u\n", options,
+			(uint32_t)read_protection, (options & STM32L0_FLASH_OPTR_WPRMOD) ? 1U : 0U,
+			(options & STM32Lx_FLASH_OPTR_WDG_SW) ? 1U : 0U, (options & STM32L0_FLASH_OPTR_BOOT1) ? 1U : 0U);
 	}
 
 	goto done;

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -744,8 +744,8 @@ static bool stm32l4_attach(target_s *const target)
 	if (!cortexm_attach(target) || !stm32l4_configure_dbgmcu(target, NULL))
 		return false;
 
-	/* Retrieve device information, and locate the device ID register */
-	const stm32l4_device_info_s *device = stm32l4_get_device_info(target->part_id);
+	/* Extract the device structure from the priv storage and enable the Flash if on an L55 part */
+	const stm32l4_device_info_s *const device = ((stm32l4_priv_s *)target->priv)->device;
 	if (device->family == STM32L4_FAMILY_L55x)
 		stm32l5_flash_enable(target);
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address an issue uncovered while poking at a BMP running pre-v1.7 firmware where the version string is not embedded in the product string. With probes in this configuration, BMDA will correctly find them but then display "Probe" as the version string and "Black Magic" as the product string due to getting handling of the versionless string wrong.

We address this by porting the Windows BMP-only probe discovery product string parsing to the libusb probe discovery logic, which also allows us to properly address probes that use alternative platforms such as Blue Pills and Black Pills and which may not have a version string if their firmware is too old, thus solving the problem.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
