### PR TITLE
Fix: Add SRAM4 to STM32U5 and enable `uid`

### DIFF
--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -153,6 +153,7 @@ const command_s stm32l4_cmd_list[] = {
 #define STM32L4_UID_BASE       0x1fff7590U
 #define STM32L4_FLASH_SIZE_REG 0x1fff75e0U
 #define STM32L5_FLASH_SIZE_REG 0x0bfa05e0U
+#define STM32U5_UID_BASE       0x0bfa0700U
 #define STM32U5_FLASH_SIZE_REG 0x0bfa07a0U
 
 #define STM32L5_RCC_APB1ENR1       0x50021058U
@@ -1127,5 +1128,9 @@ static bool stm32l4_cmd_uid(target_s *target, int argc, const char **argv)
 {
 	(void)argc;
 	(void)argv;
-	return stm32_uid(target, STM32L4_UID_BASE);
+	target_addr_t uid_base = STM32L4_UID_BASE;
+	const stm32l4_priv_s *const priv = (stm32l4_priv_s *)target->target_storage;
+	if (priv->device->family == STM32L4_FAMILY_U5xx)
+		uid_base = STM32U5_UID_BASE;
+	return stm32_uid(target, uid_base);
 }

--- a/src/target/stm32l4.c
+++ b/src/target/stm32l4.c
@@ -776,6 +776,9 @@ static bool stm32l4_attach(target_s *const target)
 	else
 		target_add_ram32(target, 0x10000000, device->sram2 * 1024U);
 	target_add_ram32(target, 0x20000000, stm32l4_main_sram_length(target));
+	/* Every STM32U5xx has 16 KiB of SRAM4 in SmartRun domain */
+	if (device->family == STM32L4_FAMILY_U5xx)
+		target_add_ram32(target, 0x28000000, 16384U);
 
 	const uint16_t flash_len = stm32l4_read_flash_size(target);
 	const uint32_t options = stm32l4_flash_read32(target, FLASH_OPTR);


### PR DESCRIPTION
## Detailed description

* There are no new features.
* The existing problem is SRAM4@0x28000000 missing from STM32U5xx memory map, and `mon uid` returning zeroes.
* The PR solves it by adding the region and extending `stm32l4_uid()` with a little logic to pass new `STM32U5_UID_BASE` to common `stm32_uid()`.

Tested against https://github.com/WeActStudio/WeActStudio.STM32U585Cx_CoreBoard via `blackpill-f411ce` and BMDA.
No idea if L4/L4+/L5 etc. also have SmartRun Domain SRAM4, it's an H7 thing originally.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
