### PR TITLE
Feature: add log message for flash_prepare()

### DIFF
--- a/src/target/target_flash.c
+++ b/src/target/target_flash.c
@@ -89,6 +89,9 @@ static bool flash_prepare(target_flash_s *flash, flash_operation_e operation)
 	if (flash->operation == operation)
 		return true;
 
+#ifndef DEBUG_TARGET_IS_NOOP
+	const char *const flash_operation_name[4] = {"none", "erase", "mass", "write"};
+#endif
 	bool result = true;
 	/* Terminate any ongoing Flash operation */
 	if (flash->operation != FLASH_OPERATION_NONE)
@@ -98,8 +101,10 @@ static bool flash_prepare(target_flash_s *flash, flash_operation_e operation)
 	if (result) {
 		flash->operation = operation;
 		/* Prepare flash for operation, unless we failed to terminate the previous one */
-		if (flash->prepare)
+		if (flash->prepare) {
+			DEBUG_TARGET("%s (for %s)\n", __func__, flash_operation_name[operation]);
 			result = flash->prepare(flash);
+		}
 
 		/* If the preparation step failed, revert back to the post-done state */
 		if (!result)


### PR DESCRIPTION
## Detailed description

* This can be called a minor new feature.
* The existing problem is `flash_prepare()` functions of target drivers called transparently but, depending on specific flash controller, double unlocking (for erase, for write) may trigger potentially hard to detect errors.
* This PR adds a log line highlighting what function with what argument is invoked when in the flashing process.

I've used a similar patch to confirm speed of `stlinkv3`+STM32H743ZI reflashing operation with help of `tio` timestamping on `ttyBmpTarg`.
There could be more such logging extracted from per-target functions into central target_flash.c API layer, but a broader refactoring requires more effort. `target_flash_erase()` is logged, `target_flash_write()` isn't. I don't like how less readable this becomes, but this is the best place to log -- when all the conditions are passed but before the actual call (which may fail or hang or throw in future drivers). I could move the string array out of two branch scopes.
C has no enum->string reflection. Not urgent for v2.0.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues