### PR TITLE
hosted/CMSIS-DAP: Do not discard devices with optional SWO endpoint

### DIFF
--- a/src/platforms/hosted/bmp_libusb.c
+++ b/src/platforms/hosted/bmp_libusb.c
@@ -473,11 +473,12 @@ static void check_cmsis_interface_type(libusb_device *const device, bmda_probe_s
 			for (uint8_t index = 0; index < descriptor->bNumEndpoints; ++index)
 				info->max_packet_length = MIN(descriptor->endpoint[index].wMaxPacketSize, info->max_packet_length);
 
-			/* Check if it's a CMSIS-DAP v2 interface */
-			if (descriptor->bInterfaceClass == 0xffU && descriptor->bNumEndpoints == 2U) {
+			/* Check if it's a CMSIS-DAP v2 interface. */
+			if (descriptor->bInterfaceClass == 0xffU &&
+				(descriptor->bNumEndpoints == 2U || descriptor->bNumEndpoints == 3U)) {
 				info->interface_num = descriptor->bInterfaceNumber;
-				/* Extract the endpoints required */
-				for (uint8_t index = 0; index < descriptor->bNumEndpoints; ++index) {
+				/* Extract the endpoints required. Ignore optional SWO trace endpoint */
+				for (uint8_t index = 0; index < 2U; ++index) {
 					const uint8_t ep = descriptor->endpoint[index].bEndpointAddress;
 					if (ep & 0x80U)
 						info->in_ep = ep;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR fixes the detection of CMSIS-DAP V2 adaptors which have the optional SWO trace USB bulk endpoint. This configuration is allowed by the [CMSIS-DAP documentation](https://arm-software.github.io/CMSIS-DAP/latest/dap_firmware.html#dap_bulk_usb). The documentation also prescribes the order of USB endpoints, meaning we are safe to ignore the optional endpoint.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [ ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Closes #2107 (tentative)