### PR TITLE
stm32f1: use PRIx32 macro for debug log

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -678,9 +678,9 @@ bool at32f40x_probe(target_s *target)
 
 	const bool read_protected = target_mem32_read32(target, FLASH_OBR) & FLASH_OBR_RDPRT;
 	if (read_protected)
-		DEBUG_TARGET("%s: Read protection enabled, UID reads as 0x%02x\n", __func__, project_id);
+		DEBUG_TARGET("%s: Read protection enabled, UID reads as 0x%02" PRIx32 "\n", __func__, project_id);
 
-	DEBUG_TARGET("%s: idcode = %08" PRIx32 ", project_id = %02x\n", __func__, idcode, project_id);
+	DEBUG_TARGET("%s: idcode = %08" PRIx32 ", project_id = %02" PRIx32 "\n", __func__, idcode, project_id);
 
 	/* 0x08: F407 (has EMAC), 0x07: F403A (only CAN+USB). 0x02 is the older F403 (200MHz). */
 	if (series == AT32F40_SERIES) {


### PR DESCRIPTION
## Detailed description

When printing a uin32_t, macros from `inttypes.h` should be used.

This fixes the build on Xtensa targets.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do