### PR TITLE
cortexm: Add v8m secure fault to vector_catch

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -1237,11 +1237,12 @@ static target_addr_t cortexm_check_watch(target_s *target)
 static bool cortexm_vector_catch(target_s *target, int argc, const char **argv)
 {
 	cortexm_priv_s *priv = target->priv;
-	static const char *const vectors[] = {"reset", NULL, NULL, NULL, "mm", "nocp", "chk", "stat", "bus", "int", "hard"};
+	static const char *const vectors[] = {
+		"reset", NULL, NULL, NULL, "mm", "nocp", "chk", "stat", "bus", "int", "hard", "sf"};
 	uint32_t tmp = 0;
 
 	if (argc < 3)
-		tc_printf(target, "usage: monitor vector_catch (enable|disable) (hard|int|bus|stat|chk|nocp|mm|reset)\n");
+		tc_printf(target, "usage: monitor vector_catch (enable|disable) (sf|hard|int|bus|stat|chk|nocp|mm|reset)\n");
 	else {
 		for (int j = 0; j < argc; j++) {
 			for (size_t i = 0; i < ARRAY_LENGTH(vectors); i++) {


### PR DESCRIPTION
## Detailed description

Add ARM v8m SecureFault exception to `vector_catch` command.

The control bit in `DEMCR` is named `VC_SFERR`, so it's shortened to `sf` following the same pattern as the existing exceptions.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
