### PR TITLE
cortexa_armv8: fix formatting args

### DIFF
--- a/src/target/cortexa_armv8.c
+++ b/src/target/cortexa_armv8.c
@@ -957,7 +957,7 @@ static void cortexa_armv8_core_regs_save(target_s *const target)
 		bool success = cortexa_armv8_core_reg_read64(target, i, &priv->core_regs.x[i]);
 
 		if (!success)
-			DEBUG_ERROR("%s: Failed to read register x%lu\n", __func__, i);
+			DEBUG_ERROR("%s: Failed to read register x%" PRIu32 "\n", __func__, (uint32_t)i);
 	}
 
 	/* Save SP/PC/SPSR registers */
@@ -1614,7 +1614,7 @@ static void cortexa_armv8_config_breakpoint(
 	else if (breakwatch->size == 2)
 		control |= CORTEXA_DBG_BCR_EL1_BYTE_SELECT_LOW_HALF;
 	else {
-		DEBUG_ERROR("Invalid breakpoint size %ld\n", breakwatch->size);
+		DEBUG_ERROR("Invalid breakpoint size %" PRIu32 "\n", (uint32_t)breakwatch->size);
 		return;
 	}
 


### PR DESCRIPTION
Fix the formatting args for cortexa_armv8. This fixes the build on ESP32.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [ ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [ ] My commit messages provide a useful short description of what the commits do