### PR TITLE
Fix: `bmputil` CLI changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -259,17 +259,31 @@ If you did not touch the build system this is not your fault, please report it
 	## Utility targets
 	## _______________
 
-	# Black Magic Probe Firmware Manager
-	bmputil = find_program('bmputil', required: false)
+	# Black Magic Probe companion utility
+	bmputil = find_program('bmputil-cli', required: false)
 	if bmputil.found()
 		message('Adding target for firmware update')
 
 		# Firmware update target
 		run_target(
 			'flash',
-			command: [bmputil, 'flash', bmf_elf.full_path()],
+			command: [bmputil, 'probe', 'update', bmf_elf.full_path()],
 			depends: bmf_elf,
 		)
+	# If we couldn't find the utility, look for the older pre-v1.0 version of it
+	else
+		# Black Magic Probe Firmware Manager
+		bmputil = find_program('bmputil', required: false)
+		if bmputil.found()
+			message('Adding target for firmware update')
+
+			# Firmware update target
+			run_target(
+				'flash',
+				command: [bmputil, 'flash', bmf_elf.full_path()],
+				depends: bmf_elf,
+			)
+		endif
 	endif
 endif
 


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

As part of getting `bmputil` ready for its v1.0 release, the tool was renamed to `bmputil-cli` and the CLI overhaulled.

This PR addresses these changes by introducing some logic for finding this version of the tool in preference for the pre-v1.0 `bmputil`, and providing logic under the new CLI structure for doing probe reprogramming via `ninja flash`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
