### PR TITLE
Fix: remove last VLA in msp432p4.c

### DIFF
--- a/src/target/msp432p4.c
+++ b/src/target/msp432p4.c
@@ -268,7 +268,7 @@ static bool msp432_flash_write(
 	DEBUG_WARN("Flash protect: 0x%08" PRIX32 "\n", target_mem32_read32(target, mf->flash_protect_register));
 
 	/* Prepare input data */
-	uint32_t *regs = alloca(target->regs_size / sizeof(uint32_t)); // Use of VLA
+	uint32_t regs[CORTEXM_GENERAL_REG_COUNT + CORTEX_FLOAT_REG_COUNT];
 	target_regs_read(target, regs);
 	regs[0] = SRAM_WRITE_BUFFER; // Address of buffer to be flashed in R0
 	regs[1] = dest;              // Flash address to be write to in R1


### PR DESCRIPTION
## Detailed description

* Not a new feature.
* The existing problem is VLA/alloca left over from PR1606 refactoring, specifically v1.9.0-1188-g f94ed09c.
* This PR completes the replacement (to arrays with known size of 20+33 matching Cortex-M4F).

Found using `ag alloca\\\( src/`, also matches `git grep "alloca(" origin/main -- src/target/*.c`. Related: v1.10.0-244-g c0a8672f of PR1661.
Not tested.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [ ] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues