### PR TITLE
stm32l1: Use DBGMCU_IDCODE for part detection

### DIFF
--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -342,7 +342,7 @@ bool stm32l1_probe(target_s *const target)
 	if (ap->partno != ID_STM32L1xxxB && ap->partno != ID_STM32L1xxxBxA && ap->partno != ID_STM32L1xxxC &&
 		ap->partno != ID_STM32L1xxxD && ap->partno != ID_STM32L1xxxE)
 		return false;
-	target->part_id = ap->partno;
+	target->part_id = target_mem32_read32(target, STM32L1_DBGMCU_IDCODE) & 0xfffU;
 
 	/* Now we have a stable debug environment, make sure the WDTs + WFI and WFE instructions can't cause problems */
 	stm32l1_configure_dbgmcu(target);


### PR DESCRIPTION
**Otherwise STM32L152RC on stm32l152c-discovery is recognized with only 4k**

## Detailed description

This PR fixes incorrect device identification on the `stm32l152c-discovery` board.

Currently, STM32L152RC may be detected with an incorrect `part_id`, which leads to it being recognized with only **4k**, causing the wrong memory layout/flash sizing to be used.

The fix is to populate `target->part_id` by reading the MCU's `DBGMCU_IDCODE` register (masked to the device ID field), instead of relying on `ap->partno`. This provides a more reliable and accurate identification for STM32L1 devices. I don’t have the stm32l152c-discovery board available to test locally, but the change is minimal and matches the downstream fix.

---

Also as some context: we’ve been developing a tool that scans downstream forks to find valuable commits that haven’t been merged back upstream, and your repo was one of the best examples we found. This commit stood out as a small but important fix, so we manually reviewed it and are submitting it here as a PR in case it’s useful for the upstream project.

If you feel this change is not desired or there’s a better upstream approach, we’d really appreciate any suggestions — both for this patch and for improving our tool’s filtering logic. Thanks for your review!

## Your checklist for this pull request

* [x] I've read the [[Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [[guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md)](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [ ] It builds for hardware native (see [[Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware)](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [ ] It builds as BMDA (see [[Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app)](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do
