### PR TITLE
Fix: mspm0: Remove a couple asserts

### DIFF
--- a/src/target/mspm0.c
+++ b/src/target/mspm0.c
@@ -23,7 +23,6 @@
 #include "buffer_utils.h"
 #include "jep106.h"
 #include "cortex.h"
-#include <assert.h>
 
 #define MSPM0_CONFIG_FLASH_DUMP_SUPPORT (CONFIG_BMDA == 1 || ENABLE_DEBUG == 1)
 
@@ -292,8 +291,9 @@ static void mspm0_flash_unprotect_sector(target_flash_s *const target_flash, con
 
 static bool mspm0_flash_erase(target_flash_s *const target_flash, const target_addr_t addr, const size_t length)
 {
+#ifdef DEBUG_TARGET_IS_NOOP
 	(void)length;
-	assert(length == target_flash->blocksize);
+#endif
 
 	target_s *const target = target_flash->t;
 
@@ -318,8 +318,9 @@ static bool mspm0_flash_erase(target_flash_s *const target_flash, const target_a
 static bool mspm0_flash_write(
 	target_flash_s *const target_flash, target_addr_t dest, const void *const src, const size_t length)
 {
+#ifdef DEBUG_TARGET_IS_NOOP
 	(void)length;
-	assert(length == target_flash->writesize);
+#endif
 
 	target_s *const target = target_flash->t;
 


### PR DESCRIPTION
* Both assert conditions are true due to all respective calls in target_flash.c being `flash->write(..., flash->writesize)` (that's 8 bytes) or `flash->erase(..., flash->blocksize)` (that's 1024 byte blocks)
* This also should restore CI to passing status (for swlink/bluepill which overflow first)
* Not touching any other refactoring opportunities in here for now (like mixed usage of DEBUG_INFO/TARGET and string deduplication for `calloc failed for`... or new mass_erase).

See #1900 for additional explanations.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues