### PR TITLE
rtt: Skip poll_rtt() when the target is being halted

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -46,11 +46,11 @@ static void bmp_poll_loop(void)
 		char c = gdb_if_getchar_to(0);
 		if (c == '\x03' || c == '\x04')
 			target_halt_request(cur_target);
-		platform_pace_poll();
 #ifdef ENABLE_RTT
-		if (rtt_enabled)
+		else if (rtt_enabled)
 			poll_rtt(cur_target);
 #endif
+		platform_pace_poll();
 	}
 
 	SET_IDLE_STATE(true);


### PR DESCRIPTION
## Detailed description

When RTT is doing halting memory access, it interferes with the ability to interrupt the target.

When `poll_rtt()` is called after `target_halt_request()`, it will send another halt request, wait for the target to halt, perform the RTT accesses and then resume the target, masking the initial halt request.

This PR fixes the issue by skipping `poll_rtt()` when the target is being halted after receiving an interrupt.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
