### PR TITLE
Fix: WiFi configuration issues via USB (HTTP/WPS provisioning sometimes unreliable)

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -113,7 +113,7 @@ const command_s cmd_list[] = {
 	{"battery", cmd_target_battery, "Reads the battery state"},
 #endif
 #ifdef PLATFORM_HAS_WIFI
-	{"wifi", cmd_wifi, "Read/Set Wi-Fi connection [AP name, passphrase]"},
+	{"wifi", cmd_wifi, "Show/Set Wi-Fi connection [-forget] [AP name,passphrase]"},
 #endif
 #ifdef ENABLE_RTT
 	{"rtt", cmd_rtt,

--- a/src/command.c
+++ b/src/command.c
@@ -551,7 +551,8 @@ static bool cmd_target_battery(target_s *t, int argc, const char **argv)
 static bool cmd_wifi(target_s *t, int argc, const char **argv)
 {
 	(void)t;
-	return platform_wifi_state(argc, argv);
+	gdb_out(platform_wifi_state(argc, argv));
+	return true;
 }
 #endif
 

--- a/src/command.c
+++ b/src/command.c
@@ -113,7 +113,7 @@ const command_s cmd_list[] = {
 	{"battery", cmd_target_battery, "Reads the battery state"},
 #endif
 #ifdef PLATFORM_HAS_WIFI
-	{"wifi", cmd_wifi, "Reads the wi-fi state"},
+	{"wifi", cmd_wifi, "Read/Set Wi-Fi connection [AP name, passphrase]"},
 #endif
 #ifdef ENABLE_RTT
 	{"rtt", cmd_rtt,

--- a/src/command.c
+++ b/src/command.c
@@ -113,7 +113,7 @@ const command_s cmd_list[] = {
 	{"battery", cmd_target_battery, "Reads the battery state"},
 #endif
 #ifdef PLATFORM_HAS_WIFI
-	{"wifi", cmd_wifi, "Show/Set Wi-Fi connection [-forget] [AP name,passphrase]"},
+	{"wifi", cmd_wifi, "Show/Set Wi-Fi connection [AP name,passphrase]"},
 #endif
 #ifdef ENABLE_RTT
 	{"rtt", cmd_rtt,

--- a/src/command.c
+++ b/src/command.c
@@ -70,6 +70,9 @@ static bool cmd_target_power(target_s *target, int argc, const char **argv);
 #ifdef PLATFORM_HAS_BATTERY
 static bool cmd_target_battery(target_s *t, int argc, const char **argv);
 #endif
+#ifdef PLATFORM_HAS_WIFI
+static bool cmd_wifi(target_s *t, int argc, const char **argv);
+#endif
 #ifdef PLATFORM_HAS_TRACESWO
 static bool cmd_swo(target_s *target, int argc, const char **argv);
 #endif
@@ -108,6 +111,9 @@ const command_s cmd_list[] = {
 #endif
 #ifdef PLATFORM_HAS_BATTERY
 	{"battery", cmd_target_battery, "Reads the battery state"},
+#endif
+#ifdef PLATFORM_HAS_WIFI
+	{"wifi", cmd_wifi, "Reads the wi-fi state"},
 #endif
 #ifdef ENABLE_RTT
 	{"rtt", cmd_rtt,
@@ -541,6 +547,14 @@ static bool cmd_target_battery(target_s *t, int argc, const char **argv)
 	return true;
 }
 #endif
+#ifdef PLATFORM_HAS_WIFI
+static bool cmd_wifi(target_s *t, int argc, const char **argv)
+{
+	(void)t;
+	return platform_wifi_state(argc, argv);
+}
+#endif
+
 #ifdef ENABLE_RTT
 static const char *on_or_off(const bool value)
 {

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -651,6 +651,17 @@ bool is_ip_address_assigned(void)
 	return res;
 }
 
+void wifi_get_ip_address(char *buffer, uint32_t size)
+{
+	if (g_wifi_connected)
+		snprintf(buffer, size, "%d.%d.%d.%d\n", conn_info.acSSID[3], conn_info.acSSID[2], conn_info.acSSID[1],
+			conn_info.acSSID[0]);
+	else {
+		memset(buffer, 0x00, size - 1);
+		memcpy(buffer, "Not connected\n", strlen("Not connected"));
+	}
+}
+
 void handle_socket_bind_event(SOCKET *sock, bool *running_state)
 {
 	if (m2m_wifi_get_socket_event_data()->bindStatus == 0)

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -666,7 +666,7 @@ void wifi_get_ip_address(char *buffer, uint32_t size)
 		snprintf(local_buffer, sizeof(local_buffer), "SSID = %s\n", conn_info.acSSID);
 		strncpy(buffer, local_buffer, size);
 		snprintf(local_buffer, sizeof(local_buffer), "RSSI = %d\n", conn_info.s8RSSI);
-		strncpy(buffer, local_buffer, size);
+		strncat(buffer, local_buffer, size);
 		snprintf(local_buffer, sizeof(local_buffer), "IP = %d.%d.%d.%d\n", conn_info.au8IPAddr[0],
 			conn_info.au8IPAddr[1], conn_info.au8IPAddr[2], conn_info.au8IPAddr[3]);
 		strncat(buffer, local_buffer, size);

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -123,6 +123,8 @@ static bool swo_trace_client_connected = false;
 static bool swo_trace_server_is_running = false;
 static bool new_swo_trace_client_conncted = false;
 
+static tstrM2MIPConfig ip_configuration;
+
 #define SWO_TRACE_INPUT_BUFFER_SIZE 32
 static uint8_t local_swo_trace_buffer[SWO_TRACE_INPUT_BUFFER_SIZE] = {0}; ///< The local buffer[ input buffer size]
 
@@ -558,10 +560,11 @@ static void app_wifi_callback(uint8_t msg_type, void *msg)
 	}
 
 	case M2M_WIFI_IP_ADDRESS_ASSIGNED_EVENT: {
-		t_wifiEventData *wifi_event_data = (t_wifiEventData *)msg;
-		if (wifi_event_data != NULL)
+		tstrM2MIPConfig *ip_config = (tstrM2MIPConfig *)msg;
+		if (ip_config != NULL) {
 			ip_address_assigned = true;
-		else
+			memcpy(&ip_configuration, ip_config, sizeof(tstrM2MIPConfig));
+		} else
 			ip_address_assigned = false;
 		break;
 	}

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -154,7 +154,8 @@ typedef enum wi_fi_app_states {
 	app_state_error,                         ///< 12
 	app_state_check_default_connections,     ///< 13
 	app_state_spin,                          ///< 14
-	app_state_wait_connection_info           ///< 15
+	app_state_wait_connection_info,          ///< 15
+	app_state_wait_for_disconnect            ///< 16
 } app_states_e;
 
 app_states_e app_state; ///< State of the application
@@ -1326,6 +1327,14 @@ void app_task(void)
 		}
 		break;
 	}
+	case app_state_wait_for_disconnect: {
+		if (!is_wifi_connected()) {
+			app_state = app_state_spin;
+			mode_task_state = mode_led_idle_state;
+			led_mode = mode_led_idle;
+		}
+		break;
+	}
 	case app_state_wait_wifi_disconnect_for_wps: {
 		if (!is_wifi_connected()) {
 			// enter WPS mode
@@ -1367,7 +1376,6 @@ void app_task(void)
 			app_state = app_state_spin;
 		}
 		break;
-		;
 	}
 
 	case app_state_error: {

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -123,7 +123,7 @@ static bool swo_trace_client_connected = false;
 static bool swo_trace_server_is_running = false;
 static bool new_swo_trace_client_conncted = false;
 
-static tstrM2MIPConfig ip_configuration;
+tstrM2MConnInfo conn_info;
 
 #define SWO_TRACE_INPUT_BUFFER_SIZE 32
 static uint8_t local_swo_trace_buffer[SWO_TRACE_INPUT_BUFFER_SIZE] = {0}; ///< The local buffer[ input buffer size]
@@ -533,6 +533,11 @@ static void app_wifi_callback(uint8_t msg_type, void *msg)
 		break;
 	}
 
+	case M2M_WIFI_CONN_INFO_RESPONSE_EVENT: {
+		tstrM2MConnInfo *connection_info = (tstrM2MConnInfo *)msg;
+		memcpy(&conn_info, connection_info, sizeof(tstrM2MConnInfo));
+		break;
+	}
 	case M2M_WIFI_CONN_STATE_CHANGED_EVENT: {
 		tstrM2mWifiStateChanged *wifi_state = (tstrM2mWifiStateChanged *)msg;
 		if (wifi_state->u8CurrState == M2M_WIFI_CONNECTED) {
@@ -563,7 +568,10 @@ static void app_wifi_callback(uint8_t msg_type, void *msg)
 		tstrM2MIPConfig *ip_config = (tstrM2MIPConfig *)msg;
 		if (ip_config != NULL) {
 			ip_address_assigned = true;
-			memcpy(&ip_configuration, ip_config, sizeof(tstrM2MIPConfig));
+			//
+			// Request the connection info, user may request it
+			//
+			m2m_wifi_get_connection_info();
 		} else
 			ip_address_assigned = false;
 		break;
@@ -604,7 +612,6 @@ static void app_wifi_callback(uint8_t msg_type, void *msg)
 		break;
 	}
 		/* Unused states. Can be implemented if needed  */
-	case M2M_WIFI_CONN_INFO_RESPONSE_EVENT:
 	case M2M_WIFI_SCAN_DONE_EVENT:
 	case M2M_WIFI_SCAN_RESULT_EVENT:
 	case M2M_WIFI_SYS_TIME_EVENT:

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -651,13 +651,26 @@ bool is_ip_address_assigned(void)
 	return res;
 }
 
+//
+// Format the current connection data for display to user
+//
+//	SSID = 'name'
+//	RSSI = xx
+//	ip = xxx.xxx.xxx.xxx
+//
 void wifi_get_ip_address(char *buffer, uint32_t size)
 {
-	if (g_wifi_connected)
-		snprintf(buffer, size, "%d.%d.%d.%d\n", conn_info.acSSID[3], conn_info.acSSID[2], conn_info.acSSID[1],
-			conn_info.acSSID[0]);
-	else {
-		memset(buffer, 0x00, size - 1);
+	char local_buffer[64] = {0};
+	memset(buffer, 0x00, size - 1);
+	if (g_wifi_connected) {
+		snprintf(local_buffer, sizeof(local_buffer), "SSID = %s\n", conn_info.acSSID);
+		strncpy(buffer, local_buffer, size);
+		snprintf(local_buffer, sizeof(local_buffer), "RSSI = %d\n", conn_info.s8RSSI);
+		strncpy(buffer, local_buffer, size);
+		snprintf(local_buffer, sizeof(local_buffer), "IP = %d.%d.%d.%d\n", conn_info.au8IPAddr[0],
+			conn_info.au8IPAddr[1], conn_info.au8IPAddr[2], conn_info.au8IPAddr[3]);
+		strncat(buffer, local_buffer, size);
+	} else {
 		memcpy(buffer, "Not connected\n", strlen("Not connected"));
 	}
 }

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -1203,6 +1203,11 @@ void app_task(void)
 			//
 			m2m_wifi_set_sleep_mode(M2M_WIFI_PS_MANUAL, 1);
 			//
+			// Get the WINC1500 firmware version
+			//
+			tstrM2mRev info = {0};
+			nm_get_firmware_info(&info);
+			//
 			// Move to reading the MAC address state
 			//
 			app_state = app_state_read_mac_address; //app_state_connect_to_wifi;

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -737,7 +737,7 @@ void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size)
 		// TODO Does this need to check current state is spin?
 		//
 		app_state = app_state_wait_for_wifi_connect;
-		m2m_wifi_connect_sc(ssid, strlen(ssid), M2M_WIFI_SEC_WPA_PSK, &pass_phrase, 6);
+		m2m_wifi_connect_sc(ssid, strlen(ssid), M2M_WIFI_SEC_WPA_PSK, &pass_phrase, M2M_WIFI_CH_ALL);
 		//
 		// For now lets spin here calling app_tasks
 		//

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -698,7 +698,7 @@ void app_task_wait_spin(void)
 //
 // Using the passed arguments, attempt to connect to a Wi-Fi AP
 //
-void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size, bool save)
+void wifi_connect(size_t argc, const char **argv, char *buffer, uint32_t size)
 {
 	char ssid[64] = {0};
 	char pass_phrase[64] = {0};
@@ -724,7 +724,7 @@ void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size, bool
 	// The remaining arguments are then concatenated into the passphrase with
 	// an space added between them.
 	//
-	for (int loop = 1; loop < argc; loop++) {
+	for (size_t loop = 1; loop < argc; loop++) {
 		delimeter = strchr(argv[loop], ',');
 		if (delimeter == NULL) {
 			if (add_space) {
@@ -767,19 +767,16 @@ void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size, bool
 		//
 		app_state = app_state_wait_for_wifi_connect;
 		m2m_wifi_connect_sc(ssid, strlen(ssid), M2M_WIFI_SEC_WPA_PSK, &pass_phrase, M2M_WIFI_CH_ALL);
-		//
-		// For now lets spin here calling app_tasks
-		//
-		uint32_t wait_timeout = 2000U;
-		while (1) {
-			platform_tasks();
-			if (app_state == app_state_spin)
-				break;
-			platform_delay(1);
-			if (wait_timeout-- == 0)
-				break;
-		}
 	}
+}
+
+//
+// Disconnect from network
+//
+void wifi_disconnect(void)
+{
+	app_state = app_state_wait_for_disconnect;
+	m2m_wifi_disconnect();
 }
 
 void handle_socket_bind_event(SOCKET *sock, bool *running_state)

--- a/src/platforms/ctxlink/WiFi_Server.c
+++ b/src/platforms/ctxlink/WiFi_Server.c
@@ -741,11 +741,14 @@ void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size)
 		//
 		// For now lets spin here calling app_tasks
 		//
+		uint32_t wait_timeout = 2000U;
 		while (1) {
 			platform_tasks();
-			if (app_state == app_state_spin) {
+			if (app_state == app_state_spin)
 				break;
-			}
+			platform_delay(1);
+			if (wait_timeout-- == 0)
+				break;
 		}
 	}
 }

--- a/src/platforms/ctxlink/WiFi_Server.h
+++ b/src/platforms/ctxlink/WiFi_Server.h
@@ -46,7 +46,7 @@ uint8_t wifi_get_next(void);
 uint8_t wifi_get_next_to(uint32_t timeout);
 
 void wifi_get_ip_address(char *buffer, uint32_t size);
-void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size, bool save);
+void wifi_connect(size_t argc, const char **argv, char *buffer, uint32_t size);
 void app_task_wait_spin(void);
 void wifi_disconnect(void);
 #ifdef __cplusplus

--- a/src/platforms/ctxlink/WiFi_Server.h
+++ b/src/platforms/ctxlink/WiFi_Server.h
@@ -46,6 +46,7 @@ uint8_t wifi_get_next(void);
 uint8_t wifi_get_next_to(uint32_t timeout);
 
 void wifi_get_ip_address(char *buffer, uint32_t size) ;
+void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size) ;
 #ifdef __cplusplus
 }
 #endif /*  __cplusplus */

--- a/src/platforms/ctxlink/WiFi_Server.h
+++ b/src/platforms/ctxlink/WiFi_Server.h
@@ -45,8 +45,10 @@ bool wifi_got_client(void);
 uint8_t wifi_get_next(void);
 uint8_t wifi_get_next_to(uint32_t timeout);
 
-void wifi_get_ip_address(char *buffer, uint32_t size) ;
-void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size) ;
+void wifi_get_ip_address(char *buffer, uint32_t size);
+void wifi_connect(int argc, const char **argv, char *buffer, uint32_t size, bool save);
+void app_task_wait_spin(void);
+void wifi_disconnect(void);
 #ifdef __cplusplus
 }
 #endif /*  __cplusplus */

