### PR TITLE
[efm32_probe] Fix detection of DI v2

### DIFF
--- a/src/target/efm32.c
+++ b/src/target/efm32.c
@@ -377,6 +377,12 @@ static uint64_t efm32_v1_read_eui64(target_s *t)
 	return ((uint64_t)target_mem32_read32(t, EFM32_V1_DI_EUI64_1) << 32U) | target_mem32_read32(t, EFM32_V1_DI_EUI64_0);
 }
 
+/* Reads the EFM32 Extended Unique Identifier EUI48 (V2) */
+static uint64_t efm32_v2_read_eui48(target_s *t)
+{
+	return ((uint64_t)target_mem32_read32(t, EFM32_V2_DI_EUI48H) << 32U) | target_mem32_read32(t, EFM32_V2_DI_EUI48L);
+}
+
 /* Reads the Unique Number (DI V2 only) */
 static uint64_t efm32_v2_read_unique(target_s *t, uint8_t di_version)
 {
@@ -538,12 +544,13 @@ bool efm32_probe(target_s *t)
 {
 	/* Check if the OUI in the EUI is silabs or energymicro.
 	 * Use this to identify the Device Identification (DI) version */
-	uint8_t di_version = 1;
-	uint64_t oui24 = ((efm32_v1_read_eui64(t) >> 40U) & 0xffffffU);
-	if (oui24 == EFM32_V1_DI_EUI_SILABS) {
+	uint8_t di_version;
+	const uint32_t oui24_v1 = (efm32_v1_read_eui64(t) >> 40U) & 0xffffffU;
+	const uint32_t oui24_v2 = (efm32_v2_read_eui48(t) >> 24U) & 0xffffffU;
+	if (oui24_v1 == EFM32_V1_DI_EUI_SILABS) {
 		/* Device Identification (DI) version 1 */
 		di_version = 1;
-	} else if (oui24 == EFM32_V2_DI_EUI_ENERGYMICRO) {
+	} else if (oui24_v2 == EFM32_V2_DI_EUI_ENERGYMICRO) {
 		/* Device Identification (DI) version 2 */
 		di_version = 2;
 	} else {


### PR DESCRIPTION
## Detailed description

#402 introduced a bug with silabs devices (efm32/efr32) related to the parsing of the DI (Device Info) page. An example is [efr32xg13](https://www.silabs.com/documents/public/reference-manuals/efr32xg13-rm.pdf), which I believe would currently be broken. I do not have any of the relevant devices and cannot test this, but I noticed it while playing with adding support for the newer "series 2" parts (eg. EFRMG24).

The driver currently knows about two versions (it calls them "version 1" and "version 2") of the DI page with completely different layouts. It decides which version to use by:

1. Reading the EUI64 from the location specified by DI layout version 1
2. checking if the 24 bit OUI therein is equal to `EFM32_V1_DI_EUI_SILABS`, in which case layout version 1 is used
3. If not, checking if that same OUI is instead equal to `EFM32_V2_DI_EUI_ENERGYMICRO`, in which case version 2 is used
4. Defaulting to version 1 if neither OUI is matched

The problem with this if `EFM32_V2_DI_EUI_ENERGYMICRO` were to appear in the DI page, it woud be in the location specified by DI layout version 2, and so we need to perform another read from there. There's no way for the current code to ever detect v2.

So, that is the change this PR makes: Also try reading the OUI per layout version 2 (from the EUI48, because there is no EUI64 in v2). This is the behavior originally introduced in #372.

As #402 discusses, this strategy of relying on the OUI to differentiate parts versions is bad in the first place because there are over 100 OUIs assigned to Silicon Labs, and it's not actually known which devices use which OUI. A better idea might be to use the PARTNO value from the IDCODE register. It is mentioned in [AN1303](https://www.silabs.com/documents/public/application-notes/an1303-efr32-dci-swd-programming.pdf) that all series 2 parts (so, not what this driver supports) have `IDCODE == 0x6BA02477`, perhaps there is similar simple rule for the older parts supported by this driver? 

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do


