### PR TITLE
Feature: Add a new target for ARMv8-A

### DIFF
--- a/src/include/target.h
+++ b/src/include/target.h
@@ -50,6 +50,7 @@ bool adiv5_swd_scan(uint32_t targetid);
 bool jtag_scan(void);
 
 size_t target_foreach(void (*callback)(size_t index, target_s *target, void *context), void *context);
+target_s *target_list_get_last();
 void target_list_free(void);
 
 target_s *target_new(void);

--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -882,6 +882,14 @@ void adi_ap_component_probe(
 			DEBUG_INFO("%s-> cortexr_probe\n", indent + 1);
 			cortexr_probe(ap, base_address);
 			break;
+		case aa_cortexa_armv8:
+			DEBUG_INFO("%s-> cortexa_armv8_dc_probe\n", indent + 1);
+			cortexa_armv8_dc_probe(ap, base_address);
+			break;
+		case aa_cti_armv8:
+			DEBUG_INFO("%s-> cortexa_armv8_cti_probe\n", indent + 1);
+			cortexa_armv8_cti_probe(ap, base_address);
+			break;
 		/* Handle when the component is a CoreSight component ROM table */
 		case aa_rom_table:
 			if (pidr & PIDR_SIZE_MASK)

--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -185,6 +185,7 @@ static const arm_coresight_component_s arm_component_lut[] = {
 	{0x9e4, 0x00, 0x0a17, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight MTE", "(Memory Tagging Extensioon)")},
 	{0x9e7, 0x11, 0x0000, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight TPIU", "(Trace Port Interface Unit)")},
 	{0x9e8, 0x21, 0x0000, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight TCM", "(Trace Memory Controller)")},
+	{0x909, 0x22, 0x0000, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight ATBR", "(ATB Replicator)")},
 	{0x9eb, 0x12, 0x0000, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight ATBF", "(ATB Funnel)")},
 	{0x9ec, 0x22, 0x0000, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight ATBR", "(ATB Replicator)")},
 	{0x9ed, 0x14, 0x1a14, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight CTI", "(Cross Trigger Interface)")},

--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -191,6 +191,13 @@ static const arm_coresight_component_s arm_component_lut[] = {
 	{0x9ed, 0x14, 0x1a14, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("CoreSight CTI", "(Cross Trigger Interface)")},
 	{0x9ee, 0x00, 0x0000, aa_nosupport, cidc_dc,
 		ARM_COMPONENT_STR("CoreSight CATU", "(CoreSight Address Translation Unit)")},
+
+	{0xd05, 0x13, 0x4a13, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-A55 ETM", "(Embedded Trace)")},
+	{0xd05, 0x14, 0x1a14, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-A55 CTI", "(Cross Trigger)")},
+	{0xd05, 0x16, 0x2a16, aa_nosupport, cidc_unknown,
+		ARM_COMPONENT_STR("Cortex-A55 PMU", "(Performance Monitor Unit)")},
+	{0xd05, 0x15, 0x8a15, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-A55", "(Debug Unit)")},
+
 	{0xfff, 0x00, 0, aa_end, cidc_unknown, ARM_COMPONENT_STR("end", "end")},
 };
 

--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -193,10 +193,10 @@ static const arm_coresight_component_s arm_component_lut[] = {
 		ARM_COMPONENT_STR("CoreSight CATU", "(CoreSight Address Translation Unit)")},
 
 	{0xd05, 0x13, 0x4a13, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-A55 ETM", "(Embedded Trace)")},
-	{0xd05, 0x14, 0x1a14, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-A55 CTI", "(Cross Trigger)")},
+	{0xd05, 0x14, 0x1a14, aa_cti_armv8, cidc_dc, ARM_COMPONENT_STR("Cortex-A55 CTI", "(Cross Trigger)")},
 	{0xd05, 0x16, 0x2a16, aa_nosupport, cidc_unknown,
 		ARM_COMPONENT_STR("Cortex-A55 PMU", "(Performance Monitor Unit)")},
-	{0xd05, 0x15, 0x8a15, aa_nosupport, cidc_dc, ARM_COMPONENT_STR("Cortex-A55", "(Debug Unit)")},
+	{0xd05, 0x15, 0x8a15, aa_cortexa_armv8, cidc_dc, ARM_COMPONENT_STR("Cortex-A55", "(Debug Unit)")},
 
 	{0xfff, 0x00, 0, aa_end, cidc_unknown, ARM_COMPONENT_STR("end", "end")},
 };

--- a/src/target/adiv5_internal.h
+++ b/src/target/adiv5_internal.h
@@ -278,6 +278,8 @@ typedef enum arm_arch {
 	aa_cortexr,
 	aa_rom_table,
 	aa_access_port,
+	aa_cortexa_armv8,
+	aa_cti_armv8,
 	aa_end
 } arm_arch_e;
 

--- a/src/target/arm_coresight_cti.c
+++ b/src/target/arm_coresight_cti.c
@@ -1,0 +1,225 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Based on work that is Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2024 Mary Guillemard <mary@mary.zone>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file implements support for ARM CoreSight Cross Trigger (CTI)
+ *
+ * References:
+ * DDI0480E - ARM CoreSight SoC-400 Technical Reference Manual
+ *   https://documentation-service.arm.com/static/5f873b64f86e16515cdb7582
+ * 100806   - Arm CoreSight System-on-Chip SoC-600 Technical Reference Manual
+ *   https://documentation-service.arm.com/static/65f96505d98ff22ceb0c0b79
+ * IHI0029  - Arm CoreSight Architecture Specification
+ *   https://documentation-service.arm.com/static/63a03a981d698c4dc521ca77
+ */
+
+#include "arm_coresight_cti.h"
+#include "general.h"
+#include <stdint.h>
+
+#define CTI_CONTROL       0x000u
+#define CTI_INTACK        0x010u
+#define CTI_APPSET        0x014u
+#define CTI_APPCLEAR      0x018u
+#define CTI_APPPULSE      0x01cu
+#define CTI_INEN(n)       (0x020u + ((n) * 4U))
+#define CTI_OUTEN(n)      (0x0a0u + ((n) * 4U))
+#define CTI_TRIGINSTATUS  0x130u
+#define CTI_TRIGOUTSTATUS 0x134u
+#define CTI_CHINSTATUS    0x138u
+#define CTI_CHOUTSTATUS   0x13cu
+#define CTI_GATE          0x140u
+#define CTI_ASIC_CTL      0x144u
+#define IT_CHINACK        0xedcU
+#define IT_TRIGINACK      0xee0U
+#define IT_CHOUT          0xee4U
+#define IT_TRIGOUT        0xee8U
+#define IT_CHOUTACK       0xeecU
+#define IT_TRIGOUTACK     0xef0U
+#define IT_CHIN           0xef4U
+#define IT_TRIGIN         0xef8U
+#define IT_CTRL           0xf00U
+#define CLAIM_SET         0xfa0U
+#define CLAIM_CLR         0xfa4U
+#define CTI_LAR           0xfb0U
+#define CTI_LSR           0xfb4U
+#define AUTH_STATUS       0xfb8U
+
+#define CTI_CONTROL_GLBEN  (1 << 0U)
+#define CTI_LAR_UNLOCK_KEY 0xc5acce55u
+#define CTI_LSR_SLI        (1 << 0U)
+#define CTI_LSR_SLK        (1 << 1U)
+
+void arm_coresight_cti_init(arm_coresight_cti_s *data, adiv5_access_port_s *ap, target_addr_t base_address)
+{
+	adiv5_ap_ref(ap);
+
+	data->ap = ap;
+	data->base_addr = base_address;
+	data->initialized = true;
+}
+
+void arm_coresight_cti_fini(arm_coresight_cti_s *data)
+{
+	if (!data->initialized)
+		return;
+
+	adiv5_ap_unref(data->ap);
+	data->initialized = false;
+}
+
+static uint32_t arm_coresight_cti_read32(arm_coresight_cti_s *const cti, const uint16_t src)
+{
+	adiv5_access_port_s *const ap = cti->ap;
+
+	uint32_t result = 0;
+	adiv5_mem_read(ap, &result, cti->base_addr + src, sizeof(result));
+	return result;
+}
+
+static void arm_coresight_cti_write32(arm_coresight_cti_s *const cti, const uint16_t dest, const uint32_t value)
+{
+	adiv5_mem_write(cti->ap, cti->base_addr + dest, &value, sizeof(value));
+}
+
+bool arm_coresight_cti_ensure_unlock(arm_coresight_cti_s *cti)
+{
+	const uint32_t lock_status = arm_coresight_cti_read32(cti, CTI_LSR);
+
+	/* If lock register is implemented and active, unlock */
+	if (lock_status & (CTI_LSR_SLI | CTI_LSR_SLK)) {
+		arm_coresight_cti_write32(cti, CTI_LAR, CTI_LAR_UNLOCK_KEY);
+
+		const bool locked = arm_coresight_cti_read32(cti, CTI_LSR) & CTI_LSR_SLK;
+
+		if (locked)
+			DEBUG_ERROR("%s: Lock sticky. Core not powered?\n", __func__);
+
+		return !locked;
+	}
+
+	return true;
+}
+
+void arm_coresight_cti_enable(arm_coresight_cti_s *cti, bool enable)
+{
+	arm_coresight_cti_write32(cti, CTI_CONTROL, enable ? CTI_CONTROL_GLBEN : 0);
+}
+
+uint32_t arm_coresight_cti_get_gate(arm_coresight_cti_s *cti)
+{
+	return arm_coresight_cti_read32(cti, CTI_GATE);
+}
+
+void arm_coresight_cti_set_gate(arm_coresight_cti_s *cti, uint32_t gate_mask)
+{
+	arm_coresight_cti_write32(cti, CTI_GATE, gate_mask);
+}
+
+void arm_coresight_cti_set_input_channel(arm_coresight_cti_s *cti, uint8_t event_idx, int8_t channel)
+{
+	if (event_idx > 31) {
+		DEBUG_ERROR("%s: Invalid event_idx %d\n", __func__, event_idx);
+		return;
+	}
+
+	if (channel > 31) {
+		DEBUG_ERROR("%s: Invalid channel %d\n", __func__, channel);
+		return;
+	}
+
+	if (channel != CTI_CHANNEL_INVALID) {
+		arm_coresight_cti_write32(cti, CTI_INEN(event_idx), CTI_CHANNEL_ID(channel));
+	} else {
+		arm_coresight_cti_write32(cti, CTI_INEN(event_idx), 0);
+	}
+}
+
+void arm_coresight_cti_set_output_channel(arm_coresight_cti_s *cti, uint8_t event_idx, int8_t channel)
+{
+	if (event_idx > 31) {
+		DEBUG_ERROR("%s: Invalid event_idx %d\n", __func__, event_idx);
+		return;
+	}
+
+	if (channel > 31) {
+		DEBUG_ERROR("%s: Invalid channel %d\n", __func__, channel);
+		return;
+	}
+
+	if (channel != CTI_CHANNEL_INVALID) {
+		arm_coresight_cti_write32(cti, CTI_OUTEN(event_idx), CTI_CHANNEL_ID(channel));
+	} else {
+		arm_coresight_cti_write32(cti, CTI_OUTEN(event_idx), 0);
+	}
+}
+
+void arm_coresight_cti_acknowledge_interrupt(arm_coresight_cti_s *cti, uint8_t event_idx)
+{
+	if (event_idx > 31) {
+		DEBUG_ERROR("%s: Invalid event_idx %d\n", __func__, event_idx);
+		return;
+	}
+
+	arm_coresight_cti_write32(cti, CTI_INTACK, 1 << event_idx);
+}
+
+void arm_coresight_cti_pulse_channel(arm_coresight_cti_s *cti, uint8_t channel)
+{
+	if (channel > 31) {
+		DEBUG_ERROR("%s: Invalid channel %d\n", __func__, channel);
+		return;
+	}
+
+	arm_coresight_cti_write32(cti, CTI_APPPULSE, CTI_CHANNEL_ID(channel));
+}
+
+bool arm_coresight_cti_read_input_channel_status(arm_coresight_cti_s *cti, uint8_t channel)
+{
+	if (channel > 31) {
+		DEBUG_ERROR("%s: Invalid channel %d\n", __func__, channel);
+		return false;
+	}
+
+	return ((arm_coresight_cti_read32(cti, CTI_CHINSTATUS) >> channel) & 1) != 0;
+}
+
+bool arm_coresight_cti_read_output_channel_status(arm_coresight_cti_s *cti, uint8_t channel)
+{
+	if (channel > 31) {
+		DEBUG_ERROR("%s: Invalid channel %d\n", __func__, channel);
+		return false;
+	}
+
+	return ((arm_coresight_cti_read32(cti, CTI_CHOUTSTATUS) >> channel) & 1) != 0;
+}

--- a/src/target/arm_coresight_cti.h
+++ b/src/target/arm_coresight_cti.h
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Based on work that is Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2024 Mary Guillemard <mary@mary.zone>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TARGET_ARM_CORESIGHT_CTI_H
+#define TARGET_ARM_CORESIGHT_CTI_H
+
+#include "general.h"
+#include "adiv5.h"
+#include <stdint.h>
+
+#define CTI_CHANNEL_INVALID -1
+#define CTI_CHANNEL_ID(ch)  (1U << ch)
+
+typedef struct arm_coresight_cti {
+	/* AP from which this CPU hangs */
+	adiv5_access_port_s *ap;
+	/* Base address for the debug interface block */
+	uint32_t base_addr;
+
+	/* Indicate if the object was properly initialized */
+	bool initialized;
+} arm_coresight_cti_s;
+
+void arm_coresight_cti_init(arm_coresight_cti_s *data, adiv5_access_port_s *ap, target_addr_t base_address);
+void arm_coresight_cti_fini(arm_coresight_cti_s *data);
+bool arm_coresight_cti_ensure_unlock(arm_coresight_cti_s *cti);
+void arm_coresight_cti_enable(arm_coresight_cti_s *cti, bool enable);
+uint32_t arm_coresight_cti_get_gate(arm_coresight_cti_s *cti);
+void arm_coresight_cti_set_gate(arm_coresight_cti_s *cti, uint32_t gate_mask);
+void arm_coresight_cti_set_input_channel(arm_coresight_cti_s *cti, uint8_t event_idx, int8_t channel);
+void arm_coresight_cti_set_output_channel(arm_coresight_cti_s *cti, uint8_t event_idx, int8_t channel);
+void arm_coresight_cti_acknowledge_interrupt(arm_coresight_cti_s *cti, uint8_t event_idx);
+void arm_coresight_cti_pulse_channel(arm_coresight_cti_s *cti, uint8_t channel);
+bool arm_coresight_cti_read_input_channel_status(arm_coresight_cti_s *cti, uint8_t channel);
+bool arm_coresight_cti_read_output_channel_status(arm_coresight_cti_s *cti, uint8_t channel);
+
+#endif /*TARGET_ARM_CORESIGHT_CTI_H*/

--- a/src/target/cortex.c
+++ b/src/target/cortex.c
@@ -103,6 +103,9 @@ void cortex_read_cpuid(target_s *const target)
 	case CORTEX_A9:
 		target->core = "A9";
 		break;
+	case CORTEX_A55:
+		target->core = "A55";
+		break;
 	case CORTEX_R4:
 		target->core = "R4";
 		break;

--- a/src/target/cortex.h
+++ b/src/target/cortex.h
@@ -56,10 +56,11 @@
 #define CORTEX_R5 0xc150U
 
 /* Cortex-A CPU IDs */
-#define CORTEX_A5 0xc050U
-#define CORTEX_A7 0xc070U
-#define CORTEX_A8 0xc080U
-#define CORTEX_A9 0xc090U
+#define CORTEX_A5  0xc050U
+#define CORTEX_A7  0xc070U
+#define CORTEX_A8  0xc080U
+#define CORTEX_A9  0xc090U
+#define CORTEX_A55 0xd050U
 
 /* Cortex general purpose register offsets */
 #define CORTEX_REG_SP      13U

--- a/src/target/cortex.h
+++ b/src/target/cortex.h
@@ -77,11 +77,12 @@
 #define CORTEX_CPUID_REVISION_MASK 0x00f00000U
 #define CORTEX_CPUID_PATCH_MASK    0x0000000fU
 
-#define CORTEX_FLOAT_REG_COUNT      33U
-#define CORTEX_DOUBLE_REG_COUNT     17U
-#define CORTEXM_GENERAL_REG_COUNT   20U /* General purpose register count for Cortex-M cores */
-#define CORTEXM_TRUSTZONE_REG_COUNT 4U  /* TrustZone register count for Cortex-M cores */
-#define CORTEXAR_GENERAL_REG_COUNT  17U /* General purpose register count for Cortex-A/R cores */
+#define CORTEX_FLOAT_REG_COUNT          33U
+#define CORTEX_DOUBLE_REG_COUNT         17U
+#define CORTEXM_GENERAL_REG_COUNT       20U /* General purpose register count for Cortex-M cores */
+#define CORTEXM_TRUSTZONE_REG_COUNT     4U  /* TrustZone register count for Cortex-M cores */
+#define CORTEXAR_GENERAL_REG_COUNT      17U /* General purpose register count for Cortex-A/R cores */
+#define CORTEXA_ARMV8_GENERAL_REG_COUNT 31U /* General purpose register count for Cortex-A/R cores in AArch64 mode */
 
 adiv5_access_port_s *cortex_ap(target_s *target);
 

--- a/src/target/cortexa_armv8.c
+++ b/src/target/cortexa_armv8.c
@@ -1,0 +1,209 @@
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Based on work that is Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2024 Mary Guillemard <mary@mary.zone>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file implements support ARMv8-A based processors.
+ *
+ * References:
+ * DDI0487 - Arm Architecture Reference Manual for A-profile architecture
+ *   https://documentation-service.arm.com/static/65fdad3c1bc22b03bca90781
+ * 100442  - Arm Cortex-A55 Core Technical Reference Manual
+ *   https://documentation-service.arm.com/static/649ac6d4df6cd61d528c2bf1
+ */
+#include "general.h"
+#include "exception.h"
+#include "adi.h"
+#include "adiv5.h"
+#include "target.h"
+#include "target_internal.h"
+#include "target_probe.h"
+#include "jep106.h"
+#include "cortex.h"
+#include "cortex_internal.h"
+#include "arm_coresight_cti.h"
+#include "gdb_reg.h"
+#include "gdb_packet.h"
+#include "maths_utils.h"
+#include "buffer_utils.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef struct cortexa_armv8_priv {
+	/* Base core information */
+	cortex_priv_s base;
+	arm_coresight_cti_s cti;
+
+	/* Cached value of EDSCR */
+	uint32_t edscr;
+
+	/* Indicate if the DC was init properly */
+	bool dc_is_valid;
+} cortexa_armv8_priv_s;
+
+#define CORTEXA_ARMV8_TARGET_NAME ("ARM Cortex-A (ARMv8-A)")
+
+#define CORTEXA_DBG_OSLAR_EL1 0x300U /* OS Lock Access Register */
+#define CORTEXA_DBG_EDPRSR    0x314U /* Debug Processor Status Register */
+
+#define CORTEXA_DBG_EDPRSR_POWERED_UP           (1U << 0U)
+#define CORTEXA_DBG_EDPRSR_STICKY_PD            (1U << 1U)
+#define CORTEXA_DBG_EDPRSR_RESET_STATUS         (1U << 2U)
+#define CORTEXA_DBG_EDPRSR_STICKY_CORE_RESET    (1U << 3U)
+#define CORTEXA_DBG_EDPRSR_HALTED               (1U << 4U)
+#define CORTEXA_DBG_EDPRSR_OS_LOCK              (1U << 5U)
+#define CORTEXA_DBG_EDPRSR_DOUBLE_LOCK          (1U << 6U)
+#define CORTEXA_DBG_EDPRSR_STICKY_DEBUG_RESTART (1U << 11U)
+
+static void cortexa_armv8_priv_free(void *const priv)
+{
+	arm_coresight_cti_fini(&((cortexa_armv8_priv_s *)priv)->cti);
+	cortex_priv_free(priv);
+}
+
+static bool cortexa_armv8_oslock_unlock(target_s *const target)
+{
+	if ((cortex_dbg_read32(target, CORTEXA_DBG_EDPRSR) & CORTEXA_DBG_EDPRSR_OS_LOCK)) {
+		/* Lock set. Try to unlock */
+		DEBUG_WARN("%s: OS lock set, unlocking\n", __func__);
+		cortex_dbg_write32(target, CORTEXA_DBG_OSLAR_EL1, 0U);
+
+		/* Read back to check if we succeeded */
+		const bool locked = cortex_dbg_read32(target, CORTEXA_DBG_EDPRSR) & CORTEXA_DBG_EDPRSR_OS_LOCK;
+		if (locked)
+			DEBUG_ERROR("%s: Lock sticky. Core not powered?\n", __func__);
+		return !locked;
+	}
+
+	return true;
+}
+
+static bool cortexa_armv8_ensure_core_powered(target_s *const target)
+{
+	uint32_t edprsr = cortex_dbg_read32(target, CORTEXA_DBG_EDPRSR);
+
+	/* XXX: We don't have any way of powering it up, check if we are missing something from the docs */
+	if (!(edprsr & CORTEXA_DBG_EDPRSR_POWERED_UP))
+		return false;
+
+	/* Check for the OS double lock */
+	if (edprsr & CORTEXA_DBG_EDPRSR_DOUBLE_LOCK)
+		return false;
+
+	/*
+	 * Finally, check for the normal OS Lock and clear it if it's set prior to halting the core.
+	 * Trying to do this after target_halt_request() does not function over JTAG and triggers
+	 * the lock sticky message.
+	 */
+	if (edprsr & CORTEXA_DBG_EDPRSR_OS_LOCK)
+		return cortexa_armv8_oslock_unlock(target);
+
+	return true;
+}
+
+bool cortexa_armv8_dc_probe(adiv5_access_port_s *const ap, const target_addr_t base_address)
+{
+	target_s *target = target_new();
+	if (!target)
+		return NULL;
+
+	adiv5_ap_ref(ap);
+	if (ap->dp->version >= 2 && ap->dp->target_designer_code != 0) {
+		/* Use TARGETID register to identify target */
+		target->designer_code = ap->dp->target_designer_code;
+		target->part_id = ap->dp->target_partno;
+	} else {
+		/* Use AP DESIGNER and AP PARTNO to identify target */
+		target->designer_code = ap->designer_code;
+		target->part_id = ap->partno;
+	}
+
+	cortexa_armv8_priv_s *const priv = calloc(1, sizeof(*priv));
+	if (!priv) { /* calloc failed: heap exhaustion */
+				 /* XXX: Free target? */
+		DEBUG_ERROR("calloc: failed in %s\n", __func__);
+		return NULL;
+	}
+
+	target->driver = CORTEXA_ARMV8_TARGET_NAME;
+	target->priv = priv;
+	target->priv_free = cortexa_armv8_priv_free;
+	priv->base.ap = ap;
+	priv->base.base_addr = base_address;
+
+	/* Ensure the core is powered up and we can talk to it */
+	if (!cortexa_armv8_ensure_core_powered(target))
+		return false;
+
+	priv->dc_is_valid = true;
+
+	return true;
+}
+
+bool cortexa_armv8_cti_probe(adiv5_access_port_s *const ap, const target_addr_t base_address)
+{
+	target_s *target = target_list_get_last();
+
+	if (!target)
+		return false;
+
+	/* Ensure that the previous target is actually from the same driver */
+	if (strcmp(target->driver, CORTEXA_ARMV8_TARGET_NAME) != 0)
+		return false;
+
+	cortexa_armv8_priv_s *const priv = (cortexa_armv8_priv_s *)target->priv;
+
+	/* Init CTI component */
+	arm_coresight_cti_init(&priv->cti, ap, base_address);
+
+	/* In case DC init failed, we should not try to do anything here */
+	if (!priv->dc_is_valid)
+		return false;
+
+	/* XXX: Configure CTI component */
+	/* XXX: Halt APIs */
+	/* XXX: Try to halt the PE */
+	/* XXX: Read CPUID */
+	/* XXX: Detect debug features */
+	/* XXX: Detect optional features */
+	/* XXX: Attach / Detach APIs */
+	/* XXX: Register IO APIs */
+	/* XXX: Memory IO APIs */
+	/* XXX: Breakpoint APIs */
+
+	target_check_error(target);
+
+	return true;
+}

--- a/src/target/meson.build
+++ b/src/target/meson.build
@@ -122,6 +122,10 @@ endif
 # We declare a dependency for each target group with the source files required
 # these dependencies are then added to the BMD core, conditinal on the targets option
 # NOTE: sourceset module might be an alternative to this method (unexplored)
+target_arm_coresight = declare_dependency(
+	sources: files('arm_coresight_cti.c'),
+)
+
 target_cortex = declare_dependency(
 	sources: files('cortex.c'),
 )

--- a/src/target/meson.build
+++ b/src/target/meson.build
@@ -142,6 +142,11 @@ target_cortexm = declare_dependency(
 	compile_args: ['-DCONFIG_CORTEXM=1'],
 )
 
+target_cortexa_armv8 = declare_dependency(
+	sources: files('cortexa_armv8.c'),
+	dependencies: [target_cortex, target_arm_coresight],
+)
+
 riscv_jtag_dtm = declare_dependency(
 	sources: files(
 		'riscv_jtag_dtm.c',
@@ -397,6 +402,7 @@ libbmd_target_deps = [
 	# Enable all architectures for libbmd
 	target_cortexar,
 	target_cortexm,
+	target_cortexa_armv8,
 	target_riscv32,
 	target_riscv64,
 	# Enable all targets for libbmd

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -76,6 +76,17 @@ target_s *target_new(void)
 	return target;
 }
 
+target_s *target_list_get_last()
+{
+	if (!target_list)
+		return NULL;
+
+	target_s *last_target = target_list;
+	while (last_target->next)
+		last_target = last_target->next;
+	return last_target;
+}
+
 size_t target_foreach(void (*callback)(size_t index, target_s *target, void *context), void *context)
 {
 	size_t idx = 0;

--- a/src/target/target_probe.c
+++ b/src/target/target_probe.c
@@ -90,6 +90,8 @@ static inline void lpc55_dp_prepare_nop(adiv5_debug_port_s *const debug_port)
 CORTEXAR_PROBE_WEAK_NOP(cortexa_probe)
 CORTEXAR_PROBE_WEAK_NOP(cortexr_probe)
 CORTEXM_PROBE_WEAK_NOP(cortexm_probe)
+CORTEXAR_PROBE_WEAK_NOP(cortexa_armv8_dc_probe)
+CORTEXAR_PROBE_WEAK_NOP(cortexa_armv8_cti_probe)
 
 TARGET_PROBE_WEAK_NOP(riscv32_probe)
 TARGET_PROBE_WEAK_NOP(riscv64_probe)

--- a/src/target/target_probe.h
+++ b/src/target/target_probe.h
@@ -41,6 +41,8 @@
 bool cortexa_probe(adiv5_access_port_s *ap, target_addr_t base_address);
 bool cortexr_probe(adiv5_access_port_s *ap, target_addr_t base_address);
 bool cortexm_probe(adiv5_access_port_s *ap);
+bool cortexa_armv8_dc_probe(adiv5_access_port_s *ap, target_addr_t base_address);
+bool cortexa_armv8_cti_probe(adiv5_access_port_s *ap, target_addr_t base_address);
 
 bool riscv32_probe(target_s *target);
 bool riscv64_probe(target_s *target);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As ARMv8-A changed entirely debug interactions, a new target was needed.

This implements a new basic target for ARMv8-A that only support AArch64 for now.

I tested all those changes with a [Solitude AML-S905D3-CC](https://libre.computer/products/aml-s905d3-cc/) on core 0 in u-boot (JTAG access can be enabled with `smc 0x82000040 2`)

Things left as todo that will not be tackled by this PR:
- Float registers
- AArch32 support (Lot of cortexar.c could be reused for this)
- Any relevant ARMv8-A extensions to expose (Pointer Authentication)
- Possibly weird CoreSight tables where the CTI component isn't after the DC
- SMP

Depends on #2017.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
