### PR TITLE
Fix: CI for native on the build-and-upload flow

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -98,6 +98,12 @@ jobs:
           meson setup build --cross-file cross-file/${{ matrix.probe }}.ini
           meson compile -C build
           mkdir src/artefacts
+          case "${{ matrix.probe }}" in
+            native-*)
+              mv build/blackmagic_native_firmware.elf build/blackmagic_${{ matrix.probe }}_firmware.elf
+              mv build/blackmagic_native_firmware.bin build/blackmagic_${{ matrix.probe }}_firmware.bin
+              ;;
+          esac
           mv build/blackmagic_*_firmware.{elf,bin} src/artefacts
 
       # Package up the artefacts and upload them


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the issues identified with builds of the `native` firwmare on the build-and-upload flow which result in the builds stomping on each other when building the firmware archive artefact.

This is due to the build system putting out the same `blackmagic_native_firmware` base name for all profiles, while to not wind up trampling each other, the variants need the variant name included as in `blackmagic_native-uncommon_firmware` or so.

This should be being smartly managed now with room for expansion if other platforms wind up requiring variants in the future.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
