### PR TITLE
Fix: noackmode zombie state handling

### DIFF
--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -81,6 +81,14 @@ void gdb_set_noackmode(bool enable)
 }
 
 #ifndef DEBUG_GDB_IS_NOOP
+/*
+ * To debug packets from the perspective of GDB we can use the following command:
+ *     set debug remote on
+ * This will print packets sent and received by the GDB client
+ * 
+ * This is not directly related to BMD, but as it's hard to find this information
+ * and it is extremely useful for debugging, we included it here for reference.
+ */
 static void gdb_packet_debug(const char *const func, const gdb_packet_s *const packet)
 {
 	/* Log packet for debugging */

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -60,19 +60,8 @@ char *gdb_packet_buffer(void)
 #endif /* EXTERNAL_PACKET_BUFFER */
 
 /* https://sourceware.org/gdb/onlinedocs/gdb/Packet-Acknowledgment.html */
-void gdb_set_noackmode(bool enable)
+void gdb_set_noackmode(const bool enable)
 {
-	/*
-	 * If we were asked to disable NoAckMode, and it was previously enabled,
-	 * it might mean we got a packet we determined to be the first of a new
-	 * GDB session, and as such it was not acknowledged (before GDB enabled NoAckMode),
-	 * better late than never.
-	 *
-	 * If we were asked after the connection was terminated, sending the ack will have no effect.
-	 */
-	if (!enable && noackmode)
-		gdb_if_putchar(GDB_PACKET_ACK, true);
-
 	/* Log only changes */
 	if (noackmode != enable)
 		DEBUG_GDB("%s NoAckMode\n", enable ? "Enabling" : "Disabling");

--- a/src/gdb_packet.c
+++ b/src/gdb_packet.c
@@ -80,6 +80,11 @@ void gdb_set_noackmode(bool enable)
 	noackmode = enable;
 }
 
+bool gdb_noackmode(void)
+{
+	return noackmode;
+}
+
 #ifndef DEBUG_GDB_IS_NOOP
 /*
  * To debug packets from the perspective of GDB we can use the following command:

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -75,6 +75,9 @@ void gdb_set_noackmode(bool enable);
 gdb_packet_s *gdb_packet_receive(void);
 void gdb_packet_send(const gdb_packet_s *packet);
 
+void gdb_packet_ack(bool ack);
+bool gdb_packet_get_ack(uint32_t timeout);
+
 char *gdb_packet_buffer(void);
 
 /* Convenience wrappers */

--- a/src/include/gdb_packet.h
+++ b/src/include/gdb_packet.h
@@ -70,6 +70,7 @@ typedef struct gdb_packet {
 
 /* GDB packet transmission configuration */
 void gdb_set_noackmode(bool enable);
+bool gdb_noackmode(void);
 
 /* Raw GDB packet transmission */
 gdb_packet_s *gdb_packet_receive(void);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

When a connection is terminated abruptly the noackmode state may be left in a "zombie" state, enabled, because we are unable to detect the connection was terminated.

We previously used the qSupported packet to signal a new connection and reset the state, but this breaks compatibility with LLDB which does not send qSupported as the first packet.

This attempts a new approach, by checking if a acknowledgement was sent in response to qSupported reply, we can detect when noackmode is enabled when it shouldn't. This also needs some special cases to acknowledge the first packets in a connection when noackmode is in a zombie state.

This introduces a small issue on LLDB connections, it tries to get an acknowledgement on qSupported which never comes, this is intended but, at least in hosted, the timeout is apparently not respected resulting in a slowdown of the connection of around ~1 second. This is an unrelated bug,  and the connection is still successful in the end so I deem it out of scope of this PR to fix it.

### Debug logs for connections after the changes

GDB, normal operation / clean state:
```yaml
gdb_packet_ack: ACK
gdb_packet_receive: qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;QThreadOptions+;no-resumed+;memory-tagging+
gdb_packet_send: PacketSize=400;qXfer:memory-map:read+;qXfer:features:read+;vContSupported+;QStartNoAckMode+
gdb_packet_get_ack: ACK
gdb_packet_ack: ACK
gdb_packet_receive: vCont?
gdb_packet_send: vCont;c;C;s;t
gdb_packet_get_ack: ACK
gdb_packet_ack: ACK
gdb_packet_receive: vMustReplyEmpty
gdb_packet_send: 
gdb_packet_get_ack: ACK
gdb_packet_ack: ACK
gdb_packet_receive: QStartNoAckMode
Enabling NoAckMode
gdb_packet_send: OK
gdb_packet_receive: !
gdb_packet_send: OK
gdb_packet_receive: Hg0
gdb_packet_send: OK
gdb_packet_receive: qXfer:features:read:target.xml:0,3fb
gdb_packet_send: E01
gdb_packet_receive: qTStatus
*** Unsupported packet: qTStatus
gdb_packet_send: 
gdb_packet_receive: ?
gdb_packet_send: W00
```

GDB, NoAckMode zombie state:
```yaml
gdb_packet_receive: qSupported:multiprocess+;swbreak+;hwbreak+;qRelocInsn+;fork-events+;vfork-events+;exec-events+;vContSupported+;QThreadEvents+;QThreadOptions+;no-resumed+;memory-tagging+
gdb_packet_ack: ACK
gdb_packet_send: PacketSize=400;qXfer:memory-map:read+;qXfer:features:read+;vContSupported+;QStartNoAckMode+
gdb_packet_get_ack: ACK
Received acknowledgment in NoAckMode, likely result of a session being terminated abruptly
Disabling NoAckMode
gdb_packet_ack: ACK
gdb_packet_receive: vCont?
gdb_packet_send: vCont;c;C;s;t
gdb_packet_get_ack: ACK
gdb_packet_ack: ACK
gdb_packet_receive: vMustReplyEmpty
gdb_packet_send: 
gdb_packet_get_ack: ACK
gdb_packet_ack: ACK
gdb_packet_receive: QStartNoAckMode
Enabling NoAckMode
gdb_packet_send: OK
gdb_packet_receive: !
gdb_packet_send: OK
gdb_packet_receive: Hg0
gdb_packet_send: OK
gdb_packet_receive: qXfer:features:read:target.xml:0,3fb
gdb_packet_send: E01
gdb_packet_receive: qTStatus
*** Unsupported packet: qTStatus
gdb_packet_send: 
gdb_packet_receive: ?
gdb_packet_send: W00
```

LLDB, normal operation / clean state:
```yaml
gdb_packet_ack: ACK
gdb_packet_receive: QStartNoAckMode
Enabling NoAckMode
gdb_packet_send: OK
gdb_packet_receive: qSupported:xmlRegisters=i386,arm,mips,arc;multiprocess+;fork-events+;vfork-events+
gdb_packet_ack: ACK
gdb_packet_send: PacketSize=400;qXfer:memory-map:read+;qXfer:features:read+;vContSupported+;QStartNoAckMode+
gdb_packet_get_ack: NACK
gdb_packet_receive: qC
gdb_packet_send: QC1
gdb_packet_receive: QListThreadsInStopReply
*** Unsupported packet: QListThreadsInStopReply
gdb_packet_send: 
gdb_packet_receive: qHostInfo
*** Unsupported packet: qHostInfo
gdb_packet_send: 
gdb_packet_receive: vCont?
gdb_packet_send: vCont;c;C;s;t
gdb_packet_receive: qVAttachOrWaitSupported
*** Unsupported packet: qVAttachOrWaitSupported
gdb_packet_send: 
gdb_packet_receive: QEnableErrorStrings
*** Unsupported packet: QEnableErrorStrings
gdb_packet_send: 
gdb_packet_receive: qProcessInfo
*** Unsupported packet: qProcessInfo
gdb_packet_send: 
gdb_packet_receive: qC
gdb_packet_send: QC1
gdb_packet_receive: ?
gdb_packet_send: W00
gdb_packet_receive: qProcessInfo
*** Unsupported packet: qProcessInfo
gdb_packet_send: 
```

LLDB, NoAckMode zombie state:
```yaml
gdb_packet_receive: QStartNoAckMode
gdb_packet_ack: ACK
gdb_packet_send: OK
gdb_packet_receive: qSupported:xmlRegisters=i386,arm,mips,arc;multiprocess+;fork-events+;vfork-events+
gdb_packet_ack: ACK
gdb_packet_send: PacketSize=400;qXfer:memory-map:read+;qXfer:features:read+;vContSupported+;QStartNoAckMode+
gdb_packet_get_ack: NACK
gdb_packet_receive: qC
gdb_packet_send: QC1
gdb_packet_receive: QListThreadsInStopReply
*** Unsupported packet: QListThreadsInStopReply
gdb_packet_send: 
gdb_packet_receive: qHostInfo
*** Unsupported packet: qHostInfo
gdb_packet_send: 
gdb_packet_receive: vCont?
gdb_packet_send: vCont;c;C;s;t
gdb_packet_receive: qVAttachOrWaitSupported
*** Unsupported packet: qVAttachOrWaitSupported
gdb_packet_send: 
gdb_packet_receive: QEnableErrorStrings
*** Unsupported packet: QEnableErrorStrings
gdb_packet_send: 
gdb_packet_receive: qProcessInfo
*** Unsupported packet: qProcessInfo
gdb_packet_send: 
gdb_packet_receive: qC
gdb_packet_send: QC1
gdb_packet_receive: ?
gdb_packet_send: W00
gdb_packet_receive: qProcessInfo
*** Unsupported packet: qProcessInfo
gdb_packet_send:
```

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
