### PR TITLE
native/platform: Fix and add documentation for TMS_DIR and TCK_DIR on native

### DIFF
--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -55,14 +55,17 @@ extern int hwversion;
  * TPWR     = PB0  (input)  -- analogue on mini design ADC1, CH8
  * nTRST    = PB1  (output) [blackmagic]
  * PWR_BR   = PB1  (output) [blackmagic_mini] -- supply power to the target, active low
- * TMS_DIR  = PA1  (output) [blackmagic_mini v2.1] -- choose direction of the TCK pin, input low, output high
+ * TMS_DIR  = PA1  (output) [blackmagic_mini v2.1] -- choose direction of the TMS pin, input low, output high
  * nRST     = PA2  (output) -- Hardware 5 and older
  *          = PA9  (output) -- Hardware 6 and newer
  * TDI      = PA3  (output) -- Hardware 5 and older
  *          = PA7  (output) -- Hardware 6 and newer
  * TMS      = PA4  (input/output for SWDIO)
  * TCK      = PA5  (output SWCLK)
- * TCK_DIR  = PC15 (output) -- Hardware 6 and newer
+ * TCK_DIR  = PC15 (output) -- Hardware 6 and newer -- choose direction of the TCK pin.
+ *                                                     external pull-up (default high, output)
+ *                                                     set to LOW to allow multiple BMP to share the TCK/SWDCLK line
+ *                                                     input low, output high
  * TDO      = PA6  (input)
  * TRACESWO = PB7  (input)  -- To allow trace decoding using USART1
  *                             Hardware 4 has a normally open jumper between TDO and TRACESWO

--- a/src/platforms/native/platform.h
+++ b/src/platforms/native/platform.h
@@ -65,6 +65,8 @@ extern int hwversion;
  * TCK_DIR  = PC15 (output) -- Hardware 6 and newer -- choose direction of the TCK pin.
  *                                                     external pull-up (default high, output)
  *                                                     set to LOW to allow multiple BMP to share the TCK/SWDCLK line
+ *                                                     for in-circuit communication (I2C, SPI) set to low to prevent conflict
+ *                                                     with other devices in the circuit
  *                                                     input low, output high
  * TDO      = PA6  (input)
  * TRACESWO = PB7  (input)  -- To allow trace decoding using USART1


### PR DESCRIPTION
## Detailed description

In the code for the native probe, the TMS_DIR and TCK_DIR weren't properly documented. This makes custom implementations of the BMP board harder.

I fixed the description of the TMS_DIR pin.
I also added description for the TCK_DIR pin, including the reason why we would like to switch the direction of the TCK signal.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

None
