### PR TITLE
Fix NULL `jtagtap_cycle()` which crashed BMDA

### DIFF
--- a/src/platforms/hosted/dap_jtag.c
+++ b/src/platforms/hosted/dap_jtag.c
@@ -41,6 +41,7 @@ static void dap_jtag_tms_seq(uint32_t tms_states, size_t clock_cycles);
 static void dap_jtag_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static void dap_jtag_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool dap_jtag_next(bool tms, bool tdi);
+static void dap_jtag_cycle(bool tms, bool tdi, size_t clock_cycles);
 
 bool dap_jtag_init(void)
 {
@@ -60,11 +61,11 @@ bool dap_jtag_init(void)
 	jtag_proc.jtagtap_tms_seq = dap_jtag_tms_seq;
 	jtag_proc.jtagtap_tdi_tdo_seq = dap_jtag_tdi_tdo_seq;
 	jtag_proc.jtagtap_tdi_seq = dap_jtag_tdi_seq;
+	jtag_proc.jtagtap_cycle = dap_jtag_cycle;
 
 	/* Ensure we're in JTAG mode */
-	for (size_t i = 0; i <= 50U; ++i)
-		dap_jtag_next(true, false); /* 50 + 1 idle cycles for SWD reset */
-	dap_jtag_tms_seq(0xe73cU, 16U); /* SWD to JTAG sequence */
+	dap_jtag_cycle(true, false, 51U); /* 50 + 1 idle cycles for SWD reset */
+	dap_jtag_tms_seq(0xe73cU, 16U);   /* SWD to JTAG sequence */
 
 	if (dap_quirks & DAP_QUIRK_NO_JTAG_MUTLI_TAP)
 		DEBUG_WARN("Multi-TAP JTAG is broken on this adaptor firmware revision, please upgrade it\n");
@@ -123,6 +124,12 @@ static bool dap_jtag_next(const bool tms, const bool tdi)
 	perform_dap_jtag_sequence(&tdi_byte, &tdo, tms, 1U);
 	DEBUG_PROBE("jtagtap_next tms=%u tdi=%u tdo=%u\n", tms_byte, tdi_byte, tdo);
 	return tdo;
+}
+
+static void dap_jtag_cycle(const bool tms, const bool tdi, const size_t clock_cycles)
+{
+	for (size_t i = 0; i < clock_cycles; i++)
+		dap_jtag_next(tms, tdi);
 }
 
 bool dap_jtag_configure(void)

--- a/src/platforms/hosted/jlink_jtag.c
+++ b/src/platforms/hosted/jlink_jtag.c
@@ -40,6 +40,7 @@ static void jlink_jtag_tms_seq(uint32_t tms_states, size_t clock_cycles);
 static void jlink_jtag_tdi_tdo_seq(uint8_t *data_out, bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static void jlink_jtag_tdi_seq(bool final_tms, const uint8_t *data_in, size_t clock_cycles);
 static bool jlink_jtag_next(bool tms, bool tdi);
+static void jlink_jtag_cycle(bool tms, bool tdi, size_t clock_cycles);
 
 static const uint8_t jlink_switch_to_jtag_seq[9U] = {0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0x3cU, 0xe7U};
 
@@ -66,6 +67,7 @@ bool jlink_jtag_init(void)
 	jtag_proc.jtagtap_tms_seq = jlink_jtag_tms_seq;
 	jtag_proc.jtagtap_tdi_tdo_seq = jlink_jtag_tdi_tdo_seq;
 	jtag_proc.jtagtap_tdi_seq = jlink_jtag_tdi_seq;
+	jtag_proc.jtagtap_cycle = jlink_jtag_cycle;
 	return true;
 }
 
@@ -116,4 +118,10 @@ static bool jlink_jtag_next(bool tms, bool tdi)
 	if (!result)
 		raise_exception(EXCEPTION_ERROR, "jtagtap_next failed");
 	return tdo;
+}
+
+static void jlink_jtag_cycle(const bool tms, const bool tdi, const size_t clock_cycles)
+{
+	for (size_t i = 0; i < clock_cycles; i++)
+		jlink_jtag_next(tms, tdi);
 }


### PR DESCRIPTION
## Detailed description

* No real new features.
* The existing problem is SIGSEGV in BMDA when trying to invoke `jtag_proc.jtagtap_cycle()` in initial JTAG scan.
* This PR solves it by providing simplified wrappers for that (around `jtagtap_next()`).

Affected backends are FTDI MPSSE, J-Link, and CMSIS-DAP.
Unaffected backends are BMP HL remote, STLINK. BMF was not affected either.
Tested with FT2232HL against a RV32I target, the other 3 callsites are not fixed.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues