### PR TITLE
gdb_packet: add missing <string.h> include

### DIFF
--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <string.h>
 
 /* Allow override in other platforms if needed */
 #ifndef GDB_PACKET_BUFFER_SIZE


### PR DESCRIPTION
gdb_packet.h now calls `strlen()`, but does not have the include for it. This causes build failures on systems where warnings are treated as errors.

Add `#include <string.h>` to `gdb_packet.h` to fix this warning.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do