### PR TITLE
Fix JTAG sanity check in BYPASS device counting

### DIFF
--- a/src/target/jtag_scan.c
+++ b/src/target/jtag_scan.c
@@ -303,9 +303,13 @@ static bool jtag_sanity_check(void)
 	/* Transition to Shift-DR */
 	DEBUG_INFO("Change state to Shift-DR\n");
 	jtagtap_shift_dr();
+	/* Preload entire DR chain of BYPASS with known 0 value */
+	jtag_proc.jtagtap_cycle(false, false, jtag_dev_count);
+
 	/* Count devices on chain */
 	size_t device = 0;
 	for (; device <= jtag_dev_count; ++device) {
+		/* Read back the known 0's, shift out 1's, expect reading 1 after the chain loops */
 		if (jtag_proc.jtagtap_next(false, true))
 			break;
 		/* Configure the DR pre/post scan values */


### PR DESCRIPTION
## Detailed description

* This is not a new feature.
* The existing problem is an error triggered in BMD logic for chips which are debuggable by OpenOCD using same adapteres.
* The PR solves it by ensuring DR value is predictable.

`jtag_scan: Sanity check failed: BYPASS dev count doesn't match IR scan`
Not tested yet. The error/warning demotion will be rebased away once I confirm the solution works.
Upd: tested to improve the situation, the chip in question became scannable by BMF. Sanity check restored.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues