### PR TITLE
ch32f1: Fixed hanging gdb load command for CH32F103C8T6 MCU's

### DIFF
--- a/src/target/ch32f1.c
+++ b/src/target/ch32f1.c
@@ -219,7 +219,7 @@ static bool ch32f1_flash_busy_wait(target_s *const target)
 static bool ch32f1_flash_eop_wait(target_s *const target)
 {
 	uint32_t status = CH32F1_FLASH_STATUS_EOP;
-	while (status & CH32F1_FLASH_STATUS_EOP) {
+	while (!(status & CH32F1_FLASH_STATUS_EOP)) {
 		status = target_mem32_read32(target, CH32F1_FLASH_STATUS);
 		if (target_check_error(target)) {
 			DEBUG_ERROR("ch32f1 flash write: comm error\n");


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

## Detailed description
It looks like a bug did slip into the code during refactoring of file src/target/ch32f1.c (commit 85cade59259dec2c170fd1225b545c9a4ff163ef).

Fix: Added missing logical not operator (!) to function ch32f1_flash_eop_wait().

<!--
Explain the **details** for making this change.
* Is a new feature implemented?
* What existing problem(s) does the pull request solve?
* How does the pull request solve these problems?
Please provide enough information so that others can review your pull request.
Information embedded in the description part of the commits doesn't count.
-->

## Your checklist for this pull request

* [x] I've read the [Code of Conduct](https://github.com/blackmagic-debug/blackmagic/blob/main/CODE_OF_CONDUCT.md)
* [x] I've read the [guidelines for contributing](https://github.com/blackmagic-debug/blackmagic/blob/main/CONTRIBUTING.md) to this repository
* [x] It builds for hardware native (see [Building the firmware](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-firmware))
* [x] It builds as BMDA (see [Building the BMDA](https://github.com/blackmagic-debug/blackmagic?tab=readme-ov-file#building-black-magic-debug-app))
* [x] I've tested it to the best of my ability
* [x] My commit messages provide a useful short description of what the commits do

## Closing issues

<!-- put "fixes #XXXX" here to auto-close the issue(s) that your PR fixes (if any). -->
