### PR TITLE
Fix: Nightly build version strings

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: true
+          fetch-tags: true
 
       # Build the firmware for all platform variants (currently available)
       - name: Build
@@ -208,6 +208,8 @@ jobs:
       # Checkout the repository and branch to build under the default location
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       # Build BMDA for Linux
       - name: Build Linux BMDA
@@ -304,6 +306,8 @@ jobs:
       # Checkout the repository and branch to build under the default location
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       # Build the default BMDA configuration
       - name: Build full BMDA
@@ -378,6 +382,8 @@ jobs:
       # Checkout the repository and branch to build under the default location
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       # Build the default BMDA configuration
       - name: Build full BMDA


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address that the build-and-upload flow doesn't properly embed the version string associated with the build being done. This is caused by a lack of tags being pulled with the cloning process the flow uses.

This should result in all future nightly (build-and-upload) builds having the full versioning information embedded in.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
