### PR TITLE
Feature: change platform GPIO slew rate when high SWCLK frequency is requested

### DIFF
--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -70,6 +70,7 @@ void platform_max_frequency_set(uint32_t frequency);
 uint32_t platform_max_frequency_get(void);
 
 void platform_target_clk_output_enable(bool enable);
+void platform_ospeed_update(uint32_t frequency);
 
 #if CONFIG_BMDA == 0
 bool platform_spi_init(spi_bus_e bus);

--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -197,6 +197,15 @@ uint32_t platform_target_voltage_sense(void)
 }
 #endif
 
+void platform_ospeed_update(const uint32_t frequency)
+{
+	const uint8_t ospeed = frequency > 2000000U ? GPIO_OSPEED_25MHZ : GPIO_OSPEED_2MHZ;
+
+	gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, ospeed, TCK_PIN);
+	gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, ospeed, TMS_PIN);
+	gpio_set_output_options(TDI_PORT, GPIO_OTYPE_PP, ospeed, TDI_PIN);
+}
+
 void platform_target_clk_output_enable(bool enable)
 {
 	if (enable) {

--- a/src/platforms/common/stm32/timing_stm32.c
+++ b/src/platforms/common/stm32/timing_stm32.c
@@ -141,6 +141,11 @@ uint32_t platform_time_ms(void)
 	return time_ms;
 }
 
+__attribute__((weak)) void platform_ospeed_update(const uint32_t frequency)
+{
+	(void)frequency;
+}
+
 /*
  * Assume some USED_SWD_CYCLES per clock and CYCLES_PER_CNT cycles
  * per delay loop count with 2 delay loops per clock
@@ -152,6 +157,7 @@ uint32_t platform_time_ms(void)
 
 void platform_max_frequency_set(const uint32_t frequency)
 {
+	platform_ospeed_update(frequency);
 #ifdef BITBANG_CALIBRATED_FREQS
 	/*
 	 * If the frequency requested is above the value given when no delays are used of any kind,

--- a/src/platforms/stlinkv3/platform.c
+++ b/src/platforms/stlinkv3/platform.c
@@ -268,6 +268,14 @@ void platform_target_clk_output_enable(bool enable)
 	}
 }
 
+void platform_ospeed_update(const uint32_t frequency)
+{
+	if (frequency > 2000000U)
+		PIN_MODE_FAST();
+	else
+		PIN_MODE_NORMAL();
+}
+
 bool platform_spi_init(const spi_bus_e bus)
 {
 	(void)bus;

--- a/src/platforms/stlinkv3/platform.h
+++ b/src/platforms/stlinkv3/platform.h
@@ -112,14 +112,14 @@ extern bool debug_bmp;
 	do {                                                                              \
 		gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TMS_PIN); \
 		gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TCK_PIN); \
-		gpio_set_output_options(TDO_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TDO_PIN); \
+		gpio_set_output_options(TDI_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_25MHZ, TDI_PIN); \
 	} while (0)
 
 #define PIN_MODE_NORMAL()                                                            \
 	do {                                                                             \
 		gpio_set_output_options(TMS_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TMS_PIN); \
 		gpio_set_output_options(TCK_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TCK_PIN); \
-		gpio_set_output_options(TDO_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TDO_PIN); \
+		gpio_set_output_options(TDI_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, TDI_PIN); \
 	} while (0)
 
 extern const struct _usbd_driver stm32f723_usb_driver;


### PR DESCRIPTION
## Detailed description

* This is a new feature.
* The existing problem is poor signal integrity (ringing/reflections, ground bounce) of `stlinkv3` and `blackpill-f4` platforms resulting in failure of initial scan on setups with poor ground connections. 
* This PR solves it by runtime-matching STM32 GPIO OSPEED to the toggle rates indicated in datasheets.

Prior changes: 
`stlinkv3`: #1945, v1.10.0-1289-g 27cbec7e
`blackpill-f4`: #1717, v1.10.0-500-g b9969de3; and #2044, v2.0.0-rc1-3-g a3bb02e9

Because STLINK/V3E onboard Nucleo-H743ZI2 outright didn't work at highest reachable frequency (above 12 MHz) at 2 MHz slew rate, I gave 25 MHz a try and it worked. That platform is able to checksum target data at about 400 KiB/s.
MiniSTM32F4x1Cx is slower, but still can hit 8.72 MHz (96/11) without significant firmware changes, and this is uncomfortably outside DS10314 ranges (C_L = 10 pF, Vdd > 2.7, F_max(IO)out = 8 MHz).
But to reduce noise at lower frequencies, I suggest a platform callback which reverts to OSPEED_2MHz when crossing some frequency boundary. There are no series resistors, no buffers, and we can't expect users to always use two good ground wires, especially when other adapters work fine with just one. Shields and carriers can help this.
I don't think STM32F1-based platforms are affected, because a) fastest SWCLK primitives (no_delay) only reach 3.6-4.0 MHz, b) datasheet indicates 2 and 10 MHz f_max(IO)out for C_L = 50 pF.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)) *and should not affect it*
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues