### PR TITLE
Fix: Treat GD32E508 in JTAG transport as ADIv5

### DIFF
--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -218,6 +218,14 @@
  * for the second and third JTAG-DPs which are still JTAG-DPv0.
  */
 #define JTAG_IDCODE_PARTNO_SOC400_4BIT_ERRATA 0xba01U
+
+/*
+ * ARM JTAG PARTNO values from Cortex-M33 TRM (ARM document ID 100230, issue 0100)
+ * A.4.2.2 Identification Code register, IDCODE, Table A-13 pg98
+ * (for TEALDAP/CM33DAP MINDP SWJ-DP/JTAG-DP)
+ */
+#define JTAG_IDCODE_PARTNO_SOC400_4BIT_CM33 0xba04U
+
 /*
  * ARM JTAG PARTNO values from CoreSight SoC-600 TRM (ARM document ID 101883, issue 0101-00)
  * §10.2.2 css600_dp register descriptions, Table 10-2 pg90

--- a/src/target/adiv5_jtag.c
+++ b/src/target/adiv5_jtag.c
@@ -83,6 +83,9 @@ void adiv5_jtag_dp_handler(const uint8_t dev_index)
 		/* Correct the LPC43xx errata PARTNO values */
 		if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_ERRATA)
 			dp->partno = JTAG_IDCODE_PARTNO_SOC400_4BIT;
+		/* Correct the GD32E50x PARTNO value */
+		else if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_CM33)
+			dp->partno = JTAG_IDCODE_PARTNO_SOC400_4BIT;
 
 		if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT || dp->partno == JTAG_IDCODE_PARTNO_SOC400_8BIT)
 			dp->version = 0U;


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is GD32E508ZE device no longer accepted by BMD since introduction of #1981 ADIv6 JTAG-DP support, v1.10.0-1445-g e0100843 (bisected), because this chip is only ADIv5.
* The PR "solves" it by recognizing 0xba04 partno and setting DP version to 0 like older JTAG-DP, which used to work.

A temporary patch "like LPC43xx errata" may not be ideal, because this is not mentioned in GD32E5 errata, but likely ends up an actual Cortex-M33 DAP ("TEALDAP") that is SWJ-DP MINDP. But I leave DPv0/v1 and ADIv6 DPv3 distinction details to maintainers. It works with JLink and with OpenOCD, and it used to work with BMD, it's not new.
Note: the other in-tree CM33 chips, STM32H5, identify as 0xba00 which corresponds to CoreSight SoC-400 JTAG-DP, and ST is known to have used CoreSight SoC-400 IP in STM32H7/MP15 (SWO and TPIU at least). And RP2350 (ADIv6) relies on SW-DP.

Tested using BMDA v2.0.0-rc1 driving JLink V9, also driving `blackpill-f411ce` around v1.10.0-1200 (as remote v0 adapter without HL).
```
ID code 0x0ba04477: ADIv5 JTAG-DP port.
ID code 0x790007a3: Gigadevice BSD.
Unknown JTAG-DP found, please report partno code ba04
Not using ADIv5 acceleration commands
DP DPIDR 0x0be11477 (v1 MINDP rev0) designer 0x43b partno 0xbe
```

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues