### PR TITLE
Fix: adjust LPC546xx Part ID printed to hexadecimal

### DIFF
--- a/src/target/lpc546xx.c
+++ b/src/target/lpc546xx.c
@@ -137,7 +137,7 @@ bool lpc546xx_probe(target_s *t)
 	uint32_t flash_size = 0;
 	uint32_t sram123_size = 0;
 
-	DEBUG_INFO("LPC546xx: Part ID 0x%08" PRIu32 "\n", chipid);
+	DEBUG_INFO("LPC546xx: Part ID 0x%08" PRIx32 "\n", chipid);
 	const lpc546xx_device_s *device = lpc546xx_get_device(chipid);
 	if (!device)
 		return false;


### PR DESCRIPTION
## Detailed description

* No new features.
* The existing problem is `LPC546xx: Part ID 0x4294264328` being logged as highlighted by recent advancements in #1520. Should be `0xfff54608`.
* The PR solves it by swapping format specifier in lpc546xx.c to lowercase hexadecimal, like in lpc11xx.c and others.

This existed since #1522 which was my 7th merged PR here, I was not as experienced or acquainted with codebase, also untested on unavailable LPC silicon. By grepping current drivers I don't see other obvious instances of this.
`grep 'DEBUG_INFO.*ID.*PRIu32' src/target/*.c` one unrelated hit in adiv5.c
`grep 'DEBUG_INFO.*ID.*PRIx32' src/target/*.c` 14 hits.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues
