### PR TITLE
Fix STM32F7 ITCM Flash alias map

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -521,13 +521,20 @@ static bool stm32f4_attach(target_s *const target)
 		 */
 		const uint32_t remaining_bank_length = stm32f4_remaining_bank_length(bank_length, 0x20000);
 		/* 128kiB in small sectors */
-		if (is_f7)
-			stm32f4_add_flash(target, ITCM_BASE, 0x10000, 0x4000, 0, split);
 		stm32f4_add_flash(target, AXIM_BASE, 0x10000, 0x4000, 0, split);
 		if (bank_length > 0x10000U) {
-			stm32f4_add_flash(target, 0x8010000, 0x10000, 0x10000, 4, split);
+			stm32f4_add_flash(target, AXIM_BASE + 0x10000U, 0x10000, 0x10000, 4, split);
 			if (remaining_bank_length)
-				stm32f4_add_flash(target, 0x8020000, remaining_bank_length, 0x20000, 5, split);
+				stm32f4_add_flash(target, AXIM_BASE + 0x20000U, remaining_bank_length, 0x20000, 5, split);
+		}
+		/* Declare ITCM alias, too */
+		if (is_f7) {
+			stm32f4_add_flash(target, ITCM_BASE, 0x10000, 0x4000, 0, split);
+			if (bank_length > 0x10000U) {
+				stm32f4_add_flash(target, ITCM_BASE + 0x10000U, 0x10000, 0x10000, 4, split);
+				if (remaining_bank_length)
+					stm32f4_add_flash(target, ITCM_BASE + 0x20000U, remaining_bank_length, 0x20000, 5, split);
+			}
 		}
 		/* If the device has an enabled second bank, we better deal with that too. */
 		if (use_dual_bank) {

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -531,11 +531,11 @@ static bool stm32f4_attach(target_s *const target)
 		}
 		/* If the device has an enabled second bank, we better deal with that too. */
 		if (use_dual_bank) {
-			if (is_f7) {
+			if (is_f7) { /* F76x in "dual_bank" mode loses "large_sectors" */
 				const uint32_t bank1_base = ITCM_BASE + bank_length;
-				stm32f4_add_flash(target, bank1_base, 0x10000, 0x4000, 0, split);
-				stm32f4_add_flash(target, bank1_base + 0x10000U, 0x10000, 0x10000, 4, split);
-				stm32f4_add_flash(target, bank1_base + 0x20000U, remaining_bank_length, 0x20000, 5, split);
+				stm32f4_add_flash(target, bank1_base, 0x10000, 0x4000, 16, split);
+				stm32f4_add_flash(target, bank1_base + 0x10000U, 0x10000, 0x10000, 20, split);
+				stm32f4_add_flash(target, bank1_base + 0x20000U, remaining_bank_length, 0x20000, 21, split);
 			}
 			const uint32_t bank2_base = AXIM_BASE + bank_length;
 			stm32f4_add_flash(target, bank2_base, 0x10000, 0x4000, 16, split);


### PR DESCRIPTION
## Detailed description

* Not a new feature.
* The existing problem is BMP/GDB `Load failed` for STM32F7 binaries linked to 0x0200_0000 ITCM flash bigger than 64 KiB.
* This PR solves it by extending/copying AXIM flash map to ITCM flash alias map.

Tested on STM32F722RE with BMDA/`blackpill-f411ce` to allow loading 512 KiB binaries (erase, write, verify, in-firmware check). Testers with F76x/F77x (like STM32F777) are otherwise welcome.

I've changed the order of first bank `stm32f4_add_flash()` calls here, maybe it's unwanted. But the following code block will also want to append to ITCM dual-bank sectors. If mixed order in-BMP is a problem, please state so. Another worry is this will interact with future `blank_check` feature, forcing it to walk entire NVM twice. I'd like to treat this separately by tracking e.g. some "is-alias" flag, also applicable to OTP pages (of G0).
Like in PR2075, please clarify whether refman references are mandatory there or here.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Closes #2006.