### PR TITLE
Feature: blackpill-f4 better control of pin mode

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -108,6 +108,11 @@ void platform_init(void)
 	gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TCK_PIN);
 	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TMS_PIN);
 
+	/* Pull up TRST pin */
+	gpio_set(TRST_PORT, TRST_PIN);
+	gpio_mode_setup(TRST_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_PULLUP, TRST_PIN);
+	gpio_set_output_options(TRST_PORT, GPIO_OTYPE_OD, GPIO_OSPEED_2MHZ, TRST_PIN);
+
 	/* Set up LED pins */
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_IDLE_RUN | LED_ERROR | LED_BOOTLOADER);
 	gpio_mode_setup(LED_PORT_UART, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_UART);

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -198,7 +198,13 @@ uint32_t platform_target_voltage_sense(void)
 
 void platform_target_clk_output_enable(bool enable)
 {
-	(void)enable;
+	if (enable) {
+		gpio_mode_setup(TCK_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TCK_PIN);
+		SWDIO_MODE_DRIVE();
+	} else {
+		gpio_mode_setup(TCK_PORT, GPIO_MODE_INPUT, GPIO_PUPD_NONE, TCK_PIN);
+		SWDIO_MODE_FLOAT();
+	}
 }
 
 bool platform_spi_init(const spi_bus_e bus)

--- a/src/platforms/common/blackpill-f4/blackpill-f4.h
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.h
@@ -137,7 +137,7 @@ extern bool debug_bmp;
 
 #define TMS_SET_MODE()                                                    \
 	gpio_mode_setup(TMS_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, TMS_PIN); \
-	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TMS_PIN);
+	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TMS_PIN);
 
 /* Perform SWDIO bus turnaround faster than a gpio_mode_setup() call */
 #define SWDIO_MODE_FLOAT()                       \


### PR DESCRIPTION
## Detailed description

* For this board, this is a new feature (from other boards).
* The existing problems are TRST unused and SWCLK always driven.
* The PR solves them by initializing TRST_PIN in output open-drain pull-up mode, and implementing `platform_target_clk_output_enable()` which switches SWCLK/SWDIO to inputs or outputs.

This should allow keeping multiple BMPs wired up to a single target for cross-testing etc. and should prevent drive fight with low pin count chips like STM32G030J6 (I don't have one) or which remap their PA13/14 to output mode otherwise. No known shields/carriers/mainboards exist for it which have directional buffers and TCK_OEn aka TCK_DIR_PIN -- it would need similar treatment.
TRST pin high is required to even scan Raspberry Pi 3B (BCM2837), otherwise its TAP is disabled (default weak pull-down).

Pending testing on `blackpill-f411ce`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #1868 point 3 for this board.