### PR TITLE
target: Support 64-bit address for break/watch point

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -160,6 +160,12 @@ if is_firmware_build and get_option('print_memory_usage')
 	add_project_link_arguments('-Wl,--print-memory-usage', language: 'c')
 endif
 
+# We need to know the size of a pointer for the machine running the code
+add_project_link_arguments('-DCONFIG_POINTER_SIZE=@0@'.format(cc_host.sizeof('void *')), language: 'c')
+if is_cross_build
+	add_project_link_arguments('-DCONFIG_POINTER_SIZE=@0@'.format(cc_native.sizeof('void *')), language: 'c', native: true)
+endif
+
 subdir('src')
 
 ## Black Magic Firmware (BMF) targets

--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -928,7 +928,7 @@ void gdb_poll_target(void)
 	}
 
 	/* poll target */
-	target_addr_t watch;
+	target_addr64_t watch;
 	target_halt_reason_e reason = target_halt_poll(cur_target, &watch);
 	if (!reason)
 		return;
@@ -947,7 +947,8 @@ void gdb_poll_target(void)
 		gdb_putpacket_str_f("T%02Xthread:1;", GDB_SIGINT);
 		break;
 	case TARGET_HALT_WATCHPOINT:
-		gdb_putpacket_str_f("T%02Xwatch:%08" PRIX32 ";", GDB_SIGTRAP, watch);
+		gdb_putpacket_str_f(
+			"T%02Xwatch:%0" PRIX32 "%08" PRIX32 ";", GDB_SIGTRAP, (uint32_t)(watch >> 32U), (uint32_t)watch);
 		break;
 	case TARGET_HALT_FAULT:
 		gdb_putpacket_str_f("T%02Xthread:1;", GDB_SIGSEGV);

