### PR TITLE
Feature: enable noackmode by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -107,7 +107,7 @@ option(
 option(
 	'advertise_noackmode',
 	type: 'boolean',
-	value: false,
+	value: true,
 	description: 'Let GDB know that the probe supports and prefers `QStartNoAckMode`'
 )
 option(


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

Enabling noackmode advertisement tells GDB we support and prefer noackmode, who will then enable it by default. Right now the mode is supported but not advertised, it needs to be explicitly enabled by the user.

This should make the protocol more efficient even if by negligible amount without any drawbacks, as we have a reliable data connection making the checksums and acknowledgements redundant.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
