### PR TITLE
Fix: reuse GDB packet buffer for m/M-packets instead of VLA

### DIFF
--- a/src/gdb_main.c
+++ b/src/gdb_main.c
@@ -150,7 +150,7 @@ int32_t gdb_main_loop(target_controller_s *const tc, const gdb_packet_s *const p
 				break;
 			}
 			DEBUG_GDB("m packet: addr = %" PRIx32 ", len = %" PRIx32 "\n", addr, len);
-			uint8_t *mem = alloca(len);
+			char *mem = gdb_packet_buffer() + GDB_PACKET_BUFFER_SIZE / 2U;
 			if (target_mem32_read(cur_target, mem, addr, len))
 				gdb_put_packet_error(1U);
 			else
@@ -180,7 +180,7 @@ int32_t gdb_main_loop(target_controller_s *const tc, const gdb_packet_s *const p
 				break;
 			}
 			DEBUG_GDB("M packet: addr = %" PRIx32 ", len = %" PRIx32 "\n", addr, len);
-			uint8_t *mem = alloca(len);
+			char *mem = gdb_packet_buffer();
 			unhexify(mem, rest, len);
 			if (target_mem32_write(cur_target, addr, mem, len))
 				gdb_put_packet_error(1U);


### PR DESCRIPTION
## Detailed description

* This is not a new feature, but still a potentially dangerous change. A sort of continuation of PR2014.
* The existing problem is gdb_main FSM performing VLA for m/M-packets.
* This PR solves it by reusing half of gdb packet buffer for (un)hexify operations.

Tested on BMDA (env CC=clang, -Db_sanitize=address) and on blackpill-f411ce against GD32VF103. Dump and compare-sections seem to match, GDB receives 512 byte (1024 hex-encoded) packets.
g/G-packets still depend on VLA because BMP supports multiple architectures with different amounts of general-purpose registers. `{armv7-m 20*4, armv8-m.main 24*4} + fpv4-sp-d16 33*4, armv7-a/r 17*4 + VFPv3 33*4, armv8-a 31*8, rv32i 33*4, rv32e 17*4, rv64i 33*8.` IMHO a static regcache of 512 bytes could be enough (with build-time static assert that no arch needs more), but it's not visibly broken now, so not touching.

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

Closes #2042. @perigoso 