### PR TITLE
ctxlink/platform: Add debug output control to platform.

### DIFF
--- a/src/platforms/ctxlink/platform.h
+++ b/src/platforms/ctxlink/platform.h
@@ -35,6 +35,12 @@
 #define PLATFORM_IDENT "(ctxLink) "
 
 #define PLATFORM_HAS_BATTERY
+
+#if ENABLE_DEBUG == 1
+#define PLATFORM_HAS_DEBUG
+extern bool debug_bmp;
+#endif
+
 /*
  * Important pin mappings for STM32 implementation:
  *


### PR DESCRIPTION
The ctxLink platform did not have the required enable/disable code for debug output. This PR adds that functionality.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None