### PR TITLE
Fix: unexpected E02 from gdb m-packets

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -145,7 +145,7 @@ int32_t gdb_main_loop(target_controller_s *const tc, const gdb_packet_s *const p
 		uint32_t addr, len;
 		ERROR_IF_NO_TARGET();
 		if (read_hex32(packet->data + 1, &rest, &addr, ',') && read_hex32(rest, NULL, &len, READ_HEX_NO_FOLLOW)) {
-			if (len > packet->size / 2U) {
+			if (len > GDB_PACKET_BUFFER_SIZE / 2U) {
 				gdb_put_packet_error(2U);
 				break;
 			}


### PR DESCRIPTION
## Detailed description

* This is a minor but important bugfix.
* The existing problem is gdbserver returning unexpected read errors E02 `Cannot access memory at address` to otherwise normal accesses.
* The PR solves it by fixing a mistranslated bounds-check introduced in ca. v1.10.0-1567-g de645593 of #2014.

Tested on gd32f103cb bluepillplus running bluepill.ini/stlink BMF; and BMDA; against stm32g474ce. At first I expected wrong RCC/Flash config or invalid SRAM mapping, but interactive debugging of BMDA and extended logging proved otherwise.
Note: `(gdb) maintenance packet m08070000,201` triggers a 513 byte read which is rejected by BMD. Only <=512 is good because of 1024 byte RSP packet buffer.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
