### PR TITLE
Revert "cortexar: Read CPUID when the core is powered"

### DIFF
--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -746,9 +746,6 @@ static bool cortexar_ensure_core_powered(target_s *const target)
 	if (status & CORTEXAR_DBG_PRSR_DOUBLE_LOCK)
 		return false;
 
-	/* Read CPUID now that the core is powered and there is no OS double lock */
-	cortex_read_cpuid(target);
-
 	/*
 	 * Finally, check for the normal OS Lock and clear it if it's set prior to halting the core.
 	 * Trying to do this after target_halt_request() does not function over JTAG and triggers
@@ -809,6 +806,7 @@ static target_s *cortexar_probe(
 	if (reason == TARGET_HALT_FAULT || reason == TARGET_HALT_ERROR)
 		return false;
 
+	cortex_read_cpuid(target);
 	/* The format of the debug identification register is described in DDI0406C §C11.11.15 pg2217 */
 	const uint32_t debug_id = cortex_dbg_read32(target, CORTEXAR_DBG_IDR);
 	/* Reserve the last available breakpoint for our use to implement single-stepping */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This reverts commit 9b68194a8dadeb790c03a181c85a84eecb8e73e7.

As reported on Discord, this seems to cause issues on some boards.

The ARMv7-A spec specify that: "If external debug over powerdown is supported, these registers can be implemented in either or both power domains."

This means that the CPUID handling on ARMv7-A is the opposite of what ARMv8-A requires.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->

/cc @dragonmux 