### PR TITLE
Fix: adiv5/6 JTAG version handling

### DIFF
--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -213,11 +213,10 @@
 #define JTAG_IDCODE_PARTNO_SOC400_4BIT 0xba00U
 #define JTAG_IDCODE_PARTNO_SOC400_8BIT 0xba03U
 /*
- * This PARTNO value comes from the LPC43xx parts which have a bugged pair of TAPs.
- * This value is actually reserved as a SWD-DPv1 value, but appears anyway on those devices
- * for the second and third JTAG-DPs which are still JTAG-DPv0.
+ * This PARTNO value comes from the LPC43xx parts which have a pair of Cortex-M0's using DPv1 TAPs.
+ * Value lifted from UM10503, §50.9 JTAG TAP Identification, Table 1170, pg1355
  */
-#define JTAG_IDCODE_PARTNO_SOC400_4BIT_ERRATA 0xba01U
+#define JTAG_IDCODE_PARTNO_SOC400_4BIT_LPC43xx 0xba01U
 
 /*
  * ARM JTAG PARTNO values from Cortex-M33 TRM (ARM document ID 100230, issue 0100_03)

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -220,8 +220,8 @@
 #define JTAG_IDCODE_PARTNO_SOC400_4BIT_ERRATA 0xba01U
 
 /*
- * ARM JTAG PARTNO values from Cortex-M33 TRM (ARM document ID 100230, issue 0100)
- * A.4.2.2 Identification Code register, IDCODE, Table A-13 pg98
+ * ARM JTAG PARTNO values from Cortex-M33 TRM (ARM document ID 100230, issue 0100_03)
+ * Appendix A, §A.4.2 Identification Code register, IDCODE, Table A-13 pg130
  * (for TEALDAP/CM33DAP MINDP SWJ-DP/JTAG-DP)
  */
 #define JTAG_IDCODE_PARTNO_SOC400_4BIT_CM33 0xba04U

--- a/src/target/adiv5_jtag.c
+++ b/src/target/adiv5_jtag.c
@@ -154,7 +154,7 @@ uint32_t adiv5_jtag_raw_access(
 	}
 
 	/* If this is an ADIv6 JTAG-DPv1, check for fault */
-	if (dp->version > 0 && ack == JTAG_ADIv6_ACK_FAULT) {
+	if (dp->version > 2 && ack == JTAG_ADIv6_ACK_FAULT) {
 		DEBUG_ERROR("JTAG access resulted in fault\n");
 		/* Use the SWD ack codes for the fault code to be completely consistent between JTAG-vs-SWD */
 		dp->fault = SWD_ACK_FAULT;
@@ -162,13 +162,13 @@ uint32_t adiv5_jtag_raw_access(
 	}
 
 	/* Check for a not-OK ack under ADIv5 JTAG-DPv0, or ADIv6 JTAG-DPv1 */
-	if ((dp->version == 0 && ack != JTAG_ADIv5_ACK_OK) || (dp->version > 0 && ack != JTAG_ADIv6_ACK_OK)) {
+	if ((dp->version < 3 && ack != JTAG_ADIv5_ACK_OK) || (dp->version > 2 && ack != JTAG_ADIv6_ACK_OK)) {
 		DEBUG_ERROR("JTAG access resulted in: %" PRIx32 ":%x\n", result, ack);
 		raise_exception(EXCEPTION_ERROR, "JTAG-DP invalid ACK");
 	}
 
 	/* ADIv6 needs 8 idle cycles run after we get done to ensure the state machine is idle */
-	if (dp->version > 0)
+	if (dp->version > 2)
 		jtag_proc.jtagtap_cycle(false, false, 8);
 	return result;
 }

--- a/src/target/adiv5_jtag.c
+++ b/src/target/adiv5_jtag.c
@@ -80,13 +80,10 @@ void adiv5_jtag_dp_handler(const uint8_t dev_index)
 
 	/* Check which version of DP we have here, if it's an ARM-made DP, and set up `dp->version` accordingly */
 	if (dp->designer_code == JEP106_MANUFACTURER_ARM) {
-		/* Correct the LPC43xx errata PARTNO values */
-		if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_ERRATA)
-			dp->partno = JTAG_IDCODE_PARTNO_SOC400_4BIT;
-
 		if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT || dp->partno == JTAG_IDCODE_PARTNO_SOC400_8BIT)
 			dp->version = 0U;
-		else if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_CM33)
+		else if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_CM33 ||
+			dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_LPC43xx)
 			dp->version = 1U;
 		else if (dp->partno == JTAG_IDCODE_PARTNO_SOC600_4BIT || dp->partno == JTAG_IDCODE_PARTNO_SOC600_8BIT)
 			dp->version = 3U;

--- a/src/target/adiv5_jtag.c
+++ b/src/target/adiv5_jtag.c
@@ -83,12 +83,11 @@ void adiv5_jtag_dp_handler(const uint8_t dev_index)
 		/* Correct the LPC43xx errata PARTNO values */
 		if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_ERRATA)
 			dp->partno = JTAG_IDCODE_PARTNO_SOC400_4BIT;
-		/* Correct the GD32E50x PARTNO value */
-		else if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_CM33)
-			dp->partno = JTAG_IDCODE_PARTNO_SOC400_4BIT;
 
 		if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT || dp->partno == JTAG_IDCODE_PARTNO_SOC400_8BIT)
 			dp->version = 0U;
+		else if (dp->partno == JTAG_IDCODE_PARTNO_SOC400_4BIT_CM33)
+			dp->version = 1U;
 		else if (dp->partno == JTAG_IDCODE_PARTNO_SOC600_4BIT || dp->partno == JTAG_IDCODE_PARTNO_SOC600_8BIT)
 			dp->version = 3U;
 		else


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a mistake made in the way that we handle DP versioning for JTAG-DPs in ADIv5 and v6.

ADIv5 implements *protocol* version 0, while ADIv6 implements version 1. This is a totaly different thing to the detectable version from the JTAG IDCODE `PARTNO` field which is related to the DP version instead.

We correct the low-level handling in adiv5_jtag.c with this, so that DPv0-2 work properly as protocol v0, while DPv3+ are protocol v1. This allows the PARTNO -> version translation to then be corrected and handled more appropriately.

Tested on a LPC4370.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
