### PR TITLE
Fix: MSPM0 cleanup

### DIFF
--- a/src/target/mspm0.c
+++ b/src/target/mspm0.c
@@ -96,8 +96,8 @@ static bool mspm0_flash_write(target_flash_s *flash, target_addr_t dest, const v
 static bool mspm0_mass_erase(target_s *target, platform_timeout_s *print_progess);
 
 #if MSPM0_CONFIG_FLASH_DUMP_SUPPORT
-static bool mspm0_dump_factory_config(target_s *const target, const int argc, const char **const argv);
-static bool mspm0_dump_bcr_config(target_s *const target, const int argc, const char **const argv);
+static bool mspm0_dump_factory_config(target_s *target, int argc, const char **argv);
+static bool mspm0_dump_bcr_config(target_s *target, int argc, const char **argv);
 
 static command_s mspm0_cmds_list[] = {
 	{"dump_factory", mspm0_dump_factory_config, "Display FACTORY registers"},


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR does some post-initial-PR cleanup for clang-tidy lints and small pattern issues that do not change functionality of the implementation but do improve code size and consistency a little. Nothing too huge - the implementation could still do with having the mass erase function refactored into a bank erase function and registered as `flash->mass_erase` rather than `target->mass_erase`, but without a part to test that against we're unwilling to go changing that for the moment.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
