### PR TITLE
ctxlink/wifi: fix the speed issues with the Wi-Fi interface

### DIFF
--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -57,6 +57,7 @@ void trace_send_data(void);
 #define TIMEOUT_TICK_COUNT 1000
 
 #define INPUT_BUFFER_SIZE 2048
+
 static uint8_t input_buffer[INPUT_BUFFER_SIZE] = {0}; ///< The input buffer[ input buffer size]
 static volatile uint32_t input_index = 0;             ///< Zero-based index of the input
 static volatile uint32_t output_index = 0;            ///< Zero-based index of the output
@@ -274,6 +275,7 @@ void tim2_isr(void)
 		else
 			timeout_tick_counter = TIMEOUT_TICK_COUNT;
 	}
+	platform_read_adc();
 }
 
 void timer_init(void)

--- a/src/platforms/ctxlink/platform.h
+++ b/src/platforms/ctxlink/platform.h
@@ -293,5 +293,6 @@ void platform_tasks(void);
 const char *platform_battery_voltage(void);
 bool platform_check_battery_voltage(void);
 bool platform_configure_uart(char *configuration_string);
+void platform_read_adc(void);
 
 #endif /* PLATFORMS_CTXLINK_PLATFORM_H */


### PR DESCRIPTION
The reading of the ADC to acquire the target and battery
voltages was being done in a blocking manner and at
a place in the code that blocked the timely servicing
of the Wi-Fi channel.

In this updated code the ADC is read in the Timer service of the Wi-Fi Server.
There are two channels and each channel conversion is started on one timer service and read on the next timer service. Giving four phases of operation.

Also, the ADC reading code is only run every 100ms.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None.
<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
