### PR TITLE
Fix: CMSIS-DAP nRST control

### DIFF
--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -422,11 +422,6 @@ dap_version_s dap_adaptor_version(const dap_info_e version_kind)
 	return version;
 }
 
-void dap_nrst_set_val(bool assert)
-{
-	dap_set_reset_state(assert);
-}
-
 void dap_dp_abort(adiv5_debug_port_s *const target_dp, const uint32_t abort)
 {
 	/* DP Write to Reg 0.*/

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -35,6 +35,7 @@ bool dap_swd_init(adiv5_debug_port_s *dp);
 void dap_jtag_dp_init(adiv5_debug_port_s *dp);
 uint32_t dap_max_frequency(uint32_t clock);
 void dap_swd_configure(uint8_t cfg);
+bool dap_nrst_get_val(void);
 bool dap_nrst_set_val(bool assert);
 
 #endif /* PLATFORMS_HOSTED_CMSIS_DAP_H */

--- a/src/platforms/hosted/cmsis_dap.h
+++ b/src/platforms/hosted/cmsis_dap.h
@@ -35,6 +35,6 @@ bool dap_swd_init(adiv5_debug_port_s *dp);
 void dap_jtag_dp_init(adiv5_debug_port_s *dp);
 uint32_t dap_max_frequency(uint32_t clock);
 void dap_swd_configure(uint8_t cfg);
-void dap_nrst_set_val(bool assert);
+bool dap_nrst_set_val(bool assert);
 
 #endif /* PLATFORMS_HOSTED_CMSIS_DAP_H */

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include "general.h"
 #include "exception.h"
+#include "cmsis_dap.h"
 #include "dap.h"
 #include "dap_command.h"
 #include "jtag_scan.h"
@@ -212,7 +213,7 @@ size_t dap_info(const dap_info_e requested_info, void *const buffer, const size_
 	return result_length;
 }
 
-bool dap_set_reset_state(const bool nrst_state)
+bool dap_nrst_set_val(const bool nrst_state)
 {
 	/* Setup the request for the pin state change request */
 	dap_swj_pins_request_s request = {

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -88,6 +88,7 @@
 static bool dap_transfer_configure(uint8_t idle_cycles, uint16_t wait_retries, uint16_t match_retries);
 
 static uint32_t dap_current_clock_freq;
+static bool dap_nrst_state = false;
 
 bool dap_connect(void)
 {
@@ -213,6 +214,11 @@ size_t dap_info(const dap_info_e requested_info, void *const buffer, const size_
 	return result_length;
 }
 
+bool dap_nrst_get_val(void)
+{
+	return dap_nrst_state;
+}
+
 bool dap_nrst_set_val(const bool nrst_state)
 {
 	/* Setup the request for the pin state change request */
@@ -230,6 +236,8 @@ bool dap_nrst_set_val(const bool nrst_state)
 		DEBUG_PROBE("%s failed\n", __func__);
 		return false;
 	}
+	/* Extract the current pin state for the device, de-inverting it */
+	dap_nrst_state = !(response & DAP_SWJ_nRST);
 	return response == request.pin_values;
 }
 

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -486,6 +486,9 @@ bool platform_nrst_get_val(void)
 
 	case PROBE_TYPE_FTDI:
 		return ftdi_nrst_get_val();
+
+	case PROBE_TYPE_CMSIS_DAP:
+		return dap_nrst_get_val();
 #endif
 
 	default:

--- a/src/platforms/hosted/platform.c
+++ b/src/platforms/hosted/platform.c
@@ -441,7 +441,7 @@ const char *platform_target_voltage(void)
 	}
 }
 
-void platform_nrst_set_val(bool assert)
+void platform_nrst_set_val(const bool assert)
 {
 	switch (bmda_probe_info.type) {
 	case PROBE_TYPE_BMP:


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address a shortcoming of BMDA's CMSIS-DAP backend - nRST control. This allows code depending on understanding the state of the nRST line, such as the connect-under-reset logic to funciton properly.

Confirmed working with a patched ORBTrace using a STM32WL55 that drops off the debug bus if allowed to come out of reset while being scanned and attached.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
