### PR TITLE
Fix AT32F405 flash size/map

### DIFF
--- a/src/target/at32f43x.c
+++ b/src/target/at32f43x.c
@@ -313,7 +313,7 @@ static bool at32f405_detect(target_s *target, const uint32_t series)
 	 */
 	const uint16_t flash_size = target_mem32_read16(target, AT32F4x_FLASHSIZE);
 	const uint16_t sector_size = series == AT32F405_SERIES_128KB ? 1024U : 2048U;
-	at32f43_add_flash(target, 0x08000000, flash_size, sector_size, AT32F43x_FLASH_BANK1_REG_OFFSET);
+	at32f43_add_flash(target, 0x08000000, flash_size * 1024U, sector_size, AT32F43x_FLASH_BANK1_REG_OFFSET);
 
 	/*
 	 * Either 96 or 102 KiB of SRAM, depending on USD bit 7 nRAM_PRT_CHK:
@@ -345,7 +345,7 @@ static bool at32f423_detect(target_s *target, const uint32_t series)
 	 */
 	const uint16_t flash_size = target_mem32_read16(target, AT32F4x_FLASHSIZE);
 	const uint16_t sector_size = series == AT32F423_SERIES_256KB ? 2048U : 1024U;
-	at32f43_add_flash(target, 0x08000000, flash_size, sector_size, AT32F43x_FLASH_BANK1_REG_OFFSET);
+	at32f43_add_flash(target, 0x08000000, flash_size * 1024U, sector_size, AT32F43x_FLASH_BANK1_REG_OFFSET);
 
 	target_add_ram32(target, 0x20000000, 48U * 1024U);
 	target->driver = "AT32F423";


### PR DESCRIPTION
## Detailed description

* The F_SIZE readout and usage as implemented in #1949 is incomplete and results in failure to reprogram internal flash of AT32F405RC.
* This PR solves that by factoring in the kibibytes multiplier, for both AT32F402/405 and AT32F423 added in that commit.

For a (C) 256 KiB flash part, the F_SIZE "register" contains not 262144 but 256, which (as used in PR1949 26d27b90) generates a target flash map of 256 byte length and 2048 (or 1024) byte erase-sectors, which is broken.

Assumed tested on some BMD-derivative platform.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