--- a/src/include/target.h
+++ b/src/include/target.h
@@ -98,7 +98,7 @@ typedef enum target_halt_reason {
 
 void target_reset(target_s *target);
 void target_halt_request(target_s *target);
-target_halt_reason_e target_halt_poll(target_s *target, target_addr_t *watch);
+target_halt_reason_e target_halt_poll(target_s *target, target_addr64_t *watch);
 void target_halt_resume(target_s *target, bool step);
 void target_set_cmdline(target_s *target, const char *cmdline, size_t cmdline_len);
 void target_set_heapinfo(target_s *target, target_addr_t heap_base, target_addr_t heap_limit, target_addr_t stack_base,

--- a/src/rtt.c
+++ b/src/rtt.c
@@ -394,7 +394,7 @@ void poll_rtt(target_s *const cur_target)
 			rtt_halt = target_mem_access_needs_halt(cur_target);
 
 		bool resume_target = false;
-		target_addr_t watch;
+		target_addr64_t watch;
 		if (rtt_halt && target_halt_poll(cur_target, &watch) == TARGET_HALT_RUNNING) {
 			/* briefly halt target during target memory access */
 			target_halt_request(cur_target);

--- a/src/target/cortexar.c
+++ b/src/target/cortexar.c
@@ -393,7 +393,7 @@ static size_t cortexar_reg_read(target_s *target, uint32_t reg, void *data, size
 static size_t cortexar_reg_write(target_s *target, uint32_t reg, const void *data, size_t max);
 
 static void cortexar_reset(target_s *target);
-static target_halt_reason_e cortexar_halt_poll(target_s *target, target_addr_t *watch);
+static target_halt_reason_e cortexar_halt_poll(target_s *target, target_addr64_t *watch);
 static void cortexar_halt_request(target_s *target);
 static void cortexar_halt_resume(target_s *target, bool step);
 static bool cortexar_halt_and_wait(target_s *target);
@@ -1405,7 +1405,7 @@ static void cortexar_halt_request(target_s *const target)
 	}
 }
 
-static target_halt_reason_e cortexar_halt_poll(target_s *const target, target_addr_t *const watch)
+static target_halt_reason_e cortexar_halt_poll(target_s *const target, target_addr64_t *const watch)
 {
 	volatile uint32_t dscr = 0;
 	TRY (EXCEPTION_ALL) {

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -64,7 +64,7 @@ static size_t cortexm_reg_read(target_s *target, uint32_t reg, void *data, size_
 static size_t cortexm_reg_write(target_s *target, uint32_t reg, const void *data, size_t max);
 
 static void cortexm_reset(target_s *target);
-static target_halt_reason_e cortexm_halt_poll(target_s *target, target_addr_t *watch);
+static target_halt_reason_e cortexm_halt_poll(target_s *target, target_addr64_t *watch);
 static void cortexm_halt_request(target_s *target);
 static int cortexm_fault_unwind(target_s *target);
 
@@ -828,7 +828,7 @@ static void cortexm_halt_request(target_s *target)
 	}
 }
 
-static target_halt_reason_e cortexm_halt_poll(target_s *target, target_addr_t *watch)
+static target_halt_reason_e cortexm_halt_poll(target_s *target, target_addr64_t *watch)
 {
 	cortexm_priv_s *priv = target->priv;
 

--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -286,7 +286,7 @@ static const char *riscv_target_description(target_s *target);
 static bool riscv_check_error(target_s *target);
 static void riscv_halt_request(target_s *target);
 static void riscv_halt_resume(target_s *target, bool step);
-static target_halt_reason_e riscv_halt_poll(target_s *target, target_addr_t *watch);
+static target_halt_reason_e riscv_halt_poll(target_s *target, target_addr64_t *watch);
 static void riscv_reset(target_s *target);
 
 void riscv_dmi_init(riscv_dmi_s *const dmi)
@@ -1033,7 +1033,7 @@ static void riscv_halt_resume(target_s *target, const bool step)
 	(void)riscv_dm_write(hart->dbg_module, RV_DM_CONTROL, hart->hartsel);
 }
 
-static target_halt_reason_e riscv_halt_poll(target_s *const target, target_addr_t *const watch)
+static target_halt_reason_e riscv_halt_poll(target_s *const target, target_addr64_t *const watch)
 {
 	(void)watch;
 	riscv_hart_s *const hart = riscv_hart_struct(target);

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -424,7 +424,7 @@ static const char *target_halt_reason_str(const target_halt_reason_e reason)
 }
 #endif
 
-target_halt_reason_e target_halt_poll(target_s *target, target_addr_t *watch)
+target_halt_reason_e target_halt_poll(target_s *target, target_addr64_t *watch)
 {
 	if (target->halt_poll) {
 		const target_halt_reason_e reason = target->halt_poll(target, watch);

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -103,12 +103,18 @@ struct target_command {
 typedef struct breakwatch breakwatch_s;
 
 struct breakwatch {
-	/* XXX: This needs adjusting for 64-bit operations */
 	breakwatch_s *next;
+#if CONFIG_POINTER_SIZE == 8
+	target_addr64_t addr;
+	size_t size;
 	target_breakwatch_e type;
-	target_addr32_t addr;
+	uint32_t reserved[2]; /* For use by the implementing driver */
+#else
+	target_breakwatch_e type;
+	target_addr64_t addr;
 	size_t size;
 	uint32_t reserved[4]; /* For use by the implementing driver */
+#endif
 };
 
 #define MAX_CMDLINE 81
@@ -139,7 +145,7 @@ struct target {
 	void (*reset)(target_s *target);
 	void (*extended_reset)(target_s *target);
 	void (*halt_request)(target_s *target);
-	target_halt_reason_e (*halt_poll)(target_s *target, target_addr_t *watch);
+	target_halt_reason_e (*halt_poll)(target_s *target, target_addr64_t *watch);
 	void (*halt_resume)(target_s *target, bool step);
 
 	/* Break-/watchpoint functions */


### PR DESCRIPTION
This change breakwatch::addr to be 64-bit as this will be required for ARMv8 AArch64 support.

This also change the layout of breakwatch to avoid extraneous padding in 64-bit and reduce the size of the reserved array to 64 bits.

<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
