### PR TITLE
stlinkv3: get rid of bmd_bootloader option and fix load address for OEM bootloader

### DIFF
--- a/src/platforms/stlinkv3/meson.build
+++ b/src/platforms/stlinkv3/meson.build
@@ -40,9 +40,7 @@ probe_stlinkv3_dfu_sources = files(
 	'usbdfu.c',
 )
 
-bmd_bootloader = get_option('bmd_bootloader')
-
-probe_stlinkv3_load_address = bmd_bootloader ? '0x08020000' : '0x08000000'
+probe_stlinkv3_load_address = '0x08020000'
 
 probe_stlinkv3_args = [
 	'-DDFU_SERIAL_LENGTH=25',
@@ -88,7 +86,7 @@ summary(
 	{
 		'Name': 'STLINK-V3',
 		'Platform': 'STM32F7',
-		'Bootloader': bmd_bootloader ? 'Black Magic Debug Bootloader' : 'OEM ST Bootloader',
+		'Bootloader': get_option('bmd_bootloader') ? 'Black Magic Debug Bootloader' : 'OEM ST Bootloader',
 		'Load Address': probe_stlinkv3_load_address,
 	},
 	section: 'Probe',


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
Testing the previous firmware on STLink-v3Mini revealed that the program load address was incorrectly configured for ST's bootloader (`-Dbmd_bootloader=false`). The correct offset is the same as for when using the BMD bootloader; hence, the option has been removed altogether now.

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
