### PR TITLE
Fix: STM32H5 reprogramming

### DIFF
--- a/src/target/stm32h5.c
+++ b/src/target/stm32h5.c
@@ -311,7 +311,7 @@ static bool stm32h5_flash_erase(target_flash_s *const target_flash, const target
 	target_s *const target = target_flash->t;
 	const stm32h5_flash_s *const flash = (stm32h5_flash_s *)target_flash;
 	/* Compute how many sectors should be erased (inclusive) and from which bank */
-	const uint32_t begin = target_flash->start - addr;
+	const uint32_t begin = addr - target_flash->start;
 	const uint32_t bank = flash->bank_and_sector_count & STM32H5_FLASH_BANK_MASK;
 	const size_t sector = begin / STM32H5_FLASH_SECTOR_SIZE;
 

--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -168,6 +168,7 @@ bool target_flash_erase(target_s *target, target_addr_t addr, size_t len)
 		if (!flash_prepare(flash, can_use_mass_erase ? FLASH_OPERATION_MASS_ERASE : FLASH_OPERATION_ERASE))
 			return false;
 
+		DEBUG_TARGET("%s: %08" PRIx32 "+%" PRIu32 "\n", __func__, local_start_addr, local_end_addr - local_start_addr);
 		/* Erase flash, either a single aligned block size or a full mass erase */
 		result &= can_use_mass_erase ? flash->mass_erase(flash, NULL) :
 									   flash->erase(flash, local_start_addr, flash->blocksize);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address an issue found by Esden where reprogramming a STM32H5 part would go wrong due to erase not completing properly.

As it turned out, this was caused by a mistake in the beginning address calculation. While fixing this we have opted to clean up the implementation using the guarantees of the target Flash API to simplify the code.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
