### PR TITLE
Fix: STM32WL55 discovery

### DIFF
--- a/src/platforms/common/usb_descriptors.h
+++ b/src/platforms/common/usb_descriptors.h
@@ -50,7 +50,7 @@ static const usb_device_descriptor_s dev_desc = {
 #endif
 	.idVendor = 0x1d50,
 	.idProduct = 0x6018,
-	.bcdDevice = 0x0109,
+	.bcdDevice = 0x0200,
 	.iManufacturer = 1,
 	.iProduct = 2,
 	.iSerialNumber = 3,

--- a/src/platforms/hosted/remote/protocol_v4_adiv5.c
+++ b/src/platforms/hosted/remote/protocol_v4_adiv5.c
@@ -40,7 +40,9 @@
 #include "exception.h"
 
 static bool remote_v4_have_dp_version_command = true;
+static bool remote_v4_have_dp_targetsel_command = true;
 static uint8_t remote_v4_current_dp_version = UINT8_MAX;
+static uint32_t remote_v4_current_dp_targetsel = UINT32_MAX;
 
 static void remote_v4_adiv5_dp_version(adiv5_debug_port_s *const dp)
 {
@@ -61,31 +63,59 @@ static void remote_v4_adiv5_dp_version(adiv5_debug_port_s *const dp)
 	else if (buffer[0] != REMOTE_RESP_OK) {
 		DEBUG_WARN("Please upgrade your firmware to allow ADIv6 devices to work properly\n");
 		remote_v4_have_dp_version_command = false;
-	}
+	} else
+		remote_v4_current_dp_version = dp->version;
+}
+
+static void remote_v4_adiv5_dp_targetsel(adiv5_debug_port_s *const dp)
+{
+	/*
+	 * Check if the probe actually has this command, skip if it does not.
+	 * Likewise check if the DP version has changed since last call.
+	 */
+	if (!remote_v4_have_dp_targetsel_command || dp->version < 2U || remote_v4_current_dp_targetsel == dp->targetsel)
+		return;
+	/* Create the request and send it to the remote */
+	char buffer[REMOTE_MAX_MSG_SIZE];
+	ssize_t length = snprintf(buffer, REMOTE_MAX_MSG_SIZE, REMOTE_DP_TARGETSEL_STR, dp->targetsel);
+	platform_buffer_write(buffer, length);
+	/* Now read back the answer and note any errors */
+	length = platform_buffer_read(buffer, REMOTE_MAX_MSG_SIZE);
+	if (length < 1)
+		DEBUG_ERROR("%s comms error: %zd\n", __func__, length);
+	else if (buffer[0] != REMOTE_RESP_OK) {
+		DEBUG_WARN("Please upgrade your firmware to allow certain multi-drop SWD devices to work properly\n");
+		remote_v4_have_dp_targetsel_command = false;
+	} else
+		remote_v4_current_dp_targetsel = dp->targetsel;
 }
 
 uint32_t remote_v4_adiv5_raw_access(
 	adiv5_debug_port_s *const dp, const uint8_t rnw, const uint16_t addr, const uint32_t request_value)
 {
 	remote_v4_adiv5_dp_version(dp);
+	remote_v4_adiv5_dp_targetsel(dp);
 	return remote_v3_adiv5_raw_access(dp, rnw, addr, request_value);
 }
 
 uint32_t remote_v4_adiv5_dp_read(adiv5_debug_port_s *const dp, const uint16_t addr)
 {
 	remote_v4_adiv5_dp_version(dp);
+	remote_v4_adiv5_dp_targetsel(dp);
 	return remote_v3_adiv5_dp_read(dp, addr);
 }
 
 uint32_t remote_v4_adiv5_ap_read(adiv5_access_port_s *const ap, const uint16_t addr)
 {
 	remote_v4_adiv5_dp_version(ap->dp);
+	remote_v4_adiv5_dp_targetsel(ap->dp);
 	return remote_v3_adiv5_ap_read(ap, addr);
 }
 
 void remote_v4_adiv5_ap_write(adiv5_access_port_s *const ap, const uint16_t addr, const uint32_t value)
 {
 	remote_v4_adiv5_dp_version(ap->dp);
+	remote_v4_adiv5_dp_targetsel(ap->dp);
 	remote_v3_adiv5_ap_write(ap, addr, value);
 }
 
