### PR TITLE
Fix: AT32F43x cleanup

### DIFF
--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -35,11 +35,14 @@
 #include "target.h"
 #include "target_internal.h"
 #include "cortexm.h"
+#include "stm32_common.h"
 
 static bool at32f43_cmd_option(target_s *target, int argc, const char **argv);
+static bool at32f43_cmd_uid(target_s *target, int argc, const char **argv);
 
 const command_s at32f43_cmd_list[] = {
 	{"option", at32f43_cmd_option, "Manipulate option bytes"},
+	{"uid", at32f43_cmd_uid, "Print unique device ID"},
 	{NULL, NULL, NULL},
 };
 
@@ -126,8 +129,10 @@ static bool at32f43_mass_erase(target_s *target);
 #define AT32F423_SERIES_256KB      0x700a3000U
 #define AT32F423_SERIES_128KB      0x700a2000U
 #define AT32F423_SERIES_64KB       0x70032000U
-#define AT32F4x_PROJECT_ID         0x1ffff7f3U
-#define AT32F4x_FLASHSIZE          0x1ffff7e0U
+
+#define AT32F4x_UID_BASE   0x1ffff7e8U
+#define AT32F4x_PROJECT_ID 0x1ffff7f3U
+#define AT32F4x_FLASHSIZE  0x1ffff7e0U
 
 typedef struct at32f43_flash {
 	target_flash_s target_flash;
@@ -707,4 +712,11 @@ static bool at32f43_cmd_option(target_s *target, int argc, const char **argv)
 	}
 
 	return true;
+}
+
+static bool at32f43_cmd_uid(target_s *target, int argc, const char **argv)
+{
+	(void)argc;
+	(void)argv;
+	return stm32_uid(target, AT32F4x_UID_BASE);
 }

--- a/src/target/meson.build
+++ b/src/target/meson.build
@@ -319,7 +319,7 @@ target_at32f4 = declare_dependency(
 	sources: files(
 		'at32f43x.c',
 	),
-	dependencies: target_cortexm,
+	dependencies: [target_cortexm, target_stm_common]
 )
 
 target_ti = declare_dependency(


### PR DESCRIPTION
## Detailed description

* The `bank_split` field of `struct at32f43_flash` can be eliminated from `_probe`/`_add_flash` if I can use a different method of accessing second bank in `_mass_erase`, checking that `target->flash->next` list has a non-NULL entry. No other functions need it because BMD API guarantees no operations span multiple banks. *This change was rebased past AT32F405 merge.*
* Also, hook the STM32-generic UID printing command to this driver and introduce a meson dependency between these TUs. Move the macros for "engineering bytes"/UID into its own group.

Verified on AT-START-F437 to not break flashloading, a firmware spanning two banks was used.
This should bring a minor reduction to target_flash priv size, and it's a preparation to refactoring this driver to carry USD_BASE and FPEC_BASE in that priv such that targets in stm32f1.c can be migrated here.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues