### PR TITLE
armv8m: make the debugger handle better faults through ICSR

### DIFF
--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -864,7 +864,21 @@ static target_halt_reason_e cortexm_halt_poll(target_s *target, target_addr64_t 
 	priv->dcache_enabled = ccr & CORTEXM_CCR_DCACHE_ENABLE;
 	priv->icache_enabled = ccr & CORTEXM_CCR_ICACHE_ENABLE;
 
-	if ((dfsr & CORTEXM_DFSR_VCATCH) && cortexm_fault_unwind(target))
+	bool fault_state = false;
+	// the V8 may stop before actually executing the instruction
+	// so reading dfsr might not work.
+	// Instead, we check if there are pending faults on ICSR
+	// meaning we stopped while trying to execute a fault
+	// but maybe did not execute it
+	if ((target->target_options & CORTEXM_TOPT_FLAVOUR_V8M)) {
+		const uint32_t icsr = target_mem32_read32(target, CORTEXM_ICSR);
+		const uint32_t pending = CORTEXM_ICSR_VEC_PENDING(icsr);
+		//  catch all pending faults
+		if (pending > 0U && pending < 8U)
+			fault_state = true;
+	} else
+		fault_state = (dfsr & CORTEXM_DFSR_VCATCH) != 0U;
+	if (fault_state && cortexm_fault_unwind(target))
 		return TARGET_HALT_FAULT;
 
 	/* Remember if we stopped on a breakpoint */

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -69,6 +69,9 @@ extern unsigned cortexm_wait_timeout;
 #define CORTEXM_DWT_MASK(i) (CORTEXM_DWT_BASE + 0x024U + (0x10U * (i)))
 #define CORTEXM_DWT_FUNC(i) (CORTEXM_DWT_BASE + 0x028U + (0x10U * (i)))
 
+/* ARMv8 External Debug Fault Status Register */
+#define CORTEXM_EDFSR (CORTEXM_SCS_BASE + 0xf98U)
+#define CORTEXM_ICSR  (CORTEXM_SCS_BASE + 0xd04U)
 /* Application Interrupt and Reset Control Register (AIRCR) */
 #define CORTEXM_AIRCR_VECTKEY (0x05faU << 16U)
 /* Bits 31:16 - Read as VECTKETSTAT, 0xfa05 */
@@ -187,6 +190,10 @@ extern unsigned cortexm_wait_timeout;
 
 #define CORTEXM_XPSR_THUMB          (1U << 24U)
 #define CORTEXM_XPSR_EXCEPTION_MASK 0x0000001fU
+
+/* ICSR for ARMv8-M, the exception are the same as IPSR */
+#define CORTEXM_ICSR_VEC_PENDING(x) (((x) >> 12U) & 0x1ffU)
+#define CORTEXM_ICSR_VEC_ACTIVE(x)  (((x) >> 0U) & 0x1ffU)
 
 bool cortexm_attach(target_s *target);
 void cortexm_detach(target_s *target);


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
The ArmV8m does not handle faults the same way. The two main differences are :
- The fault will trigger BEFORE executing the fault rather than after
- The info is split between between DFSR and the new ICSR
- 
As a result the current code does not handle fault very well.
Put a breakpoint on a fault (for example __asm__("udf #0") and try to "si" on it.

Gdb  will appear to get stuck there because the debugger will see the state  BEFORE the fault is actually executed and as a result not detect the fault.

The MR adds a separate path that , for ArmV8M, it checks if a fault is pending on ICSR 
The "si" command on a fault now works and you proceed on to the handler.

I tested it on a RP2350 and on another CortexM33 successfully. 
I'm not convinced all cases are covered as some parts are configurable, but at least it's working better.

Not sure either if the new two new registers should be renamed with _V8M_ in the name or something.


## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

N/A