### PR TITLE
Fix BMD Bootloader to handle DFU_DETACH requests explicitly

### DIFF
--- a/src/platforms/common/stm32/dfucore.c
+++ b/src/platforms/common/stm32/dfucore.c
@@ -208,6 +208,15 @@ static void usbdfu_getstatus_complete(usbd_device *dev, usb_setup_data_s *req)
 	}
 }
 
+static void usbdfu_detach_complete(usbd_device *const dev, usb_setup_data_s *const req)
+{
+	(void)dev;
+	(void)req;
+
+	/* Delegate to platform-specific impls */
+	dfu_detach();
+}
+
 static usbd_request_return_codes_e usbdfu_control_request(usbd_device *dev, usb_setup_data_s *req, uint8_t **buf,
 	uint16_t *len, void (**complete)(usbd_device *dev, usb_setup_data_s *req))
 {
@@ -279,6 +288,10 @@ static usbd_request_return_codes_e usbdfu_control_request(usbd_device *dev, usb_
 		/* Return state with no state transition */
 		data[0] = usbdfu_state;
 		*len = 1;
+		return USBD_REQ_HANDLED;
+	case DFU_DETACH:
+		/* Accept this request and schedule a reboot */
+		*complete = usbdfu_detach_complete;
 		return USBD_REQ_HANDLED;
 	}
 


### PR DESCRIPTION
## Detailed description

* This is a minor feature with no new code.
* The existing problem is BMD bootloader ignoring `dfu-util --detach` requests. It still does reboot on `dfu-util -s :leave`.
* This PR solves it by adding an explicit request handler.

DFU runtime is unaffected, it already handles DFU_DETACH.
BMD bootloader still auto-reboots in Manifest phase when it has written a new firmware, this is not about that.
Tested on `blackpill-f411ce` with `dfu-util -v` and `bmputil`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues