### PR TITLE
misc: Ensure all inline functions are also static

### DIFF
--- a/src/include/platform_support.h
+++ b/src/include/platform_support.h
@@ -38,7 +38,7 @@ void platform_pace_poll(void);
 #else
 void platform_init(void);
 
-inline void platform_pace_poll(void)
+static inline void platform_pace_poll(void)
 {
 }
 

--- a/src/platforms/hosted/serial_unix.c
+++ b/src/platforms/hosted/serial_unix.c
@@ -48,7 +48,7 @@ static size_t read_buffer_fullness = 0U;
 static size_t read_buffer_offset = 0U;
 
 #ifndef _WIN32
-inline int closesocket(const int socket)
+static inline int closesocket(const int socket)
 {
 	return close(socket);
 }


### PR DESCRIPTION
I hit a linker error due to a non-static inline function. While I were at it, I grepped through the source and found another, so I fixed both.

## Detailed description

All inline functions should be static. I don't expect I need to provide a lecture on why. 🙂 

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
