### PR TITLE
Add option to compile blackpill-f4* with SHIELD option, using meson

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -118,6 +118,13 @@ option(
 	description: 'Alternative pinout for probe (only applicable to blackpill-f4*)'
 )
 option(
+	'shield',
+	type: 'combo',
+	choices: ['0', '1'],
+	value: '0',
+	description: 'Select that blackpill-f4* is used with a shield (only applicable to blackpill-f4*)'
+)
+option(
 	'trace_protocol',
 	type: 'combo',
 	choices: ['1','2', '3'],

--- a/src/platforms/common/blackpill-f4/meson.build
+++ b/src/platforms/common/blackpill-f4/meson.build
@@ -62,6 +62,11 @@ if blackpill_alternative_pinout != '0'
 	probe_blackpill_args += [f'-DALTERNATIVE_PINOUT=@blackpill_alternative_pinout@']
 endif
 
+blackpill_shield = get_option('shield')
+if blackpill_shield != '0'
+	probe_blackpill_args += [f'-DSHIELD=@blackpill_shield@']
+endif
+
 if on_carrier_board
 	probe_blackpill_args += ['-DON_CARRIER_BOARD']
 endif


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
This PR adds back the option to compile using the `SHIELD` macro for blackpill-f4* boards.

This functionality was available when the code was compiled using make, but got lost in the translation to meson. This PR adds back this functionality.


<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
