### PR TITLE
Fix: CMSIS-DAP HID I/O

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -2,7 +2,7 @@
  * This file is part of the Black Magic Debug project.
  *
  * Copyright (C) 2020 - 2022 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
- * Copyright (C) 2022-2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2022-2025 1BitSquared <info@1bitsquared.com>
  * Written by Sid Price <sid@sidprice.com>
  * Written by Rachel Mant <git@dragonmux.network>
  *
@@ -285,7 +285,10 @@ static probe_info_s *process_ftdi_probe(void)
 
 				if (probe_skip) { // Clean up any previous serial number to skip
 					use_serial = true;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 					free((void *)probe_skip);
+#pragma GCC diagnostic pop
 					probe_skip = NULL;
 				}
 
@@ -323,7 +326,10 @@ static probe_info_s *process_ftdi_probe(void)
 		}
 	}
 	if (probe_skip)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 		free((void *)probe_skip);
+#pragma GCC diagnostic pop
 	free(dev_info);
 	return probe_list;
 }

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -498,8 +498,9 @@ ssize_t dbg_dap_cmd_hid_io(const uint8_t *const request_data, const size_t reque
 		return response;
 	}
 	/* If we got a good response, copy the data for it to the response buffer */
-	memcpy(response_data, buffer, response_length);
-	return response;
+	const size_t bytes_transferred = MIN((size_t)response, response_length);
+	memcpy(response_data, buffer, bytes_transferred);
+	return (int)bytes_transferred;
 }
 
 ssize_t dbg_dap_cmd_hid(const uint8_t *const request_data, const size_t request_length, uint8_t *const response_data,
@@ -597,7 +598,7 @@ static ssize_t dap_run_cmd_raw(const uint8_t *const request_data, const size_t r
 
 	ssize_t response = -1;
 	if (type == CMSIS_TYPE_HID)
-		response = dbg_dap_cmd_hid(request_data, request_length, data, dap_packet_size);
+		response = dbg_dap_cmd_hid(request_data, request_length, data, MIN(response_length + 1U, dap_packet_size));
 	else if (type == CMSIS_TYPE_BULK)
 		response = dbg_dap_cmd_bulk(request_data, request_length, data, dap_packet_size);
 	if (response < 0)
@@ -610,7 +611,7 @@ static ssize_t dap_run_cmd_raw(const uint8_t *const request_data, const size_t r
 	DEBUG_WIRE("\n");
 
 	if (response_length)
-		memcpy(response_data, data + 1, MIN(response_length, result));
+		memcpy(response_data, data + 1, MIN(response_length, result - 1U));
 	return response;
 }
 

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -222,9 +222,9 @@ static bool dap_init_hid(void)
 
 	/*
 	 * Base the report length information for the device on the max packet length from its descriptors.
-	 * Add 1 to account for HIDAPI's need to prefix with a report type byte. Limit to at most 512 bytes.
+	 * Add 1 to account for HIDAPI's need to prefix with a report type byte. Limit to at most 513 bytes.
 	 */
-	dap_packet_size = MIN(bmda_probe_info.max_packet_length + 1U, 512U);
+	dap_packet_size = MIN(bmda_probe_info.max_packet_length + 1U, 513U);
 
 	/* Handle the NXP LPC11U3x CMSIS-DAP v1.0.7 implementation needing a 64 byte report length */
 	if (bmda_probe_info.vid == 0x1fc9U && bmda_probe_info.pid == 0x0132U)

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -540,6 +540,8 @@ ssize_t dbg_dap_cmd_hid(const uint8_t *const request_data, const size_t request_
 			memcpy(response_data, buffer, response_length);
 		}
 	}
+	if (response > 0)
+		return MIN((size_t)response, response_length);
 	return response;
 }
 
@@ -568,7 +570,7 @@ ssize_t dbg_dap_cmd_bulk(const uint8_t *const request_data, const size_t request
 	} while (response_data[0] != request_data[0]);
 
 	/* If the response requested is the size of the packet size for the adaptor, generate a ZLP read to clean state */
