### PR TITLE
cortemx: use a global define to make sure we allocate enough room for registers

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -47,6 +47,9 @@
 
 #include <assert.h>
 
+/* This is the size (in 32 bits integers) you must allocate when reading cortem registers */
+#define CORTEXM_MAX_REG_COUNT (CORTEXM_GENERAL_REG_COUNT + CORTEX_FLOAT_REG_COUNT + CORTEXM_TRUSTZONE_REG_COUNT)
+
 static bool cortexm_vector_catch(target_s *target, int argc, const char **argv);
 
 const command_s cortexm_cmd_list[] = {
@@ -942,7 +945,7 @@ static int cortexm_fault_unwind(target_s *target)
 	 */
 	if ((hfsr & CORTEXM_HFSR_FORCED) || cfsr) {
 		/* Unwind exception */
-		uint32_t regs[CORTEXM_GENERAL_REG_COUNT + CORTEX_FLOAT_REG_COUNT];
+		uint32_t regs[CORTEXM_MAX_REG_COUNT];
 		uint32_t stack[8];
 		/* Read registers for post-exception stack pointer */
 		target_regs_read(target, regs);
@@ -992,7 +995,7 @@ static int cortexm_fault_unwind(target_s *target)
 
 bool cortexm_run_stub(target_s *target, uint32_t loadaddr, uint32_t r0, uint32_t r1, uint32_t r2, uint32_t r3)
 {
-	uint32_t regs[CORTEXM_GENERAL_REG_COUNT + CORTEX_FLOAT_REG_COUNT] = {0};
+	uint32_t regs[CORTEXM_MAX_REG_COUNT] = {0};
 
 	regs[0] = r0;
 	regs[1] = r1;
@@ -1010,7 +1013,7 @@ bool cortexm_run_stub(target_s *target, uint32_t loadaddr, uint32_t r0, uint32_t
 	/* Execute the stub */
 	target_halt_reason_e reason = TARGET_HALT_RUNNING;
 #if defined(PLATFORM_HAS_DEBUG)
-	uint32_t arm_regs_start[CORTEXM_GENERAL_REG_COUNT + CORTEX_FLOAT_REG_COUNT];
+	uint32_t arm_regs_start[CORTEXM_MAX_REG_COUNT];
 	target_regs_read(target, arm_regs_start);
 #endif
 	cortexm_halt_resume(target, 0);
@@ -1021,7 +1024,7 @@ bool cortexm_run_stub(target_s *target, uint32_t loadaddr, uint32_t r0, uint32_t
 			cortexm_halt_request(target);
 #if defined(PLATFORM_HAS_DEBUG)
 			DEBUG_WARN("Stub hung\n");
-			uint32_t arm_regs[CORTEXM_GENERAL_REG_COUNT + CORTEX_FLOAT_REG_COUNT];
+			uint32_t arm_regs[CORTEXM_MAX_REG_COUNT];
 			target_regs_read(target, arm_regs);
 			for (uint32_t i = 0; i < 20U; ++i)
 				DEBUG_WARN("%2" PRIu32 ": %08" PRIx32 ", %08" PRIx32 "\n", i, arm_regs_start[i], arm_regs[i]);


### PR DESCRIPTION
## Detailed description

This is a partial workaround for  #2094  
The core problem is depending on the option enabled ( FPU, Trustzone,..) the size needed for target_read/write_regs varies. Part of the code was wrongly computing the needed size and causing stack overflow/corruption and FPU+Trustzone was present.

The partial workaround is to use a define correctly settings the needed size and using it in cortemx.c
This is only partial because :
1- It is local only. There are similar wrong constructs in lpc55 code at least.
2- It does not really solve the core issue of ensuring the proper size has been allocated by design.

On option for the later would be to define a structure cortexm_registers / riscv_registers.. 
with the proper size. 

I tested it on my test case which adds more trustzone registers (msplim/psplim) and was crashing easily.
I dont have that crash any longer with that change injected. 
(The debugged MCU was a RP2350 with both trustzone and FPU)

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab
=readme-ov-file#building-black-magic-debug-firmware))

Does not link due to flash overflow

* [X] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [X] I've tested it to the best of my ability
* [X] My commit messages provide a useful short description of what the commits do

## Closing issues


<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
