### PR TITLE
Blackpill/readme: Update to describe need for "on_carrier_board" option

### DIFF
--- a/src/platforms/common/blackpill-f4/README.md
+++ b/src/platforms/common/blackpill-f4/README.md
@@ -50,6 +50,10 @@ meson setup build --cross-file=cross-file/blackpill-xxxxxx.ini -Dbmd_bootloader=
 
   Note: While the above command uses the 'build' directory, the name used is arbitrary, meaning, should a user wish to have multiple platforms built, they may use a more descriptive folder name.
 
+  Also Note: If the bootloader and firmware are going to be built for a Blackpill connected to a "Blackpill Carrier", the above
+  setup MUST have "-Don_carrier_board=true" added to it. This is required to ensure the LEDs are correctly mapped to
+  the Blackpill Carrier Board.
+  
 2. Compile the firmware and bootloader
 
 ```sh


### PR DESCRIPTION
This PR updates the Blackpill-F4 readme to describe the need for the "on_carrier_board" bujild option.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
None
<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
