### PR TITLE
Feature: implementation of `jtagtap_cycle()` for FTDI backend

### DIFF
--- a/src/platforms/hosted/ftdi_jtag.c
+++ b/src/platforms/hosted/ftdi_jtag.c
@@ -166,7 +166,7 @@ static void ftdi_jtag_cycle(const bool tms, const bool tdi, const size_t clock_c
 	 * 0x8f CLK_BYTES: Length of 0..n will generate 1..1+n byte cycles,
 	 * i.e. emit 8..8*(n+1) clocks, so adjust clock_bytes down by 1.
 	 */
-	size_t clock_bytes = clock_cycles / 8U;
+	size_t clock_bytes = clock_cycles >> 3U;
 	if (clock_bytes > 0) {
 		clock_bytes--;
 		const uint8_t cmd8[3U] = {
@@ -177,7 +177,7 @@ static void ftdi_jtag_cycle(const bool tms, const bool tdi, const size_t clock_c
 		ftdi_buffer_write_arr(cmd8);
 	}
 	/* 0x8e CLK_BITS: Length of 0..7 will emit 1..8 clocks */
-	const uint8_t clock_bits = clock_cycles % 8U - 1U;
+	const uint8_t clock_bits = (clock_cycles & 7U) - 1U;
 	if (clock_bits >= 8U)
 		return;
 	const uint8_t cmd1[2U] = {


### PR DESCRIPTION
## Detailed description

* This is a minor new feature.
* The problem is BMD logic expects to use `jtagtap_cycle()` sometimes, but BMDA hasn't always provided it.
* This PR solves it by providing one moderately optimized implementation for FTDI MPSSE backend.

Tested on FT2232HL against a RISC-V MCU. Based on #2179. See #2180 for tracking other backends.
I would like some explanation, is buffering beneficial in the handlers, or does it exist externally (between two flush calls), then I can discard the 2nd commit.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues