### PR TITLE
icepick: use formatting macros for debugging

### DIFF
--- a/src/target/icepick.c
+++ b/src/target/icepick.c
@@ -120,7 +120,7 @@ void icepick_router_handler(const uint8_t dev_index)
 		DEBUG_ERROR("ICEPick is not a type-D controller (%08" PRIx32 ")\n", icepick_idcode);
 		return;
 	}
-	DEBUG_INFO("ICEPick type-D controller v%u.%u (%08" PRIx32 ")\n",
+	DEBUG_INFO("ICEPick type-D controller v%" PRIu32 ".%" PRIu32 " (%08" PRIx32 ")\n",
 		(icepick_idcode >> ICEPICK_MAJOR_SHIFT) & ICEPICK_MAJOR_MASK,
 		(icepick_idcode >> ICEPICK_MINOR_SHIFT) & ICEPICK_MINOR_MASK, icepick_idcode);
 


### PR DESCRIPTION

## Detailed description

Use PRIu32 for formatting the uint32_t `icepick_idcode` value. This is required when building for targets where `%u` doesn't mean `uint32_t`.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

