### PR TITLE
Fix: Version and copyright display

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
 # This file is part of the Black Magic Debug project.
 #
-# Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+# Copyright (C) 2023-2025 1BitSquared <info@1bitsquared.com>
 # Written by Rafael Silva <perigoso@riseup.net>
+# Modified by Rachel Mant <git@dragonmux.network>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -31,7 +32,7 @@
 project(
 	'Black Magic Debug',
 	'c',
-	version: '1.10.0',
+	version: '2.0.0-rc2',
 	license: 'GPL-3.0-or-later OR BSD-3-Clause OR MIT',
 	# license_files: ['COPYING', 'COPYING-BSD', 'COPYING-MIT'], # Only available in meson 1.1.0
 	default_options: [

--- a/src/command.c
+++ b/src/command.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2011 Black Sphere Technologies Ltd.
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
  * Copyright (C) 2021 Uwe Bonnes (bon@elektron.ikp.physik.tu-darmstadt.de)
- * Copyright (C) 2023 1BitSquared <info@1bitsquared.com>
+ * Copyright (C) 2023-2025 1BitSquared <info@1bitsquared.com>
  * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -208,7 +208,7 @@ bool cmd_version(target_s *target, int argc, const char **argv)
 #endif
 	gdb_outf(", Hardware Version %d\n", platform_hwversion());
 #endif
-	gdb_out("Copyright (C) 2010-2024 Black Magic Debug Project\n");
+	gdb_out("Copyright (C) 2010-2025 Black Magic Debug Project\n");
 	gdb_out("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n\n");
 
 	return true;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses the version number reported from a tarball of the source being wrong (v1.10.0) and similarly addresses the displayed copyright string when the firmware is asked for its version.

This solves a couple of cosmetic problems with the latest release candidate - note that the Meson-reported version number will need updating again when the full release is performed.

A better way of maintaining this version number will be a goal for v2.1 as having to update it every release is going to be a drag.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
