### PR TITLE
hosted: assert ntrst as part of connecting

### DIFF
--- a/src/platforms/hosted/dap.h
+++ b/src/platforms/hosted/dap.h
@@ -81,6 +81,8 @@ extern uint8_t dap_quirks;
 
 bool dap_connect(void);
 bool dap_disconnect(void);
+bool dap_ntrst_get_val(void);
+bool dap_ntrst_set_val(const bool ntrst_state);
 bool dap_led(dap_led_type_e type, bool state);
 size_t dap_info(dap_info_e requested_info, void *buffer, size_t buffer_length);
 bool dap_set_reset_state(bool nrst_state);

--- a/src/platforms/hosted/dap_jtag.c
+++ b/src/platforms/hosted/dap_jtag.c
@@ -52,6 +52,8 @@ bool dap_jtag_init(void)
 	dap_disconnect();
 	dap_mode = DAP_CAP_JTAG;
 	dap_connect();
+	dap_ntrst_set_val(true);
+	dap_ntrst_set_val(false);
 
 	jtag_proc.jtagtap_reset = dap_jtag_reset;
 	jtag_proc.jtagtap_next = dap_jtag_next;


### PR DESCRIPTION
## Detailed description

Assert the nTRST when connecting via JTAG. This is required for targets that use this pin to enable the JTAG circuitry.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [ ] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
