### PR TITLE
Fix: STM32 DBGMCU attach/detach behaviour

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -80,7 +80,7 @@ jobs:
 
       # Install BMDA's deps (libftdi1, hidapi-hidraw)
       - name: Install BMDA dependencies
-        run: sudo apt-get -y install libftdi1-dev libhidapi-dev
+        run: sudo apt-get -y install libftdi1-dev libhidapi-dev libudev-dev
 
       # Record the versions of all the tools used in the build
       - name: Version tools

--- a/cross-file/bluepill.ini
+++ b/cross-file/bluepill.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'bluepill'
-targets = 'cortexm,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
+targets = 'cortexm,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
 rtt_support = false
 bmd_bootloader = true

--- a/cross-file/swlink.ini
+++ b/cross-file/swlink.ini
@@ -19,6 +19,6 @@ endian = 'little'
 
 [project options]
 probe = 'swlink'
-targets = 'cortexm,efm,hc32,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
+targets = 'cortexm,lpc,nrf,nxp,renesas,rp,sam,stm,ti'
 rtt_support = false
 bmd_bootloader = false

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -142,14 +142,14 @@ bool nrf51_probe(target_s *t)
 	uint32_t info_part = target_mem32_read32(t, NRF52_PART_INFO);
 	if (info_part != 0xffffffffU && info_part != 0 && (info_part & 0x00ff000U) == 0x52000U) {
 		uint32_t ram_size = target_mem32_read32(t, NRF52_INFO_RAM);
-		t->driver = "Nordic nRF52";
+		t->driver = "nRF52";
 		t->target_options |= TOPT_INHIBIT_NRST;
 		target_add_ram32(t, 0x20000000U, ram_size * 1024U);
 		nrf51_add_flash(t, 0, page_size * code_size, page_size);
 		nrf51_add_flash(t, NRF51_UICR, page_size, page_size);
 		target_add_commands(t, nrf51_cmd_list, "nRF52");
 	} else {
-		t->driver = "Nordic nRF51";
+		t->driver = "nRF51";
 		/*
 		 * Use the biggest RAM size seen in NRF51 fammily.
 		 * IDCODE is kept as '0', as deciphering is hard and there is later no usage.
@@ -429,12 +429,12 @@ bool nrf51_ctrl_ap_probe(adiv5_access_port_s *ap)
 	t->priv = ap;
 	t->priv_free = (void *)adiv5_ap_unref;
 
-	uint32_t status = adiv5_ap_read(ap, CTRL_AP_PROT_EN);
-	status = adiv5_ap_read(ap, CTRL_AP_PROT_EN);
+	adiv5_ap_read(ap, CTRL_AP_PROT_EN);
+	const uint32_t status = adiv5_ap_read(ap, CTRL_AP_PROT_EN);
 	if (status)
-		t->driver = "Nordic nRF52 Access Port";
+		t->driver = "nRF52 Access Port";
 	else
-		t->driver = "Nordic nRF52 Access Port (protected)";
+		t->driver = "nRF52 Access Port (protected)";
 	t->regs_size = 0;
 
 	return true;

--- a/src/target/nrf91.c
+++ b/src/target/nrf91.c
@@ -92,7 +92,7 @@ bool nrf91_probe(target_s *target)
 
 	switch (ap->dp->target_partno) {
 	case 0x90:
-		target->driver = "Nordic nRF9160";
+		target->driver = "nRF9160";
 		target->target_options |= TOPT_INHIBIT_NRST;
 		target_add_ram32(target, 0x20000000, 256U * 1024U);
 		nrf91_add_flash(target, 0, 4096U * 256U, 4096U);

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -2,7 +2,7 @@
  * This file is part of the Black Magic Debug project.
  *
  * Copyright (C) 2017-2020 Uwe Bonnes bon@elektron.ikp.physik.tu-darmstadt.de
- * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2022-2024 1BitSquared <info@1bitsquared.com>
  * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -187,7 +187,6 @@ typedef struct stm32h7_flash {
 } stm32h7_flash_s;
 
 typedef struct stm32h7_priv {
-	uint32_t dbgmcu_config;
 	char name[STM32H7_NAME_MAX_LENGTH];
 } stm32h7_priv_s;
 
@@ -273,32 +272,31 @@ bool stm32h7_probe(target_s *target)
 	target->part_id = ap->partno;
 
 	/* Save private storage */
-	stm32h7_priv_s *priv_storage = calloc(1, sizeof(*priv_storage));
-	if (!priv_storage) { /* calloc failed: heap exhaustion */
+	stm32h7_priv_s *priv = calloc(1, sizeof(*priv));
+	if (!priv) { /* calloc failed: heap exhaustion */
 		DEBUG_ERROR("calloc: failed in %s\n", __func__);
 		return false;
 	}
-	priv_storage->dbgmcu_config = target_mem32_read32(target, STM32H7_DBGMCU_CONFIG);
-	target->target_storage = priv_storage;
+	target->target_storage = priv;
 
-	memcpy(priv_storage->name, "STM32", 5U);
+	memcpy(priv->name, "STM32", 5U);
 	switch (target->part_id) {
 	case ID_STM32H72x:
-		write_be4((uint8_t *)priv_storage->name, 5U, target_mem32_read32(target, STM32H7_CHIP_IDENT));
-		priv_storage->name[9] = '\0';
+		write_be4((uint8_t *)priv->name, 5U, target_mem32_read32(target, STM32H7_CHIP_IDENT));
+		priv->name[9] = '\0';
 		break;
 	case ID_STM32H74x:
-		memcpy(priv_storage->name + 5U, "H74x", 5U); /* H742/H743/H753/H750 */
+		memcpy(priv->name + 5U, "H74x", 5U); /* H742/H743/H753/H750 */
 		break;
 	case ID_STM32H7Bx:
-		memcpy(priv_storage->name + 5U, "H7Bx", 5U); /* H7A3/H7B3/H7B0 */
+		memcpy(priv->name + 5U, "H7Bx", 5U); /* H7A3/H7B3/H7B0 */
 		break;
 	default:
-		memcpy(priv_storage->name + 5U, "H7", 3U);
+		memcpy(priv->name + 5U, "H7", 3U);
 		break;
 	}
 
-	target->driver = priv_storage->name;
+	target->driver = priv->name;
 	target->attach = stm32h7_attach;
 	target->detach = stm32h7_detach;
 	target->mass_erase = stm32h7_mass_erase;
@@ -312,8 +310,9 @@ bool stm32h7_probe(target_s *target)
 	 * debugging through sleep, stop and standby states for domain D1
 	 */
 	target_mem32_write32(target, STM32H7_DBGMCU_CONFIG,
-		priv_storage->dbgmcu_config | STM32H7_DBGMCU_CONFIG_DBGSLEEP_D1 | STM32H7_DBGMCU_CONFIG_DBGSTOP_D1 |
-			STM32H7_DBGMCU_CONFIG_DBGSTBY_D1 | STM32H7_DBGMCU_CONFIG_D1DBGCKEN | STM32H7_DBGMCU_CONFIG_D3DBGCKEN);
+		target_mem32_read32(target, STM32H7_DBGMCU_CONFIG) | STM32H7_DBGMCU_CONFIG_DBGSLEEP_D1 |
+			STM32H7_DBGMCU_CONFIG_DBGSTOP_D1 | STM32H7_DBGMCU_CONFIG_DBGSTBY_D1 | STM32H7_DBGMCU_CONFIG_D1DBGCKEN |
+			STM32H7_DBGMCU_CONFIG_D3DBGCKEN);
 	stm32h7_configure_wdts(target);
 
 	/* Build the RAM map */
@@ -422,8 +421,10 @@ static bool stm32h7_attach(target_s *target)
 
 static void stm32h7_detach(target_s *target)
 {
-	stm32h7_priv_s *priv = (stm32h7_priv_s *)target->target_storage;
-	target_mem32_write32(target, STM32H7_DBGMCU_CONFIG, priv->dbgmcu_config);
+	target_mem32_write32(target, STM32H7_DBGMCU_CONFIG,
+		target_mem32_read32(target, STM32H7_DBGMCU_CONFIG) &
+			~(STM32H7_DBGMCU_CONFIG_DBGSLEEP_D1 | STM32H7_DBGMCU_CONFIG_DBGSTOP_D1 | STM32H7_DBGMCU_CONFIG_DBGSTBY_D1 |
+				STM32H7_DBGMCU_CONFIG_D1DBGCKEN | STM32H7_DBGMCU_CONFIG_D3DBGCKEN));
 	cortexm_detach(target);
 }
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In #1882 we introduced control of the WDT halt state to prevent debug sessions getting clobbered by them while the part is intentionally halted. In that PR we stored the state of the DBGMCU on attach, and restored it on detach - which on its face seems like a reasonable heuristic, however.. we worried at the time and have since had that fear confirmed that this doesn't work well because both the user code and the debugger can change the state of the DBGMCU register in question itself to do things like enabling tracing, and users want to be able to detach from the target to leave tracing running.

In the scenario outlined above, however, BMD will disable tracing by restoring the pre-image of the DBGMCU control register, and undo any other freeze configuration by restoring the freeze register for the WDTs and this breaks setups and re-disables tracing. This PR fixes that by always doing a RMW cycle on the registers regardless and dropping the stored state component.

We also include a small fix for some Flash size issues to restore the build on the swlink platform.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
