### PR TITLE
Fix: MCU-Link CMSIS-DAP version handling issues

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -393,6 +393,19 @@ dap_version_s dap_adaptor_version(const dap_info_e version_kind)
 	/* If that failed, return just the major */
 	if (!end)
 		return version;
+
+	/* Special-case the MCU-Link firmware to correct some version numbering mistakes they've made */
+	if (strncmp(bmda_probe_info.product, "MCU-Link", 8U) == 0) {
+		/* If this is a v1.10+ MCU-Link */
+		if (minor > 9U) {
+			/* Then unpack the version number - CMSIS-DAP v1.1.0 is (wrongly) encoded as v1.10 on these adaptors */
+			version.minor = minor / 10U;
+			version.revision = minor % 10U;
+			/* Now return early as we're now done */
+			return version;
+		}
+	}
+
 	version.minor = minor;
 	/* Check if it's worth trying to convert anything more */
 	if ((size_t)(end - version_str) >= version_length || end[0] != '.')


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In Uwe's #1614, the point was raised that some older NXP MCU-Link firmware misbehaves in how it reports CMSIS-DAP versioning and such. This PR seeks to address that properly by special-casing the handling of version strings hitting the buggy behaviour.

This PR supersedes that one as after more than a year it has seen no response to the review given. This should leave just one quasi-bug remaining from that PR which is to do with interfacing with older CMSIS-DAP v1.x firmware as we use a feature that is not supported.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