--- a/src/platforms/ctxlink/WiFi_Server.h
+++ b/src/platforms/ctxlink/WiFi_Server.h
@@ -44,6 +44,8 @@ void wifi_gdb_flush(bool force);
 bool wifi_got_client(void);
 uint8_t wifi_get_next(void);
 uint8_t wifi_get_next_to(uint32_t timeout);
+
+void wifi_get_ip_address(char *buffer, uint32_t size) ;
 #ifdef __cplusplus
 }
 #endif /*  __cplusplus */

--- a/src/platforms/ctxlink/ctxLink_mode_led.c
+++ b/src/platforms/ctxlink/ctxLink_mode_led.c
@@ -108,8 +108,8 @@ void mode_led_task(void)
 			 */
 		if (led_mode != mode_led_idle) {
 			/*
-				 * Set up the led control registers according to the requested mode
-				 */
+			 * Set up the led control registers according to the requested mode
+			 */
 			mode_task_state = mode_led_state_on;
 #ifndef INSTRUMENT
 			gpio_set(LED_PORT, LED_MODE);

--- a/src/platforms/ctxlink/ctxLink_mode_led.h
+++ b/src/platforms/ctxlink/ctxLink_mode_led.h
@@ -35,12 +35,12 @@ extern mode_led_task_states_e mode_task_state;
 // Define the various modes of the "mode led"
 //
 typedef enum {
-	mode_led_invalid = -1,
-	mode_led_idle = 0,         //	 0
-	mode_led_battery_low,      //	 1
-	mode_led_ap_connected,     //	 2
-	mode_led_wps_active,       //	 3
-	mode_led_http_provisioning //	 4
+	mode_led_idle = 0,          //	 0
+	mode_led_battery_low,       //	 1
+	mode_led_ap_connected,      //	 2
+	mode_led_wps_active,        //	 3
+	mode_led_http_provisioning, //	 4
+	mode_led_invalid = 255U
 } mode_led_modes_e;
 
 extern mode_led_modes_e led_mode;

--- a/src/platforms/ctxlink/ctxlink_gdb_if.c
+++ b/src/platforms/ctxlink/ctxlink_gdb_if.c
@@ -58,7 +58,7 @@ void gdb_usb_flush(const bool force)
 
 	/* We need to send an empty packet for some hosts to accept this as a complete transfer. */
 	if (force && count_in == CDCACM_PACKET_SIZE) {
-		/* 
+		/*
 		 * libopencm3 needs a change for us to confirm when that transfer is complete,
 		 * so we just send a packet containing a null character for now.
 		 */
@@ -114,6 +114,7 @@ char gdb_usb_getchar(void)
 		 * The WFI here is safe because any interrupt, including the regular SysTick
 		 * will cause the processor to resume from the WFI instruction.
 		 */
+		platform_tasks();
 		if (!gdb_serial_get_dtr()) {
 			__WFI();
 			return '\x04';

--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -161,11 +161,10 @@ static char parameters[128] = {0};
 const char *platform_wifi_state(int argc, const char **argv)
 {
 	(void)argv;
-	if (argc == 1) {
-		wifi_get_ip_address(parameters, sizeof(parameters));
-		return parameters;
-	}
-	return "Unknown";
+	if (argc > 1)
+		wifi_connect(argc, argv, parameters, sizeof(parameters));
+	wifi_get_ip_address(parameters, sizeof(parameters));
+	return parameters;
 }
 
 void platform_init(void)

--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -156,6 +156,13 @@ int platform_hwversion(void)
 	return 0;
 }
 
+bool platform_wifi_state(int argc, const char **argv)
+{
+	if (argc == 1) {
+	}
+	return true;
+}
+
 void platform_init(void)
 {
 	/* Enable GPIO peripherals */

--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -156,11 +156,12 @@ int platform_hwversion(void)
 	return 0;
 }
 
+static char parameters[128] = {0};
+
 const char *platform_wifi_state(int argc, const char **argv)
 {
 	(void)argv;
 	if (argc == 1) {
-		static char parameters[64] = {0};
 		wifi_get_ip_address(parameters, sizeof(parameters));
 		return parameters;
 	}

--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -161,8 +161,31 @@ static char parameters[128] = {0};
 const char *platform_wifi_state(int argc, const char **argv)
 {
 	(void)argv;
-	if (argc > 1)
-		wifi_connect(argc, argv, parameters, sizeof(parameters));
+	memset(parameters, 0x00, sizeof(parameters));
+	if (argc > 1) {
+		bool forget = false;
+		bool save = false;
+		//
+		// Check for an option
+		//
+		if (argv[1][0] == '-') {
+			//
+			// two options are support:
+			//	-forget <- forget the current Wi-Fi connection
+			//  -save <- Save the parameters in NVM (Passed to the wifi_connect call)
+			//
+			if (argv[1][1] == 's')
+				save = true;
+			else if (argv[1][1] == 'f')
+				forget = true;
+		}
+		if (forget)
+			wifi_disconnect() ;
+		else
+			wifi_connect(argc, argv, parameters, sizeof(parameters), save);
+
+		app_task_wait_spin();
+	}
 	wifi_get_ip_address(parameters, sizeof(parameters));
 	return parameters;
 }

--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -156,11 +156,15 @@ int platform_hwversion(void)
 	return 0;
 }
 
-bool platform_wifi_state(int argc, const char **argv)
+const char *platform_wifi_state(int argc, const char **argv)
 {
+	(void)argv;
 	if (argc == 1) {
+		static char parameters[64] = {0};
+		wifi_get_ip_address(parameters, sizeof(parameters));
+		return parameters;
 	}
-	return true;
+	return "Unknown";
 }
 
 void platform_init(void)

--- a/src/platforms/ctxlink/platform.c
+++ b/src/platforms/ctxlink/platform.c
@@ -160,30 +160,9 @@ static char parameters[128] = {0};
 
 const char *platform_wifi_state(int argc, const char **argv)
 {
-	(void)argv;
 	memset(parameters, 0x00, sizeof(parameters));
 	if (argc > 1) {
-		bool forget = false;
-		bool save = false;
-		//
-		// Check for an option
-		//
-		if (argv[1][0] == '-') {
-			//
-			// two options are support:
-			//	-forget <- forget the current Wi-Fi connection
-			//  -save <- Save the parameters in NVM (Passed to the wifi_connect call)
-			//
-			if (argv[1][1] == 's')
-				save = true;
-			else if (argv[1][1] == 'f')
-				forget = true;
-		}
-		if (forget)
-			wifi_disconnect() ;
-		else
-			wifi_connect(argc, argv, parameters, sizeof(parameters), save);
-
+		wifi_connect(argc, argv, parameters, sizeof(parameters));
 		app_task_wait_spin();
 	}
 	wifi_get_ip_address(parameters, sizeof(parameters));

--- a/src/platforms/ctxlink/platform.h
+++ b/src/platforms/ctxlink/platform.h
@@ -301,5 +301,5 @@ const char *platform_battery_voltage(void);
 bool platform_check_battery_voltage(void);
 bool platform_configure_uart(char *configuration_string);
 void platform_read_adc(void);
-bool platform_wifi_state(int argc, const char **argv);
+const char *platform_wifi_state(int argc, const char **argv);
 #endif /* PLATFORMS_CTXLINK_PLATFORM_H */

--- a/src/platforms/ctxlink/platform.h
+++ b/src/platforms/ctxlink/platform.h
@@ -31,6 +31,7 @@
 
 #define PLATFORM_HAS_TRACESWO
 #define PLATFORM_HAS_POWER_SWITCH
+#define PLATFORM_HAS_WIFI
 
 #define PLATFORM_IDENT "(ctxLink) "
 
@@ -300,5 +301,5 @@ const char *platform_battery_voltage(void);
 bool platform_check_battery_voltage(void);
 bool platform_configure_uart(char *configuration_string);
 void platform_read_adc(void);
-
+bool platform_wifi_state(int argc, const char **argv);
 #endif /* PLATFORMS_CTXLINK_PLATFORM_H */


### PR DESCRIPTION
This PR adds Wi-Fi management for ctxLink using GDB and a new monitor command.

With the original releases of ctxLink some users had issues using the HTTP and WPS provisioning features of ctxLink.

Also, after provisioning some users found it hard to discover the IP address of ctxLink, this is required to connect to the probe.

The new monitor command is "wifi".

To inspect the current Wi-Fi status the following command is used:

mon wifi

This will display either "Not Connected," or the SSID, Signal Strength (RSSI), and IP address of the connected Access Point.

To connect to a Wi-Fi Access Point the following command is used, substituting the SSID and PassPhrase settings of the AP:

mon wifi SSID,Passphrase

Spaces are accepted for these two parameters, however, there should be no space before or after the ",".


## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

None.
