### PR TITLE
Fix/casting conversion warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,8 +38,7 @@ project(
 		'c_std=c11',
 		'optimization=s',
 		'debug=true',
-		# 'warning_level=3', # TODO: Enable by default when all warnings are fixed
-		'warning_level=2',
+		'warning_level=3',
 		'werror=false',
 		'b_ndebug=if-release',
 	],

--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -107,7 +107,7 @@ bool platform_configure_uart(char *configuration_string)
 		uint32_t stopBits;
 		char parity;
 		int count = sscanf(
-			configuration_string, "%" SCNd32 ",%" SCNd32 ",%c,%" SCNd32 "", &baudRate, &bits, &parity, &stopBits);
+			configuration_string, "%" SCNu32 ",%" SCNu32 ",%c,%" SCNu32 "", &baudRate, &bits, &parity, &stopBits);
 		if (count == 4) {
 			uint32_t parityValue;
 			usart_set_baudrate(USBUSART, baudRate);

--- a/src/platforms/hosted/gdb_if.c
+++ b/src/platforms/hosted/gdb_if.c
@@ -140,7 +140,7 @@ static sockaddr_storage_s sockaddr_prepare(const uint16_t port)
 	addrinfo_s *results = NULL;
 	int res = getaddrinfo(NULL, "0", &hints, &results);
 	if (res || !results) {
-		DEBUG_WARN("getaddrinfo returned %d (errno = %d), results is %p\n", res, errno, results);
+		DEBUG_WARN("getaddrinfo returned %d (errno = %d), results is %p\n", res, errno, (void *)results);
 		return (sockaddr_storage_s){AF_UNSPEC};
 	}
 

--- a/src/platforms/stlinkv3/usb_f723.c
+++ b/src/platforms/stlinkv3/usb_f723.c
@@ -208,7 +208,7 @@ static void stm32f723_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type
 			OTG_DIEPCTL0_SNAK | (type << 18) | OTG_DIEPCTL0_USBAEP | OTG_DIEPCTLX_SD0PID | (addr << 22) | max_size;
 
 		if (callback)
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_IN] = (void *)callback;
+			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_IN] = callback;
 	}
 
 	if (!dir) {
@@ -218,7 +218,7 @@ static void stm32f723_ep_setup(usbd_device *usbd_dev, uint8_t addr, uint8_t type
 			(type << 18) | max_size;
 
 		if (callback)
-			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] = (void *)callback;
+			usbd_dev->user_callback_ctr[addr][USB_TRANSACTION_OUT] = callback;
 	}
 }
 

--- a/src/target/adi.c
+++ b/src/target/adi.c
@@ -253,7 +253,7 @@ static const char *adi_cid_class_string(const cid_class_e cid_class)
 	default:
 		return "Unknown component"; /* Noted as reserved in the spec */
 	}
-};
+}
 #endif
 
 uint16_t adi_designer_from_pidr(const uint64_t pidr)

--- a/src/target/ch579.c
+++ b/src/target/ch579.c
@@ -92,10 +92,10 @@
 #define CH579_CONST_ROM_CMD_PROGRAM_INFO 0x99U
 
 /* Flash Protect base value; upper bits must be set*/
-#define CH579_RB_ROM_WE_MUST_10 0b10000000U
+#define CH579_RB_ROM_WE_MUST_10 (1U << 7U)
 /* Flash Protect Bitmasks */
-#define CH579_RB_ROM_CODE_WE 1U << 3U
-#define CH579_RB_ROM_DATA_WE 1U << 2U
+#define CH579_RB_ROM_CODE_WE (1U << 3U)
+#define CH579_RB_ROM_DATA_WE (1U << 2U)
 /* Flash Protect Standard value */
 #define CH579_RB_ROM_WRITE_ENABLE  CH579_RB_ROM_WE_MUST_10 | CH579_RB_ROM_CODE_WE | CH579_RB_ROM_DATA_WE
 #define CH579_RB_ROM_WRITE_DISABLE CH579_RB_ROM_WE_MUST_10

--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -954,7 +954,7 @@ bool efm32_aap_probe(adiv5_access_port_s *ap)
 
 	adiv5_ap_ref(ap);
 	t->priv = ap;
-	t->priv_free = (void *)adiv5_ap_unref;
+	t->priv_free = (priv_free_func)adiv5_ap_unref;
 
 	/* Read status */
 	DEBUG_INFO("EFM32: AAP STATUS=%08" PRIx32 "\n", adiv5_ap_read(ap, AAP_STATUS));

--- a/src/target/kinetis.c
+++ b/src/target/kinetis.c
@@ -573,7 +573,7 @@ bool kinetis_mdm_probe(adiv5_access_port_s *ap)
 	t->mass_erase = kinetis_mdm_mass_erase;
 	adiv5_ap_ref(ap);
 	t->priv = ap;
-	t->priv_free = (void *)adiv5_ap_unref;
+	t->priv_free = (priv_free_func)adiv5_ap_unref;
 
 	t->driver = "Kinetis Recovery (MDM-AP)";
 	t->regs_size = 0;

--- a/src/target/nrf51.c
+++ b/src/target/nrf51.c
@@ -427,7 +427,7 @@ bool nrf51_ctrl_ap_probe(adiv5_access_port_s *ap)
 	t->mass_erase = nrf51_ctrl_ap_mass_erase;
 	adiv5_ap_ref(ap);
 	t->priv = ap;
-	t->priv_free = (void *)adiv5_ap_unref;
+	t->priv_free = (priv_free_func)adiv5_ap_unref;
 
 	adiv5_ap_read(ap, CTRL_AP_PROT_EN);
 	const uint32_t status = adiv5_ap_read(ap, CTRL_AP_PROT_EN);

--- a/src/target/nrf54l.c
+++ b/src/target/nrf54l.c
@@ -153,7 +153,7 @@ bool nrf54l_ctrl_ap_probe(adiv5_access_port_s *ap)
 	target->mass_erase = nrf54l_ctrl_ap_mass_erase;
 	adiv5_ap_ref(ap);
 	target->priv = ap;
-	target->priv_free = (void *)adiv5_ap_unref;
+	target->priv_free = (priv_free_func)adiv5_ap_unref;
 
 	const uint32_t status = adiv5_ap_read(ap, NRF54L_CTRL_AP_APPROTECT_STATUS);
 

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -80,7 +80,7 @@ struct target_flash {
 };
 
 /*
- * ¹the mass_erase method must not cause any side effects outside the scope/address space of the flash 
+ * ¹the mass_erase method must not cause any side effects outside the scope/address space of the flash
  * consider using the target mass_erase method instead for such cases
  */
 
@@ -112,6 +112,8 @@ struct breakwatch {
 };
 
 #define MAX_CMDLINE 81
+
+typedef void (*priv_free_func)(void *flash);
 
 struct target {
 	target_controller_s *tc;
@@ -180,7 +182,7 @@ struct target {
 	target_s *next;
 
 	void *priv;
-	void (*priv_free)(void *);
+	priv_free_func priv_free;
 
 	/* Target designer and ID / partno */
 	uint16_t designer_code;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As part of cleaning up for the v2.0 release, we noticed that there weren't many warnings left of the set enabled by `warning_level=3` in Meson and that some of them solve UB conversions that were taking place. This PR fixes those remaining warnings and the issues they make visible.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
