### PR TITLE
fix/ctxlink/readme: Update ctxlink readme to reflect the recent build system changes

### DIFF
--- a/src/platforms/ctxlink/README.md
+++ b/src/platforms/ctxlink/README.md
@@ -16,15 +16,6 @@ Allows the use of ctxLink board as a Black Magic Probe.
 * PC7: TDO/TRACESWO
 * PA2: nRST
 
-## How to Flash with DFU
-
-After build:
-
-1) `apt install dfu-util`
-2) Force ctxLink into system bootloader mode by holding down the Mode switch while
-   pressing reset. Release reset followed by Mode. System bootloader should appear.
-3) `dfu-util -a 0 --dfuse-address 0x08000000:leave -D blackmagic_ctxlink_firmware.bin`
-
 ## 10 pin male from pins
 
 ctxLink uses the common 2 x 5 0.05" pin-header.
@@ -39,8 +30,42 @@ ctxLink uses the common 2 x 5 0.05" pin-header.
 | SWDIO/TMS |  SWCLK/TCK  | TRACESWO/TDO |     TDI    |   RESET   |
 +-----------+-------------+--------------+------------+-----------+
 
+
+## Compiling the ctxLink firmware
+
+1. Clone the Blackmagic Debug Repository
+
+```sh
+git clone https://github.com/blackmagic-debug/blackmagic.git
+cd blackmagic
+```
+
+2. Create the build configuration for the ctxLink firmware
+
+```sh
+meson setup build --cross-file=cross-file/ctxlink.ini
+```
+
+3. Compile the ctxLink firmware
+   note: ctxLink uses the ST System Bootloader and does not have a bootloader itself.
+
+```sh
+ninja -C build
+```
+
+## How to Flash with DFU
+
+After build:
+
+4) Install dfu-util
+5) Force ctxLink into system bootloader mode by holding down the Mode switch while
+   pressing reset. Release reset followed by Mode. System bootloader should appear.
+6) Flash the firmware
+
+```sh
+dfu-util -a 0 --dfuse-address 0x08000000:leave -D blackmagic_ctxlink_firmware.bin
+```
+
 ## SWD/JTAG frequency setting
 
 https://github.com/blackmagic-debug/blackmagic/pull/783#issue-529197718
-
-`mon freq 900k` helps at most


### PR DESCRIPTION
This PR updates the ctxLink README to reflect the current Blackmagic Debug build system.

Also, some changes were made to clarify the instructions and some steps were reordered.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None