### PR TITLE
Fix: Rename RISC-V machine scratch CSR

### DIFF
--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -176,7 +176,7 @@ static const riscv_csr_descriptor_s riscv_csrs[] = {
 	{"misa", RV_CSR_MISA},
 	{"mie", RV_CSR_MIE},
 	{"mtvec", RV_CSR_MTVEC},
-	{"tscratch", RV_CSR_MSCRATCH},
+	{"mscratch", RV_CSR_MSCRATCH},
 	{"mepc", RV_CSR_MEPC},
 	{"mcause", RV_CSR_MCAUSE},
 	{"mtval", RV_CSR_MTVAL},


### PR DESCRIPTION
## Detailed description

* This is a small typo fix.
* The existing problem is `tscratch` description for gdb target.xml of MSCRATCH CSR.
* The PR solves it by renaming to `mscratch`.

Not tested on anything, because I don't have a gd32vf1/sipeed longan nano, and ESP32-C3 needs burning OTP eFuses for external JTAG (USJ is not supported by BMDA). Unsure what uses this.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues