### PR TITLE
Feature: STM32F1 logging cleanup

### DIFF
--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -1091,7 +1091,6 @@ static bool stm32f1_flash_erase(target_flash_s *flash, target_addr_t addr, size_
 {
 	target_s *target = flash->t;
 	target_addr_t end = addr + length - 1U;
-	DEBUG_TARGET("%s: at %08" PRIx32 "\n", __func__, addr);
 
 	/* Unlocked an appropriate flash bank */
 	if ((stm32f1_is_dual_bank(target->part_id) && end >= FLASH_BANK_SPLIT &&
@@ -1126,7 +1125,6 @@ static bool stm32f1_flash_write(target_flash_s *flash, target_addr_t dest, const
 {
 	target_s *target = flash->t;
 	const size_t offset = stm32f1_bank1_length(dest, len);
-	DEBUG_TARGET("%s: at %08" PRIx32 " for %zu bytes\n", __func__, dest, len);
 
 	/* Allow wider writes on Gigadevices and Arterytek */
 	const align_e psize = (target->target_options & STM32F1_TOPT_32BIT_WRITES) ? ALIGN_32BIT : ALIGN_16BIT;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description

In this PR we clean up the logging for the STM32F1 support which now duplicates that in the Target Flash API layer. This causes logs to be confusing and messy, so let's remove the extra logging.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
