### PR TITLE
Fix: Declare correct RAM sizes for STM32F4

### DIFF
--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -461,7 +461,23 @@ static bool stm32f4_attach(target_s *const target)
 	} else {
 		if (has_ccm_ram)
 			target_add_ram32(target, STM32F4_CCM_RAM_BASE, 0x10000); /* 64 KiB CCM RAM */
-		target_add_ram32(target, STM32F4_AHB_SRAM_BASE, 0x50000);    /* 320 KiB RAM */
+		/* F405/415, F407/417 have 112+16=128 KiB AHB SRAM */
+		uint32_t ram_size = 128U * 1024U;
+		/* F411, F446 also have a single chunk of 128 KiB AHB SRAM, so treat others specially */
+		if (target->part_id == ID_STM32F46X || target->part_id == ID_STM32F413)
+			ram_size = 320U * 1024U; /* 320 KiB AHB SRAM */
+		else if (target->part_id == ID_STM32F412)
+			ram_size = 256U * 1024U; /* 256 KiB AHB SRAM */
+		else if (target->part_id == ID_STM32F42X)
+			ram_size = 192U * 1024U; /* 192 KiB AHB SRAM */
+		else if (target->part_id == ID_STM32F401E)
+			ram_size = 96U * 1024U; /* 96 KiB AHB SRAM */
+		else if (target->part_id == ID_STM32F401C)
+			ram_size = 64U * 1024U; /* 64 KiB AHB SRAM */
+		else if (target->part_id == ID_STM32F410)
+			ram_size = 32U * 1024U; /* 32 KiB AHB SRAM */
+		/* TODO: F20x can have 128, but also 96 or 64 */
+		target_add_ram32(target, STM32F4_AHB_SRAM_BASE, ram_size);
 
 		if (dual_bank && max_flashsize < 2048U) {
 			/* Check the dual-bank status on 1MiB Flash devices */

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -331,8 +331,8 @@ bool gd32f4_probe(target_s *const target)
 	target->driver = stm32f4_get_chip_name(target->part_id);
 	target_add_commands(target, stm32f4_cmd_list, target->driver);
 
-	target_add_ram32(target, 0x10000000, 0x10000); /* 64 k CCM Ram*/
-	target_add_ram32(target, 0x20000000, 0x50000); /* 320 k RAM */
+	target_add_ram32(target, STM32F4_CCM_RAM_BASE, 0x10000);  /* 64 KiB CCM RAM */
+	target_add_ram32(target, STM32F4_AHB_SRAM_BASE, 0x50000); /* 320 KiB RAM */
 
 	/* TODO implement DBS mode */
 	const uint8_t split = 12;
@@ -460,8 +460,9 @@ static bool stm32f4_attach(target_s *const target)
 		}
 	} else {
 		if (has_ccm_ram)
-			target_add_ram32(target, 0x10000000, 0x10000); /* 64kiB CCM RAM */
-		target_add_ram32(target, 0x20000000, 0x50000);     /* 320kiB RAM */
+			target_add_ram32(target, STM32F4_CCM_RAM_BASE, 0x10000); /* 64 KiB CCM RAM */
+		target_add_ram32(target, STM32F4_AHB_SRAM_BASE, 0x50000);    /* 320 KiB RAM */
+
 		if (dual_bank && max_flashsize < 2048U) {
 			/* Check the dual-bank status on 1MiB Flash devices */
 			const uint32_t option_ctrl = target_mem32_read32(target, FLASH_OPTCR);


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is too generous AHB SRAM maps for most STM32F4 families which are smaller than STM32F469. This triggers SWD faults for access beyond end of physical RAM (including RTT auto-search). CCM is fine.
* This PR solves it by matching AHB SRAM size to part ID per refmans.

Follow-up to #2075.
I can only test on F411CE and maybe F427, F469. Entire series is described by (14 datasheets and) 8 refmans, of which only 2 are linked now.

Note that STM32F207/217 is defaulted to 128 KiB here, F205/215 likewise, which is correct, but some F205 parts also come in 96 and 64 KiB smaller flavours -- I have no idea how to do this cheaply other than coupling this to (B)/(C) flash size read out from F_ID engineering bytes. Their RM0033+PM0059 and DS6329+DS6697 can be added when that's implemented and tested.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues