### PR TITLE
Add ESP32-P4 support

### DIFF
--- a/src/target/jtag_devs.c
+++ b/src/target/jtag_devs.c
@@ -413,6 +413,32 @@ const jtag_dev_descr_s dev_descr[] = {
 #endif
 		.handler = riscv_jtag_dtm_handler,
 	},
+	{
+		.idcode = 0x00012c25U,
+		.idmask = 0x0fffffffU,
+#if ENABLE_DEBUG == 1
+		.descr = "ESP32-P4",
+#endif
+		.handler = riscv_jtag_dtm_handler,
+		.ir_quirks =
+			{
+				.ir_length = 5U,
+				.ir_value = 5U,
+			},
+	},
+	{
+		.idcode = 0x00012c25U,
+		.idmask = 0x0fffffffU,
+#if ENABLE_DEBUG == 1
+		.descr = "ESP32-P4",
+#endif
+		.handler = riscv_jtag_dtm_handler,
+		.ir_quirks =
+			{
+				.ir_length = 5U,
+				.ir_value = 1U,
+			},
+	},
 #endif
 #if defined(CONFIG_CORTEXAR) // && defined(ENABLE_SITARA)
 	{

--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -210,9 +210,17 @@ static void jtag_display_idcodes(void)
 
 static jtag_ir_quirks_s jtag_device_get_quirks(const uint32_t idcode)
 {
+	static size_t previous_idx = 0;
+
 	for (size_t idx = 0; dev_descr[idx].idcode; ++idx) {
 		if ((idcode & dev_descr[idx].idmask) == dev_descr[idx].idcode)
+		{
+			/* workaround for ESP32-P4 which has 2 different ir_value */
+			if (idcode == 0x12c25U && previous_idx == idx)
+				idx++;
+			previous_idx = idx;
 			return dev_descr[idx].ir_quirks;
+		}
 	}
 	return (jtag_ir_quirks_s){0};
 }


### PR DESCRIPTION
Continuation of mistakenly closed #2063

Here is commit with start of support for ESP32-P4.

I have started working on flashing support but I need to shelve that plan for the time being.
I am pushing the things which seems to work - patch is rough, but more will hopefully come later.

Tested with BMA and ESP-prog (FT2232H) on FreeBSD with Waveshare ESP32-P4 board with flashed IDF example.

Works:
- JTAG scan
- attach to target
- run program
- reset
- hardware breakpoint
- continue
- printing of var in SRAM
```
>>> p var
$4 = 123
>>> p &var
$5 = (uint32_t *) 0x4ff26334
>>> x /d 0x4ff26334
0x4ff26334:     123
```
- changing value of var:
```
>>> set var var = 100
>>> p var
$8 = 100
>>> x /d 0x4ff26334
0x4ff26334:     100
```

What doesn't work:
- software breakpoint (needs flash support)
- stepping
- single instruction stepping
 