### PR TITLE
stlink: add config for the ISOL variant

### DIFF
--- a/cross-file/stlink.ini
+++ b/cross-file/stlink.ini
@@ -23,3 +23,4 @@ targets = 'cortexm,lpc,nrf,nxp,renesas,sam,stm,ti'
 rtt_support = false
 stlink_swim_nrst_as_uart = false
 bmd_bootloader = false
+stlink_v2_isol = false

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -87,6 +87,12 @@ option(
 	description: 'Use the BMD bootloader (not always applicable)'
 )
 option(
+	'stlink_v2_isol',
+	type: 'boolean',
+	value: false,
+	description: 'Build for the ISOL variant of ST-Link v2'
+)
+option(
 	'stlink_swim_nrst_as_uart',
 	type: 'boolean',
 	value: false,

--- a/src/platforms/stlink/meson.build
+++ b/src/platforms/stlink/meson.build
@@ -40,6 +40,8 @@ probe_stlink_dfu_sources = files(
 	'usbdfu.c',
 )
 
+stlink_v2_isol = get_option('stlink_v2_isol')
+
 bmd_bootloader = get_option('bmd_bootloader')
 
 probe_stlink_dfu_serial_length = bmd_bootloader ? '9' : '25'
@@ -48,6 +50,9 @@ probe_stlink_load_address = bmd_bootloader ? '0x8002000' : '0x8004000'
 probe_stlink_args = [
 	f'-DDFU_SERIAL_LENGTH=@probe_stlink_dfu_serial_length@',
 ]
+if stlink_v2_isol
+	probe_stlink_args += ['-DSTLINK_V2_ISOL']
+endif
 if not bmd_bootloader
 	probe_stlink_args += ['-DST_BOOTLOADER']
 endif


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
Just an addition to https://github.com/blackmagic-debug/blackmagic/pull/1720 since the Makefile buld system was removed, this adds support for the host while building with meson
<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
