### PR TITLE
Fix: Shrink SRAM sizes of STM32F0

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -965,35 +965,35 @@ bool stm32f1_probe(target_s *target)
 
 	case 0x444U: /* STM32F03 RM0091 Rev. 7, STM32F030x[4|6] RM0360 Rev. 4 */
 		target->driver = "STM32F03";
-		ram_size = 0x5000;
+		ram_size = 0x1000;
 		flash_size = 0x8000;
 		block_size = 0x400;
 		break;
 
 	case 0x445U: /* STM32F04 RM0091 Rev. 7, STM32F070x6 RM0360 Rev. 4 */
 		target->driver = "STM32F04/F070x6";
-		ram_size = 0x5000;
+		ram_size = 0x1800;
 		flash_size = 0x8000;
 		block_size = 0x400;
 		break;
 
 	case 0x440U: /* STM32F05 RM0091 Rev. 7, STM32F030x8 RM0360 Rev. 4 */
 		target->driver = "STM32F05/F030x8";
-		ram_size = 0x5000;
+		ram_size = 0x2000;
 		flash_size = 0x10000;
 		block_size = 0x400;
 		break;
 
 	case 0x448U: /* STM32F07 RM0091 Rev. 7, STM32F070xb RM0360 Rev. 4 */
 		target->driver = "STM32F07";
-		ram_size = 0x5000;
+		ram_size = 0x4000;
 		flash_size = 0x20000;
 		block_size = 0x800;
 		break;
 
 	case 0x442U: /* STM32F09 RM0091 Rev. 7, STM32F030xc RM0360 Rev. 4 */
 		target->driver = "STM32F09/F030xc";
-		ram_size = 0x5000;
+		ram_size = 0x8000;
 		flash_size = 0x40000;
 		block_size = 0x800;
 		break;


### PR DESCRIPTION
## Detailed description

* Not a feature.
* The existing problem is incorrect SRAM size declared in stm32f1.c for STM32F0 families, 20 KiB, which matches neither of them (but might have been copied from STM32F103). This interacts badly with RTT auto search.
* This PR adjusts ram_size values to whatever documented in reference manuals, just like flash size.

Tested on 32F072B-Disco to no longer trigger lots of `SWD access resulted in fault, retrying` every time mainloop calls `poll_rtt()` and that crosses 0x20004000 boundary of a 16 KiB SRAM F072RB device to "search" for control blocks up to 0x20005000.
I think also the DUT BMF (which I ported there as a f072-if derivative) got stuck when this bug was triggering, judging by the morse blinky stopping.
My problem is specifically advertising 20 KiB on a 16 KiB device; for 32 KiB devices it's probably less of an issue (like stack not readable). I know there is `mon rtt ram 0x20000000 0x20004000` as a workaround, and it indeed works, but BMD is supposed to be automatic, with no configuration.

However, on per grid pics from ST website there are more variations on SRAM/Flash than 2 TRMs contain, and I did not feel like downloading all 12 datasheets to try to match the 5 part IDs to them, but note that there is `F_SIZE` at 0x1FFF_F7CC for a 16-bit flash size in kibibytes that someone could try to read as a better alternative to static flash capacity associations.

Size increase on `native` is +40 bytes because the constants are no longer identical: 4,6,8,16,32 not 20.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues