### PR TITLE
Fix: ADI structural cleanup and ARMv8-M debug improvements

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -852,7 +852,7 @@ static void handle_v_packet(char *packet, const size_t plen)
 	 */
 	if (strcmp(packet, "vMustReplyEmpty") != 0)
 		DEBUG_GDB("*** Unsupported packet: %s\n", packet);
-	gdb_putpacket("", 0);
+	gdb_putpacketz("");
 }
 
 static void handle_z_packet(char *packet, const size_t plen)
@@ -890,7 +890,7 @@ void gdb_main(char *pbuf, size_t pbuf_size, size_t size)
 	gdb_main_loop(&gdb_controller, pbuf, pbuf_size, size, false);
 }
 
-/* halt target */
+/* Request halt on the active target */
 void gdb_halt_target(void)
 {
 	if (cur_target)
@@ -900,7 +900,7 @@ void gdb_halt_target(void)
 		gdb_putpacketz("W00");
 }
 
-/* poll running target */
+/* Poll the running target to see if it halted yet */
 void gdb_poll_target(void)
 {
 	if (!cur_target) {

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -634,7 +634,7 @@ static void exec_v_attach(const char *packet, const size_t length)
 			 * https://sourceware.org/pipermail/gdb-patches/2022-April/188058.html
 			 * https://sourceware.org/pipermail/gdb-patches/2022-July/190869.html
 			 */
-			gdb_putpacketz("T05thread:1;");
+			gdb_putpacket_f("T%02Xthread:1;", GDB_SIGTRAP);
 		} else
 			gdb_putpacketz("E01");
 
@@ -926,15 +926,15 @@ void gdb_poll_target(void)
 		morse("TARGET LOST.", true);
 		break;
 	case TARGET_HALT_REQUEST:
-		gdb_putpacket_f("T%02X", GDB_SIGINT);
+		gdb_putpacket_f("T%02Xthread:1;", GDB_SIGINT);
 		break;
 	case TARGET_HALT_WATCHPOINT:
 		gdb_putpacket_f("T%02Xwatch:%08" PRIX32 ";", GDB_SIGTRAP, watch);
 		break;
 	case TARGET_HALT_FAULT:
-		gdb_putpacket_f("T%02X", GDB_SIGSEGV);
+		gdb_putpacket_f("T%02Xthread:1;", GDB_SIGSEGV);
 		break;
 	default:
-		gdb_putpacket_f("T%02X", GDB_SIGTRAP);
+		gdb_putpacket_f("T%02Xthread:1;", GDB_SIGTRAP);
 	}
 }

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -241,9 +241,9 @@ int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, siz
 				gdb_putpacketz("EFF");
 			else {
 				uint8_t val[8];
-				size_t s = target_reg_read(cur_target, reg, val, sizeof(val));
-				if (s != 0)
-					gdb_putpacket(hexify(pbuf, val, s), s * 2U);
+				const size_t length = target_reg_read(cur_target, reg, val, sizeof(val));
+				if (length != 0)
+					gdb_putpacket(hexify(pbuf, val, length), length * 2U);
 				else
 					gdb_putpacketz("EFF");
 			}

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -341,7 +341,8 @@ int32_t gdb_main_loop(target_controller_s *tc, char *pbuf, size_t pbuf_size, siz
 		break;
 
 	case 'X': { /* 'X addr,len:XX': Write binary data to addr */
-		uint32_t addr, len;
+		target_addr32_t addr;
+		uint32_t len;
 		ERROR_IF_NO_TARGET();
 		if (read_hex32(pbuf + 1, &rest, &addr, ',') && read_hex32(rest, &rest, &len, ':')) {
 			if (len > (size - (size_t)(rest - pbuf))) {
@@ -405,10 +406,10 @@ static void exec_q_rcmd(const char *packet, const size_t length)
 	unhexify(data, packet, datalen);
 	data[datalen] = 0; /* add terminating null */
 
-	const int c = command_process(cur_target, data);
-	if (c < 0)
+	const int result = command_process(cur_target, data);
+	if (result < 0)
 		gdb_putpacketz("");
-	else if (c == 0)
+	else if (result == 0)
 		gdb_putpacketz("OK");
 	else {
 		const char *const response = "Failed\n";
@@ -757,6 +758,8 @@ static void exec_v_cont(const char *packet, const size_t length)
 		target_halt_resume(cur_target, single_step);
 		SET_RUN_STATE(true);
 		gdb_target_running = true;
+		break;
+	default:
 		break;
 	}
 }

--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -858,31 +858,31 @@ void adi_ap_component_probe(
 		/* Look the component up and dispatch to a probe routine accordingly */
 		const arm_coresight_component_s *const component =
 			adi_lookup_component(base_address, entry_number, indent, cid_class, pidr, dev_type, arch_id);
+		if (component == NULL)
+			return;
 
-		if (component) {
-			switch (component->arch) {
-			case aa_cortexm:
-				DEBUG_INFO("%s-> cortexm_probe\n", indent + 1);
-				cortexm_probe(ap);
-				break;
-			case aa_cortexa:
-				DEBUG_INFO("%s-> cortexa_probe\n", indent + 1);
-				cortexa_probe(ap, base_address);
-				break;
-			case aa_cortexr:
-				DEBUG_INFO("%s-> cortexr_probe\n", indent + 1);
-				cortexr_probe(ap, base_address);
-				break;
-			/* Handle when the component is a CoreSight component ROM table */
-			case aa_rom_table:
-				if (pidr & PIDR_SIZE_MASK)
-					DEBUG_ERROR("Fault reading ROM table\n");
-				else
-					adi_parse_coresight_v0_rom_table(ap, base_address, recursion, indent, pidr);
-				break;
-			default:
-				break;
-			}
+		switch (component->arch) {
+		case aa_cortexm:
+			DEBUG_INFO("%s-> cortexm_probe\n", indent + 1);
+			cortexm_probe(ap);
+			break;
+		case aa_cortexa:
+			DEBUG_INFO("%s-> cortexa_probe\n", indent + 1);
+			cortexa_probe(ap, base_address);
+			break;
+		case aa_cortexr:
+			DEBUG_INFO("%s-> cortexr_probe\n", indent + 1);
+			cortexr_probe(ap, base_address);
+			break;
+		/* Handle when the component is a CoreSight component ROM table */
+		case aa_rom_table:
+			if (pidr & PIDR_SIZE_MASK)
+				DEBUG_ERROR("Fault reading ROM table\n");
+			else
+				adi_parse_coresight_v0_rom_table(ap, base_address, recursion, indent, pidr);
+			break;
+		default:
+			break;
 		}
 	}
 }

--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -347,7 +347,7 @@ static void adi_display_ap(const adiv5_access_port_s *const ap)
 #endif
 }
 
-bool adi_configure_mem_ap(adiv5_access_port_s *const ap)
+static bool adi_configure_mem_ap(adiv5_access_port_s *const ap)
 {
 	const uint8_t ap_type = ADIV5_AP_IDR_TYPE(ap->idr);
 

--- a/src/target/adiv5_internal.h
+++ b/src/target/adiv5_internal.h
@@ -276,6 +276,7 @@ typedef enum arm_arch {
 	aa_cortexm,
 	aa_cortexa,
 	aa_cortexr,
+	aa_rom_table,
 	aa_access_port,
 	aa_end
 } arm_arch_e;

--- a/src/target/adiv5_swd.c
+++ b/src/target/adiv5_swd.c
@@ -78,11 +78,11 @@ static void dormant_to_swd_sequence(void)
 	/* Send at least 8 SWCLKTCK cycles with SWDIOTMS HIGH */
 	swd_line_reset_sequence(false);
 
-	/* 
-	 * If the target is both JTAG and SWD with JTAG as default, switch JTAG->DS first. 
+	/*
+	 * If the target is both JTAG and SWD with JTAG as default, switch JTAG->DS first.
 	 * See B5.3.2
 	 */
-	DEBUG_INFO("Switching from JTAG do dormant\n");
+	DEBUG_INFO("Switching from JTAG to dormant\n");
 	swd_proc.seq_out(ADIV5_JTAG_TO_DORMANT_SEQUENCE0, 5U);
 	swd_proc.seq_out(ADIV5_JTAG_TO_DORMANT_SEQUENCE1, 31U);
 	swd_proc.seq_out(ADIV5_JTAG_TO_DORMANT_SEQUENCE2, 8U);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -79,7 +79,7 @@ typedef struct cortexm_priv {
 	bool stepping;
 	bool on_bkpt;
 	/* Flash Patch controller configuration */
-	uint32_t flash_patch_revision;
+	uint8_t flash_patch_revision;
 	/* Copy of DEMCR for vector-catch */
 	uint32_t demcr;
 } cortexm_priv_s;
@@ -1090,7 +1090,7 @@ static int cortexm_breakwatch_set(target_s *target, breakwatch_s *breakwatch)
 
 	switch (breakwatch->type) {
 	case TARGET_BREAK_HARD:
-		if (priv->flash_patch_revision == 0) {
+		if (priv->flash_patch_revision == 0U) {
 			val &= 0x1ffffffcU;
 			val |= (breakwatch->addr & 2U) ? 0x80000000U : 0x40000000U;
 		}

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -922,7 +922,7 @@ void cortexm_halt_resume(target_s *const target, const bool step)
 	}
 
 	if (priv->base.icache_line_length)
-		target_mem32_write32(target, CORTEXM_ICIALLU, 0);
+		target_mem32_write32(target, CORTEXM_ICIALLU, 0U);
 
 	/* Release C_HALT to resume the core in whichever mode is selected */
 	target_mem32_write32(target, CORTEXM_DHCSR, dhcsr);
@@ -1060,9 +1060,9 @@ bool cortexm_run_stub(target_s *target, uint32_t loadaddr, uint32_t r0, uint32_t
  */
 static uint32_t cortexm_dwt_mask(size_t len)
 {
-	if (len < 2)
-		return 0;
-	return MIN(ulog2(len - 1), 31);
+	if (len < 2U)
+		return 0U;
+	return MIN(ulog2(len - 1U), 31U);
 }
 
 static uint32_t cortexm_dwt_func(target_s *target, target_breakwatch_e type)

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -32,6 +32,7 @@ extern unsigned cortexm_wait_timeout;
 
 #define CORTEXM_CPUID   (CORTEXM_SCS_BASE + 0xd00U)
 #define CORTEXM_AIRCR   (CORTEXM_SCS_BASE + 0xd0cU)
+#define CORTEXM_CCR     (CORTEXM_SCS_BASE + 0xd14U)
 #define CORTEXM_CFSR    (CORTEXM_SCS_BASE + 0xd28U)
 #define CORTEXM_HFSR    (CORTEXM_SCS_BASE + 0xd2cU)
 #define CORTEXM_DFSR    (CORTEXM_SCS_BASE + 0xd30U)
@@ -49,9 +50,10 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_CSSELR (CORTEXM_SCS_BASE + 0xd84U)
 
 /* Cache maintenance operations */
-#define CORTEXM_ICIALLU  (CORTEXM_SCS_BASE + 0xf50U)
-#define CORTEXM_DCCMVAC  (CORTEXM_SCS_BASE + 0xf68U)
-#define CORTEXM_DCCIMVAC (CORTEXM_SCS_BASE + 0xf70U)
+#define CORTEXM_ICIALLU  (CORTEXM_SCS_BASE + 0xf50U) /* I-Cache Invalidate All to Point of Unification */
+#define CORTEXM_DCCMVAU  (CORTEXM_SCS_BASE + 0xf64U) /* D-Cache Clean by Address to Point of Unification */
+#define CORTEXM_DCCMVAC  (CORTEXM_SCS_BASE + 0xf68U) /* D-Cache Clean by Address to Point of Coherency */
+#define CORTEXM_DCCIMVAC (CORTEXM_SCS_BASE + 0xf70U) /* D-Cache Clean and Invalidate by Address to Point of Coherency */
 
 #define CORTEXM_FPB_BASE (CORTEXM_PPB_BASE + 0x2000U)
 
@@ -77,6 +79,10 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_AIRCR_SYSRESETREQ   (1U << 2U)
 #define CORTEXM_AIRCR_VECTCLRACTIVE (1U << 1U)
 #define CORTEXM_AIRCR_VECTRESET     (1U << 0U)
+
+/* Configuration and Control Register (CCR) */
+#define CORTEXM_CCR_DCACHE_ENABLE (1U << 16U)
+#define CORTEXM_CCR_ICACHE_ENABLE (1U << 17U)
 
 /* HardFault Status Register (HFSR) */
 #define CORTEXM_HFSR_DEBUGEVT (1U << 31U)

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -107,20 +107,25 @@ extern unsigned cortexm_wait_timeout;
 /* This key must be written to bits 31:16 for write to take effect */
 #define CORTEXM_DHCSR_DBGKEY 0xa05f0000U
 /* Bits 31:26 - Reserved */
-#define CORTEXM_DHCSR_S_RESET_ST  (1U << 25U)
-#define CORTEXM_DHCSR_S_RETIRE_ST (1U << 24U)
-/* Bits 23:20 - Reserved */
-#define CORTEXM_DHCSR_S_LOCKUP (1U << 19U)
-#define CORTEXM_DHCSR_S_SLEEP  (1U << 18U)
-#define CORTEXM_DHCSR_S_HALT   (1U << 17U)
-#define CORTEXM_DHCSR_S_REGRDY (1U << 16U)
-/* Bits 15:6 - Reserved */
-#define CORTEXM_DHCSR_C_SNAPSTALL (1U << 5U) /* v7m only */
+#define CORTEXM_DHCSR_S_RESET_ST  (1U << 25U) /* 1 if at least one reset happened since last read */
+#define CORTEXM_DHCSR_S_RETIRE_ST (1U << 24U) /* 1 if at least one instruction completed since last read */
+#define CORTEXM_DHCSR_S_FPD       (1U << 23U) /* Floating Point Debuggable? (ARMv8-M+, 1 if false) */
+#define CORTEXM_DHCSR_S_SUIDE     (1U << 22U) /* Secure invasive halting enabled? (ARMv8-M+, requires SE + UDE) */
+#define CORTEXM_DHCSR_S_NSUIDE    (1U << 21U) /* Non-Secure invasive halting enabled? (ARMv8-M+, requires SE + UDE) */
+#define CORTEXM_DHCSR_S_SDE       (1U << 20U) /* Secure debug enabled? (ARMv8-M+, requires SE) */
+#define CORTEXM_DHCSR_S_LOCKUP    (1U << 19U) /* 1 if the CPU is in the loocked up state */
+#define CORTEXM_DHCSR_S_SLEEP     (1U << 18U) /* 1 if the CPU is in a sleeping state pending IRQ or Event */
+#define CORTEXM_DHCSR_S_HALT      (1U << 17U) /* 1 if the CPU is halted in debug state */
+#define CORTEXM_DHCSR_S_REGRDY    (1U << 16U) /* 1 if DCRSR is ready for further writes */
+/* Bits 15:7 - Reserved */
+#define CORTEXM_DHCSR_C_PMOV (1U << 6U) /* 1 if C_DEBUGEN and a PMU overflow occcurs (ARMv8-M+) */
+#define CORTEXM_DHCSR_C_SNAPSTALL \
+	(1U << 5U) /* 1 if debug state can be netered imprecisely by forcing load/store to be abandoned ARMv7-M+ */
 /* Bit 4 - Reserved */
-#define CORTEXM_DHCSR_C_MASKINTS (1U << 3U)
-#define CORTEXM_DHCSR_C_STEP     (1U << 2U)
-#define CORTEXM_DHCSR_C_HALT     (1U << 1U)
-#define CORTEXM_DHCSR_C_DEBUGEN  (1U << 0U)
+#define CORTEXM_DHCSR_C_MASKINTS (1U << 3U) /* 1 if all maskable interrupts are masked (disabled) by the debugger */
+#define CORTEXM_DHCSR_C_STEP     (1U << 2U) /* 1 if the CPU should step one instruction when next unhalted */
+#define CORTEXM_DHCSR_C_HALT     (1U << 1U) /* 1 if the CPU should halt and enter debug state */
+#define CORTEXM_DHCSR_C_DEBUGEN  (1U << 0U) /* 1 if debugging is enabled on the CPU */
 
 /* Debug Core Register Selector Register (DCRSR) */
 #define CORTEXM_DCRSR_REGWnR      0x00010000U

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -143,10 +143,12 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_DEMCR_VC_CORERESET (1U << 0U)
 
 /* Flash Patch and Breakpoint Control Register (FP_CTRL) */
-/* Bits 32:15 - Reserved */
-/* Bits 14:12 - NUM_CODE2 */ /* v7m only */
-/* Bits 11:8 - NUM_LIT */    /* v7m only */
-/* Bits 7:4 - NUM_CODE1 */
+#define CORTEXM_FPB_CTRL_REV_MASK  0xfU
+#define CORTEXM_FPB_CTRL_REV_SHIFT 28U
+/* Bits 28:15 - Reserved */
+#define CORTEXM_FPB_CTRL_NUM_CODE_H (0x7U << 12U)
+#define CORTEXM_FPB_CTRL_NUM_LIT    (0xfU << 8U)
+#define CORTEXM_FPB_CTRL_NUM_CODE_L (0xfU << 4U)
 /* Bits 3:2 - Unspecified */
 #define CORTEXM_FPB_CTRL_KEY    (1U << 1U)
 #define CORTEXM_FPB_CTRL_ENABLE (1U << 0U)


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address some structural clean-up that is needed in the wake of all the ADIv6 work and some issues in Cortex-M debug of ARMv8-M targets.

This has wound up touching the ADI, Cortex-M, target and GDB layers so apologies that this PR is a little all over the place. With this however, we now have proper diagnostics on what GDB is asking us to do vs what we're doing in regards to `step`/`next`/`stepi`/`continue`/`run`/etc and ARMv8-M debug works properly. Tested on a Cortex-M33 and Cortex-M4 (to ensure we didn't break ARMv7-M debug in the process).

This solves what we could reproduce of the final issue raised in #1970. Any further issues in relation to ARMv8-M debug are likely to do with S vs NS modes and what debug is allowed per the DHCSR.

The GDB changes fix GDB trying to guess which "thread" (core) halted when we report halt events back to it, making the output from `set debug remote on` go from
```
[remote] wait: enter
  [remote] Packet received: T05
  [remote] select_thread_for_ambiguous_stop_reply: enter
    [remote] select_thread_for_ambiguous_stop_reply: process_wide_stop = 0
    [remote] select_thread_for_ambiguous_stop_reply: first resumed thread is Thread 1
    [remote] select_thread_for_ambiguous_stop_reply: is this guess ambiguous? = 0
  [remote] select_thread_for_ambiguous_stop_reply: exit
[remote] wait: exit
```
to
```
[remote] wait: enter
  [remote] Packet received: T05thread:1;
[remote] wait: exit
```

As far as we can tell this is a fully backwards compatible change, but the GDB documentation does not make this easy to determine.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
