### PR TITLE
Cortex-M: Temptative fix for watchpoints so they work on ARMv8-M cores (eg Cortex-M33)

### DIFF
--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -164,6 +164,13 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_DWT_FUNC_FUNC_READ      (5U << 0U)
 #define CORTEXM_DWT_FUNC_FUNC_WRITE     (6U << 0U)
 #define CORTEXM_DWT_FUNC_FUNC_ACCESS    (7U << 0U)
+/* Variant for DWTv2 */
+#define CORTEXM_DWTv2_FUNC_MATCH_READ         (6U << 0U)
+#define CORTEXM_DWTv2_FUNC_MATCH_WRITE        (5U << 0U)
+#define CORTEXM_DWTv2_FUNC_MATCH_ACCESS       (4U << 0U)
+#define CORTEXM_DWTv2_FUNC_ACTION_TRIGGER     (0U << 4U)
+#define CORTEXM_DWTv2_FUNC_ACTION_DEBUG_EVENT (1U << 4U)
+#define CORTEXM_DWTv2_FUNC_LEN_VALUE(len)     (((len) >> 1) << 10U)
 
 #define CORTEXM_XPSR_THUMB          (1U << 24U)
 #define CORTEXM_XPSR_EXCEPTION_MASK 0x0000001fU


### PR DESCRIPTION

## Detailed description

The DWT block is different on Arm V8m compared to older revisions.  As a result the watchpoint(s) function are not working. 
The patch adds a second path dealing with the ArmV8m  .
Tested on cortex m33, check setup watch some_variable  (such as xTickCount on freeRtos)
- without the patch, does not stop
- with the patch, does stop as expected

It was partially tested, i dont have other chip with that DWT block. Only test write watchpoints.
As far as i can tell, watchpoints are still working with older chips (cortex M4)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
