### PR TITLE
Fix: SAMx7x support

### DIFF
--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -536,7 +536,7 @@ static bool sam_flash_erase(target_flash_s *flash, target_addr_t addr, size_t le
 	uint32_t chunk = (addr - flash->start) / SAM_LARGE_PAGE_SIZE;
 
 	for (size_t offset = 0; offset < len; offset += flash->blocksize) {
-		int16_t arg = chunk | 0x1U;
+		uint16_t arg = chunk | 0x0001U;
 		if (!sam_flash_cmd(target, base, EEFC_FCR_FCMD_EPA, arg))
 			return false;
 		chunk += 8U;

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -30,7 +30,7 @@
 #include "cortexm.h"
 
 /* Enhanced Embedded Flash Controller (EEFC) Register Map */
-#define SAMX7X_EEFC_BASE   0x400e0c00U
+#define SAMx7x_EEFC_BASE   0x400e0c00U
 #define SAM3N_EEFC_BASE    0x400e0a00U
 #define SAM3X_EEFC_BASE(x) (0x400e0a00U + ((x) * 0x200U))
 #define SAM3U_EEFC_BASE(x) (0x400e0800U + ((x) * 0x200U))
@@ -66,68 +66,62 @@
 #define SAM_LARGE_PAGE_SIZE 512U
 
 /* CHIPID Register Map */
-#define SAM_CHIPID_CIDR      0x400e0940U
+#define SAM_CHIPID_BASE      0x400e0940U
+#define SAM_CHIPID_CIDR      (SAM_CHIPID_BASE + 0x0U)
+#define SAM_CHIPID_EXID      (SAM_CHIPID_BASE + 0x4U)
 #define SAM34NSU_CHIPID_CIDR 0x400e0740U
-
-#define SAM_CHIPID_EXID (SAM_CHIPID_CIDR + 0x4U)
 
 #define CHIPID_CIDR_VERSION_MASK 0x1fU
 
-#define CHIPID_CIDR_EPROC_OFFSET 5U
-#define CHIPID_CIDR_EPROC_MASK   (0x7U << CHIPID_CIDR_EPROC_OFFSET)
-#define CHIPID_CIDR_EPROC_CM7    (0x0U << CHIPID_CIDR_EPROC_OFFSET)
-#define CHIPID_CIDR_EPROC_CM3    (0x3U << CHIPID_CIDR_EPROC_OFFSET)
-#define CHIPID_CIDR_EPROC_CM4    (0x7U << CHIPID_CIDR_EPROC_OFFSET)
+#define CHIPID_CIDR_EPROC_MASK (0x7U << 5U)
+#define CHIPID_CIDR_EPROC_CM7  (0x0U << 5U)
+#define CHIPID_CIDR_EPROC_CM3  (0x3U << 5U)
+#define CHIPID_CIDR_EPROC_CM4  (0x7U << 5U)
 
-#define CHIPID_CIDR_NVPSIZ_OFFSET 8U
-#define CHIPID_CIDR_NVPSIZ_MASK   (0xfU << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_8K     (0x1U << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_16K    (0x2U << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_32K    (0x3U << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_64K    (0x5U << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_128K   (0x7U << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_256K   (0x9U << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_512K   (0xaU << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_1024K  (0xcU << CHIPID_CIDR_NVPSIZ_OFFSET)
-#define CHIPID_CIDR_NVPSIZ_2048K  (0xeU << CHIPID_CIDR_NVPSIZ_OFFSET)
+#define CHIPID_CIDR_NVPSIZ_MASK  (0xfU << 8U)
+#define CHIPID_CIDR_NVPSIZ_8K    (0x1U << 8U)
+#define CHIPID_CIDR_NVPSIZ_16K   (0x2U << 8U)
+#define CHIPID_CIDR_NVPSIZ_32K   (0x3U << 8U)
+#define CHIPID_CIDR_NVPSIZ_64K   (0x5U << 8U)
+#define CHIPID_CIDR_NVPSIZ_128K  (0x7U << 8U)
+#define CHIPID_CIDR_NVPSIZ_256K  (0x9U << 8U)
+#define CHIPID_CIDR_NVPSIZ_512K  (0xaU << 8U)
+#define CHIPID_CIDR_NVPSIZ_1024K (0xcU << 8U)
+#define CHIPID_CIDR_NVPSIZ_2048K (0xeU << 8U)
 
-#define CHIPID_CIDR_NVPSIZ2_OFFSET 12U
-#define CHIPID_CIDR_NVPSIZ2_MASK   (0xfU << CHIPID_CIDR_NVPSIZ2_OFFSET)
+#define CHIPID_CIDR_NVPSIZ2_MASK (0xfU << 12U)
 
-#define CHIPID_CIDR_SRAMSIZ_OFFSET 16U
-#define CHIPID_CIDR_SRAMSIZ_MASK   (0xfU << CHIPID_CIDR_SRAMSIZ_OFFSET)
-#define CHIPID_CIDR_SRAMSIZ_384K   (0x2U << CHIPID_CIDR_SRAMSIZ_OFFSET)
-#define CHIPID_CIDR_SRAMSIZ_256K   (0xdU << CHIPID_CIDR_SRAMSIZ_OFFSET)
+#define CHIPID_CIDR_SRAMSIZ_MASK (0xfU << 16U)
+#define CHIPID_CIDR_SRAMSIZ_384K (0x2U << 16U)
+#define CHIPID_CIDR_SRAMSIZ_256K (0xdU << 16U)
 
-#define CHIPID_CIDR_ARCH_OFFSET  20U
-#define CHIPID_CIDR_ARCH_MASK    (0xffU << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAME70  (0x10U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAMS70  (0x11U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAMV71  (0x12U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAMV70  (0x13U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3UxC (0x80U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3UxE (0x81U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3XxC (0x84U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3XxE (0x85U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3XxG (0x86U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3NxA (0x93U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3NxB (0x94U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3NxC (0x95U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3SxA (0x88U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3SxB (0x89U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM3SxC (0x8aU << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM4SxA (0x88U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM4SxB (0x89U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM4SxC (0x8aU << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM4SDB (0x99U << CHIPID_CIDR_ARCH_OFFSET)
-#define CHIPID_CIDR_ARCH_SAM4SDC (0x9aU << CHIPID_CIDR_ARCH_OFFSET)
+#define CHIPID_CIDR_ARCH_MASK    (0xffU << 20U)
+#define CHIPID_CIDR_ARCH_SAME70  (0x10U << 20U)
+#define CHIPID_CIDR_ARCH_SAMS70  (0x11U << 20U)
+#define CHIPID_CIDR_ARCH_SAMV71  (0x12U << 20U)
+#define CHIPID_CIDR_ARCH_SAMV70  (0x13U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3UxC (0x80U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3UxE (0x81U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3XxC (0x84U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3XxE (0x85U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3XxG (0x86U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3NxA (0x93U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3NxB (0x94U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3NxC (0x95U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3SxA (0x88U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3SxB (0x89U << 20U)
+#define CHIPID_CIDR_ARCH_SAM3SxC (0x8aU << 20U)
+#define CHIPID_CIDR_ARCH_SAM4SxA (0x88U << 20U)
+#define CHIPID_CIDR_ARCH_SAM4SxB (0x89U << 20U)
+#define CHIPID_CIDR_ARCH_SAM4SxC (0x8aU << 20U)
+#define CHIPID_CIDR_ARCH_SAM4SDB (0x99U << 20U)
+#define CHIPID_CIDR_ARCH_SAM4SDC (0x9aU << 20U)
 
-#define CHIPID_CIDR_NVPTYP_OFFSET    28U
-#define CHIPID_CIDR_NVPTYP_MASK      (0x7U << CHIPID_CIDR_NVPTYP_OFFSET)
-#define CHIPID_CIDR_NVPTYP_FLASH     (0x2U << CHIPID_CIDR_NVPTYP_OFFSET)
-#define CHIPID_CIDR_NVPTYP_ROM_FLASH (0x3U << CHIPID_CIDR_NVPTYP_OFFSET)
+#define CHIPID_CIDR_NVPTYP_MASK      (0x7U << 28U)
+#define CHIPID_CIDR_NVPTYP_FLASH     (0x2U << 28U)
+#define CHIPID_CIDR_NVPTYP_ROM_FLASH (0x3U << 28U)
 
-#define CHIPID_CIDR_EXT (0x01U << 31U)
+#define CHIPID_CIDR_EXT (1U << 31U)
 
 #define CHIPID_EXID_SAMX7X_PINS_MASK 0x3U
 #define CHIPID_EXID_SAMX7X_PINS_Q    0x2U
@@ -135,19 +129,17 @@
 #define CHIPID_EXID_SAMX7X_PINS_J    0x0U
 
 /* GPNVM */
-#define GPNVM_SAMX7X_SECURITY_BIT_MASK 0x1
+#define GPNVM_SAMX7X_SECURITY_BIT_MASK 0x01U
 
-#define GPNVM_SAMX7X_BOOT_BIT_OFFSET 1U
-#define GPNVM_SAMX7X_BOOT_BIT_MASK   (0x1U << GPNVM_SAMX7X_BOOT_BIT_OFFSET)
-#define GPNVM_SAMX7X_BOOT_ROM        (0x0U << GPNVM_SAMX7X_BOOT_BIT_OFFSET)
-#define GPNVM_SAMX7X_BOOT_FLASH      (0x1U << GPNVM_SAMX7X_BOOT_BIT_OFFSET)
+#define GPNVM_SAMX7X_BOOT_BIT_MASK (0x1U << 1U)
+#define GPNVM_SAMX7X_BOOT_ROM      (0x0U << 1U)
+#define GPNVM_SAMX7X_BOOT_FLASH    (0x1U << 1U)
 
-#define GPNVM_SAMX7X_TCM_BIT_OFFSET 7U
-#define GPNVM_SAMX7X_TCM_BIT_MASK   (0x3U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
-#define GPNVM_SAMX7X_TCM_0K         (0x0U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
-#define GPNVM_SAMX7X_TCM_32K        (0x1U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
-#define GPNVM_SAMX7X_TCM_64K        (0x2U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
-#define GPNVM_SAMX7X_TCM_128K       (0x3U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
+#define GPNVM_SAMX7X_TCM_BIT_MASK (0x3U << 7U)
+#define GPNVM_SAMX7X_TCM_0K       (0x0U << 7U)
+#define GPNVM_SAMX7X_TCM_32K      (0x1U << 7U)
+#define GPNVM_SAMX7X_TCM_64K      (0x2U << 7U)
+#define GPNVM_SAMX7X_TCM_128K     (0x3U << 7U)
 
 static bool sam_cmd_gpnvm(target_s *target, int argc, const char **argv);
 
@@ -401,31 +393,31 @@ bool samx7x_probe(target_s *target)
 
 	/* Check and see what TCM config is set up on the device */
 	uint32_t tcm_config = 0;
-	if (!sam_gpnvm_get(target, SAMX7X_EEFC_BASE, &tcm_config))
+	if (!sam_gpnvm_get(target, SAMx7x_EEFC_BASE, &tcm_config))
 		return false;
 	tcm_config &= GPNVM_SAMX7X_TCM_BIT_MASK;
 
 	/* Wait for the Flash controller to become idle and then read the Flash descriptor */
-	while (!(target_mem32_read32(target, EEFC_FSR(SAMX7X_EEFC_BASE)) & EEFC_FSR_FRDY))
+	while (!(target_mem32_read32(target, EEFC_FSR(SAMx7x_EEFC_BASE)) & EEFC_FSR_FRDY))
 		continue;
-	target_mem32_write32(target, EEFC_FCR(SAMX7X_EEFC_BASE), EEFC_FCR_FKEY | EEFC_FCR_FCMD_GETD);
-	while (!(target_mem32_read32(target, EEFC_FSR(SAMX7X_EEFC_BASE)) & EEFC_FSR_FRDY))
+	target_mem32_write32(target, EEFC_FCR(SAMx7x_EEFC_BASE), EEFC_FCR_FKEY | EEFC_FCR_FCMD_GETD);
+	while (!(target_mem32_read32(target, EEFC_FSR(SAMx7x_EEFC_BASE)) & EEFC_FSR_FRDY))
 		continue;
 #ifndef DEBUG_TARGET_IS_NOOP
 	/* Now FRR contains FL_ID, so read that to discard it (reporting it as info) */
 	const uint32_t flash_id =
 #endif
-		target_mem32_read32(target, EEFC_FRR(SAMX7X_EEFC_BASE));
+		target_mem32_read32(target, EEFC_FRR(SAMx7x_EEFC_BASE));
 	DEBUG_TARGET("Flash ID: %08" PRIx32 "\n", flash_id);
 	/* Now extract the Flash size and then the Flash page size */
-	const uint32_t flash_size = target_mem32_read32(target, EEFC_FRR(SAMX7X_EEFC_BASE));
-	const uint32_t flash_page_size = target_mem32_read32(target, EEFC_FRR(SAMX7X_EEFC_BASE));
+	const uint32_t flash_size = target_mem32_read32(target, EEFC_FRR(SAMx7x_EEFC_BASE));
+	const uint32_t flash_page_size = target_mem32_read32(target, EEFC_FRR(SAMx7x_EEFC_BASE));
 	DEBUG_TARGET(
 		"Found %" PRIu32 " bytes of Flash with a %" PRIu32 " byte Flash page size\n", flash_size, flash_page_size);
 
 	/* Register appropriate RAM and Flash for the part */
 	samx7x_add_ram(target, tcm_config, priv_storage->descr.ram_size);
-	sam_add_flash(target, SAMX7X_EEFC_BASE, 0x00400000, flash_size, flash_page_size);
+	sam_add_flash(target, SAMx7x_EEFC_BASE, 0x00400000, flash_size, flash_page_size);
 	/* Register target-specific commands */
 	target_add_commands(target, sam_cmd_list, "SAMx7x");
 
@@ -637,7 +629,7 @@ static bool sam_cmd_gpnvm(target_s *target, int argc, const char **argv)
 		break;
 	case DRIVER_SAMX7X:
 		gpnvm_mask = 0x1bfU;
-		base = SAMX7X_EEFC_BASE;
+		base = SAMx7x_EEFC_BASE;
 		break;
 	default:
 		/* unknown / invalid driver*/

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -563,11 +563,11 @@ static bool sam_flash_write(target_flash_s *flash, target_addr_t dest, const voi
 {
 	target_s *const target = flash->t;
 	sam_flash_s *const sf = (sam_flash_s *)flash;
-	const uint32_t base = sf->eefc_base;
-	const uint32_t chunk = (dest - flash->start) / flash->writesize;
+
+	const uint32_t page = (dest - flash->start) / flash->writesize;
 
 	target_mem32_write(target, dest, src, len);
-	return sam_flash_cmd(target, base, sf->write_cmd, chunk);
+	return sam_flash_cmd(target, sf->eefc_base, sf->write_cmd, page);
 }
 
 static bool sam_mass_erase(target_flash_s *const flash, platform_timeout_s *const print_progress)

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -413,6 +413,8 @@ bool samx7x_probe(target_s *target)
 	/* Now extract the Flash size and then the Flash page size */
 	const uint32_t flash_size = target_mem32_read32(target, EEFC_FRR(SAMX7X_EEFC_BASE));
 	const uint32_t flash_page_size = target_mem32_read32(target, EEFC_FRR(SAMX7X_EEFC_BASE));
+	DEBUG_TARGET(
+		"Found %" PRIu32 " bytes of Flash with a %" PRIu32 " byte Flash page size\n", flash_size, flash_page_size);
 
 	samx7x_add_ram(target, tcm_config, priv_storage->descr.ram_size);
 	sam_add_flash(target, SAMX7X_EEFC_BASE, 0x00400000, flash_size, flash_page_size);

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -1,8 +1,10 @@
 /*
  * This file is part of the Black Magic Debug project.
  *
- * Copyright (C) 2015  Black Sphere Technologies Ltd.
+ * Copyright (C) 2015 Black Sphere Technologies Ltd.
+ * Copyright (C) 2022-2025 1BitSquared <info@1bitsquared.com>
  * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ * Modified by Rachel Mant <git@dragonmux.network>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/target/sam3x.c
+++ b/src/target/sam3x.c
@@ -29,20 +29,6 @@
 #include "target_internal.h"
 #include "cortexm.h"
 
-static bool sam_flash_erase(target_flash_s *flash, target_addr_t addr, size_t len);
-static bool sam3_flash_erase(target_flash_s *flash, target_addr_t addr, size_t len);
-static bool sam_flash_write(target_flash_s *flash, target_addr_t dest, const void *src, size_t len);
-static bool sam_mass_erase(target_flash_s *flash, platform_timeout_s *print_progress);
-
-static bool sam_gpnvm_get(target_s *target, uint32_t base, uint32_t *gpnvm);
-
-static bool sam_cmd_gpnvm(target_s *target, int argc, const char **argv);
-
-const command_s sam_cmd_list[] = {
-	{"gpnvm", sam_cmd_gpnvm, "Set/Get GPVNM bits"},
-	{NULL, NULL, NULL},
-};
-
 /* Enhanced Embedded Flash Controller (EEFC) Register Map */
 #define SAMX7X_EEFC_BASE   0x400e0c00U
 #define SAM3N_EEFC_BASE    0x400e0a00U
@@ -162,6 +148,20 @@ const command_s sam_cmd_list[] = {
 #define GPNVM_SAMX7X_TCM_32K        (0x1U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
 #define GPNVM_SAMX7X_TCM_64K        (0x2U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
 #define GPNVM_SAMX7X_TCM_128K       (0x3U << GPNVM_SAMX7X_TCM_BIT_OFFSET)
+
+static bool sam_cmd_gpnvm(target_s *target, int argc, const char **argv);
+
+const command_s sam_cmd_list[] = {
+	{"gpnvm", sam_cmd_gpnvm, "Set/Get GPVNM bits"},
+	{NULL, NULL, NULL},
+};
+
+static bool sam_flash_erase(target_flash_s *flash, target_addr_t addr, size_t len);
+static bool sam3_flash_erase(target_flash_s *flash, target_addr_t addr, size_t len);
+static bool sam_flash_write(target_flash_s *flash, target_addr_t dest, const void *src, size_t len);
+static bool sam_mass_erase(target_flash_s *flash, platform_timeout_s *print_progress);
+
+static bool sam_gpnvm_get(target_s *target, uint32_t base, uint32_t *gpnvm);
 
 typedef enum sam_driver {
 	DRIVER_SAM3X,


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we address a report from user dhylands on Discord where his SAMV71 based board would refuse to take firmware past the first 8KiB of Flash with an erase failure.

This PR consists of two parts - modernisation of the code, and then addressing the user's issue. In modernisation we have fixed nomenclature and file organisation, bringing things inline with, eg, stm32h5.c. To address the user's issue, we have implemented proper mass erase support, and found an erase page count that should be common to all the Flash on SAMx7x parts, having the code switch between sizes depending on what the part's detected as being (SAM4x vs SAMx7x).

This has been tested working by the user, erasing and programming 2MiB of Flash successfully.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
