### PR TITLE
Fix: log string deduplication

### DIFF
--- a/src/target/lpc17xx.c
+++ b/src/target/lpc17xx.c
@@ -173,17 +173,17 @@ static bool lpc17xx_mass_erase(target_s *const target, platform_timeout_s *const
 	iap_result_s result;
 
 	if (lpc17xx_iap_call(target, &result, print_progess, IAP_CMD_PREPARE, 0, FLASH_NUM_SECTOR - 1U)) {
-		DEBUG_ERROR("lpc17xx_cmd_erase: prepare failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("%s: prepare failed %" PRIu32 "\n", __func__, result.return_code);
 		return false;
 	}
 
 	if (lpc17xx_iap_call(target, &result, print_progess, IAP_CMD_ERASE, 0, FLASH_NUM_SECTOR - 1U, CPU_CLK_KHZ)) {
-		DEBUG_ERROR("lpc17xx_cmd_erase: erase failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("%s: erase failed %" PRIu32 "\n", __func__, result.return_code);
 		return false;
 	}
 
 	if (lpc17xx_iap_call(target, &result, print_progess, IAP_CMD_BLANKCHECK, 0, FLASH_NUM_SECTOR - 1U)) {
-		DEBUG_ERROR("lpc17xx_cmd_erase: blankcheck failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("%s: blankcheck failed %" PRIu32 "\n", __func__, result.return_code);
 		return false;
 	}
 

--- a/src/target/lpc40xx.c
+++ b/src/target/lpc40xx.c
@@ -167,17 +167,17 @@ static bool lpc40xx_mass_erase(target_s *const target, platform_timeout_s *const
 	iap_result_s result;
 
 	if (lpc40xx_iap_call(target, &result, print_progess, IAP_CMD_PREPARE, 0, FLASH_NUM_SECTOR - 1U)) {
-		DEBUG_ERROR("lpc40xx_cmd_erase: prepare failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("%s: prepare failed %" PRIu32 "\n", __func__, result.return_code);
 		return false;
 	}
 
 	if (lpc40xx_iap_call(target, &result, print_progess, IAP_CMD_ERASE, 0, FLASH_NUM_SECTOR - 1U, CPU_CLK_KHZ)) {
-		DEBUG_ERROR("lpc40xx_cmd_erase: erase failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("%s: erase failed %" PRIu32 "\n", __func__, result.return_code);
 		return false;
 	}
 
 	if (lpc40xx_iap_call(target, &result, print_progess, IAP_CMD_BLANKCHECK, 0, FLASH_NUM_SECTOR - 1U)) {
-		DEBUG_ERROR("lpc40xx_cmd_erase: blankcheck failed %" PRIu32 "\n", result.return_code);
+		DEBUG_ERROR("%s: blankcheck failed %" PRIu32 "\n", __func__, result.return_code);
 		return false;
 	}
 

--- a/src/target/lpc55xx.c
+++ b/src/target/lpc55xx.c
@@ -102,6 +102,17 @@ typedef enum lpc55xx_iap_cmd {
 	IAP_CMD_FFR_GET_UUID,
 } lpc55xx_iap_cmd_e;
 
+#ifndef DEBUG_ERROR_IS_NOOP
+/* Reflection strings for enum above */
+static const char *const lpc55xx_iap_cmd_descr[] = {
+	"FLASH_INIT",
+	"FLASH_ERASE",
+	"FLASH_PROGRAM",
+	"FFR_INIT",
+	"FFR_GET_UUID",
+};
+#endif
+
 /* The possible IAP errors are documented here for easy reference */
 typedef enum lpc55xx_iap_status {
 	IAP_STATUS_FLASH_SUCCESS = 0,
@@ -341,7 +352,7 @@ static bool lpc55xx_flash_init(target_s *target, lpc55xx_flash_config_s *config)
 
 	const lpc55xx_iap_status_e status = iap_call_raw(target, IAP_CMD_FLASH_INIT, 0, 0, 0);
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_ERROR("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: %s (%d)\n", lpc55xx_iap_cmd_descr[IAP_CMD_FLASH_INIT], status);
 		goto exit;
 	}
 
@@ -370,19 +381,19 @@ static bool lpc55xx_get_uuid(target_s *target, uint8_t *uuid)
 
 	lpc55xx_iap_status_e status = iap_call_raw(target, IAP_CMD_FLASH_INIT, 0, 0, 0);
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_ERROR("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: %s (%d)\n", lpc55xx_iap_cmd_descr[IAP_CMD_FLASH_INIT], status);
 		goto exit;
 	}
 
 	status = iap_call_raw(target, IAP_CMD_FFR_INIT, 0, 0, 0);
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_ERROR("LPC55xx: IAP error: FFR_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: %s (%d)\n", lpc55xx_iap_cmd_descr[IAP_CMD_FFR_INIT], status);
 		goto exit;
 	}
 
 	status = iap_call_raw(target, IAP_CMD_FFR_GET_UUID, LPC55xx_UUID_ADDRESS, 0, 0);
 	if (status != IAP_STATUS_FLASH_SUCCESS) {
-		DEBUG_ERROR("LPC55xx: IAP error: FFR_GET_UUID (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: %s (%d)\n", lpc55xx_iap_cmd_descr[IAP_CMD_FFR_GET_UUID], status);
 		goto exit;
 	}
 
@@ -430,7 +441,7 @@ static bool lpc55xx_flash_prepare(target_flash_s *flash)
 
 	const lpc55xx_iap_status_e status = iap_call_raw(flash->t, IAP_CMD_FLASH_INIT, 0, 0, 0);
 	if (status != IAP_STATUS_FLASH_SUCCESS)
-		DEBUG_ERROR("LPC55xx: IAP error: FLASH_INIT (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: %s (%d)\n", lpc55xx_iap_cmd_descr[IAP_CMD_FLASH_INIT], status);
 	return status == IAP_STATUS_FLASH_SUCCESS;
 }
 
@@ -439,7 +450,7 @@ static bool lpc55xx_flash_erase(target_flash_s *flash, target_addr_t addr, size_
 	const lpc55xx_iap_status_e status =
 		iap_call_raw(flash->t, IAP_CMD_FLASH_ERASE, addr, (uint32_t)len, LPC55xx_ERASE_KEY);
 	if (status != IAP_STATUS_FLASH_SUCCESS)
-		DEBUG_ERROR("LPC55xx: IAP error: FLASH_ERASE (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: %s (%d)\n", lpc55xx_iap_cmd_descr[IAP_CMD_FLASH_ERASE], status);
 	return status == IAP_STATUS_FLASH_SUCCESS;
 }
 
@@ -450,7 +461,7 @@ static bool lpc55xx_flash_write(target_flash_s *flash, target_addr_t dest, const
 	const lpc55xx_iap_status_e status =
 		iap_call_raw(flash->t, IAP_CMD_FLASH_PROGRAM, dest, LPC55xx_WRITE_BUFFER_ADDRESS, (uint32_t)len);
 	if (status != IAP_STATUS_FLASH_SUCCESS)
-		DEBUG_ERROR("LPC55xx: IAP error: FLASH_PROGRAM (%d)\n", status);
+		DEBUG_ERROR("LPC55xx: IAP error: %s (%d)\n", lpc55xx_iap_cmd_descr[IAP_CMD_FLASH_PROGRAM], status);
 	return status == IAP_STATUS_FLASH_SUCCESS;
 }
 

--- a/src/target/renesas_ra.c
+++ b/src/target/renesas_ra.c
@@ -458,24 +458,21 @@ bool renesas_ra_probe(target_s *const target)
 		 */
 
 		if (renesas_pnr_read(target, RENESAS_FIXED2_PNR, pnr)) {
-			DEBUG_WARN("Found renesas chip (%.*s) with pnr location RENESAS_FIXED2_PNR and unsupported Part ID %x "
-					   "please report it\n",
-				(int)sizeof(pnr), pnr, target->part_id);
+			DEBUG_WARN("Found renesas chip (%.*s) with %s and unsupported Part ID 0x%x, please report it\n",
+				(int)sizeof(pnr), pnr, "pnr location RENESAS_FIXED2_PNR", target->part_id);
 			break;
 		}
 
 		if (renesas_pnr_read(target, RENESAS_FIXED1_PNR, pnr)) {
-			DEBUG_WARN("Found renesas chip (%.*s) with pnr location RENESAS_FIXED1_PNR and unsupported Part ID 0x%x "
-					   "please report it\n",
-				(int)sizeof(pnr), pnr, target->part_id);
+			DEBUG_WARN("Found renesas chip (%.*s) with %s and unsupported Part ID 0x%x, please report it\n",
+				(int)sizeof(pnr), pnr, "pnr location RENESAS_FIXED1_PNR", target->part_id);
 			break;
 		}
 
 		flash_root_table = renesas_fmifrt_read(target);
 		if (renesas_pnr_read(target, RENESAS_FMIFRT_PNR(flash_root_table), pnr)) {
-			DEBUG_WARN("Found renesas chip (%.*s) with Flash Root Table and unsupported Part ID 0x%x "
-					   "please report it\n",
-				(int)sizeof(pnr), pnr, target->part_id);
+			DEBUG_WARN("Found renesas chip (%.*s) with %s and unsupported Part ID 0x%x, please report it\n",
+				(int)sizeof(pnr), pnr, "Flash Root Table", target->part_id);
 			break;
 		}
 

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -500,7 +500,6 @@ static uint32_t stm32h7_flash_cr(uint32_t sector_size, const uint32_t ctrl, cons
 	/* H74x, H72x IP: 128 KiB and has PSIZE */
 	if (sector_size == FLASH_SECTOR_SIZE) {
 		command |= sector_number << STM32H7_FLASH_CTRL_SECTOR_NUM_SHIFT;
-		DEBUG_TARGET("%s: patching FLASH_CR from 0x%08" PRIx32 " to 0x%08" PRIx32 "\n", __func__, ctrl, command);
 		return command;
 	}
 
@@ -513,7 +512,6 @@ static uint32_t stm32h7_flash_cr(uint32_t sector_size, const uint32_t ctrl, cons
 	command |= temp_fw_start >> 2U;
 	/* SNB offset is different, too */
 	command |= sector_number << STM32H7BX_FLASH_CTRL_SECTOR_NUM_SHIFT;
-	DEBUG_TARGET("%s: patching FLASH_CR from 0x%08" PRIx32 " to 0x%08" PRIx32 "\n", __func__, ctrl, command);
 	return command;
 }
 

--- a/src/target/target_probe.h
+++ b/src/target/target_probe.h
@@ -27,7 +27,7 @@
 /* Probe launch macro used by the CPU-generic layers to then call CPU-specific routines safely */
 #define PROBE(x)                                    \
 	do {                                            \
-		DEBUG_TARGET("Calling " STRINGIFY(x) "\n"); \
+		DEBUG_TARGET("Calling %s\n", STRINGIFY(x)); \
 		if ((x)(target))                            \
 			return true;                            \
 		target_check_error(target);                 \


### PR DESCRIPTION
## Detailed description

* No significant new features.
* The existing problem is suboptimal/repeating message strings for DEBUG_ERROR/WARN/TARGET().
* This PR solves it by factoring out unique substrings and enabling linker relaxation across newly-identical strings.

Discovered by staring at `strings -n16 build-f411ce/blackmagic_blackpill_f411ce_firmware.bin | less` output.
1. First commit saves up to 256 bytes when all targets are enabled and `DEBUG_TARGET()` is enabled.
2. In `stm32h7.c`, I drop the logline I added previously for H7B3 compat FLASH_CR patcher helper, because the driver is tested to work and that logline spams output during flashing. -116 bytes.
3. Renesas RA driver has three really long warnings with identical prefix/suffix and missing comma. -136 bytes.
4. LPC17xx & LPC40xx have similar mass-erase functions in which strings differ and hence don't get merged. -104 bytes.
5. LPC55xx reports IAP errors for five unique commands, and I decided to extract these instead. -52 bytes.

I would need some autobuilder script to measure size savings from each commit, but they're on the order of 50-100 bytes, for a total of about -292 bytes up to DEBUG_WARN, and -372 bytes more up to DEBUG_TARGET (-664).
Can't test on most of targets modified in PR scope. Idea similar to #1527 and #1863. Should have no effect on release firmware with disabled logging. When `-Ddebug_output=true`, default `native` and `swlink`/`stlink`/`bluepill` and `f072` builds still overflow by 17-23 KiB. The other probe platforms are not 128 KiB but 256 KiB or even larger.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues