### PR TITLE
DRAFT: samx5x: make `lock_bootprot` configurable

### DIFF
--- a/src/target/samx5x.c
+++ b/src/target/samx5x.c
@@ -719,6 +719,19 @@ static int samx5x_set_flashlock(target_s *t, uint32_t value)
 	return 0;
 }
 
+static bool parse_unsigned(const char *str, uint32_t *val)
+{
+	char *end = NULL;
+	unsigned long num;
+
+	num = strtoul(str, &end, 0);
+	if (end == NULL || end == str)
+		return false;
+
+	*val = (uint32_t)num;
+	return true;
+}
+
 static bool samx5x_cmd_lock_flash(target_s *t, int argc, const char **argv)
 {
 	(void)argc;
@@ -769,9 +782,26 @@ static int samx5x_set_bootprot(target_s *t, uint8_t value)
 
 static bool samx5x_cmd_lock_bootprot(target_s *t, int argc, const char **argv)
 {
-	(void)argc;
-	(void)argv;
-	if (samx5x_set_bootprot(t, 0U)) {
+	/* Locks first 0x7 .. 0, 0x6 .. 512, 0x5 .. 1024, ..., 0x0 .. 32768 bytes of flash*/
+	if (argc > 2) {
+		tc_printf(t, "usage: monitor lock_bootprot [number]\n");
+		return false;
+	}
+
+	uint32_t val = 0;
+	if (argc == 2) {
+		if (!parse_unsigned(argv[1], &val)) {
+			tc_printf(t, "number must be either decimal or 0x prefixed hexadecimal\n");
+			return false;
+		}
+
+		if (val > 15U) {
+			tc_printf(t, "number must be between 0 and 15\n");
+			return false;
+		}
+	}
+
+	if (samx5x_set_bootprot(t, (uint8_t)val)) {
 		tc_printf(t, "Error writing NVM page\n");
 		return false;
 	}


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
For `samx5x` devices, blackmagic provides a `lock_bootprot` command to conveniently write-protect the bootloader section in the RAM. As stated on page 598 of the [datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D5xE5x_Family_Data_Sheet_DS60001507F.pdf), the bootloader region can be marked using `BOOTPROT` value in the user page using $(15 - BOOTPROT) * 8 KiB$.

Currently, `lock_bootprot` hardcodes `BOOTPROT` to 0, which means that 120 KiB of the flash is write-protected. For bootloaders like [Adafruit's Arduino bootloader for SAMD51](https://github.com/adafruit/uf2-samdx1), this does not work since Arduino generates binaries that start with a 16 KiB offset, which is the size of the bootloader.

This PR allows the user to specify exactly how much space has to be reserved for the bootloader, like how it is handled for SAMD21 devices in blackmagic. 

Things I need review on:
- `lock_bootprot` accepts an argument which is the BOOTPROT value from the datasheet. It would be more developer-friendly if the command just accepted the number of 16 KiB pages to reserve and explained this in the `monitor help`  accordingly.
- `parse_unsigned` is currently copied over to samx5x source. How do I share it between samd and samx5x devices? 

<!--
Explain the **details** for making this change.
* Is a new feature implemented? Y
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [ ] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [ ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [ ] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
