### PR TITLE
Feature: implementation of `jtagtap_cycle` for JLink backend

### DIFF
--- a/src/platforms/hosted/jlink_jtag.c
+++ b/src/platforms/hosted/jlink_jtag.c
@@ -42,8 +42,6 @@ static void jlink_jtag_tdi_seq(bool final_tms, const uint8_t *data_in, size_t cl
 static bool jlink_jtag_next(bool tms, bool tdi);
 static void jlink_jtag_cycle(bool tms, bool tdi, size_t clock_cycles);
 
-static const uint8_t jlink_switch_to_jtag_seq[9U] = {0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0x3cU, 0xe7U};
-
 bool jlink_jtag_init(void)
 {
 	DEBUG_PROBE("-> jlink_jtag_init\n");
@@ -56,7 +54,10 @@ bool jlink_jtag_init(void)
 
 	/* Ensure we're in JTAG mode */
 	DEBUG_PROBE("%s: Switch to JTAG\n", __func__);
-	if (!jlink_transfer(sizeof(jlink_switch_to_jtag_seq) * 8U, jlink_switch_to_jtag_seq, NULL, NULL)) {
+	jlink_jtag_cycle(true, false, 56U - 5U);
+	uint8_t tms_swd_to_jtag_seq[2] = {0x3cU, 0xe7U};
+	bool res = jlink_transfer(16U, tms_swd_to_jtag_seq, NULL, NULL);
+	if (!res) {
 		DEBUG_ERROR("Switch to JTAG failed\n");
 		return false;
 	}


### PR DESCRIPTION
## Detailed description

* This is a minor new feature.
* The problem is rudimentary/poor implementation of `jtagtap_cycle()` in jlink.c backend used by BMDA. (and it didn't even exist until very recently)
* This PR solves it by providing one moderately optimized variant.

Tracking: #2180.
Note that `jlink_jtag_init()` used to rely on a direct `jlink_transfer()` of a baked byte buffer with 56 idle clocks and SWD-to-JTAG switch sequence, I replaced that with a `jlink_jtag_cycle()` call for 56-5=51 clocks and a shorter, 16-bit sequence. The caveat is that new function may raise an exception, and at scan time it results in immediate SIGABRT because it's unhandled (by any TRY-CATCH up the callsite). It also happens to be the first 0xCF opcode transfer. If such behaviour is unwanted, discard commit 1.

Tested on J-Link V9 against a RISC-V MCU.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues