### PR TITLE
Fix: RISC-V ISA identification

### DIFF
--- a/src/target/riscv_debug.c
+++ b/src/target/riscv_debug.c
@@ -422,7 +422,7 @@ static void riscv_hart_read_ids(riscv_hart_s *const hart)
 static size_t riscv_snprint_isa_subset(
 	char *const string_buffer, const size_t buffer_size, const uint8_t access_width, const uint32_t extensions)
 {
-	size_t offset = snprintf(string_buffer, buffer_size, "rv%" PRIu8, access_width);
+	size_t offset = snprintf(string_buffer, buffer_size, "rv%u", access_width);
 
 	const bool is_embedded = extensions & RV_ISA_EXT_EMBEDDED;
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

This PR addresses a bug reported to us on Discord. The bug manifests as the string `rvhu<extensions>` being returned to GDB from the firmware (but not BMDA) for identifying the exact RISC-V ISA of a core.

This is caused by newlib-nano not understanding width modifiers (which `PRIx8` is defined with on ARM, giving `%hu` instead of `%u` for the core bit width format specifier).

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
