### PR TITLE
Fix: vCont single stepping

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -133,7 +133,7 @@ int32_t gdb_main_loop(target_controller_s *const tc, const gdb_packet_s *const p
 			/**
 			 * Register data is unavailable
 			 * See: https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html#read-registers-packet
-			 * 
+			 *
 			 * ... the stub may also return a string of literal ‘x’ in place of the register data digits,
 			 * to indicate that the corresponding register’s value is unavailable.
 			 */
@@ -258,7 +258,7 @@ int32_t gdb_main_loop(target_controller_s *const tc, const gdb_packet_s *const p
 			/**
 			 * Register data is unavailable
 			 * See: https://sourceware.org/gdb/current/onlinedocs/gdb.html/Packets.html#read-registers-packet
-			 * 
+			 *
 			 * ... the stub may also return a string of literal ‘x’ in place of the register data digits,
 			 * to indicate that the corresponding register’s value is unavailable.
 			 */
@@ -466,7 +466,7 @@ static void exec_q_supported(const char *packet, const size_t length)
 	 * This might be the first packet of a GDB connection, If NoAckMode is enabled it might
 	 * be because the previous session was terminated abruptly, and we need to acknowledge
 	 * the first packet of the new session.
-	 * 
+	 *
 	 * If NoAckMode was intentionally enabled before (e.g. LLDB enables NoAckMode first),
 	 * the acknowledgment should be safely ignored.
 	 */
@@ -773,7 +773,7 @@ static void exec_v_cont(const char *packet, const size_t length)
 		 *
 		 * TODO: Support the 't' (stop) action needed for non-stop debug so GDB can request a halt.
 		 */
-		gdb_put_packet_str("vCont;c;C;s;t");
+		gdb_put_packet_str("vCont;c;C;s;S;t");
 		return;
 	}
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address the issue of single stepping having broken as reported in #2124.

As it turns out in newer GDBs, if we don't report that we support the signaled version of single stepping in response to `vCont?`, then single stepping will be entirely turned off, `vCont;s` will never be generated. With this fixed, it will and stepping with `stepi` goes back to working how one expects it to.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Fixes #2124
