### PR TITLE
blackpill/platform: Correct the condiitonal compilation symbol to initialize the bootloader LED pin.

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -116,7 +116,7 @@ void platform_init(void)
 	/* Set up LED pins */
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_IDLE_RUN | LED_ERROR);
 	/* Set up LED_BOOTLOADER if it hasn't been set up yet in the bootloader section above */
-#ifdef BMP_BOOTLOADER
+#ifdef BMD_BOOTLOADER
 	gpio_mode_setup(LED_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_BOOTLOADER);
 #endif
 	gpio_mode_setup(LED_PORT_UART, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, LED_UART);


### PR DESCRIPTION
This PR corrects a naming issue with the Blackpill-F4 platform.

The bootloader LED pin was not being setup.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None
<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
