### PR TITLE
ctxlink/wifi_server: Change winc1500 power mode to manual.

### DIFF
--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -1072,9 +1072,9 @@ void app_task(void)
 			//
 			m2m_wifi_set_device_name(CTXLINK_NETWORK_NAME, strlen(CTXLINK_NETWORK_NAME));
 			//
-			// Select the "Deep Automatic" power mode
+			// Select the "Manual" power mode
 			//
-			m2m_wifi_set_sleep_mode(M2M_WIFI_PS_DEEP_AUTOMATIC, 1);
+			m2m_wifi_set_sleep_mode(M2M_WIFI_PS_MANUAL, 1);
 			//
 			// Move to reading the MAC address state
 			//


### PR DESCRIPTION
This PR enables a transfer speed increse for file loading and other operations over wi-fi. It does this through management of the power saving modes of the WINC1500.

The WINC1500 API was also updated to better control the power saving API.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

None