### PR TITLE
Fix: minor deduplication in Puya driver

### DIFF
--- a/src/target/puya.c
+++ b/src/target/puya.c
@@ -162,11 +162,11 @@ static bool puya_flash_prepare(target_flash_s *flash)
 	const uint32_t eppara2 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 8);
 	const uint32_t eppara3 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 12);
 	const uint32_t eppara4 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 16);
-	DEBUG_TARGET("PY32 flash timing cal 0: %08" PRIx32 "\n", eppara0);
-	DEBUG_TARGET("PY32 flash timing cal 1: %08" PRIx32 "\n", eppara1);
-	DEBUG_TARGET("PY32 flash timing cal 2: %08" PRIx32 "\n", eppara2);
-	DEBUG_TARGET("PY32 flash timing cal 3: %08" PRIx32 "\n", eppara3);
-	DEBUG_TARGET("PY32 flash timing cal 4: %08" PRIx32 "\n", eppara4);
+	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 0, eppara0);
+	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 1, eppara1);
+	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 2, eppara2);
+	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 3, eppara3);
+	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 4, eppara4);
 
 	target_mem32_write32(flash->t, PUYA_FLASH_TS0, eppara0 & 0xffU);
 	target_mem32_write32(flash->t, PUYA_FLASH_TS1, (eppara0 >> 16U) & 0x1ffU);

--- a/src/target/puya.c
+++ b/src/target/puya.c
@@ -157,26 +157,20 @@ static bool puya_flash_prepare(target_flash_s *flash)
 		hsi_fs = 0;
 	DEBUG_TARGET("HSI frequency selection is %d\n", hsi_fs);
 
-	const uint32_t eppara0 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 0);
-	const uint32_t eppara1 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 4);
-	const uint32_t eppara2 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 8);
-	const uint32_t eppara3 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 12);
-	const uint32_t eppara4 = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + 16);
-	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 0, eppara0);
-	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 1, eppara1);
-	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 2, eppara2);
-	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 3, eppara3);
-	DEBUG_TARGET("PY32 flash timing cal %d: %08" PRIx32 "\n", 4, eppara4);
-
-	target_mem32_write32(flash->t, PUYA_FLASH_TS0, eppara0 & 0xffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_TS1, (eppara0 >> 16U) & 0x1ffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_TS3, (eppara0 >> 8U) & 0xffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_TS2P, eppara1 & 0xffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_TPS3, (eppara1 >> 16U) & 0x7ffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_PERTPE, eppara2 & 0x1ffffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_SMERTPE, eppara3 & 0x1ffffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_PRGTPE, eppara4 & 0xffffU);
-	target_mem32_write32(flash->t, PUYA_FLASH_PRETPE, (eppara4 >> 16U) & 0x3fffU);
+	uint32_t eppara[5] = {0};
+	for (uint16_t i = 0; i < 5; i++) {
+		eppara[i] = target_mem32_read32(flash->t, PUYA_FLASH_TIMING_CAL_BASE + hsi_fs * 20 + i * 4U);
+		DEBUG_TARGET("PY32 flash timing cal %u: %08" PRIx32 "\n", i, eppara[i]);
+	}
+	target_mem32_write32(flash->t, PUYA_FLASH_TS0, eppara[0] & 0xffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_TS1, (eppara[0] >> 16U) & 0x1ffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_TS3, (eppara[0] >> 8U) & 0xffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_TS2P, eppara[1] & 0xffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_TPS3, (eppara[1] >> 16U) & 0x7ffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_PERTPE, eppara[2] & 0x1ffffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_SMERTPE, eppara[3] & 0x1ffffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_PRGTPE, eppara[4] & 0xffffU);
+	target_mem32_write32(flash->t, PUYA_FLASH_PRETPE, (eppara[4] >> 16U) & 0x3fffU);
 
 	return true;
 }


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is code in `puya_flash_prepare()` is notably WET (or five-times), affecting BMF size in some configurations.
* This PR tries to dry it a bit by picking the low-hanging fruit: `epparaN` is replaced by an array and a loop.

Not tested on any py32 devices which I don't have.
Discovered via staring at `strings -n16 build-f411ce/blackmagic_blackpill_f411ce_firmware.bin | less` output.

First commit doesn't affect BMF size, or saves 136 bytes when DEBUG_TARGET is enabled (in Farpatch or else). Consider this as preparation to enabling `DEBUG_TARGET` firmware-wide. Which is unlikely to happen in v2.0, so this can be tracked to v2.1.

Second commit brings minor savings of 32 bytes in release, or 64 with logging, probably by eliminating 4 extra calls to `target_mem32_read32()` and `printf()`. It does lose `const`-ness of `eppara[5]` but the scope is fairly small. I guess I could even optimize this to a 20-byte block read `target_mem32_read()` but it'd change behaviour, and I don't know how Puya flash controller reacts to it.

CC #1817 by @ArcaneNibble 

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