@@ -96,6 +126,7 @@ void remote_v4_adiv5_mem_read_bytes(
 	if (!read_length)
 		return;
 	remote_v4_adiv5_dp_version(ap->dp);
+	remote_v4_adiv5_dp_targetsel(ap->dp);
 	char *const data = (char *)dest;
 	DEBUG_PROBE("%s: @%08" PRIx64 "+%zx\n", __func__, src, read_length);
 	char buffer[REMOTE_MAX_MSG_SIZE];
@@ -131,6 +162,7 @@ void remote_v4_adiv5_mem_write_bytes(adiv5_access_port_s *const ap, const target
 	if (!write_length)
 		return;
 	remote_v4_adiv5_dp_version(ap->dp);
+	remote_v4_adiv5_dp_targetsel(ap->dp);
 	const char *data = (const char *)src;
 	DEBUG_PROBE("%s: @%08" PRIx64 "+%zx alignment %u\n", __func__, dest, write_length, align);
 	/* + 1 for terminating NUL character */

--- a/src/platforms/hosted/remote/protocol_v4_defs.h
+++ b/src/platforms/hosted/remote/protocol_v4_defs.h
@@ -58,8 +58,12 @@
 #define REMOTE_ACCEL_RISCV     (1U << 2U)
 #define REMOTE_ACCEL_ADIV6     (1U << 3U)
 
-/* This version of the protocol introduces an ADIv5 command for setting the version of the DP being talked to */
-#define REMOTE_DP_VERSION 'V'
+/*
+ * This version of the protocol introduces ADIv5 commands for setting the version of the DP being talked to,
+ * and the TARGETSEL value for the DP for SWD multi-drop
+ */
+#define REMOTE_DP_VERSION   'V'
+#define REMOTE_DP_TARGETSEL 'T'
 
 /* This version of the protocol introduces 64-bit support for the ADIv5 acceleration protocol */
 #define REMOTE_UINT64           '%', '0', '1', '6', 'l', 'l', 'x'
@@ -90,6 +94,11 @@
 	(char[])                                                                                       \
 	{                                                                                              \
 		REMOTE_SOM, REMOTE_ADIV5_PACKET, REMOTE_DP_VERSION, REMOTE_ADIV5_DP_VERSION, REMOTE_EOM, 0 \
+	}
+#define REMOTE_DP_TARGETSEL_STR                                                                \
+	(char[])                                                                                   \
+	{                                                                                          \
+		REMOTE_SOM, REMOTE_ADIV5_PACKET, REMOTE_DP_TARGETSEL, REMOTE_ADIV5_DATA, REMOTE_EOM, 0 \
 	}
 
 /* ADIv6 acceleration protocol elements */

--- a/src/remote.c
+++ b/src/remote.c
@@ -402,6 +402,18 @@ static void remote_packet_process_adiv5(const char *const packet, const size_t p
 			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
 		return;
 	}
+	/* Check if this is a DP targetsel packet and handle it if it is */
+	else if (packet[1] == REMOTE_DP_TARGETSEL) {
+		/* Check if there are enough bytes for the request */
+		if (packet_len == 10U) {
+			/* Extract the new targetsel information into the DP */
+			remote_dp.targetsel = hex_string_to_num(8U, packet + 2U);
+			remote_respond(REMOTE_RESP_OK, 0);
+		} else
+			/* There weren't enough bytes, so tell the host and get out of here */
+			remote_respond(REMOTE_RESP_ERR, REMOTE_ERROR_WRONGLEN);
+		return;
+	}
 
 	/* Our shortest ADIv5 packet is 8 bytes long, check that we have at least that */
 	if (packet_len < 8U) {

--- a/src/remote.c
+++ b/src/remote.c
@@ -403,7 +403,7 @@ static void remote_packet_process_adiv5(const char *const packet, const size_t p
 		return;
 	}
 	/* Check if this is a DP targetsel packet and handle it if it is */
-	else if (packet[1] == REMOTE_DP_TARGETSEL) {
+	if (packet[1] == REMOTE_DP_TARGETSEL) {
 		/* Check if there are enough bytes for the request */
 		if (packet_len == 10U) {
 			/* Extract the new targetsel information into the DP */

--- a/src/remote.h
+++ b/src/remote.h
@@ -262,6 +262,7 @@
 #define REMOTE_MEM_READ         'm'
 #define REMOTE_MEM_WRITE        'M'
 #define REMOTE_DP_VERSION       'V'
+#define REMOTE_DP_TARGETSEL     'T'
 
 #define REMOTE_ADIV5_DEV_INDEX  REMOTE_UINT8
 #define REMOTE_ADIV5_AP_SEL     REMOTE_UINT8
@@ -322,6 +323,11 @@
 	(char[])                                                                                       \
 	{                                                                                              \
 		REMOTE_SOM, REMOTE_ADIV5_PACKET, REMOTE_DP_VERSION, REMOTE_ADIV5_DP_VERSION, REMOTE_EOM, 0 \
+	}
+#define REMOTE_DP_TARGETSEL_STR                                                                \
+	(char[])                                                                                   \
+	{                                                                                          \
+		REMOTE_SOM, REMOTE_ADIV5_PACKET, REMOTE_DP_TARGETSEL, REMOTE_ADIV5_DATA, REMOTE_EOM, 0 \
 	}
 
 /* ADIv6 acceleration protocol elements */


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address issues found while trying to debug STM32WL55 discovery. This process found bugs in both the error recovery implementation for SWD, and in the remote protocol.

On the SWD side, the error detection code failed to properly notice when a read of the DP's CTRL/STAT register failed and then properly handle that with protocol recovery. This slightly complicates the routine, but makes the error discovery and recovery process significantly more robust.

On the remote protocol side, the protocol failed to transfer the TARGETSEL value to use for a given DP for SWD multi-drop, resulting in protocol recovery failing to execute correctly to re-select the target and resume communications. This is corrected by addition of a new command for transferring this information to the shadow DP the probe maintains. Users running firmware from before this point will get a neat message displayed from BMDA informing them of the need to upgrade their firmware.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #2033
