### PR TITLE
Fix: Config macro errors

### DIFF
--- a/src/remote.c
+++ b/src/remote.c
@@ -390,7 +390,7 @@ static void remote_packet_process_high_level(const char *packet, const size_t pa
 #if CONFIG_CH579
 				REMOTE_FAMILY_CH579 |
 #endif
-#if CONFIG_EFM
+#if CONFIG_EFM32
 				REMOTE_FAMILY_EFM |
 #endif
 #if CONFIG_GD32
@@ -414,10 +414,10 @@ static void remote_packet_process_high_level(const char *packet, const size_t pa
 #if CONFIG_PUYA
 				REMOTE_FAMILY_PUYA |
 #endif
-#if CONFIG_RENESAS_RA
+#if CONFIG_RA
 				REMOTE_FAMILY_RENESAS_RA |
 #endif
-#if CONFIG_RENESAS_RZ
+#if CONFIG_RZ
 				REMOTE_FAMILY_RENESAS_RZ |
 #endif
 #if CONFIG_RP

--- a/src/remote.c
+++ b/src/remote.c
@@ -363,13 +363,13 @@ static void remote_packet_process_high_level(const char *packet, const size_t pa
 	case REMOTE_HL_ARCHS: /* Ha = request what architecture support is enabled */
 		/* Build a response value that depends on what things are built into the firmware */
 		remote_respond(REMOTE_RESP_OK,
-#if CONFIG_CORTEXM
+#if defined(CONFIG_CORTEXM) && CONFIG_CORTEXM == 1
 			REMOTE_ARCH_CORTEXM |
 #endif
-#if CONFIG_CORTEXAR
+#if defined(CONFIG_CORTEXAR) && CONFIG_CORTEXAR == 1
 				REMOTE_ARCH_CORTEXAR |
 #endif
-#if CONFIG_RISCV
+#if defined(CONFIG_RISCV) && CONFIG_RISCV == 1
 				REMOTE_ARCH_RISCV32 | REMOTE_ARCH_RISCV64 |
 #endif
 				0U);
@@ -378,61 +378,61 @@ static void remote_packet_process_high_level(const char *packet, const size_t pa
 	case REMOTE_HL_FAMILIES: /* Ha = request what architecture support is enabled */
 		/* Build a response value that depends on what things are built into the firmware */
 		remote_respond(REMOTE_RESP_OK,
-#if CONFIG_AT32
+#if defined(CONFIG_AT32) && CONFIG_AT32 == 1
 			REMOTE_FAMILY_AT32 |
 #endif
-#if CONFIG_APOLLO3
+#if defined(CONFIG_APOLLO3) && CONFIG_APOLLO3 == 1
 				REMOTE_FAMILY_APOLLO3 |
 #endif
-#if CONFIG_CH32
+#if defined(CONFIG_CH32) && CONFIG_CH32 == 1
 				REMOTE_FAMILY_CH32 |
 #endif
-#if CONFIG_CH579
+#if defined(CONFIG_CH579) && CONFIG_CH579 == 1
 				REMOTE_FAMILY_CH579 |
 #endif
-#if CONFIG_EFM32
+#if defined(CONFIG_EFM32) && CONFIG_EFM32 == 1
 				REMOTE_FAMILY_EFM |
 #endif
-#if CONFIG_GD32
+#if defined(CONFIG_GD32) && CONFIG_GD32 == 1
 				REMOTE_FAMILY_GD32 |
 #endif
-#if CONFIG_HC32
+#if defined(CONFIG_HC32) && CONFIG_HC32 == 1
 				REMOTE_FAMILY_HC32 |
 #endif
-#if CONFIG_LPC
+#if defined(CONFIG_LPC) && CONFIG_LPC == 1
 				REMOTE_FAMILY_LPC |
 #endif
-#if CONFIG_MM32
+#if defined(CONFIG_MM32) && CONFIG_MM32 == 1
 				REMOTE_FAMILY_MM32 |
 #endif
-#if CONFIG_NRF
+#if defined(CONFIG_NRF) && CONFIG_NRF == 1
 				REMOTE_FAMILY_NRF |
 #endif
-#if CONFIG_NXP
+#if defined(CONFIG_NXP) && CONFIG_NXP == 1
 				REMOTE_FAMILY_NXP_KINETIS | REMOTE_FAMILY_NXP_IMXRT |
 #endif
-#if CONFIG_PUYA
+#if defined(CONFIG_PUYA) && CONFIG_PUYA == 1
 				REMOTE_FAMILY_PUYA |
 #endif
-#if CONFIG_RA
+#if defined(CONFIG_RA) && CONFIG_RA == 1
 				REMOTE_FAMILY_RENESAS_RA |
 #endif
-#if CONFIG_RZ
+#if defined(CONFIG_RZ) && CONFIG_RZ == 1
 				REMOTE_FAMILY_RENESAS_RZ |
 #endif
-#if CONFIG_RP
+#if defined(CONFIG_RP) && CONFIG_RP == 1
 				REMOTE_FAMILY_RP |
 #endif
-#if CONFIG_SAM
+#if defined(CONFIG_SAM) && CONFIG_SAM == 1
 				REMOTE_FAMILY_SAM |
 #endif
-#if CONFIG_STM
+#if defined(CONFIG_STM) && CONFIG_STM == 1
 				REMOTE_FAMILY_STM32 |
 #endif
-#if CONFIG_TI
+#if defined(CONFIG_TI) && CONFIG_TI == 1
 				REMOTE_FAMILY_TI |
 #endif
-#if CONFIG_XILINX
+#if defined(CONFIG_XILINX) && CONFIG_XILINX == 1
 				REMOTE_FAMILY_XILINX |
 #endif
 				0U);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we clean up after #2129 where a couple of mistake were made that can result in incorrect values getting generated from the new remote protocol packets.

The mistakes consist of two things: 3 typos in the config macros checked (`CONFIG_EFM` => `CONFIG_EFM32`, `CONFIG_RENESAS_R{A,Z}` => `CONFIG_R{A,Z}`; and some bad logic for checking if the values are defined as on/set.

To explain the latter slightly, in the C standard an undefined macro is allowed to be interpreted by the preprocessor in `#if` checks as if it were defined to 0; however this may generate a diagnostic and is allowed to be overridden. In the case that a config macro is set and to a value that's not expected, or the compiler is treating undefined macros as errors, the old logic would go wrong. The pattern required to navigate this correctly is to first check if the macro is defined and then check its value coresponds to our choice of truthy token (1 in this case).

Thanks to ALTracer for making us aware of the main mistake.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
