### PR TITLE
blackpill-f4: change slew speed frequency cutoff to 3 MHz

### DIFF
--- a/src/platforms/common/blackpill-f4/blackpill-f4.c
+++ b/src/platforms/common/blackpill-f4/blackpill-f4.c
@@ -143,7 +143,7 @@ void platform_init(void)
 	OTG_FS_GCCFG &= ~(OTG_GCCFG_VBUSBSEN | OTG_GCCFG_VBUSASEN);
 
 	/* By default, do not drive the SWD bus too fast. */
-	platform_max_frequency_set(3000000);
+	platform_max_frequency_set(2000000);
 }
 
 void platform_nrst_set_val(bool assert)


### PR DESCRIPTION
## Detailed description

In #1717, the output slew rate for the JTAG/SWD pins on bluepill-f4 was changed to 25MHz. This leads to failing target scans even with low bus speeds when the target isn't connected by e.g. two ground wires. In #2065, this was mitigated by switching output slew rate depending on requested speed. However, the cutoff was set at 2MHz, while the default bus speed is 3MHz. This keeps the bad out-of-the-box experience for users that don't know or are not able to set their own bus frequency.

The 2MHz slew rate is fine for a signal frequency of 3MHz, see datasheet DS10314.

cc @ALTracer 

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