-	if ((dap_quirks & DAP_QUIRK_NEEDS_EXTRA_ZLP_READ) && transferred == (int)dap_packet_size) {
+	if ((dap_quirks & DAP_QUIRK_NEEDS_EXTRA_ZLP_READ) && (size_t)transferred == dap_packet_size) {
 		uint8_t zlp;
 		int zlp_read = 0;
 		libusb_bulk_transfer(usb_handle, in_ep, &zlp, sizeof(zlp), &zlp_read, TRANSFER_TIMEOUT_MS);

--- a/src/platforms/hosted/cmsis_dap.c
+++ b/src/platforms/hosted/cmsis_dap.c
@@ -200,7 +200,7 @@ static void dap_hid_print_permissions(const uint16_t vid, const uint16_t pid, co
 static bool dap_init_hid(void)
 {
 	/* Initialise HIDAPI */
-	DEBUG_INFO("Using hid transfer\n");
+	DEBUG_INFO("Using HID transfer\n");
 	if (hid_init())
 		return false;
 
@@ -283,10 +283,8 @@ bool dap_init(bool allow_fallback)
 		}
 	}
 
-	if (type == CMSIS_TYPE_HID) {
-		if (!dap_init_hid())
-			return false;
-	}
+	if (type == CMSIS_TYPE_HID && !dap_init_hid())
+		return false;
 
 	/* Ensure the adaptor is idle and not prepared for any protocol in particular */
 	dap_disconnect();

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013-2015 Alex Taradov <alex@taradov.com>
  * Copyright (C) 2020-2021 Uwe Bonnes <bon@elektron.ikp.physik.tu-darmstadt.de>
- * Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2023-2025 1BitSquared <info@1bitsquared.com>
  * Modified by Rachel Mant <git@dragonmux.network>
  * All rights reserved.
  *
@@ -37,11 +37,6 @@
 #include "dap_command.h"
 #include "jtag_scan.h"
 #include "buffer_utils.h"
-
-#define DAP_TRANSFER_APnDP (1U << 0U)
-#define DAP_TRANSFER_RnW   (1U << 1U)
-
-#define DAP_TRANSFER_WAIT (1U << 1U)
 
 #define SWD_DP_R_IDCODE    0x00U
 #define SWD_DP_W_ABORT     0x00U

--- a/src/platforms/hosted/dap.c
+++ b/src/platforms/hosted/dap.c
@@ -258,7 +258,7 @@ void dap_write_reg(adiv5_debug_port_s *target_dp, const uint8_t reg, const uint3
 	};
 
 	do {
-		if (perform_dap_transfer(target_dp, &request, 1U, NULL, 0))
+		if (perform_dap_transfer(target_dp, &request, 1U, NULL, 0U))
 			return;
 	} while (target_dp->fault == DAP_TRANSFER_WAIT);
 }

--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -2,7 +2,7 @@
  * This file is part of the Black Magic Debug project.
  *
  * Copyright (c) 2013-2015, Alex Taradov <alex@taradov.com>
- * Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2023-2025 1BitSquared <info@1bitsquared.com>
  * Modified by Rachel Mant <git@dragonmux.network>
  * All rights reserved.
  *
@@ -73,11 +73,11 @@ typedef enum dap_led_type {
 #define DAP_QUIRK_BAD_SWD_NO_RESP_DATA_PHASE (1U << 1U)
 #define DAP_QUIRK_BROKEN_SWD_SEQUENCE        (1U << 2U)
 #define DAP_QUIRK_NEEDS_EXTRA_ZLP_READ       (1U << 3U)
+#define DAP_QUIRK_NO_SWD_SEQUENCE            (1U << 4U)
 
 extern uint8_t dap_caps;
 extern dap_cap_e dap_mode;
 extern uint8_t dap_quirks;
-extern bool dap_has_swd_sequence;
 
 bool dap_connect(void);
 bool dap_disconnect(void);

--- a/src/platforms/hosted/dap_command.c
+++ b/src/platforms/hosted/dap_command.c
@@ -354,7 +354,7 @@ bool perform_dap_jtag_sequence(
 		memcpy(data_out, response + 1U, sequence_length);
 		/* And the final bit from the second response LSb */
 		if (sequences == 2U)
-			data_out[final_byte] = (response[1 + sequence_length] & 1U) << final_bit;
+			data_out[final_byte] |= (response[1 + sequence_length] & 1U) << final_bit;
 	}
 	/* And check that it succeeded */
 	return response[0] == DAP_RESPONSE_OK;

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -91,6 +91,11 @@ typedef enum dap_info_status {
 #define DAP_SWJ_nTRST     (1U << 5U)
 #define DAP_SWJ_nRST      (1U << 7U)
 
+#define DAP_TRANSFER_APnDP (1U << 0U)
+#define DAP_TRANSFER_RnW   (1U << 1U)
+
+#define DAP_TRANSFER_WAIT (1U << 1U)
+
 typedef struct dap_transfer_request {
 	uint8_t request;
 	uint32_t data;

--- a/src/platforms/hosted/dap_command.h
+++ b/src/platforms/hosted/dap_command.h
@@ -147,6 +147,8 @@ typedef struct dap_swj_pins_request {
 
 bool perform_dap_transfer(adiv5_debug_port_s *target_dp, const dap_transfer_request_s *transfer_requests,
 	size_t requests, uint32_t *response_data, size_t responses);
+bool perform_dap_transfer_swd_unchecked(
+	const dap_transfer_request_s *transfer_requests, size_t requests, uint32_t *response_data, size_t responses);
 bool perform_dap_transfer_recoverable(adiv5_debug_port_s *target_dp, const dap_transfer_request_s *transfer_requests,
 	size_t requests, uint32_t *response_data, size_t responses);
 bool perform_dap_transfer_block_read(

--- a/src/platforms/hosted/dap_jtag.c
+++ b/src/platforms/hosted/dap_jtag.c
@@ -44,7 +44,7 @@ static bool dap_jtag_next(bool tms, bool tdi);
 
 bool dap_jtag_init(void)
 {
-	/* If we are not able to talk SWD with this adaptor, make this insta-fail */
+	/* If we are not able to talk JTAG with this adaptor, make this insta-fail */
 	if (!(dap_caps & DAP_CAP_JTAG))
 		return false;
 
@@ -113,7 +113,7 @@ static void dap_jtag_tdi_seq(const bool final_tms, const uint8_t *const data_in,
 
 static bool dap_jtag_next(const bool tms, const bool tdi)
 {
-#if ENABLE_DEBUG == 1
+#ifndef DEBUG_PROBE_IS_NOOP
 	const uint8_t tms_byte = tms ? 1 : 0;
 #endif
 	const uint8_t tdi_byte = tdi ? 1 : 0;

--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2023-2024 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2023-2025 1BitSquared <info@1bitsquared.com>
  * Written by Rachel Mant <git@dragonmux.network>
  * All rights reserved.
  *
@@ -77,7 +77,7 @@ bool dap_swd_init(adiv5_debug_port_s *target_dp)
 	swd_proc.seq_out_parity = dap_swd_seq_out_parity;
 
 	/* If we have SWD sequences available, make use of them */
-	if (dap_has_swd_sequence) {
+	if (!(dap_quirks & DAP_QUIRK_NO_SWD_SEQUENCE)) {
 		target_dp->write_no_check = dap_write_reg_no_check;
 		target_dp->read_no_check = dap_read_reg_no_check;
 	} else {

--- a/src/platforms/hosted/dap_swd.c
+++ b/src/platforms/hosted/dap_swd.c
@@ -76,15 +76,9 @@ bool dap_swd_init(adiv5_debug_port_s *target_dp)
 	swd_proc.seq_out = dap_swd_seq_out;
 	swd_proc.seq_out_parity = dap_swd_seq_out_parity;
 
-	/* If we have SWD sequences available, make use of them */
-	if (!(dap_quirks & DAP_QUIRK_NO_SWD_SEQUENCE)) {
-		target_dp->write_no_check = dap_write_reg_no_check;
-		target_dp->read_no_check = dap_read_reg_no_check;
-	} else {
-		target_dp->write_no_check = NULL;
-		target_dp->read_no_check = NULL;
-	}
 	/* Set up the accelerated SWD functions for basic target operations */
+	target_dp->write_no_check = dap_write_reg_no_check;
+	target_dp->read_no_check = dap_read_reg_no_check;
 	target_dp->dp_read = dap_dp_read_reg;
 	target_dp->low_access = dap_dp_raw_access;
 	target_dp->abort = dap_dp_abort;

--- a/src/platforms/hosted/windows/ftdi.c
+++ b/src/platforms/hosted/windows/ftdi.c
@@ -1,8 +1,9 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2023,2025 1BitSquared <info@1bitsquared.com>
  * Written by Sid Price <sid@sidprice.com>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -151,7 +152,10 @@ int ftdi_write_data(struct ftdi_context *ftdi, const unsigned char *buf, int siz
 {
 	(void)ftdi;
 	DWORD bytes_written;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 	if (FT_Write(ftdi_handle, (unsigned char *)buf, size, &bytes_written) != FT_OK)
+#pragma GCC diagnostic pop
 		return 0;
 	return bytes_written;
 }


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address several issues encountered with certain CMSIS-DAP adaptors, notably ones from Atmel such as the JTAGICE3 which use HID (CMSIS-DAP v1.0.0, the unpublished spec) and massive packets (512 bytes) over HS.

We aim with this to fix the transfer behaviour for these adaptors (the packets are one byte too short before this, causing problems with the communication cycle), and provide various fallbacks and such for commands not implemented in the older versions of the spec.

The over-all result should be a more stable CMSIS-DAP experience and saner behaviour out of HID based adaptors.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
