### PR TITLE
Fix: Declare correct RAM sizes for STM32F7

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -32,6 +32,17 @@
  *   https://www.st.com/resource/en/reference_manual/rm0401-stm32f410-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
  * GD32F4xx Arm® Cortex®-M4 32-bit MCU User Manual, Rev. 3.0
  *   https://www.gigadevice.com.cn/Public/Uploads/uploadfile/files/20240407/GD32F4xx_User_Manual_Rev3.0.pdf
+ * References for STM32F7xx:
+ * RM0385 - STM32F75xxx and STM32F74xxx advanced Arm®-based 32-bit MCUs, Rev. 9
+ *   https://www.st.com/resource/en/reference_manual/rm0385-stm32f75xxx-and-stm32f74xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * RM0410 - STM32F76xxx and STM32F77xxx advanced Arm®-based 32-bit MCUs, Rev. 5
+ *   https://www.st.com/resource/en/reference_manual/rm0410-stm32f76xxx-and-stm32f77xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * RM0431 - STM32F72xxx and STM32F73xxx advanced Arm®-based 32-bit MCUs, Rev. 4
+ *   https://www.st.com/resource/en/reference_manual/rm0431-stm32f72xxx-and-stm32f73xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+ * AN4667 - STM32F7 Series system architecture and performance, Rev. 4
+ *   https://www.st.com/resource/en/application_note/an4667-stm32f7-series-system-architecture-and-performance-stmicroelectronics.pdf
+ * AN4826 - STM32F7 Series Flash memory dual bank mode, Rev. 2
+ *   https://www.st.com/resource/en/application_note/an4826-stm32f7-series-flash-memory-dual-bank-mode-stmicroelectronics.pdf
  */
 
 #include "general.h"

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -423,17 +423,21 @@ static bool stm32f4_attach(target_s *const target)
 	/* And rebuild the RAM map */
 	bool use_dual_bank = !is_f7 && dual_bank;
 	if (is_f7) {
-		target_add_ram32(target, 0x00000000, 0x4000); /* 16kiB ITCM RAM */
-		if (target->part_id == ID_STM32F72X) {
-			target_add_ram32(target, 0x20000000, 0x10000); /* 64kiB DTCM RAM */
-			target_add_ram32(target, 0x20010000, 0x30000); /* 192kiB SRAM1/2 (176+16) */
-		} else if (target->part_id == ID_STM32F74X) {
-			target_add_ram32(target, 0x20000000, 0x10000); /* 64kiB DTCM RAM */
-			target_add_ram32(target, 0x20010000, 0x40000); /* 256kiB SRAM1/2 (240+16) */
-		} else if (target->part_id == ID_STM32F76X) {
-			target_add_ram32(target, 0x20000000, 0x20000); /* 128kiB DTCM RAM */
-			target_add_ram32(target, 0x20020000, 0x60000); /* 384kiB SRAM1/2 (368+16) */
+		uint32_t dtcm_size = 64U * 1024U; /* 64kiB DTCM RAM */
+		uint32_t ahbsram_size = 16U * 1024U;
+		if (target->part_id == ID_STM32F72X)
+			ahbsram_size = (176U + 16U) * 1024U; /* 192kiB SRAM1/2 */
+		else if (target->part_id == ID_STM32F74X)
+			ahbsram_size = (240U + 16U) * 1024U; /* 256kiB SRAM1/2 */
+		else if (target->part_id == ID_STM32F76X) {
+			dtcm_size = 128U * 1024U;            /* 128kiB DTCM RAM */
+			ahbsram_size = (368U + 16U) * 1024U; /* 384kiB SRAM1/2 */
 		}
+		target_add_ram32(target, 0x00000000U, 0x4000U); /* 16kiB ITCM RAM */
+		/* On STM32F7, DTCM and AHB SRAM are contiguous */
+		target_add_ram32(target, 0x20000000U, dtcm_size);
+		target_add_ram32(target, 0x20000000U + dtcm_size, ahbsram_size);
+
 		if (dual_bank) {
 			const uint32_t option_ctrl = target_mem32_read32(target, FLASH_OPTCR);
 			use_dual_bank = !(option_ctrl & FLASH_OPTCR_nDBANK);

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -423,9 +423,17 @@ static bool stm32f4_attach(target_s *const target)
 	/* And rebuild the RAM map */
 	bool use_dual_bank = !is_f7 && dual_bank;
 	if (is_f7) {
-		target_add_ram32(target, 0x00000000, 0x4000);  /* 16kiB ITCM RAM */
-		target_add_ram32(target, 0x20000000, 0x20000); /* 128kiB DTCM RAM */
-		target_add_ram32(target, 0x20020000, 0x60000); /* 384kiB RAM */
+		target_add_ram32(target, 0x00000000, 0x4000); /* 16kiB ITCM RAM */
+		if (target->part_id == ID_STM32F72X) {
+			target_add_ram32(target, 0x20000000, 0x10000); /* 64kiB DTCM RAM */
+			target_add_ram32(target, 0x20010000, 0x30000); /* 192kiB SRAM1/2 (176+16) */
+		} else if (target->part_id == ID_STM32F74X) {
+			target_add_ram32(target, 0x20000000, 0x10000); /* 64kiB DTCM RAM */
+			target_add_ram32(target, 0x20010000, 0x40000); /* 256kiB SRAM1/2 (240+16) */
+		} else if (target->part_id == ID_STM32F76X) {
+			target_add_ram32(target, 0x20000000, 0x20000); /* 128kiB DTCM RAM */
+			target_add_ram32(target, 0x20020000, 0x60000); /* 384kiB SRAM1/2 (368+16) */
+		}
 		if (dual_bank) {
 			const uint32_t option_ctrl = target_mem32_read32(target, FLASH_OPTCR);
 			use_dual_bank = !(option_ctrl & FLASH_OPTCR_nDBANK);

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -99,6 +99,11 @@
 #define AXIM_BASE 0x8000000U
 #define ITCM_BASE 0x0200000U
 
+#define STM32F7_ITCM_RAM_BASE 0x00000000U
+#define STM32F4_CCM_RAM_BASE  0x10000000U
+#define STM32F4_AHB_SRAM_BASE 0x20000000U
+#define STM32F7_DTCM_RAM_BASE STM32F4_AHB_SRAM_BASE
+
 #define STM32F4_DBGMCU_CTRL_DBG_SLEEP   (1U << 0U)
 #define STM32F4_DBGMCU_CTRL_DBG_STOP    (1U << 1U)
 #define STM32F4_DBGMCU_CTRL_DBG_STANDBY (1U << 2U)
@@ -433,10 +438,10 @@ static bool stm32f4_attach(target_s *const target)
 			dtcm_size = 128U * 1024U;            /* 128kiB DTCM RAM */
 			ahbsram_size = (368U + 16U) * 1024U; /* 384kiB SRAM1/2 */
 		}
-		target_add_ram32(target, 0x00000000U, 0x4000U); /* 16kiB ITCM RAM */
+		target_add_ram32(target, STM32F7_ITCM_RAM_BASE, 0x4000U); /* 16kiB ITCM RAM */
 		/* On STM32F7, DTCM and AHB SRAM are contiguous */
-		target_add_ram32(target, 0x20000000U, dtcm_size);
-		target_add_ram32(target, 0x20000000U + dtcm_size, ahbsram_size);
+		target_add_ram32(target, STM32F7_DTCM_RAM_BASE, dtcm_size);
+		target_add_ram32(target, STM32F7_DTCM_RAM_BASE + dtcm_size, ahbsram_size);
 
 		if (dual_bank) {
 			const uint32_t option_ctrl = target_mem32_read32(target, FLASH_OPTCR);


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is RTT Auto Search triggering lots of SWD Fault past end of physical SRAM on STM32F722.
* This PR solves it by shrinking declared memory map and dispatching datasheet values per-family.

As I've tried to inspect/debug a project on a board involving STM32F722, the RTT Auto Search feature (which is supposed to be plug&play without configuration) started scrubbing available RAM but fell off the 192 KiB cliff trying to scan all 384 KiB of AHB SRAM which should be present on STM32F777. Confirmed with `blackpill-f411ce` and BMDA. I know about `mon rtt mem` ranges but this sounds more like a workaround rather than fix, BMD should provide knowledge of DUT flash and RAM maps and sizes.

Note this was not rigorously tested with a real project yet. I don't like the seven function calls, this can be further reduced to three via stack locals, should be cheaper than a full LUT. Update: reduced, was +80, now is +48 bytes size-diff.
Tested on STM32F722RE to no longer generate "SWD access resulted in fault" messages during reads outside RAM bounds, and to create a smaller correct RAM map.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #2006.