### PR TITLE
command: pass optional baudrate argument to swo_init in Manchester mode

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -666,7 +666,7 @@ static bool cmd_swo_enable(int argc, const char **argv)
 #endif
 #if SWO_ENCODING == 2 || SWO_ENCODING == 3
 	/* Handle the optional baud rate argument if present */
-	if (capture_mode == swo_nrz_uart && argc > decode_arg && argv[decode_arg][0] >= '0' && argv[decode_arg][0] <= '9') {
+	if (argc > decode_arg && argv[decode_arg][0] >= '0' && argv[decode_arg][0] <= '9') {
 		baudrate = strtoul(argv[decode_arg], NULL, 0);
 		if (baudrate == 0U)
 			baudrate = SWO_DEFAULT_BAUD;


### PR DESCRIPTION
## Detailed description

I'm working on a custom platform, and because my Manchester decoding implementation is based on the RP2040 PIO, I need to pass the incoming signal's baud rate to the device in Manchester mode as well.  
I believe this change will not affect other platforms, since the baudrate argument in the swo command is optional, and in the general swo_init implementation, the baudrate is only used in UART mode.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
